### PR TITLE
feat: support loc_store(w) instructions

### DIFF
--- a/codegen/masm/src/emulator/mod.rs
+++ b/codegen/masm/src/emulator/mod.rs
@@ -1055,6 +1055,29 @@ impl Emulator {
                     debug_assert!(addr < self.memory.len() as u32);
                     self.stack.push_u32(addr * 16);
                 }
+                Op::LocStore(id) => {
+                    let addr = (state.fp() + id.as_usize() as u32) as usize;
+                    debug_assert!(addr < self.memory.len());
+                    let value = pop!(self);
+                    self.memory[addr][0] = value;
+                    return Ok(EmulatorEvent::MemoryWrite {
+                        addr: addr as u32,
+                        size: 4,
+                    });
+                }
+                Op::LocStorew(id) => {
+                    let addr = (state.fp() + id.as_usize() as u32) as usize;
+                    assert!(addr < self.memory.len() - 4, "out of bounds memory access");
+                    let word = self
+                        .stack
+                        .peekw()
+                        .expect("operand stack does not contain a full word");
+                    self.memory[addr] = word;
+                    return Ok(EmulatorEvent::MemoryWrite {
+                        addr: addr as u32,
+                        size: 16,
+                    });
+                }
                 Op::MemLoad => {
                     let addr = pop_addr!(self);
                     self.stack.push(self.memory[addr][0]);

--- a/codegen/masm/src/stackify/emitter.rs
+++ b/codegen/masm/src/stackify/emitter.rs
@@ -1747,7 +1747,9 @@ fn rewrite_inline_assembly_block(
                 *body_blk = rewrites[&prev_body_blk];
                 rewrite_inline_assembly_block(f_prime, asm, prev_body_blk, *body_blk, rewrites);
             }
-            Op::LocAddr(_) => todo!(),
+            Op::LocAddr(_) | Op::LocStore(_) | Op::LocStorew(_) => {
+                unimplemented!("locals are not currently supported in inline assembly blocks")
+            }
             _ => (),
         }
         f_prime.blocks[new].push(op);

--- a/hir/src/asm/builder.rs
+++ b/hir/src/asm/builder.rs
@@ -1672,7 +1672,7 @@ fn apply_op_stack_effects(
         MasmOp::AssertEqw => {
             stack.dropn(8);
         }
-        MasmOp::LocAddr(_id) => unreachable!(),
+        MasmOp::LocAddr(_id) | MasmOp::LocStore(_id) | MasmOp::LocStorew(_id) => unreachable!(),
         MasmOp::MemLoad | MasmOp::MemLoadOffset => {
             let ty = stack.pop().expect("operand stack is empty");
             assert_matches!(

--- a/hir/src/asm/display.rs
+++ b/hir/src/asm/display.rs
@@ -107,7 +107,6 @@ impl<'a> fmt::Display for DisplayOp<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", DisplayIndent(self.indent))?;
         match self.op {
-            MasmOp::Padw => f.write_str("padw"),
             MasmOp::Push(imm) => write!(f, "push.{imm}"),
             MasmOp::Push2([a, b]) => write!(f, "push.{a}.{b}"),
             MasmOp::Pushw(word) => write!(
@@ -118,39 +117,25 @@ impl<'a> fmt::Display for DisplayOp<'a> {
             MasmOp::PushU8(imm) => write!(f, "push.{imm}"),
             MasmOp::PushU16(imm) => write!(f, "push.{imm}"),
             MasmOp::PushU32(imm) => write!(f, "push.{imm}"),
-            MasmOp::Drop => f.write_str("drop"),
-            MasmOp::Dropw => f.write_str("dropw"),
-            MasmOp::Dup(idx) => write!(f, "dup.{idx}"),
-            MasmOp::Dupw(idx) => write!(f, "dupw.{idx}"),
-            MasmOp::Swap(idx) => write!(f, "swap.{idx}"),
-            MasmOp::Swapw(idx) => write!(f, "swapw.{idx}"),
-            MasmOp::Movup(idx) => write!(f, "movup.{idx}"),
-            MasmOp::Movupw(idx) => write!(f, "movupw.{idx}"),
-            MasmOp::Movdn(idx) => write!(f, "movdn.{idx}"),
-            MasmOp::Movdnw(idx) => write!(f, "movdnw.{idx}"),
-            MasmOp::Cswap => f.write_str("cswap"),
-            MasmOp::Cswapw => f.write_str("cswapw"),
-            MasmOp::Cdrop => f.write_str("cdrop"),
-            MasmOp::Cdropw => f.write_str("cdropw"),
-            MasmOp::Assert => f.write_str("assert"),
-            MasmOp::Assertz => f.write_str("assertz"),
-            MasmOp::AssertEq => f.write_str("assert_eq"),
-            MasmOp::AssertEqw => f.write_str("assert_eqw"),
-            MasmOp::LocAddr(id) => write!(f, "locaddr.{}", id.as_usize()),
-            MasmOp::MemLoad | MasmOp::MemLoadOffset => write!(f, "mem_load"),
-            MasmOp::MemLoadImm(addr) => write!(f, "mem_load.{}", Address(*addr)),
-            MasmOp::MemLoadOffsetImm(addr, offset) => {
-                write!(f, "mem_load.{}.{offset}", Address(*addr))
+            op @ (MasmOp::Dup(idx)
+            | MasmOp::Dupw(idx)
+            | MasmOp::Swap(idx)
+            | MasmOp::Swapw(idx)
+            | MasmOp::Movup(idx)
+            | MasmOp::Movupw(idx)
+            | MasmOp::Movdn(idx)
+            | MasmOp::Movdnw(idx)) => write!(f, "{op}.{idx}"),
+            op @ (MasmOp::LocAddr(id) | MasmOp::LocStore(id) | MasmOp::LocStorew(id)) => {
+                write!(f, "{op}.{}", id.as_usize())
             }
-            MasmOp::MemLoadw => write!(f, "mem_loadw"),
-            MasmOp::MemLoadwImm(addr) => write!(f, "mem_loadw.{}", Address(*addr)),
-            MasmOp::MemStore | MasmOp::MemStoreOffset => write!(f, "mem_store"),
-            MasmOp::MemStoreImm(addr) => write!(f, "mem_store.{}", Address(*addr)),
-            MasmOp::MemStoreOffsetImm(addr, offset) => {
-                write!(f, "mem_store.{}.{offset}", Address(*addr))
+            op @ (MasmOp::MemLoadImm(addr)
+            | MasmOp::MemLoadwImm(addr)
+            | MasmOp::MemStoreImm(addr)
+            | MasmOp::MemStorewImm(addr)) => write!(f, "{op}.{}", Address(*addr)),
+            op @ (MasmOp::MemLoadOffsetImm(addr, offset)
+            | MasmOp::MemStoreOffsetImm(addr, offset)) => {
+                write!(f, "{op}.{}.{offset}", Address(*addr))
             }
-            MasmOp::MemStorew => write!(f, "mem_storew"),
-            MasmOp::MemStorewImm(addr) => write!(f, "mem_storew.{}", Address(*addr)),
             MasmOp::If(then_blk, else_blk) => {
                 f.write_str("if.true\n")?;
                 {
@@ -244,121 +229,46 @@ impl<'a> fmt::Display for DisplayOp<'a> {
                     write!(f, "syscall.{alias}::{function}")
                 }
             }
-            MasmOp::Add => f.write_str("add"),
-            MasmOp::AddImm(imm) => write!(f, "add.{imm}"),
-            MasmOp::Sub => f.write_str("sub"),
-            MasmOp::SubImm(imm) => write!(f, "sub.{imm}"),
-            MasmOp::Mul => f.write_str("mul"),
-            MasmOp::MulImm(imm) => write!(f, "mul.{imm}"),
-            MasmOp::Div => f.write_str("div"),
-            MasmOp::DivImm(imm) => write!(f, "div.{imm}"),
-            MasmOp::Neg => f.write_str("neg"),
-            MasmOp::Inv => f.write_str("inv"),
-            MasmOp::Incr => f.write_str("incr"),
-            MasmOp::Pow2 => f.write_str("pow2"),
-            MasmOp::Exp => f.write_str("exp.u64"),
-            MasmOp::ExpImm(imm) => write!(f, "exp.{imm}"),
-            MasmOp::Not => f.write_str("not"),
-            MasmOp::And => f.write_str("and"),
-            MasmOp::AndImm(imm) => write!(f, "and.{imm}"),
-            MasmOp::Or => f.write_str("or"),
-            MasmOp::OrImm(imm) => write!(f, "or.{imm}"),
-            MasmOp::Xor => f.write_str("xor"),
-            MasmOp::XorImm(imm) => write!(f, "xor.{imm}"),
-            MasmOp::Eq => f.write_str("eq"),
-            MasmOp::EqImm(imm) => write!(f, "eq.{imm}"),
-            MasmOp::Neq => f.write_str("neq"),
-            MasmOp::NeqImm(imm) => write!(f, "neq.{imm}"),
-            MasmOp::Gt => f.write_str("gt"),
-            MasmOp::GtImm(imm) => write!(f, "gt.{imm}"),
-            MasmOp::Gte => f.write_str("gte"),
-            MasmOp::GteImm(imm) => write!(f, "gte.{imm}"),
-            MasmOp::Lt => f.write_str("lt"),
-            MasmOp::LtImm(imm) => write!(f, "lt.{imm}"),
-            MasmOp::Lte => f.write_str("lte"),
-            MasmOp::LteImm(imm) => write!(f, "lte.{imm}"),
-            MasmOp::IsOdd => f.write_str("is_odd"),
-            MasmOp::Eqw => f.write_str("eqw"),
-            MasmOp::Clk => f.write_str("clk"),
-            MasmOp::U32Test => f.write_str("u32.test"),
-            MasmOp::U32Testw => f.write_str("u32.testw"),
-            MasmOp::U32Assert => f.write_str("u32.assert"),
-            MasmOp::U32Assert2 => f.write_str("u32.assert2"),
-            MasmOp::U32Assertw => f.write_str("u32.assertw"),
-            MasmOp::U32Cast => f.write_str("u23.cast"),
-            MasmOp::U32Split => f.write_str("u32.split"),
-            MasmOp::U32CheckedAdd => f.write_str("u32.add.checked"),
-            MasmOp::U32CheckedAddImm(imm) => write!(f, "u32.add.checked.{imm}"),
-            MasmOp::U32OverflowingAdd => f.write_str("u32.add.overflowing"),
-            MasmOp::U32OverflowingAddImm(imm) => write!(f, "u32.add.overflowing.{imm}"),
-            MasmOp::U32WrappingAdd => f.write_str("u32.add.wrapping"),
-            MasmOp::U32WrappingAddImm(imm) => write!(f, "u32.add.wrapping.{imm}"),
-            MasmOp::U32OverflowingAdd3 => f.write_str("u32.add3.overflowing"),
-            MasmOp::U32WrappingAdd3 => f.write_str("u32.add3.wrapping"),
-            MasmOp::U32CheckedSub => f.write_str("u32.sub.checked"),
-            MasmOp::U32CheckedSubImm(imm) => write!(f, "u32.sub.checked.{imm}"),
-            MasmOp::U32OverflowingSub => f.write_str("u32.sub.overflowing"),
-            MasmOp::U32OverflowingSubImm(imm) => write!(f, "u32.sub.overflowing.{imm}"),
-            MasmOp::U32WrappingSub => f.write_str("u32.sub.wrapping"),
-            MasmOp::U32WrappingSubImm(imm) => write!(f, "u32.sub.wrapping.{imm}"),
-            MasmOp::U32CheckedMul => f.write_str("u32.mul.checked"),
-            MasmOp::U32CheckedMulImm(imm) => write!(f, "u32.mul.checked.{imm}"),
-            MasmOp::U32OverflowingMul => f.write_str("u32.mul.overflowing"),
-            MasmOp::U32OverflowingMulImm(imm) => write!(f, "u32.mul.overflowing.{imm}"),
-            MasmOp::U32WrappingMul => f.write_str("u32.mul.wrapping"),
-            MasmOp::U32WrappingMulImm(imm) => write!(f, "u32.mul.wrapping.{imm}"),
-            MasmOp::U32OverflowingMadd => f.write_str("u32.madd.overflowing"),
-            MasmOp::U32WrappingMadd => f.write_str("u32.madd.wrapping"),
-            MasmOp::U32CheckedDiv => f.write_str("u32.div.checked"),
-            MasmOp::U32CheckedDivImm(imm) => write!(f, "u32.div.checked.{imm}"),
-            MasmOp::U32UncheckedDiv => f.write_str("u32.div.unchecked"),
-            MasmOp::U32UncheckedDivImm(imm) => write!(f, "u32.div.unchecked.{imm}"),
-            MasmOp::U32CheckedMod => f.write_str("u32.mod.checked"),
-            MasmOp::U32CheckedModImm(imm) => write!(f, "u32.mod.unchecked.{imm}"),
-            MasmOp::U32UncheckedMod => f.write_str("u32.mod.unchecked"),
-            MasmOp::U32UncheckedModImm(imm) => write!(f, "u32.mod.unchecked.{imm}"),
-            MasmOp::U32CheckedDivMod => f.write_str("u32.divmod.checked"),
-            MasmOp::U32CheckedDivModImm(imm) => write!(f, "u32.divmod.checked.{imm}"),
-            MasmOp::U32UncheckedDivMod => f.write_str("u32.divmod.unchecked"),
-            MasmOp::U32UncheckedDivModImm(imm) => write!(f, "u32.divmod.unchecked.{imm}"),
-            MasmOp::U32And => f.write_str("u32.and"),
-            MasmOp::U32Or => f.write_str("u32.or"),
-            MasmOp::U32Xor => f.write_str("u32.xor"),
-            MasmOp::U32Not => f.write_str("u32.not"),
-            MasmOp::U32CheckedShl => f.write_str("u32.shl.checked"),
-            MasmOp::U32CheckedShlImm(imm) => write!(f, "u32.shl.checked.{imm}"),
-            MasmOp::U32UncheckedShl => f.write_str("u32.shl.unchecked"),
-            MasmOp::U32UncheckedShlImm(imm) => write!(f, "u32.shl.unchecked.{imm}"),
-            MasmOp::U32CheckedShr => f.write_str("u32.shr.checked"),
-            MasmOp::U32CheckedShrImm(imm) => write!(f, "u32.shr.checked.{imm}"),
-            MasmOp::U32UncheckedShr => f.write_str("u32.shr.unchecked"),
-            MasmOp::U32UncheckedShrImm(imm) => write!(f, "u32.shr.unchecked.{imm}"),
-            MasmOp::U32CheckedRotl => f.write_str("u32.rotl.checked"),
-            MasmOp::U32CheckedRotlImm(imm) => write!(f, "u32.rotl.checked.{imm}"),
-            MasmOp::U32UncheckedRotl => f.write_str("u32.rotl.unchecked"),
-            MasmOp::U32UncheckedRotlImm(imm) => write!(f, "u32.rotl.unchecked.{imm}"),
-            MasmOp::U32CheckedRotr => f.write_str("u32.rotr.checked"),
-            MasmOp::U32CheckedRotrImm(imm) => write!(f, "u32.rotr.checked.{imm}"),
-            MasmOp::U32UncheckedRotr => f.write_str("u32.rotr.unchecked"),
-            MasmOp::U32UncheckedRotrImm(imm) => write!(f, "u32.rotr.unchecked.{imm}"),
-            MasmOp::U32CheckedPopcnt => f.write_str("u32.popcnt.checked"),
-            MasmOp::U32UncheckedPopcnt => f.write_str("u32.popcnt.unchecked"),
-            MasmOp::U32Eq => f.write_str("u32.eq"),
-            MasmOp::U32EqImm(imm) => write!(f, "u32.eq.{}", imm),
-            MasmOp::U32Neq => f.write_str("u32.neq"),
-            MasmOp::U32NeqImm(imm) => write!(f, "u32.neq.{}", imm),
-            MasmOp::U32CheckedLt => f.write_str("u32.lt.checked"),
-            MasmOp::U32UncheckedLt => f.write_str("u32.lt.unchecked"),
-            MasmOp::U32CheckedLte => f.write_str("u32.lte.checked"),
-            MasmOp::U32UncheckedLte => f.write_str("u32.lte.unchecked"),
-            MasmOp::U32CheckedGt => f.write_str("u32.gt.checked"),
-            MasmOp::U32UncheckedGt => f.write_str("u32.gt.unchecked"),
-            MasmOp::U32CheckedGte => f.write_str("u32.gte.checked"),
-            MasmOp::U32UncheckedGte => f.write_str("u32.gte.unchecked"),
-            MasmOp::U32CheckedMin => f.write_str("u32.min.checked"),
-            MasmOp::U32UncheckedMin => f.write_str("u32.min.unchecked"),
-            MasmOp::U32CheckedMax => f.write_str("u32.max.checked"),
-            MasmOp::U32UncheckedMax => f.write_str("u32.max.unchecked"),
+            op @ (MasmOp::AndImm(imm) | MasmOp::OrImm(imm) | MasmOp::XorImm(imm)) => {
+                write!(f, "{op}.{imm}")
+            }
+            op @ MasmOp::ExpImm(imm) => write!(f, "{op}.{imm}"),
+            op @ (MasmOp::AddImm(imm)
+            | MasmOp::SubImm(imm)
+            | MasmOp::MulImm(imm)
+            | MasmOp::DivImm(imm)
+            | MasmOp::EqImm(imm)
+            | MasmOp::NeqImm(imm)
+            | MasmOp::GtImm(imm)
+            | MasmOp::GteImm(imm)
+            | MasmOp::LtImm(imm)
+            | MasmOp::LteImm(imm)) => write!(f, "{op}.{imm}"),
+            op @ (MasmOp::U32CheckedAddImm(imm)
+            | MasmOp::U32OverflowingAddImm(imm)
+            | MasmOp::U32WrappingAddImm(imm)
+            | MasmOp::U32CheckedSubImm(imm)
+            | MasmOp::U32OverflowingSubImm(imm)
+            | MasmOp::U32WrappingSubImm(imm)
+            | MasmOp::U32CheckedMulImm(imm)
+            | MasmOp::U32OverflowingMulImm(imm)
+            | MasmOp::U32WrappingMulImm(imm)
+            | MasmOp::U32CheckedDivImm(imm)
+            | MasmOp::U32UncheckedDivImm(imm)
+            | MasmOp::U32CheckedModImm(imm)
+            | MasmOp::U32UncheckedModImm(imm)
+            | MasmOp::U32CheckedDivModImm(imm)
+            | MasmOp::U32UncheckedDivModImm(imm)
+            | MasmOp::U32CheckedShlImm(imm)
+            | MasmOp::U32UncheckedShlImm(imm)
+            | MasmOp::U32CheckedShrImm(imm)
+            | MasmOp::U32UncheckedShrImm(imm)
+            | MasmOp::U32CheckedRotlImm(imm)
+            | MasmOp::U32UncheckedRotlImm(imm)
+            | MasmOp::U32CheckedRotrImm(imm)
+            | MasmOp::U32UncheckedRotrImm(imm)
+            | MasmOp::U32EqImm(imm)
+            | MasmOp::U32NeqImm(imm)) => write!(f, "{op}.{imm}"),
+            op => write!(f, "{op}"),
         }
     }
 }


### PR DESCRIPTION
This implements support for storing elements/words to locals in the MASM instruction set, and cleans up the ISA code a bit. This was originally part of #39, but that PR is being closed, and I'm extracting these changes from that PR to be merged separately.