### PR TITLE
Always create the destination branch argument for the sentinel value when looking for the value definition in the predecessors

### DIFF
--- a/tests/integration/expected/fib.hir
+++ b/tests/integration/expected/fib.hir
@@ -8,10 +8,29 @@ global external @gv2 : i32 = $0 { id = 2 };
 
 pub fn fib(i32) -> i32 {
 block0(v0: i32):
-    v2 = const.i32 1000 : i32;
-    v3 = cast v0 : u32;
-    v4 = cast v2 : u32;
-    v5 = lt v3, v4 : i1;
-    v6 = cast v5 : i32;
-    ret v6;
+    br block2(v0);
+
+block1(v1: i32):
+
+block2(v3: i32):
+    v4 = const.i32 3 : i32;
+    v5 = cast v3 : u32;
+    v6 = cast v4 : u32;
+    v7 = gt v5, v6 : i1;
+    v8 = cast v7 : i32;
+    v9 = neq v8, 0 : i1;
+    condbr v9, block4, block5;
+
+block3(v2: i32):
+
+block4:
+    v10 = const.i32 3 : i32;
+    v11 = cast v3 : u32;
+    v12 = cast v10 : u32;
+    v13 = div.checked v11, v12 : u32;
+    v14 = cast v13 : i32;
+    br block2(v14);
+
+block5:
+    ret v3;
 }

--- a/tests/integration/expected/fib.masm
+++ b/tests/integration/expected/fib.masm
@@ -668,17 +668,58 @@ end
 
 export.fib
   dup.0
-  push.2147483648
-  u32.and
-  eq.2147483648
-  assertz
-  push.1000
   dup.0
   push.2147483648
   u32.and
   eq.2147483648
   assertz
-  u32.lt.checked
+  push.3
+  dup.0
+  push.2147483648
+  u32.and
+  eq.2147483648
+  assertz
+  u32.gt.checked
+  u32.neq.0
+  push.1
+  while.true
+    if.true
+      dup.0
+      push.2147483648
+      u32.and
+      eq.2147483648
+      assertz
+      push.3
+      dup.0
+      push.2147483648
+      u32.and
+      eq.2147483648
+      assertz
+      u32.div.checked
+      dup.0
+      push.2147483648
+      u32.and
+      eq.2147483648
+      assertz
+      dup.0
+      dup.0
+      push.2147483648
+      u32.and
+      eq.2147483648
+      assertz
+      push.3
+      dup.0
+      push.2147483648
+      u32.and
+      eq.2147483648
+      assertz
+      u32.gt.checked
+      u32.neq.0
+      push.1
+    else
+      push.0
+    end
+  end
 
 end
 begin

--- a/tests/integration/expected/fib.wat
+++ b/tests/integration/expected/fib.wat
@@ -1,9 +1,21 @@
 (module
   (type (;0;) (func (param i32) (result i32)))
   (func $fib (;0;) (type 0) (param i32) (result i32)
-    local.get 0
-    i32.const 1000
-    i32.lt_u
+    loop (result i32) ;; label = @1
+      block ;; label = @2
+        local.get 0
+        i32.const 3
+        i32.gt_u
+        br_if 0 (;@2;)
+        local.get 0
+        return
+      end
+      local.get 0
+      i32.const 3
+      i32.div_u
+      local.set 0
+      br 0 (;@1;)
+    end
   )
   (table (;0;) 1 1 funcref)
   (memory (;0;) 16)

--- a/tests/rust-apps/fib/src/lib.rs
+++ b/tests/rust-apps/fib/src/lib.rs
@@ -12,9 +12,9 @@ pub fn fib(n: u32) -> u32 {
     // }
     // a
 
-    if n < 1000 {
-        1
-    } else {
-        0
+    let mut a = n;
+    while a > 3 {
+        a = a / 3;
     }
+    a
 }


### PR DESCRIPTION
Cherry-picked commit from #58 
 
Close #51

Close #40 since the only use case for `emit_zero` at the start of the block was in the code removed by this PR.

**This PR is ready for review but is built on top and is intended to be merged after #49.**

This removes the remnants of the previously removed `ValueData::Alias` variant. It does not matter if we find the definition in the predecessors since we cannot swap all sentinel value uses with it. So, this fix always makes the sentinel value into a block argument.