### PR TITLE
chore: update miden-assembly to next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,9 +817,8 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa086b50e9fc3f808e171cb69f81fe464efbc01f996df3db0e450caaf070749"
+version = "0.8.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=next#ed0e87019fd1354b782cfab9bfbe5daa183a4e16"
 dependencies = [
  "miden-core",
  "winter-air",
@@ -827,9 +826,8 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c483ade3de7375f869a2c99de2396d0545cb6df96e0e96d693a40e298b4cfea"
+version = "0.8.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=next#ed0e87019fd1354b782cfab9bfbe5daa183a4e16"
 dependencies = [
  "miden-core",
  "num_enum",
@@ -859,9 +857,8 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baf9ff16e3f7a6c045c8ece8d2d7ebf4521eab92de07cc9edb11f3e9c853143"
+version = "0.8.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=next#ed0e87019fd1354b782cfab9bfbe5daa183a4e16"
 dependencies = [
  "miden-crypto",
  "winter-crypto",
@@ -871,9 +868,8 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32dd571edafdd5e8947e4006a905a1c5373f2f8b08b270fea3c998db5be131cf"
+version = "0.8.0"
+source = "git+https://github.com/0xPolygonMiden/crypto?branch=next#9f0aaf626bea4f676738eb9d4f80472f258a0399"
 dependencies = [
  "blake3",
  "cc",
@@ -1056,9 +1052,8 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229cd9564e22c81d0d0122377c248f07e4e85706d566c778d65a53b8005fcda6"
+version = "0.8.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=next#ed0e87019fd1354b782cfab9bfbe5daa183a4e16"
 dependencies = [
  "log",
  "miden-air",
@@ -1068,9 +1063,8 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6deebc865ae05b19e130644fd52051cbd591f024edc2920fdd7b66d4fc8198"
+version = "0.8.0"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?branch=next#ed0e87019fd1354b782cfab9bfbe5daa183a4e16"
 dependencies = [
  "miden-assembly",
 ]
@@ -2025,10 +2019,11 @@ dependencies = [
 
 [[package]]
 name = "winter-air"
-version = "0.6.4"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e952a5774c8e5d13cc015f29351f7f76511ce41440aa39d01c12365bb70e285e"
+checksum = "5f005354ab46d1b3f7340cf174063eb330eb6f6ec6d08c6c4138d02ed8fb8a1f"
 dependencies = [
+ "libm",
  "winter-crypto",
  "winter-fri",
  "winter-math",
@@ -2037,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "winter-crypto"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a20b2a4499797cbaeb38c980f9f34e6e60d993e8e170a6deb354345f50cbfb"
+checksum = "9d832015262e7d8ce6c160d3c8eb52e3a1c1352a7760523a25c4094c5d250cb9"
 dependencies = [
  "blake3",
  "sha3",
@@ -2049,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "winter-fri"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60de4e8baf33cc388b82f79808e42dacd7cb208e8c17bd10e3f8b8bdbdae1668"
+checksum = "23a218e3e37f316b933790f58298344b2ba94941fc7b5cc28adb2be6a9d4a959"
 dependencies = [
  "winter-crypto",
  "winter-math",
@@ -2060,18 +2055,18 @@ dependencies = [
 
 [[package]]
 name = "winter-math"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1795f5323f03c987a6aada6e8229f2c7f9353956cfa1b648b9c6cf5440958caa"
+checksum = "9f51c43e0756c89607b74a2da621ca472306bfb1ecc352a44a97dfe73cd0503d"
 dependencies = [
  "winter-utils",
 ]
 
 [[package]]
 name = "winter-prover"
-version = "0.6.4"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adea1eb4620fd1b3e8a7647a2a45bd4ebcab4cda14c9719b70039db05762191"
+checksum = "9dd3744a539c4b9f92ba43123a5eed5b0f6402204f92c6a3187de30189693e7b"
 dependencies = [
  "log",
  "winter-air",
@@ -2083,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "winter-utils"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903fda6a50cce2aa5a172a9269aca0f09b25df20afb1faa427db76d40779671"
+checksum = "9e914055793322b3efa7ea6acd5116edf65aebcb704a09b1c4d1308c82509992"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,10 +59,10 @@ smallvec = { version = "1.9", features = [
 smallstr = { version = "0.3", features = ["union"] }
 thiserror = "1.0"
 toml = { version = "0.5", features = ["preserve_order"] }
-miden-assembly = "0.7"
-miden-core = "0.7"
-miden-processor = "0.7"
-miden-stdlib = "0.6"
+miden-assembly = { git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
+miden-core = { git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
+miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
+miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm", branch = "next" }
 miden-codegen-masm = { path = "codegen/masm" }
 miden-diagnostics = "0.1"
 miden-hir = { path = "hir" }

--- a/codegen/masm/intrinsics/i32.masm
+++ b/codegen/masm/intrinsics/i32.masm
@@ -7,14 +7,14 @@ const.NEG1=4294967295 # u32::MAX
 #
 # This function consumes `a`.
 export.is_signed # [a]
-    push.SIGN_BIT u32checked_and push.SIGN_BIT eq
+    push.SIGN_BIT u32and push.SIGN_BIT eq
 end
 
 # Get the negation of `a`
 #
 # This operation is unchecked, so if the input is not a valid i32 the behavior is undefined
 export.unchecked_neg # [a]
-    u32checked_not u32wrapping_add.1
+    u32not u32wrapping_add.1
 end
 
 # Get the negation of `a`
@@ -214,7 +214,7 @@ export.checked_div # [b, a]
     dup.0 movdn.5 cdrop         # [|b|, |a|, is_a_signed, is_b_signed]
 
     # divide
-    u32unchecked_div            # [|a / b|, is_a_signed, is_b_signed]
+    u32div            # [|a / b|, is_a_signed, is_b_signed]
 
     # if the signs differ, negate the result
     movdn.2 neq                 # [signs_differ, |a / b|]
@@ -230,12 +230,12 @@ export.icmp # [b, a]
 
     # get the most-significant bit of `b`
     push.SIGN_BIT   # [1<<31, b, a, b, a]
-    u32checked_and  # [b_msb, a, b, a]
+    u32and          # [b_msb, a, b, a]
 
     # get the most-significant bit of `a`
     swap.1          # [a, b_msb, b, a]
     push.SIGN_BIT   # [1<<31, a, b_msb, b, a]
-    u32checked_and  # [a_msb, b_msb, b, a]
+    u32and          # [a_msb, b_msb, b, a]
 
     eq.0             # [a_msb == 0, b_msb, b, a]
     swap.1 eq.0      # [b_msb == 0, a_msb == 0, b, a]
@@ -252,8 +252,8 @@ export.icmp # [b, a]
         # which we get for free via the lt/gt ops
         drop                      # [b, a]
         dup.1 dup.1               # [b, a, b, a]
-        u32unchecked_gt movdn.2   # [b, a, a > b]
-        u32unchecked_lt           # [a < b, a > b]
+        u32gt movdn.2             # [b, a, a > b]
+        u32lt                     # [a < b, a > b]
         push.0 push.NEG1 push.1
         swap.3                    # [a < b, -1, 0, 1, a > b]
         cdrop                     # [-1 or 0, 1, a > b]
@@ -286,15 +286,15 @@ end
 export.pow2 # [n]
     dup.0
     push.31
-    u32checked_lt  # [n < 31, pow]
+    u32lt          # [n < 31, pow]
     assert         # [n]
     push.1 swap.1  # [n, 1]
-    u32checked_shl # [1 << n]
+    u32shl         # [1 << n]
 end
 
 # Compute a^b, where `b` must be a positive i32 value < 31
 export.ipow # [b, a]
-    dup.0 push.31 u32checked_lt assert # assert that `b` is < 31
+    dup.0 push.31 u32lt assert # assert that `b` is < 31
     dup.0 eq.0       # [b == 0, b, a]
     dup.2 eq.0       # [a == 0, b == 0, b, a]
     or               # [a == 0 || b == 0, b, a]
@@ -310,23 +310,23 @@ export.ipow # [b, a]
         push.1         # [acc, b, a]
         dup.1          # [b, acc, b, a]
         push.1         # [1, b, acc, b, a]
-        u32checked_gt  # [b > 1, acc, b, a]
+        u32gt          # [b > 1, acc, b, a]
         while.true     # [acc, b, a => base]
             dup.2 dup.1      # [acc, base, acc, b, base]
             u32wrapping_mul  # [base * acc, acc, b, base]
             dup.2            # [b, base * acc, acc, b, base]
             push.1           # [1, b, base * acc, acc, b, base]
-            u32checked_and   # [b & 1, base * acc, acc, b, base]
+            u32and           # [b & 1, base * acc, acc, b, base]
             eq.1             # [b & 1 == 1, base * acc, acc, b, base]
             cdrop            # [acc, b, base]
             swap.1           # [b, acc, base]
-            u32checked_div.2 # [b /= 2, acc, base]
+            u32div.2         # [b /= 2, acc, base]
             movup.2 dup.0    # [base, base, b, acc]
             u32wrapping_mul  # [base * base, b, acc]
             swap.1           # [b, base, acc]
             movup.2          # [acc, b, base]
             dup.1 push.1     # [1, b, acc, b, base]
-            u32checked_gt    # [b > 1, acc, b, base]
+            u32gt            # [b > 1, acc, b, base]
         end
         swap.1 drop     # [acc, base]
         u32wrapping_mul # [acc * base]
@@ -341,7 +341,7 @@ end
 export.checked_shr # [b, a]
     # validate the shift is valid
     dup.0 push.32
-    u32checked_lt   # [b < 32, b, a]
+    u32lt          # [b < 32, b, a]
     assert
 
     # if the input is zero, the output is always zero,
@@ -359,27 +359,29 @@ export.checked_shr # [b, a]
         # get the signedness of the value
         dup.1                           # [a, b, a]
         push.SIGN_BIT                   # [1<<31, a, b, a]
-        u32checked_and push.SIGN_BIT eq # [is_signed, b, a]
+        u32and push.SIGN_BIT eq         # [is_signed, b, a]
 
         # if the value is signed, we must sign-extend the result,
         # otherwise we can treat it as an unsigned shift
         if.true  # [b, a]
             swap.1             # [a, b]
             dup.1              # [b, a, b]
-            u32checked_shr     # [shifted, b]
+            u32shr             # [shifted, b]
 
             # compute the extension mask
             push.1 dup.2       # [b, 1, shifted, b]
-            u32unchecked_shl
+            u32shl
             sub.1              # [(1 << b) - 1, shifted, b]
 
             # shift the mask into place
             push.32 movup.3    # [b, 32, mask, shifted]
             sub                # [32 - b, mask, shifted]
-            u32unchecked_shl   # [mask << (32 - b), shifted]
-            u32checked_or      # [shifted | mask]
+            u32shl             # [mask << (32 - b), shifted]
+            u32or              # [shifted | mask]
+            u32assert
         else
-            u32checked_shr
+            u32shr
+            u32assert
         end
     end
 end

--- a/codegen/masm/intrinsics/mem.masm
+++ b/codegen/masm/intrinsics/mem.masm
@@ -59,7 +59,7 @@ end
 export.load_sw # [waddr, index, offset]
     # check for alignment and offset validity
     dup.2 eq.0
-    dup.3 push.8 u32checked_lt assert # offset must be < 8
+    dup.3 push.8 u32lt assert # offset must be < 8
     # if the pointer is naturally aligned..
     if.true
         # drop the byte offset
@@ -78,13 +78,13 @@ export.load_sw # [waddr, index, offset]
             # drop the unused elements
             movup.3 movup.3 drop drop
             # shift high bits left by the offset
-            dup.2 u32checked_shl  # [hi, w1, offset]
+            dup.2 u32shl # [hi, w1, offset]
             # move the low bits to the top and shift them as well
             swap.1 push.32 movup.3 # [offset, 32, w1, hi]
-            u32checked_sub # [32 - offset, w1, hi]
-            u32checked_shr # [lo, hi]
+            u32overflowing_sub assertz # [32 - offset, w1, hi]
+            u32shr           # [lo, hi]
             # combine the two halves
-            u32checked_or  # [result]
+            u32or            # [result]
         else
             # check if the load starts in the second element
             dup.1 eq.1
@@ -97,13 +97,13 @@ export.load_sw # [waddr, index, offset]
                 # drop the unused elements
                 drop movdn.2 movdn.2 drop # [w1, w2, offset]
                 # shift the high bits
-                dup.2 u32checked_shl  # [hi, w2, offset]
+                dup.2 u32shl # [hi, w2, offset]
                 # shift the low bits
-                swap.1 push.32 movup.3  # [offset, 32, w2, hi]
-                u32checked_sub  # [32 - offset, w2, hi]
-                u32checked_shr  # [lo, hi]
+                swap.1 push.32 movup.3     # [offset, 32, w2, hi]
+                u32overflowing_sub assertz # [32 - offset, w2, hi]
+                u32shr # [lo, hi]
                 # combine the two halves
-                u32checked_or   # [result]
+                u32or  # [result]
             else
                 # check if the load starts in the third element
                 swap.1 eq.2
@@ -113,30 +113,30 @@ export.load_sw # [waddr, index, offset]
                     # drop first two unused
                     drop drop # [w2, w3, offset]
                     # shift the high bits
-                    dup.2 u32checked_shl  # [hi, w3, offset]
+                    dup.2 u32shl # [hi, w3, offset]
                     # shift the low bits
-                    swap.1 push.32 movup.3  # [offset, 32, w3, hi]
-                    u32checked_sub  # [32 - offset, w3, hi]
-                    u32checked_shr  # [lo, hi]
+                    swap.1 push.32 movup.3     # [offset, 32, w3, hi]
+                    u32overflowing_sub assertz # [32 - offset, w3, hi]
+                    u32shr # [lo, hi]
                     # combine the two halves
-                    u32checked_or   # [result]
+                    u32or  # [result]
                 else
                     # the load crosses a word boundary
                     # start with the word containing the low bits
                     dup.0  # [waddr, waddr, offset]
-                    u32checked_add.1 # [waddr + 1, waddr, offset]
+                    u32overflowing_add.1 assertz # [waddr + 1, waddr, offset]
                     # load the word and drop the unused elements
                     padw movup.4 mem_loadw movdn.4 drop drop drop # [w0, waddr, offset]
                     # shift the low bits
                     push.32 dup.3  # [offset, 32, w0, waddr, offset]
-                    u32checked_sub # [32 - offset, w0, waddr, offset]
-                    u32checked_shr # [lo, waddr, offset]
+                    u32overflowing_sub assertz # [32 - offset, w0, waddr, offset]
+                    u32shr # [lo, waddr, offset]
                     # load the word with the high bits, drop unused elements
                     swap.1 padw movup.4 mem_loadw drop drop drop # [w3, lo, offset]
                     # shift high bits
-                    movup.2 u32checked_shl  # [hi, lo]
+                    movup.2 u32shl # [hi, lo]
                     # combine the two halves
-                    u32checked_or # [result]
+                    u32or # [result]
                 end
             end
         end
@@ -191,7 +191,7 @@ export.realign_dw # [chunk_hi, chunk_mid, chunk_lo, offset]
     # Re-align the high bits by shifting out the offset
     #
     # This gives us the first half of the first word.
-    dup.3 u32checked_shl # [x_hi_hi, chunk_mid, chunk__lo, offset]
+    dup.3 u32shl # [x_hi_hi, chunk_mid, chunk__lo, offset]
 
     # Move the value below the other chunks temporarily
     movdn.2 # [chunk_mid, chunk_lo, x_hi_hi, offset]
@@ -209,7 +209,7 @@ export.realign_dw # [chunk_hi, chunk_mid, chunk_lo, offset]
     # Then, we shift the chunk right by 32 - offset bits,
     # re-aligning the low bits of the first word, and
     # isolating them.
-    push.32 dup.4 u32checked_shr  # [x_hi_lo, chunk_mid, chunk_lo, offset, x_hi_hi]
+    push.32 dup.4 u32shr  # [x_hi_lo, chunk_mid, chunk_lo, offset, x_hi_hi]
 
     # Move the high bits back to the top
     #
@@ -217,7 +217,7 @@ export.realign_dw # [chunk_hi, chunk_mid, chunk_lo, offset]
     movup.4 # [x_hi_hi, x_hi_lo, chunk_mid, chunk_lo, offset]
 
     # OR the two parts of the `x_hi` chunk together
-    u32checked_or # [x_hi, chunk_mid, chunk_lo, offset]
+    u32or # [x_hi, chunk_mid, chunk_lo, offset]
 
     # Move `x_hi` to the bottom for later
     movdn.2 # [chunk_mid, chunk_lo, x_hi, offset]
@@ -229,16 +229,16 @@ export.realign_dw # [chunk_hi, chunk_mid, chunk_lo, offset]
     # This gives us the first half of the second word.
     #
     # [x_lo_hi, chunk_lo, x_hi]
-    dup.3 u32checked_shl # [x_lo_hi, chunk_lo, x_hi, offset]
+    dup.3 u32shl # [x_lo_hi, chunk_lo, x_hi, offset]
 
     # Next, swap the low bit chunk to the top temporarily
     swap.1
 
     # Shift the value right, as done previously for the middle chunk
-    push.32 movup.4 u32checked_shr # [x_lo_lo, x_lo_hi, x_hi]
+    push.32 movup.4 u32shr # [x_lo_lo, x_lo_hi, x_hi]
 
     # OR the two halves together, giving us our second word, `x_lo`
-    u32checked_or # [x_lo, x_hi]
+    u32or # [x_lo, x_hi]
 
     # Swap the words so they are in the correct order
     swap.1 # [x_hi, x_lo]
@@ -249,7 +249,7 @@ end
 export.load_dw # [waddr, index, offset]
     # check for alignment and offset validity
     dup.2 eq.0
-    dup.3 push.8 u32checked_lt assert # offset must be < 8
+    dup.3 push.8 u32lt assert # offset must be < 8
     # if the pointer is naturally aligned..
     if.true
         # drop byte offset
@@ -279,7 +279,7 @@ export.load_dw # [waddr, index, offset]
                 padw movup.4 mem_loadw drop drop
               else
                 # load first element of next word, drop the rest
-                dup.0 u32checked_add.1 padw movup.4 mem_loadw
+                dup.0 u32overflowing_add.1 assertz padw movup.4 mem_loadw
                 movup.4 movup.4 movup.4
                 drop drop drop
                 # load fourth element, and we're done
@@ -312,7 +312,7 @@ export.load_dw # [waddr, index, offset]
                 swap.1 eq.2
                 if.true
                     # load one element from the next word
-                    dup.0 u32checked_add.1 padw movup.4 mem_loadw
+                    dup.0 u32overflowing_add.1 assertz padw movup.4 mem_loadw
                     movup.4 movup.4 movup.4 drop drop drop
                     # load two elements from the first word
                     swap.1 padw movup.4 mem_loadw drop drop
@@ -320,7 +320,7 @@ export.load_dw # [waddr, index, offset]
                     exec.realign_dw
                 else
                     # load the two least-significant elements from the next word first
-                    dup.0 u32checked_add.1 padw movup.4 mem_loadw
+                    dup.0 u32overflowing_add.1 assertz padw movup.4 mem_loadw
                     movup.4 movup.4 drop drop
                     # load the most significant element from the first word
                     movup.2 padw movup.4 mem_loadw drop drop drop

--- a/codegen/masm/src/emulator/functions.rs
+++ b/codegen/masm/src/emulator/functions.rs
@@ -650,7 +650,7 @@ mod tests {
         assert_eq!(
             activation.peek_with_op(),
             Some(InstructionWithOp {
-                op: Op::U32UncheckedLt,
+                op: Op::U32Lt,
                 continuing_from: None,
                 ip: InstructionPointer {
                     block: loop_body,
@@ -661,7 +661,7 @@ mod tests {
         );
 
         // Advance the instruction pointer, obtaining the last instruction of the loop body
-        assert_eq!(activation.next().map(|ix| ix.op), Some(Op::U32UncheckedLt));
+        assert_eq!(activation.next().map(|ix| ix.op), Some(Op::U32Lt));
 
         // Exit while.true
         assert_eq!(
@@ -746,7 +746,7 @@ mod tests {
             body.push(Op::PushU8(1));
             body.push(Op::Dup(1));
             body.push(Op::Dup(1));
-            body.push(Op::U32UncheckedLt);
+            body.push(Op::U32Lt);
             body.push(Op::If(then_blk, else_blk));
             body.push(Op::Exec("test::foo".parse().unwrap()));
         }
@@ -757,14 +757,14 @@ mod tests {
         }
         {
             let else_body = function.block_mut(else_blk);
-            else_body.push(Op::U32UncheckedMax);
+            else_body.push(Op::U32Max);
         }
         {
             let while_body = function.block_mut(while_blk);
             while_body.push(Op::Dup(1));
             while_body.push(Op::Dup(1));
             while_body.push(Op::Incr);
-            while_body.push(Op::U32UncheckedLt);
+            while_body.push(Op::U32Lt);
         }
 
         Arc::new(function)

--- a/codegen/masm/src/stackify/emit/int64.rs
+++ b/codegen/masm/src/stackify/emit/int64.rs
@@ -38,7 +38,7 @@ impl<'a> OpEmitter<'a> {
             // Check that the remaining bits fit in range
             Op::Dup(0),
             Op::Push(Felt::new(2u64.pow(n) - 1)),
-            Op::U32UncheckedLte,
+            Op::U32Lte,
         ]);
     }
 

--- a/codegen/masm/src/stackify/emit/mem.rs
+++ b/codegen/masm/src/stackify/emit/mem.rs
@@ -91,25 +91,25 @@ impl<'a> OpEmitter<'a> {
             // Obtain the absolute offset
             //
             // [abs_offset, addr]
-            Op::U32CheckedModImm(16),
+            Op::U32ModImm(16),
             // Obtain the byte offset
             //
             // [abs_offset, abs_offset, addr]
             Op::Dup(0),
             // [offset, abs_offset, addr]
-            Op::U32CheckedModImm(4),
+            Op::U32ModImm(4),
             // Obtain the element index
             //
             // [abs_offset, offset, addr]
             Op::Swap(1),
             // [index, byte_offset, addr]
-            Op::U32CheckedDivImm(4),
+            Op::U32DivImm(4),
             // Translate the address to Miden's address space
             //
             // [addr, index, offset]
             Op::Movup(2),
             // [waddr, index, offset]
-            Op::U32CheckedDivImm(16),
+            Op::U32DivImm(16),
         ]);
     }
 
@@ -195,10 +195,10 @@ impl<'a> OpEmitter<'a> {
                     Op::Drop,
                     Op::Drop,
                     // Shift the high bits left by the offset
-                    Op::U32CheckedShlImm(ptr.offset as u32),
+                    Op::U32ShlImm(ptr.offset as u32),
                     // Move the low bits to the top and shift them right
                     Op::Swap(1),
-                    Op::U32CheckedShrImm(rshift),
+                    Op::U32ShrImm(rshift),
                     // OR the high and low bits together
                     Op::U32Or,
                 ]);
@@ -229,10 +229,10 @@ impl<'a> OpEmitter<'a> {
                     // Drop the remaining unused element
                     Op::Drop,
                     // Shift the high bits left by the offset
-                    Op::U32CheckedShlImm(ptr.offset as u32),
+                    Op::U32ShlImm(ptr.offset as u32),
                     // Move the low bits to the top and shift them right
                     Op::Swap(1),
-                    Op::U32CheckedShrImm(rshift),
+                    Op::U32ShrImm(rshift),
                     // OR the high and low bits together
                     Op::U32Or,
                 ]);
@@ -257,10 +257,10 @@ impl<'a> OpEmitter<'a> {
                     Op::Drop,
                     Op::Drop,
                     // Shift the high bits left by the offset
-                    Op::U32CheckedShlImm(ptr.offset as u32),
+                    Op::U32ShlImm(ptr.offset as u32),
                     // Move the low bits to the top and shift them right
                     Op::Swap(1),
-                    Op::U32CheckedShrImm(rshift),
+                    Op::U32ShrImm(rshift),
                     // OR the high and low bits together
                     Op::U32Or,
                 ]);
@@ -286,7 +286,7 @@ impl<'a> OpEmitter<'a> {
                     Op::Drop,
                     Op::Drop,
                     // Shift the low bits right by the offset
-                    Op::U32CheckedShrImm(rshift),
+                    Op::U32ShrImm(rshift),
                     // Load the quad-word containing the high bits
                     Op::Padw,
                     Op::MemLoadwImm(ptr.waddr),
@@ -295,7 +295,7 @@ impl<'a> OpEmitter<'a> {
                     Op::Drop,
                     Op::Drop,
                     // Shift the high bits left by the offset
-                    Op::U32CheckedShlImm(ptr.offset as u32),
+                    Op::U32ShlImm(ptr.offset as u32),
                     // OR the high and low bits together
                     Op::U32Or,
                 ]);
@@ -621,7 +621,7 @@ impl<'a> OpEmitter<'a> {
             // This gives us the first half of the first word.
             //
             // [x_hi_hi, chunk_mid, chunk__lo]
-            Op::U32CheckedShlImm(ptr.offset as u32),
+            Op::U32ShlImm(ptr.offset as u32),
             // Move the value below the other chunks temporarily
             //
             // [chunk_mid, chunk_lo, x_hi_hi]
@@ -641,7 +641,7 @@ impl<'a> OpEmitter<'a> {
             // isolating them.
             //
             // [x_hi_lo, chunk_mid, chunk_lo, x_hi_hi]
-            Op::U32CheckedShrImm(32 - ptr.offset as u32),
+            Op::U32ShrImm(32 - ptr.offset as u32),
             // Move the high bits back to the top
             //
             // [x_hi_hi, x_hi_lo, chunk_mid, chunk_lo]
@@ -659,11 +659,11 @@ impl<'a> OpEmitter<'a> {
             // This gives us the first half of the second word.
             //
             // [x_lo_hi, chunk_lo, x_hi]
-            Op::U32CheckedShlImm(ptr.offset as u32),
+            Op::U32ShlImm(ptr.offset as u32),
             // Next, swap the low bit chunk to the top temporarily
             Op::Swap(1),
             // Shift the value right, as done previously for the middle chunk
-            Op::U32CheckedShrImm(32 - ptr.offset as u32),
+            Op::U32ShrImm(32 - ptr.offset as u32),
             // OR the two halves together, giving us our second word, `x_lo`
             //
             // [x_lo, x_hi]
@@ -702,7 +702,7 @@ impl<'a> OpEmitter<'a> {
             // This gives us the first half of `x_hi2`.
             //
             // [x_hi2_hi, chunk_mid_hi, chunk_mid_mid, chunk_mid_lo, chunk__lo]
-            Op::U32CheckedShlImm(ptr.offset as u32),
+            Op::U32ShlImm(ptr.offset as u32),
             // Move the value below the other chunks temporarily
             //
             // [chunk_mid_hi, chunk_mid_mid, chunk_mid_lo, chunk__lo, x_hi2_hi]
@@ -720,7 +720,7 @@ impl<'a> OpEmitter<'a> {
             // re-aligning the low bits of `x_hi2`, and isolating them.
             //
             // [x_hi2_lo, chunk_mid_hi, chunk_mid_mid, chunk_mid_lo, chunk_lo, x_hi2_hi]
-            Op::U32CheckedShrImm(32 - ptr.offset as u32),
+            Op::U32ShrImm(32 - ptr.offset as u32),
             // Move the high bits of `x_hi2` back to the top
             //
             // [x_hi2_hi, x_hi2_lo, chunk_mid_hi, chunk_mid_mid, chunk_mid_lo, chunk_lo]
@@ -739,7 +739,7 @@ impl<'a> OpEmitter<'a> {
             // This gives us the first half of `x_hi1`
             //
             // [x_hi1_hi, chunk_mid_mid, chunk_mid_lo, chunk_lo, x_hi2]
-            Op::U32CheckedShlImm(ptr.offset as u32),
+            Op::U32ShlImm(ptr.offset as u32),
             // Next, move the chunk containing the low bits of `x_hi1` to the top temporarily
             //
             // [chunk_mid_mid, chunk_mid_lo, chunk_lo, x_hi2, x_hi1_hi]
@@ -751,7 +751,7 @@ impl<'a> OpEmitter<'a> {
             // Shift the value right, as done previously for the low bits of `x_hi2`
             //
             // [x_hi1_lo, chunk_mid_mid, chunk_mid_lo, chunk_lo, x_hi2, x_hi1_hi]
-            Op::U32CheckedShrImm(32 - ptr.offset as u32),
+            Op::U32ShrImm(32 - ptr.offset as u32),
             // Move the high bits of `x_hi1` to the top
             Op::Movup(5),
             // OR the two halves together, giving us our second word, `x_hi1`
@@ -766,7 +766,7 @@ impl<'a> OpEmitter<'a> {
             // the remaining copy of `chunk_mid_mid`, as done previously.
             //
             // [x_lo2_hi, chunk_mid_lo, chunk_lo, x_hi2, x_hi1]
-            Op::U32CheckedShlImm(ptr.offset as u32),
+            Op::U32ShlImm(ptr.offset as u32),
             // Next, move the chunk containing the low bits of `x_lo2` to the top temporarily
             //
             // [chunk_mid_lo, chunk_lo, x_hi2, x_hi1, x_lo2_hi]
@@ -778,7 +778,7 @@ impl<'a> OpEmitter<'a> {
             // Shift the value right to get the low bits of `x_lo2`
             //
             // [x_lo2_lo, chunk_mid_lo, chunk_lo, x_hi2, x_hi1, x_lo2_hi]
-            Op::U32CheckedShrImm(32 - ptr.offset as u32),
+            Op::U32ShrImm(32 - ptr.offset as u32),
             // Move the high bits of `x_lo2` to the top
             //
             // [x_lo2_hi, x_lo2_lo, chunk_mid_lo, chunk_lo, x_hi2, x_hi1]
@@ -794,13 +794,13 @@ impl<'a> OpEmitter<'a> {
             // Re-align the high bits of `x_lo1`
             //
             // [x_lo1_hi, chunk_lo, x_hi2, x_hi1, x_lo2]
-            Op::U32CheckedShlImm(ptr.offset as u32),
+            Op::U32ShlImm(ptr.offset as u32),
             // Move the chunk containing the low bits to the top
             //
             // [chunk_lo, x_hi2, x_hi1, x_lo2, x_lo1_hi]
             Op::Movdn(5),
             // Shift the value right to get the low bits of `x_lo1`
-            Op::U32CheckedShrImm(32 - ptr.offset as u32),
+            Op::U32ShrImm(32 - ptr.offset as u32),
             // Move the high bits of `x_lo1` to the top
             //
             // [x_lo1_hi, x_lo1_lo, x_hi2, x_hi1, x_lo2]

--- a/codegen/masm/src/stackify/emit/smallint.rs
+++ b/codegen/masm/src/stackify/emit/smallint.rs
@@ -313,13 +313,13 @@ impl<'a> OpEmitter<'a> {
         match overflow {
             Overflow::Unchecked => (),
             Overflow::Checked => self.int32_to_uint(n),
-            Overflow::Wrapping => self.emit(Op::U32CheckedModImm(2u32.pow(n))),
+            Overflow::Wrapping => self.emit(Op::U32ModImm(2u32.pow(n))),
             Overflow::Overflowing => {
                 self.try_int32_to_uint(n);
                 self.emit_all(&[
                     // move result to top, and wrap it at 2^n
                     Op::Swap(1),
-                    Op::U32CheckedModImm(2u32.pow(n)),
+                    Op::U32ModImm(2u32.pow(n)),
                     // move is_valid flag to top, and invert it
                     Op::Swap(1),
                     Op::Not,

--- a/codegen/masm/src/stackify/emit/unary.rs
+++ b/codegen/masm/src/stackify/emit/unary.rs
@@ -367,21 +367,21 @@ impl<'a> OpEmitter<'a> {
             Type::I128 => {
                 self.emit_all(&[
                     // [x3, x2, x1, x0]
-                    Op::U32CheckedPopcnt,
+                    Op::U32Popcnt,
                     // [popcnt3, x2, x1, x0]
                     Op::Swap(1),
                     // [x2, popcnt3, x1, x0]
-                    Op::U32CheckedPopcnt,
+                    Op::U32Popcnt,
                     // [popcnt2, popcnt3, x1, x0]
                     Op::Add,
                     // [popcnt_hi, x1, x0]
                     Op::Movdn(2),
                     // [x1, x0, popcnt]
-                    Op::U32CheckedPopcnt,
+                    Op::U32Popcnt,
                     // [popcnt1, x0, popcnt]
                     Op::Swap(1),
                     // [x0, popcnt1, popcnt]
-                    Op::U32CheckedPopcnt,
+                    Op::U32Popcnt,
                     // [popcnt0, popcnt1, popcnt]
                     //
                     // This last instruction adds all three values together mod 2^32
@@ -391,16 +391,16 @@ impl<'a> OpEmitter<'a> {
             Type::I64 | Type::U64 => {
                 self.emit_all(&[
                     // Get popcnt of high bits
-                    Op::U32CheckedPopcnt,
+                    Op::U32Popcnt,
                     // Swap to low bits and repeat
                     Op::Swap(1),
-                    Op::U32CheckedPopcnt,
+                    Op::U32Popcnt,
                     // Add both counts to get the total count
                     Op::Add,
                 ]);
             }
             Type::I32 | Type::U32 | Type::I16 | Type::U16 | Type::I8 | Type::U8 | Type::I1 => {
-                self.emit(Op::U32CheckedPopcnt);
+                self.emit(Op::U32Popcnt);
             }
             ty if !ty.is_integer() => {
                 panic!("invalid popcnt on {ty}: only integral types can be negated")

--- a/hir/Cargo.toml
+++ b/hir/Cargo.toml
@@ -34,7 +34,7 @@ rustc-hash.workspace = true
 smallvec.workspace = true
 thiserror.workspace = true
 typed-arena = "2.0"
-winter-math = { version = "0.6", default-features = false }
+winter-math = { version = "0.7", default-features = false }
 
 [dev-dependencies]
 pretty_assertions = "1.0"

--- a/hir/src/asm/display.rs
+++ b/hir/src/asm/display.rs
@@ -139,6 +139,9 @@ impl<'a> fmt::Display for DisplayOp<'a> {
             | MasmOp::MemStoreOffsetImm(addr, offset)) => {
                 write!(f, "{op}.{}.{offset}", Address(*addr))
             }
+            op @ MasmOp::AdvPush(n) => {
+                write!(f, "{op}.{n}")
+            }
             MasmOp::If(then_blk, else_blk) => {
                 write!(
                     f,
@@ -185,20 +188,13 @@ impl<'a> fmt::Display for DisplayOp<'a> {
                     DisplayIndent(self.indent),
                 )
             }
-            MasmOp::Exec(FunctionIdent { module, function }) => {
+            op @ (MasmOp::Exec(id) | MasmOp::Syscall(id) | MasmOp::ProcRef(id)) => {
+                let FunctionIdent { module, function } = id;
                 if self.is_local_module(module) {
-                    write!(f, "exec.{function}")
+                    write!(f, "{op}.{function}")
                 } else {
                     let alias = self.get_module_alias(*module);
-                    write!(f, "exec.{alias}::{function}")
-                }
-            }
-            MasmOp::Syscall(FunctionIdent { module, function }) => {
-                if self.is_local_module(module) {
-                    write!(f, "syscall.{function}")
-                } else {
-                    let alias = self.get_module_alias(*module);
-                    write!(f, "syscall.{alias}::{function}")
+                    write!(f, "{op}.{alias}::{function}")
                 }
             }
             op @ (MasmOp::AndImm(imm) | MasmOp::OrImm(imm) | MasmOp::XorImm(imm)) => {
@@ -215,31 +211,19 @@ impl<'a> fmt::Display for DisplayOp<'a> {
             | MasmOp::GteImm(imm)
             | MasmOp::LtImm(imm)
             | MasmOp::LteImm(imm)) => write!(f, "{op}.{imm}"),
-            op @ (MasmOp::U32CheckedAddImm(imm)
-            | MasmOp::U32OverflowingAddImm(imm)
+            op @ (MasmOp::U32OverflowingAddImm(imm)
             | MasmOp::U32WrappingAddImm(imm)
-            | MasmOp::U32CheckedSubImm(imm)
             | MasmOp::U32OverflowingSubImm(imm)
             | MasmOp::U32WrappingSubImm(imm)
-            | MasmOp::U32CheckedMulImm(imm)
             | MasmOp::U32OverflowingMulImm(imm)
             | MasmOp::U32WrappingMulImm(imm)
-            | MasmOp::U32CheckedDivImm(imm)
-            | MasmOp::U32UncheckedDivImm(imm)
-            | MasmOp::U32CheckedModImm(imm)
-            | MasmOp::U32UncheckedModImm(imm)
-            | MasmOp::U32CheckedDivModImm(imm)
-            | MasmOp::U32UncheckedDivModImm(imm)
-            | MasmOp::U32CheckedShlImm(imm)
-            | MasmOp::U32UncheckedShlImm(imm)
-            | MasmOp::U32CheckedShrImm(imm)
-            | MasmOp::U32UncheckedShrImm(imm)
-            | MasmOp::U32CheckedRotlImm(imm)
-            | MasmOp::U32UncheckedRotlImm(imm)
-            | MasmOp::U32CheckedRotrImm(imm)
-            | MasmOp::U32UncheckedRotrImm(imm)
-            | MasmOp::U32EqImm(imm)
-            | MasmOp::U32NeqImm(imm)) => write!(f, "{op}.{imm}"),
+            | MasmOp::U32DivImm(imm)
+            | MasmOp::U32ModImm(imm)
+            | MasmOp::U32DivModImm(imm)
+            | MasmOp::U32ShlImm(imm)
+            | MasmOp::U32ShrImm(imm)
+            | MasmOp::U32RotlImm(imm)
+            | MasmOp::U32RotrImm(imm)) => write!(f, "{op}.{imm}"),
             op => write!(f, "{op}"),
         }
     }

--- a/hir/src/immediates.rs
+++ b/hir/src/immediates.rs
@@ -290,6 +290,30 @@ impl PartialEq for Immediate {
         }
     }
 }
+impl PartialEq<isize> for Immediate {
+    fn eq(&self, other: &isize) -> bool {
+        let y = *other;
+        match *self {
+            Self::I1(x) => x == (y == 1),
+            Self::U8(_) if y < 0 => false,
+            Self::U8(x) => x as isize == y,
+            Self::I8(x) => x as isize == y,
+            Self::U16(_) if y < 0 => false,
+            Self::U16(x) => x as isize == y,
+            Self::I16(x) => x as isize == y,
+            Self::U32(_) if y < 0 => false,
+            Self::U32(x) => x as isize == y,
+            Self::I32(x) => x as isize == y,
+            Self::U64(_) if y < 0 => false,
+            Self::U64(x) => x == y as i64 as u64,
+            Self::I64(x) => x == y as i64,
+            Self::I128(x) => x == y as i128,
+            Self::F64(_) => false,
+            Self::Felt(_) if y < 0 => false,
+            Self::Felt(x) => x.as_int() == y as i64 as u64,
+        }
+    }
+}
 impl PartialOrd for Immediate {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))

--- a/midenc-session/src/inputs.rs
+++ b/midenc-session/src/inputs.rs
@@ -79,6 +79,10 @@ impl InputFile {
         }
     }
 
+    pub fn is_real(&self) -> bool {
+        matches!(self.file, InputType::Real(_))
+    }
+
     pub fn filestem(&self) -> &str {
         match &self.file {
             InputType::Real(ref path) => path.file_stem().unwrap().to_str().unwrap(),

--- a/tests/integration/expected/and_bool.masm
+++ b/tests/integration/expected/and_bool.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_and
+  u32and
 end
 
 program

--- a/tests/integration/expected/and_i16.masm
+++ b/tests/integration/expected/and_i16.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_and
+  u32and
 end
 
 program

--- a/tests/integration/expected/and_i32.masm
+++ b/tests/integration/expected/and_i32.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_and
+  u32and
 end
 
 program

--- a/tests/integration/expected/and_i8.masm
+++ b/tests/integration/expected/and_i8.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_and
+  u32and
 end
 
 program

--- a/tests/integration/expected/and_u16.masm
+++ b/tests/integration/expected/and_u16.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_and
+  u32and
 end
 
 program

--- a/tests/integration/expected/and_u32.masm
+++ b/tests/integration/expected/and_u32.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_and
+  u32and
 end
 
 program

--- a/tests/integration/expected/and_u8.masm
+++ b/tests/integration/expected/and_u8.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_and
+  u32and
 end
 
 program

--- a/tests/integration/expected/eq_i16.masm
+++ b/tests/integration/expected/eq_i16.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_eq
+  eq
 end
 
 program

--- a/tests/integration/expected/eq_i32.masm
+++ b/tests/integration/expected/eq_i32.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_eq
+  eq
 end
 
 program

--- a/tests/integration/expected/eq_i64.masm
+++ b/tests/integration/expected/eq_i64.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,11 @@ end
 mod noname
 
 export.entrypoint
-  eqw
+  movup.2
+  eq
+  movdn.3
+  eq
+  and
 end
 
 program

--- a/tests/integration/expected/eq_i8.masm
+++ b/tests/integration/expected/eq_i8.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_eq
+  eq
 end
 
 program

--- a/tests/integration/expected/eq_u16.masm
+++ b/tests/integration/expected/eq_u16.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_eq
+  eq
 end
 
 program

--- a/tests/integration/expected/eq_u32.masm
+++ b/tests/integration/expected/eq_u32.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_eq
+  eq
 end
 
 program

--- a/tests/integration/expected/eq_u64.masm
+++ b/tests/integration/expected/eq_u64.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,11 @@ end
 mod noname
 
 export.entrypoint
-  eqw
+  movup.2
+  eq
+  movdn.3
+  eq
+  and
 end
 
 program

--- a/tests/integration/expected/eq_u8.masm
+++ b/tests/integration/expected/eq_u8.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_eq
+  eq
 end
 
 program

--- a/tests/integration/expected/fib.masm
+++ b/tests/integration/expected/fib.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -649,51 +659,52 @@ export.fib
   dup.0
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   push.3
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_gt
-  u32checked_neq.0
+  u32gt
+  neq.0
   push.1
   while.true
     if.true
       dup.0
       push.2147483648
-      u32checked_and
+      u32and
       eq.2147483648
       assertz
       push.3
       dup.0
       push.2147483648
-      u32checked_and
+      u32and
       eq.2147483648
       assertz
-      u32checked_div
+      u32d_div
+      u32assert
       dup.0
       push.2147483648
-      u32checked_and
+      u32and
       eq.2147483648
       assertz
       dup.0
       dup.0
       push.2147483648
-      u32checked_and
+      u32and
       eq.2147483648
       assertz
       push.3
       dup.0
       push.2147483648
-      u32checked_and
+      u32and
       eq.2147483648
       assertz
-      u32checked_gt
-      u32checked_neq.0
+      u32gt
+      neq.0
       push.1
     else
       push.0

--- a/tests/integration/expected/ge_u16.masm
+++ b/tests/integration/expected/ge_u16.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -648,16 +658,16 @@ mod noname
 export.entrypoint
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   swap.1
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_gte
+  u32gte
 end
 
 program

--- a/tests/integration/expected/ge_u32.masm
+++ b/tests/integration/expected/ge_u32.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -648,16 +658,16 @@ mod noname
 export.entrypoint
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   swap.1
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_gte
+  u32gte
 end
 
 program

--- a/tests/integration/expected/ge_u8.masm
+++ b/tests/integration/expected/ge_u8.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -648,16 +658,16 @@ mod noname
 export.entrypoint
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   swap.1
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_gte
+  u32gte
 end
 
 program

--- a/tests/integration/expected/gt_u16.masm
+++ b/tests/integration/expected/gt_u16.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -648,16 +658,16 @@ mod noname
 export.entrypoint
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   swap.1
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_gt
+  u32gt
 end
 
 program

--- a/tests/integration/expected/gt_u32.masm
+++ b/tests/integration/expected/gt_u32.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -648,16 +658,16 @@ mod noname
 export.entrypoint
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   swap.1
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_gt
+  u32gt
 end
 
 program

--- a/tests/integration/expected/gt_u8.masm
+++ b/tests/integration/expected/gt_u8.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -648,16 +658,16 @@ mod noname
 export.entrypoint
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   swap.1
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_gt
+  u32gt
 end
 
 program

--- a/tests/integration/expected/le_u16.masm
+++ b/tests/integration/expected/le_u16.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -648,16 +658,16 @@ mod noname
 export.entrypoint
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   swap.1
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_lte
+  u32lte
 end
 
 program

--- a/tests/integration/expected/le_u32.masm
+++ b/tests/integration/expected/le_u32.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -648,16 +658,16 @@ mod noname
 export.entrypoint
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   swap.1
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_lte
+  u32lte
 end
 
 program

--- a/tests/integration/expected/le_u8.masm
+++ b/tests/integration/expected/le_u8.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -648,16 +658,16 @@ mod noname
 export.entrypoint
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   swap.1
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_lte
+  u32lte
 end
 
 program

--- a/tests/integration/expected/lt_u16.masm
+++ b/tests/integration/expected/lt_u16.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -648,16 +658,16 @@ mod noname
 export.entrypoint
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   swap.1
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_lt
+  u32lt
 end
 
 program

--- a/tests/integration/expected/lt_u32.masm
+++ b/tests/integration/expected/lt_u32.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -648,16 +658,16 @@ mod noname
 export.entrypoint
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   swap.1
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_lt
+  u32lt
 end
 
 program

--- a/tests/integration/expected/lt_u8.masm
+++ b/tests/integration/expected/lt_u8.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -648,16 +658,16 @@ mod noname
 export.entrypoint
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   swap.1
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_lt
+  u32lt
 end
 
 program

--- a/tests/integration/expected/not_bool.masm
+++ b/tests/integration/expected/not_bool.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -647,7 +657,7 @@ mod noname
 
 export.entrypoint
   push.1
-  u32checked_xor
+  u32xor
 end
 
 program

--- a/tests/integration/expected/not_i16.masm
+++ b/tests/integration/expected/not_i16.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -647,7 +657,7 @@ mod noname
 
 export.entrypoint
   push.4294967295
-  u32checked_xor
+  u32xor
 end
 
 program

--- a/tests/integration/expected/not_i32.masm
+++ b/tests/integration/expected/not_i32.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -647,7 +657,7 @@ mod noname
 
 export.entrypoint
   push.4294967295
-  u32checked_xor
+  u32xor
 end
 
 program

--- a/tests/integration/expected/not_i8.masm
+++ b/tests/integration/expected/not_i8.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -647,7 +657,7 @@ mod noname
 
 export.entrypoint
   push.4294967295
-  u32checked_xor
+  u32xor
 end
 
 program

--- a/tests/integration/expected/not_u16.masm
+++ b/tests/integration/expected/not_u16.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -647,7 +657,7 @@ mod noname
 
 export.entrypoint
   push.65535
-  u32checked_xor
+  u32xor
 end
 
 program

--- a/tests/integration/expected/not_u32.masm
+++ b/tests/integration/expected/not_u32.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -647,7 +657,7 @@ mod noname
 
 export.entrypoint
   push.4294967295
-  u32checked_xor
+  u32xor
 end
 
 program

--- a/tests/integration/expected/not_u8.masm
+++ b/tests/integration/expected/not_u8.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -647,7 +657,7 @@ mod noname
 
 export.entrypoint
   push.255
-  u32checked_xor
+  u32xor
 end
 
 program

--- a/tests/integration/expected/or_bool.masm
+++ b/tests/integration/expected/or_bool.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_or
+  u32or
 end
 
 program

--- a/tests/integration/expected/or_i16.masm
+++ b/tests/integration/expected/or_i16.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_or
+  u32or
 end
 
 program

--- a/tests/integration/expected/or_i32.masm
+++ b/tests/integration/expected/or_i32.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_or
+  u32or
 end
 
 program

--- a/tests/integration/expected/or_i8.masm
+++ b/tests/integration/expected/or_i8.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_or
+  u32or
 end
 
 program

--- a/tests/integration/expected/or_u16.masm
+++ b/tests/integration/expected/or_u16.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_or
+  u32or
 end
 
 program

--- a/tests/integration/expected/or_u32.masm
+++ b/tests/integration/expected/or_u32.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_or
+  u32or
 end
 
 program

--- a/tests/integration/expected/or_u8.masm
+++ b/tests/integration/expected/or_u8.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_or
+  u32or
 end
 
 program

--- a/tests/integration/expected/shr_u16.masm
+++ b/tests/integration/expected/shr_u16.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -648,21 +658,21 @@ mod noname
 export.entrypoint
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   push.15
   movup.2
-  u32checked_and
+  u32and
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_shr
+  u32shr
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
 end

--- a/tests/integration/expected/shr_u32.masm
+++ b/tests/integration/expected/shr_u32.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -648,19 +658,19 @@ mod noname
 export.entrypoint
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   swap.1
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_shr
+  u32shr
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
 end

--- a/tests/integration/expected/shr_u8.masm
+++ b/tests/integration/expected/shr_u8.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -648,21 +658,21 @@ mod noname
 export.entrypoint
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
   push.7
   movup.2
-  u32checked_and
+  u32and
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
-  u32checked_shr
+  u32shr
   dup.0
   push.2147483648
-  u32checked_and
+  u32and
   eq.2147483648
   assertz
 end

--- a/tests/integration/expected/xor_bool.masm
+++ b/tests/integration/expected/xor_bool.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_xor
+  u32xor
 end
 
 program

--- a/tests/integration/expected/xor_i16.masm
+++ b/tests/integration/expected/xor_i16.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_xor
+  u32xor
 end
 
 program

--- a/tests/integration/expected/xor_i32.masm
+++ b/tests/integration/expected/xor_i32.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_xor
+  u32xor
 end
 
 program

--- a/tests/integration/expected/xor_i8.masm
+++ b/tests/integration/expected/xor_i8.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_xor
+  u32xor
 end
 
 program

--- a/tests/integration/expected/xor_u16.masm
+++ b/tests/integration/expected/xor_u16.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_xor
+  u32xor
 end
 
 program

--- a/tests/integration/expected/xor_u32.masm
+++ b/tests/integration/expected/xor_u32.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_xor
+  u32xor
 end
 
 program

--- a/tests/integration/expected/xor_u8.masm
+++ b/tests/integration/expected/xor_u8.masm
@@ -2,13 +2,13 @@ mod intrinsics::i32
 
 export.is_signed
   push.2147483648
-  u32checked_and
+  u32and
   push.2147483648
   eq
 end
 
 export.unchecked_neg
-  u32checked_not
+  u32not
   u32wrapping_add.1
 end
 
@@ -180,7 +180,7 @@ export.checked_div
   dup.0
   movdn.5
   cdrop
-  u32unchecked_div
+  u32d_div
   movdn.2
   neq
   dup.1
@@ -193,10 +193,10 @@ export.icmp
   dup.1
   dup.1
   push.2147483648
-  u32checked_and
+  u32and
   swap.1
   push.2147483648
-  u32checked_and
+  u32and
   eq.0
   swap.1
   eq.0
@@ -215,9 +215,9 @@ export.icmp
     drop
     dup.1
     dup.1
-    u32unchecked_gt
+    u32gt
     movdn.2
-    u32unchecked_lt
+    u32lt
     push.0
     push.4294967295
     push.1
@@ -253,17 +253,17 @@ end
 export.pow2
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   push.1
   swap.1
-  u32checked_shl
+  u32shl
 end
 
 export.ipow
   dup.0
   push.31
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -282,18 +282,18 @@ export.ipow
     push.1
     dup.1
     push.1
-    u32checked_gt
+    u32gt
     while.true
       dup.2
       dup.1
       u32wrapping_mul
       dup.2
       push.1
-      u32checked_and
+      u32and
       eq.1
       cdrop
       swap.1
-      u32checked_div.2
+      u32d_div.2
       movup.2
       dup.0
       u32wrapping_mul
@@ -301,7 +301,7 @@ export.ipow
       movup.2
       dup.1
       push.1
-      u32checked_gt
+      u32gt
     end
     swap.1
     drop
@@ -312,7 +312,7 @@ end
 export.checked_shr
   dup.0
   push.32
-  u32checked_lt
+  u32lt
   assert
   dup.0
   eq.0
@@ -328,24 +328,26 @@ export.checked_shr
   else
     dup.1
     push.2147483648
-    u32checked_and
+    u32and
     push.2147483648
     eq
     if.true
       swap.1
       dup.1
-      u32checked_shr
+      u32shr
       push.1
       dup.2
-      u32unchecked_shl
+      u32shl
       sub.1
       push.32
       movup.3
       sub
-      u32unchecked_shl
-      u32checked_or
+      u32shl
+      u32or
+      u32assert
     else
-      u32checked_shr
+      u32shr
+      u32assert
     end
   end
 end
@@ -393,7 +395,7 @@ export.load_sw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -413,13 +415,14 @@ export.load_sw
       drop
       drop
       dup.2
-      u32checked_shl
+      u32shl
       swap.1
       push.32
       movup.3
-      u32checked_sub
-      u32checked_shr
-      u32checked_or
+      u32overflowing_sub
+      assertz
+      u32shr
+      u32or
     else
       dup.1
       eq.1
@@ -434,13 +437,14 @@ export.load_sw
         movdn.2
         drop
         dup.2
-        u32checked_shl
+        u32shl
         swap.1
         push.32
         movup.3
-        u32checked_sub
-        u32checked_shr
-        u32checked_or
+        u32overflowing_sub
+        assertz
+        u32shr
+        u32or
       else
         swap.1
         eq.2
@@ -451,16 +455,18 @@ export.load_sw
           drop
           drop
           dup.2
-          u32checked_shl
+          u32shl
           swap.1
           push.32
           movup.3
-          u32checked_sub
-          u32checked_shr
-          u32checked_or
+          u32overflowing_sub
+          assertz
+          u32shr
+          u32or
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -470,8 +476,9 @@ export.load_sw
           drop
           push.32
           dup.3
-          u32checked_sub
-          u32checked_shr
+          u32overflowing_sub
+          assertz
+          u32shr
           swap.1
           padw
           movup.4
@@ -480,8 +487,8 @@ export.load_sw
           drop
           drop
           movup.2
-          u32checked_shl
-          u32checked_or
+          u32shl
+          u32or
         end
       end
     end
@@ -490,22 +497,22 @@ end
 
 export.realign_dw
   dup.3
-  u32checked_shl
+  u32shl
   movdn.2
   dup.0
   push.32
   dup.4
-  u32checked_shr
+  u32shr
   movup.4
-  u32checked_or
+  u32or
   movdn.2
   dup.3
-  u32checked_shl
+  u32shl
   swap.1
   push.32
   movup.4
-  u32checked_shr
-  u32checked_or
+  u32shr
+  u32or
   swap.1
 end
 
@@ -514,7 +521,7 @@ export.load_dw
   eq.0
   dup.3
   push.8
-  u32checked_lt
+  u32lt
   assert
   if.true
     movup.2
@@ -554,7 +561,8 @@ export.load_dw
           drop
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -602,7 +610,8 @@ export.load_dw
         eq.2
         if.true
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -621,7 +630,8 @@ export.load_dw
           exec.realign_dw
         else
           dup.0
-          u32checked_add.1
+          u32overflowing_add.1
+          assertz
           padw
           movup.4
           mem_loadw
@@ -646,7 +656,7 @@ end
 mod noname
 
 export.entrypoint
-  u32checked_xor
+  u32xor
 end
 
 program


### PR DESCRIPTION
**NOTE:** This is intended to be merged after #65.

This updates our `miden-assembly` dependency, and handles all of the changes to the instruction set, as well as cleans up a few places that were hacky because of missing APIs in `miden-assembly`.

There are still a couple changes to make once this is merged (fleshing out support for indirect calls and assertions with error codes; creating `.masl` files when requested), but I'll do that separately to keep this PR smaller.