### PR TITLE
fix: improper handling of inlined blocks in inline-blocks transform

### DIFF
--- a/frontend-wasm/src/function_builder_ext.rs
+++ b/frontend-wasm/src/function_builder_ext.rs
@@ -436,7 +436,7 @@ pub struct FuncInstBuilderExt<'a, 'b: 'a, 'c, 'd: 'c> {
 }
 impl<'a, 'b, 'c, 'd> FuncInstBuilderExt<'a, 'b, 'c, 'd> {
     fn new(builder: &'a mut FunctionBuilderExt<'b, 'c, 'd>, block: Block) -> Self {
-        assert!(builder.data_flow_graph().is_block_inserted(block));
+        assert!(builder.data_flow_graph().is_block_linked(block));
         Self {
             builder,
             ip: InsertionPoint::after(ProgramPoint::Block(block)),

--- a/hir-analysis/src/validation/block.rs
+++ b/hir-analysis/src/validation/block.rs
@@ -137,7 +137,7 @@ impl<'a> Rule<BlockData> for BlockValidator<'a> {
         diagnostics: &DiagnosticsHandler,
     ) -> Result<(), ValidationError> {
         // Ignore blocks which are not attached to the function body
-        if !block_data.link.is_linked() {
+        if !self.dfg.is_block_linked(block_data.id) {
             return Ok(());
         }
 
@@ -168,8 +168,7 @@ impl<'a> Rule<BlockData> for BlockValidator<'a> {
         }
         match terminator.analyze_branch(&self.dfg.value_lists) {
             BranchInfo::SingleDest(destination, _) => {
-                let dest = self.dfg.block(destination);
-                if !dest.link.is_linked() {
+                if !self.dfg.is_block_linked(destination) {
                     invalid_instruction!(
                         diagnostics,
                         terminator.key,
@@ -193,9 +192,8 @@ impl<'a> Rule<BlockData> for BlockValidator<'a> {
 
                 let mut seen = SmallVec::<[Block; 4]>::default();
                 for jt in jts.iter() {
-                    let dest = self.dfg.block(jt.destination);
                     let destination = jt.destination;
-                    if !dest.link.is_linked() {
+                    if !self.dfg.is_block_linked(destination) {
                         invalid_instruction!(
                             diagnostics,
                             terminator.key,
@@ -206,7 +204,7 @@ impl<'a> Rule<BlockData> for BlockValidator<'a> {
                         );
                     }
 
-                    if seen.contains(&jt.destination) {
+                    if seen.contains(&destination) {
                         invalid_instruction!(
                             diagnostics,
                             terminator.key,
@@ -217,7 +215,7 @@ impl<'a> Rule<BlockData> for BlockValidator<'a> {
                         );
                     }
 
-                    seen.push(jt.destination);
+                    seen.push(destination);
                 }
             }
             BranchInfo::NotABranch => (),

--- a/hir-transform/src/inline_blocks.rs
+++ b/hir-transform/src/inline_blocks.rs
@@ -65,9 +65,15 @@ impl RewritePass for InlineBlocks {
                 continue;
             }
 
+            // If the block is detached, then it has already been inlined,
+            // so we do not need to run inlining on it, however we should
+            // visit its successors anyway, as there may be inlining
+            // opportunities later in the CFG.
+            let is_detached = !function.dfg.is_block_linked(p);
+
             // If this block has multiple successors, or multiple predecessors, add all of it's
             // successors to the work queue and move on.
-            if cfg.num_successors(p) > 1 || cfg.num_predecessors(p) > 1 {
+            if is_detached || cfg.num_successors(p) > 1 || cfg.num_predecessors(p) > 1 {
                 for b in cfg.succ_iter(p) {
                     worklist.push_back(b);
                 }

--- a/hir/src/block.rs
+++ b/hir/src/block.rs
@@ -1,6 +1,6 @@
 use cranelift_entity::entity_impl;
 use intrusive_collections::linked_list::{Cursor, CursorMut};
-use intrusive_collections::{LinkedListLink, UnsafeRef};
+use intrusive_collections::UnsafeRef;
 
 use super::*;
 
@@ -22,7 +22,6 @@ impl Default for Block {
 /// Blocks have arguments, and consist of a sequence of instructions.
 pub struct BlockData {
     pub id: Block,
-    pub link: LinkedListLink,
     pub params: ValueList,
     pub insts: InstructionList,
 }
@@ -35,7 +34,6 @@ impl Clone for BlockData {
     fn clone(&self) -> Self {
         Self {
             id: self.id,
-            link: Default::default(),
             params: self.params,
             insts: Default::default(),
         }
@@ -45,7 +43,6 @@ impl BlockData {
     pub(crate) fn new(id: Block) -> Self {
         Self {
             id,
-            link: Default::default(),
             params: ValueList::new(),
             insts: Default::default(),
         }

--- a/hir/src/builder.rs
+++ b/hir/src/builder.rs
@@ -97,7 +97,7 @@ pub struct DefaultInstBuilder<'f> {
 }
 impl<'f> DefaultInstBuilder<'f> {
     pub(crate) fn new(dfg: &'f mut DataFlowGraph, block: Block) -> Self {
-        assert!(dfg.is_block_inserted(block));
+        assert!(dfg.is_block_linked(block));
 
         Self {
             dfg,

--- a/hir/src/dataflow.rs
+++ b/hir/src/dataflow.rs
@@ -567,7 +567,7 @@ impl DataFlowGraph {
         self.blocks[block].last()
     }
 
-    pub fn is_block_inserted(&self, block: Block) -> bool {
+    pub fn is_block_linked(&self, block: Block) -> bool {
         self.blocks.contains(block)
     }
 

--- a/hir/src/layout.rs
+++ b/hir/src/layout.rs
@@ -372,6 +372,10 @@ impl<K: EntityRef, V> OrderedArenaMap<K, V> {
     /// clone the map, and drop the original.
     pub fn remove(&mut self, key: K) {
         if let Some(value) = self.map.get(key) {
+            assert!(
+                value.link.is_linked(),
+                "cannot remove a value that is not linked"
+            );
             let mut cursor = unsafe { self.list.cursor_mut_from_ptr(value) };
             cursor.remove();
         }


### PR DESCRIPTION
This patches the inline-blocks pass to ensure that inlined blocks are not visited multiple times by the inliner - once inlined, these blocks are treated as not inlineable from that point forward, allowing us to visit successor blocks with the inliner normally without considering the inlined block itself.

Additionally, the following issues are addressed:

* We did not raise an error if attempting to remove a node from its OrderedArenaMap if it had already been removed. These nodes remain accessible via the map so that outstanding references are still usable, but are treated in all other respects as if they are not contained in the map - this was not being handled properly by `remove`
* The `link` field of `BlockData` was superfluous and has been for some time, but was missed because it is a public field of a public struct, and there are places where we were incorrectly referencing this field as if it was in use. In fact, the `link` field we care about is the one associated with the `LayoutNode` used by `OrderedArenaMap`, and the `BlockData` one was never linked into anything, resulting in some places incorrectly treating blocks as detached when they were in fact attached.

Closes #85

I'll merge #83 after this is merged