### PR TITLE
feat: set up lit infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target/
 bin/midenc
-bin/filecheck
+bin/litcheck
+.crates.toml
+.crates2.json

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -140,7 +140,7 @@ args = ["-Z", "unstable-options", "build", "-p", "midenc", "--out-dir", "${CARGO
 category = "Build"
 description = "Runs cargo build on the workspace"
 run_task = [
-  { name = ["midenc", "build-filecheck"] },
+  { name = ["midenc"] },
 ]
 
 [tasks.install]
@@ -165,7 +165,7 @@ args = ["clean", "${@}"]
 [tasks.test]
 category = "Test"
 description = "Runs all tests"
-dependencies = ["test-rust", "test-filecheck"]
+dependencies = ["test-rust"]
 
 [tasks.install-midenc]
 category = "Install"
@@ -204,29 +204,17 @@ command = "cargo"
 args = ["test", "@@remove-empty(CARGO_MAKE_CARGO_VERBOSE_FLAGS)", "@@split(CARGO_MAKE_CARGO_BUILD_TEST_FLAGS, )", "${@}"]
 dependencies = ["install-wasm-target", "install-wasm-wasi-target", "install-rust-src", "install-cargo-component"]
 
-[tasks.test-filecheck]
+[tasks.test-lit]
 category = "Test"
-description = "Runs file-based checks using filecheck"
-command = "bin/filecheck"
-args = ["-t", "hir", "-t", "sw", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/tests/lit"]
-dependencies = [
-  "build-filecheck",
-]
-
-[tasks.filecheck]
-category = "Test"
-description = "Invokes filecheck with the given arguments"
-command = "bin/filecheck"
-args = ["${@}"]
-dependencies = [
-  "build",
-]
-
-[tasks.build-filecheck]
-category = "Build"
-description = "Builds the filecheck helper"
-command = "cargo"
-args = ["-Z", "unstable-options", "build", "-p", "filecheck", "--release", "--out-dir", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/bin"]
+description = "Runs the lit/filecheck test suite"
+command = "bin/lit"
+install_script = '''
+if [ ! -f "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/bin/litcheck" ]; then
+    cargo install --git 'https://github.com/bitwalker/litcheck' --root "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}"
+    bin/litcheck help
+fi
+'''
+args = ["run", "--path", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/bin", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/tests/lit/parse"]
 
 [tasks.book]
 category = "Build"

--- a/bin/filecheck
+++ b/bin/filecheck
@@ -1,0 +1,1 @@
+litcheck

--- a/bin/lit
+++ b/bin/lit
@@ -1,0 +1,1 @@
+litcheck

--- a/tests/lit/parse/fib.hir
+++ b/tests/lit/parse/fib.hir
@@ -1,0 +1,41 @@
+; RUN: midenc compile --stdout --emit=hir %s | filecheck %s
+
+module test
+
+pub fn fib(u32) -> u32 {
+block0(v0: u32):
+    v1 = const.u32 0 : u32;
+    v2 = const.u32 1 : u32;
+    br block1(v1, v2, v1)
+
+block1(v3: u32, v4: u32, v5: u32):
+    v6 = lt v5, v0 : i1
+    cond_br v6, block2, block3(v3)
+
+block2:
+    v7 = add.checked v3, v4 : u32
+    v8 = incr.wrapping v5: u32
+    br block1(v4, v7, v8)
+
+block3(v9: u32):
+    ret v9
+}
+
+; CHECK-LABEL: pub fn fib(u32) -> u32 {
+; CHECK-NEXT: block0(v0: u32):
+; CHECK-NEXT:     v1 = const.u32 0 : u32;
+; CHECK-NEXT:     v2 = const.u32 1 : u32;
+; CHECK-NEXT:     br block1(v1, v2, v1)
+; CHECK-EMPTY:
+; CHECK-NEXT: block1(v3: u32, v4: u32, v5: u32):
+; CHECK-NEXT:     v6 = lt v5, v0 : i1
+; CHECK-NEXT:     cond_br v6, block2, block3(v3)
+; CHECK-EMPTY:
+; CHECK-NEXT: block2:
+; CHECK-NEXT:     v7 = add.checked v3, v4 : u32
+; CHECK-NEXT:     v8 = incr.wrapping v5: u32
+; CHECK-NEXT:     br block1(v4, v7, v8)
+; CHECK-EMPTY:
+; CHECK-NEXT: block3(v9: u32):
+; CHECK-NEXT:     ret v9
+; CHECK-NEXT: }

--- a/tests/lit/parse/lit.suite.toml
+++ b/tests/lit/parse/lit.suite.toml
@@ -1,0 +1,4 @@
+name = "parsing"
+patterns = ["*.hir"]
+
+[format.shtest]


### PR DESCRIPTION
This commit simply wires up the test suite, follow on PRs will introduce the actual tests for the suite. Until that is done, test-lit has been removed from the default test command to avoid annoying developers until the suite is stable.

@greenhat I added an example test here for you to look at, but it currently is busted due to a parser issue. The suite is temporarily disabled while I get a few more tests written up and all of them passing, but this just makes sure the infra is in place.