### PR TITLE
Fix mdbook config

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -7,3 +7,9 @@ title = "Miden Compiler Documentation"
 
 [output.html]
 git-repository-url = "https://github.com/0xPolygonMiden/compiler/"
+
+[preprocessor.katex]
+after = ["links"]
+
+[output.linkcheck]
+warning-policy = "ignore"


### PR DESCRIPTION
This PR updates `mdbook` config. Without these changes, the docs get built in a different directory and the deploy job does not pick them up. We could also change the CI job to deploy from different directory, but I think being able to write formulas in docs is generally useful.