### PR TITLE
[3/x] Remove invocation method from component imports/exports

### DIFF
--- a/frontend-wasm/src/component/build_ir.rs
+++ b/frontend-wasm/src/component/build_ir.rs
@@ -67,9 +67,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        component::StaticModuleIndex,
-        config::{ExportMetadata, ImportMetadata},
-        test_utils::test_diagnostics,
+        component::StaticModuleIndex, config::ImportMetadata, test_utils::test_diagnostics,
     };
 
     #[test]
@@ -101,18 +99,7 @@ mod tests {
         );
         let wasm = wat::parse_str(wat).unwrap();
         let diagnostics = test_diagnostics();
-        let export_metadata = [(
-            Symbol::intern("add").into(),
-            ExportMetadata {
-                invoke_method: miden_hir::FunctionInvocationMethod::Call,
-            },
-        )]
-        .into_iter()
-        .collect();
-        let config = WasmTranslationConfig {
-            export_metadata,
-            ..Default::default()
-        };
+        let config = Default::default();
         let (mut component_types_builder, parsed_component) =
             parse(&config, &wasm, &diagnostics).unwrap();
         let component_translation =
@@ -204,22 +191,13 @@ mod tests {
             interface_function_ident.clone(),
             ImportMetadata {
                 digest: RpoDigest::default(),
-                invoke_method: miden_hir::FunctionInvocationMethod::Call,
             },
         )]
         .into_iter()
         .collect();
-        let export_metadata = [(
-            Symbol::intern("inc").into(),
-            ExportMetadata {
-                invoke_method: miden_hir::FunctionInvocationMethod::Call,
-            },
-        )]
-        .into_iter()
-        .collect();
+
         let config = WasmTranslationConfig {
             import_metadata,
-            export_metadata,
             ..Default::default()
         };
         let (mut component_types_builder, parsed_component) =

--- a/frontend-wasm/src/component/translator.rs
+++ b/frontend-wasm/src/component/translator.rs
@@ -1,7 +1,7 @@
 use miden_diagnostics::DiagnosticsHandler;
 use miden_hir::{
-    cranelift_entity::PrimaryMap, ComponentBuilder, ComponentExport, FunctionExportName,
-    FunctionIdent, Ident, InterfaceFunctionIdent, InterfaceIdent, Symbol,
+    cranelift_entity::PrimaryMap, ComponentBuilder, ComponentExport, FunctionIdent, Ident,
+    InterfaceFunctionIdent, InterfaceIdent, Symbol,
 };
 use miden_hir_type::LiftedFunctionType;
 use rustc_hash::FxHashMap;
@@ -269,7 +269,6 @@ impl<'a, 'data> ComponentTranslator<'a, 'data> {
         let component_import = miden_hir::ComponentImport {
             function_ty: lifted_func_ty,
             interface_function,
-            invoke_method: import_metadata.invoke_method,
             digest: import_metadata.digest.clone(),
         };
         Ok(component_import)
@@ -285,7 +284,7 @@ impl<'a, 'data> ComponentTranslator<'a, 'data> {
         match export {
             Export::LiftedFunction { ty, func, options } => {
                 let export_name = Symbol::intern(name).into();
-                let export = self.build_export_lifted_function(&export_name, func, ty, options)?;
+                let export = self.build_export_lifted_function(func, ty, options)?;
                 component_builder.add_export(export_name, export);
                 Ok(())
             }
@@ -303,8 +302,8 @@ impl<'a, 'data> ComponentTranslator<'a, 'data> {
                 "Exporting of an imported module is not supported".to_string(),
             )),
             Export::Type(_) => {
-                // Besides the function exports the individual type are also exported from the component
-                // We can ignore them for now
+                // Besides the function exports the individual type are also exported from the
+                // component We can ignore them for now
                 Ok(())
             }
         }
@@ -313,7 +312,6 @@ impl<'a, 'data> ComponentTranslator<'a, 'data> {
     /// Build an IR Component export from the given lifted Wasm core module function export
     fn build_export_lifted_function(
         &self,
-        function_export_name: &FunctionExportName,
         func: &CoreDef,
         ty: &TypeFuncIndex,
         options: &CanonicalOptions,
@@ -358,16 +356,9 @@ impl<'a, 'data> ComponentTranslator<'a, 'data> {
             }
         };
         let lifted_func_ty = convert_lifted_func_ty(ty, &self.component_types);
-        let Some(export_metadata) = self.config.export_metadata.get(function_export_name) else {
-            return Err(WasmError::MissingExportMetadata(format!(
-                "Export metadata for interface function {:?} not found",
-                function_export_name,
-            )));
-        };
         let export = miden_hir::ComponentExport {
             function: func_ident,
             function_ty: lifted_func_ty,
-            invoke_method: export_metadata.invoke_method,
         };
         Ok(export)
     }

--- a/frontend-wasm/src/config.rs
+++ b/frontend-wasm/src/config.rs
@@ -1,7 +1,7 @@
 use alloc::{borrow::Cow, collections::BTreeMap};
 
 use miden_core::crypto::hash::RpoDigest;
-use miden_hir::{FunctionExportName, FunctionInvocationMethod, InterfaceFunctionIdent};
+use miden_hir::InterfaceFunctionIdent;
 
 /// Represents Miden VM codegen metadata for a function import.
 /// This struct will have more fields in the future e.g. where the function
@@ -10,15 +10,6 @@ use miden_hir::{FunctionExportName, FunctionInvocationMethod, InterfaceFunctionI
 pub struct ImportMetadata {
     /// The MAST root hash of the function to be used in codegen
     pub digest: RpoDigest,
-    /// The method of calling the function
-    pub invoke_method: FunctionInvocationMethod,
-}
-
-/// Represents function export metadata
-#[derive(Debug, Clone)]
-pub struct ExportMetadata {
-    /// The method of calling the function
-    pub invoke_method: FunctionInvocationMethod,
 }
 
 /// Configuration for the WASM translation.
@@ -42,9 +33,6 @@ pub struct WasmTranslationConfig {
     /// each imported function. Having it here might be a temporary solution,
     /// later we might want to move it to Wasm custom section.
     pub import_metadata: BTreeMap<InterfaceFunctionIdent, ImportMetadata>,
-
-    /// Export metadata for calling convention, etc.
-    pub export_metadata: BTreeMap<FunctionExportName, ExportMetadata>,
 }
 
 impl Default for WasmTranslationConfig {
@@ -55,7 +43,6 @@ impl Default for WasmTranslationConfig {
             generate_native_debuginfo: false,
             parse_wasm_debuginfo: false,
             import_metadata: Default::default(),
-            export_metadata: Default::default(),
         }
     }
 }

--- a/hir/src/component/mod.rs
+++ b/hir/src/component/mod.rs
@@ -11,24 +11,6 @@ mod interface;
 
 pub use interface::*;
 
-/// Represents the method by which a component function should be invoked in Miden VM
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum FunctionInvocationMethod {
-    /// A function should be invoked by a `call` Miden VM instruction
-    Call,
-    /// A function should be invoked by a `exec` Miden VM instruction
-    #[default]
-    Exec,
-}
-impl fmt::Display for FunctionInvocationMethod {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Call => f.write_str("call"),
-            Self::Exec => f.write_str("exec"),
-        }
-    }
-}
-
 /// A component import
 #[derive(Debug, Clone)]
 pub struct ComponentImport {
@@ -36,8 +18,6 @@ pub struct ComponentImport {
     pub interface_function: InterfaceFunctionIdent,
     /// The component(lifted) type of the imported function
     pub function_ty: LiftedFunctionType,
-    /// The method of calling the function
-    pub invoke_method: FunctionInvocationMethod,
     /// The MAST root hash of the function to be used in codegen
     pub digest: RpoDigest,
 }
@@ -54,10 +34,6 @@ impl formatter::PrettyPrint for ComponentImport {
             + const_text("import")
             + const_text(" ")
             + display(self.digest)
-            + const_text(" ")
-            + const_text("(")
-            + display(self.invoke_method)
-            + const_text(")")
             + const_text(" ")
             + const_text("(")
             + const_text("type")
@@ -81,8 +57,6 @@ pub struct ComponentExport {
     pub function: FunctionIdent,
     /// The component(lifted) type of the exported function
     pub function_ty: LiftedFunctionType,
-    /// The method of calling the function
-    pub invoke_method: FunctionInvocationMethod,
 }
 
 /// A [Component] is a collection of [Module]s that are being compiled together as a package and

--- a/tests/integration/expected/components/inc_wasm_component.hir
+++ b/tests/integration/expected/components/inc_wasm_component.hir
@@ -1,6 +1,6 @@
 (component 
     ;; Component Imports
-    (lower (import 0x0000000000000000000000000000000000000000000000000000000000000000 (call) (type (func (param u32) (param u32) (result u32)))) (#inc_wasm_component.wasm #inc_wasm_component::bindings::miden::add_package::add_interface::add::wit_import)
+    (lower (import 0x0000000000000000000000000000000000000000000000000000000000000000 (type (func (param u32) (param u32) (result u32)))) (#inc_wasm_component.wasm #inc_wasm_component::bindings::miden::add_package::add_interface::add::wit_import)
 
     ;; Modules
     (module #inc_wasm_component.wasm

--- a/tests/integration/expected/sdk_basic_wallet/basic_wallet.hir
+++ b/tests/integration/expected/sdk_basic_wallet/basic_wallet.hir
@@ -1,8 +1,8 @@
 (component 
     ;; Component Imports
-    (lower (import 0x0000000000000000000000000000000000000000000000000000000000000000 (call) (type (func (param (struct (struct (struct u64) (struct u64) (struct u64) (struct u64)))) (param (struct (struct u64))) (param (struct (struct (struct u64) (struct u64) (struct u64) (struct u64)))) (result (struct (struct u64)))))) (#basic_wallet.wasm #basic_wallet::bindings::miden::base::tx::create_note::wit_import)
-    (lower (import 0x0000000000000000000000000000000000000000000000000000000000000000 (call) (type (func (param (struct (struct (struct u64) (struct u64) (struct u64) (struct u64)))) (result (struct (struct (struct u64) (struct u64) (struct u64) (struct u64))))))) (#wit-component:fixups #func0)
-    (lower (import 0x0000000000000000000000000000000000000000000000000000000000000000 (call) (type (func (param (struct (struct (struct u64) (struct u64) (struct u64) (struct u64)))) (result (struct (struct (struct u64) (struct u64) (struct u64) (struct u64))))))) (#wit-component:fixups #func1)
+    (lower (import 0x0000000000000000000000000000000000000000000000000000000000000000 (type (func (param (struct (struct (struct u64) (struct u64) (struct u64) (struct u64)))) (param (struct (struct u64))) (param (struct (struct (struct u64) (struct u64) (struct u64) (struct u64)))) (result (struct (struct u64)))))) (#basic_wallet.wasm #basic_wallet::bindings::miden::base::tx::create_note::wit_import)
+    (lower (import 0x0000000000000000000000000000000000000000000000000000000000000000 (type (func (param (struct (struct (struct u64) (struct u64) (struct u64) (struct u64)))) (result (struct (struct (struct u64) (struct u64) (struct u64) (struct u64))))))) (#wit-component:fixups #func0)
+    (lower (import 0x0000000000000000000000000000000000000000000000000000000000000000 (type (func (param (struct (struct (struct u64) (struct u64) (struct u64) (struct u64)))) (result (struct (struct (struct u64) (struct u64) (struct u64) (struct u64))))))) (#wit-component:fixups #func1)
 
     ;; Modules
     (module #wit-component:shim

--- a/tests/integration/src/rust_masm_tests/components.rs
+++ b/tests/integration/src/rust_masm_tests/components.rs
@@ -1,6 +1,6 @@
 use expect_test::expect_file;
 use miden_core::crypto::hash::RpoDigest;
-use miden_frontend_wasm::{ExportMetadata, ImportMetadata, WasmTranslationConfig};
+use miden_frontend_wasm::{ImportMetadata, WasmTranslationConfig};
 use miden_hir::{InterfaceFunctionIdent, InterfaceIdent, LiftedFunctionType, Symbol, Type};
 
 use crate::CompilerTest;
@@ -8,18 +8,7 @@ use crate::CompilerTest;
 #[test]
 fn wcm_add() {
     // Has no imports
-    let export_metadata = [(
-        Symbol::intern("add").into(),
-        ExportMetadata {
-            invoke_method: miden_hir::FunctionInvocationMethod::Call,
-        },
-    )]
-    .into_iter()
-    .collect();
-    let config = WasmTranslationConfig {
-        export_metadata,
-        ..Default::default()
-    };
+    let config = Default::default();
     let mut test = CompilerTest::rust_source_cargo_component("add-comp", config);
     let artifact_name = test.source.artifact_name();
     test.expect_wasm(expect_file![format!("../../expected/components/{artifact_name}.wat")]);
@@ -40,22 +29,13 @@ fn wcm_inc() {
         interface_function_ident.clone(),
         ImportMetadata {
             digest: RpoDigest::default(),
-            invoke_method: miden_hir::FunctionInvocationMethod::Call,
         },
     )]
     .into_iter()
     .collect();
-    let export_metadata = [(
-        Symbol::intern("inc").into(),
-        ExportMetadata {
-            invoke_method: miden_hir::FunctionInvocationMethod::Call,
-        },
-    )]
-    .into_iter()
-    .collect();
+
     let config = WasmTranslationConfig {
         import_metadata,
-        export_metadata,
         ..Default::default()
     };
     let mut test = CompilerTest::rust_source_cargo_component("inc-comp", config);

--- a/tests/integration/src/rust_masm_tests/sdk.rs
+++ b/tests/integration/src/rust_masm_tests/sdk.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use expect_test::expect_file;
 use miden_core::crypto::hash::RpoDigest;
-use miden_frontend_wasm::{ExportMetadata, ImportMetadata, WasmTranslationConfig};
+use miden_frontend_wasm::{ImportMetadata, WasmTranslationConfig};
 use miden_hir::{FunctionExportName, InterfaceFunctionIdent, InterfaceIdent, Symbol};
 
 use crate::CompilerTest;
@@ -35,45 +35,27 @@ fn sdk_basic_wallet() {
             create_note_ident.clone(),
             ImportMetadata {
                 digest: RpoDigest::default(),
-                invoke_method: miden_hir::FunctionInvocationMethod::Call,
             },
         ),
         (
             remove_asset_ident.clone(),
             ImportMetadata {
                 digest: RpoDigest::default(),
-                invoke_method: miden_hir::FunctionInvocationMethod::Call,
             },
         ),
         (
             add_asset_ident.clone(),
             ImportMetadata {
                 digest: RpoDigest::default(),
-                invoke_method: miden_hir::FunctionInvocationMethod::Call,
             },
         ),
     ]
     .into_iter()
     .collect();
-    let export_metadata: BTreeMap<FunctionExportName, ExportMetadata> = [
-        (
-            Symbol::intern("send-asset").into(),
-            ExportMetadata {
-                invoke_method: miden_hir::FunctionInvocationMethod::Call,
-            },
-        ),
-        (
-            Symbol::intern("receive-asset").into(),
-            ExportMetadata {
-                invoke_method: miden_hir::FunctionInvocationMethod::Call,
-            },
-        ),
-    ]
-    .into_iter()
-    .collect();
+    let expected_exports: Vec<FunctionExportName> =
+        vec![Symbol::intern("send-asset").into(), Symbol::intern("receive-asset").into()];
     let config = WasmTranslationConfig {
         import_metadata: import_metadata.clone(),
-        export_metadata: export_metadata.clone(),
         ..Default::default()
     };
     let mut test = CompilerTest::rust_source_cargo_component("sdk/basic-wallet", config);
@@ -84,7 +66,7 @@ fn sdk_basic_wallet() {
     for (_, import) in ir.imports() {
         assert!(import_metadata.contains_key(&import.interface_function));
     }
-    for (name, _meta) in export_metadata {
+    for name in expected_exports {
         assert!(ir.exports().contains_key(&name));
     }
 }


### PR DESCRIPTION
**This PR is stacked on top of #131 and should be merged after it**

Since at component boundaries, every function is invoked via `call`. 