### PR TITLE
docs: fix broken example code snippets

### DIFF
--- a/docs/src/guides/rust_to_wasm.md
+++ b/docs/src/guides/rust_to_wasm.md
@@ -7,7 +7,7 @@ modules and compile them on to Miden Assembly, which will be covered in the next
 ## Setup
 
 First, let's set up a simple Rust project that contains an implementation of the Fibonacci
-function (I know, its overdone, but we're trying to keep things as simple as possible to 
+function (I know, its overdone, but we're trying to keep things as simple as possible to
 make it easier to show the results at each step, so bear with me):
 
 Start by creating a new library crate:
@@ -57,17 +57,17 @@ panic = "abort"
 opt-level = "z"
 ```
 
-Most of these things are done to keep the generated code size as small as possible. Miden is a target 
-where the conventional wisdom about performance should be treated very carefully: we're almost always 
-going to benefit from less code, even if conventionally that code would be less efficient, simply due 
-to the difference in proving time accumulated due to extra instructions. That said, there are no hard 
+Most of these things are done to keep the generated code size as small as possible. Miden is a target
+where the conventional wisdom about performance should be treated very carefully: we're almost always
+going to benefit from less code, even if conventionally that code would be less efficient, simply due
+to the difference in proving time accumulated due to extra instructions. That said, there are no hard
 and fast rules, but these defaults are good ones to start with.
 
-> [!TIP] 
+> [!TIP]
 > We recommended `wee_alloc` here, but any simple allocator will do, including a hand-written
 > bump allocator. The trade offs made by these small allocators are not generally suitable for long-
 > running, or allocation-heavy applications, as they "leak" memory (generally because they make little
-> to no attempt to recover freed allocations), however they are very useful for one-shot programs that 
+> to no attempt to recover freed allocations), however they are very useful for one-shot programs that
 > do minimal allocation, which is going to be the typical case for Miden programs.
 
 Next, edit `src/lib.rs` as shown below:
@@ -82,7 +82,7 @@ Next, edit `src/lib.rs` as shown below:
 // Do not link against libstd (i.e. anything defined in `std::`)
 #![no_std]
 
-// However, we could still use some standard library types while 
+// However, we could still use some standard library types while
 // remaining no-std compatible, if we uncommented the following lines:
 //
 // extern crate alloc;
@@ -131,7 +131,7 @@ This places a `wasm_fib.wasm` file under the `target/wasm32-unknown-unknown/rele
 we can then examine with [wasm2wat](https://github.com/WebAssembly/wabt) to set the code we generated:
 
     wasm2wat target/wasm32-unknown-unknown/release/wasm_fib.wasm
-    
+
 Which dumps the following output (may differ slightly on your machine, depending on the specific compiler version):
 
 ```wat

--- a/docs/src/guides/rust_to_wasm.md
+++ b/docs/src/guides/rust_to_wasm.md
@@ -96,7 +96,7 @@ Next, edit `src/lib.rs` as shown below:
 
 // Required for no-std crates
 #[panic_handler]
-fn panic(info: core::panic::PanicInfo) -> ! {
+fn panic(_info: &core::panic::PanicInfo) -> ! {
     core::intrinsics::abort()
 }
 

--- a/docs/src/guides/wasm_to_masm.md
+++ b/docs/src/guides/wasm_to_masm.md
@@ -92,14 +92,16 @@ it is not a program, but a library module:
     begin
         exec.wasm_fib::fib
     end
+    EOF
 
 We will also need a `.inputs` file to pass arguments to the program:
 
     cat <<EOF > wasm_fib.inputs
     {
         "operand_stack": ["10"],
-        "advice_stack": ["0"],
+        "advice_stack": ["0"]
     }
+    EOF
 
 Next, we need to build a MASL library (normally `midenc` would do this, but there is a bug
 blocking it at the moment, this example will be updated accordingly soon):

--- a/docs/src/guides/wasm_to_masm.md
+++ b/docs/src/guides/wasm_to_masm.md
@@ -1,17 +1,17 @@
 # Compiling WebAssembly to Miden Assembly
 
-This chapter will walk you through compiling a WebAssembly (Wasm) module, in binary form 
+This chapter will walk you through compiling a WebAssembly (Wasm) module, in binary form
 (i.e. a `.wasm` file), to an corresponding Miden Assembly (Masm) module (i.e. a `.masm` file).
 
 ## Setup
 
-We will be making use of the example crate we created in [Compiling Rust to WebAssembly](rust_to_wasm.md), 
-which produces a small, lightweight Wasm module that is easy to examine in Wasm 
-text format, and demonstrates a good set of default choices for a project compiling 
+We will be making use of the example crate we created in [Compiling Rust to WebAssembly](rust_to_wasm.md),
+which produces a small, lightweight Wasm module that is easy to examine in Wasm
+text format, and demonstrates a good set of default choices for a project compiling
 to Miden Assembly via WebAssembly.
 
 In this chapter, we will be compiling Wasm to MASM using the `midenc` executable, so ensure that
-you have followed the instructions in the [Getting Started (midenc)](../usage/midenc.md) guide 
+you have followed the instructions in the [Getting Started (midenc)](../usage/midenc.md) guide
 and then return here.
 
 ## Compiling to Miden Assembly
@@ -20,16 +20,16 @@ In the last chapter, we compiled a Rust crate to WebAssembly that contains an im
 of the Fibonacci function called `fib`, that was emitted to `target/wasm32-unknown-unknown/release/wasm_fib.wasm`.
 All that remains is to tell `midenc` to compile this module to WebAssembly, as shown below:
 
-> [!NOTE] 
+> [!NOTE]
 > The compiler is still under heavy development, so there are some known bugs that
 > may interfere with compilation depending on the flags you use - for the moment, the compiler
-> invocation we have to use is quite verbose, but this is a short term situation while we 
+> invocation we have to use is quite verbose, but this is a short term situation while we
 > address various other higher-priority tasks. Ultimately, using `midenc` directly will be
 > less common than other use cases (such as using `cargo miden`, or using the compiler as a
 > library for your own language frontend).
 
     midenc compile -o wasm_fib.masm --emit=masm target/wasm32-unknown-unknown/release/wasm_fib.wasm
-    
+
 This will place the generated Miden Assembly code for our `wasm_fib` crate in the current directory.
 If we dump the contents of this file, we'll see the following generated code:
 
@@ -68,7 +68,7 @@ end
 ```
 
 If you compare this to the WebAssembly text format, you can see that this is a fairly
-faithful translation, but there may be areas where we generate sub-optimal Miden Assembly. 
+faithful translation, but there may be areas where we generate sub-optimal Miden Assembly.
 
 At the moment the compiler does only minimal optimization, late in the pipeline during codegen,
 and only in regards to operand stack management. In other words, if you see an instruction
@@ -77,22 +77,22 @@ the code we generate will match what you would write by hand.
 
 ## Testing with the Miden VM
 
-> [!NOTE] 
+> [!NOTE]
 > This example is more complicated than it needs to be at the moment, bear with us!
 
 Assuming you have followed the instruction for installing the Miden VM locally,
 we can test this program out as follows:
 
-First, we need to define a program to link our `wasm_fib.masm` module into, since 
+First, we need to define a program to link our `wasm_fib.masm` module into, since
 it is not a program, but a library module:
 
     cat <<EOF > main.masm
     use.wasm_fib::wasm_fib
-    
+
     begin
         exec.wasm_fib::fib
     end
-    
+
 We will also need a `.inputs` file to pass arguments to the program:
 
     cat <<EOF > wasm_fib.inputs
@@ -100,7 +100,7 @@ We will also need a `.inputs` file to pass arguments to the program:
         "operand_stack": ["10"],
         "advice_stack": ["0"],
     }
-    
+
 Next, we need to build a MASL library (normally `midenc` would do this, but there is a bug
 blocking it at the moment, this example will be updated accordingly soon):
 
@@ -129,13 +129,11 @@ With these in place, we can put it all together and run it:
         ├── Memory chiplet rows: 0
         └── Kernel ROM rows: 0
 
-
 Success! We got the expected result of `55`.
-
 
 ## Next Steps
 
-This guide is not comprehensive, as we have not yet examined in detail the differences between 
+This guide is not comprehensive, as we have not yet examined in detail the differences between
 compiling libraries vs programs, linking together multiple libraries, emitting a `.masl` library,
 or discussed some of the compiler options. We will be updating this documentation with those
 details and more in the coming days, so bear with us while we flesh out our guides!


### PR DESCRIPTION
- Fixed small errors in the example shell code
- Modified example `lib.rs` to match test case (was throwing type error previously)
- Stripped whitespace in guide docs