### PR TITLE
[0/x] Fix: add `inttoptr` after emitting the address of a global variable

### DIFF
--- a/codegen/masm/src/codegen/emit/mem.rs
+++ b/codegen/masm/src/codegen/emit/mem.rs
@@ -825,12 +825,12 @@ impl<'a> OpEmitter<'a> {
         let ptr = self.stack.pop().expect("operand stack is empty");
         let value = self.stack.pop().expect("operand stack is empty");
         let ptr_ty = ptr.ty();
-        assert!(ptr_ty.is_pointer(), "expected load operand to be a pointer, got {ptr_ty}");
+        assert!(ptr_ty.is_pointer(), "expected store operand to be a pointer, got {ptr_ty}");
         let value_ty = value.ty();
         assert!(!value_ty.is_zst(), "cannot store a zero-sized type in memory");
         match ptr_ty {
             Type::Ptr(_) => {
-                // Converet the pointer to a native pointer representation
+                // Convert the pointer to a native pointer representation
                 self.emit_native_ptr();
                 match value_ty {
                     Type::I128 => self.store_quad_word(None),

--- a/codegen/masm/src/codegen/emitter.rs
+++ b/codegen/masm/src/codegen/emitter.rs
@@ -432,7 +432,7 @@ impl<'b, 'f: 'b> BlockEmitter<'b, 'f> {
             hir::GlobalValueData::IAddImm { .. } | hir::GlobalValueData::Symbol { .. } => {
                 let mut emitter = self.inst_emitter(inst_info.inst);
                 emitter.stack_mut().push(addr);
-                emitter.inttoptr(&Type::Ptr(Type::Unknown.into()));
+                emitter.inttoptr(&Type::Ptr(Type::U8.into()));
             }
         }
     }

--- a/codegen/masm/src/codegen/emitter.rs
+++ b/codegen/masm/src/codegen/emitter.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use cranelift_entity::SecondaryMap;
+use hir::Type;
 use miden_hir::{self as hir, adt::SparseMap, assert_matches};
 use miden_hir_analysis::{
     DominatorTree, GlobalVariableLayout, LivenessAnalysis, Loop, LoopAnalysis,
@@ -431,6 +432,7 @@ impl<'b, 'f: 'b> BlockEmitter<'b, 'f> {
             hir::GlobalValueData::IAddImm { .. } | hir::GlobalValueData::Symbol { .. } => {
                 let mut emitter = self.inst_emitter(inst_info.inst);
                 emitter.stack_mut().push(addr);
+                emitter.inttoptr(&Type::Ptr(Type::Unknown.into()));
             }
         }
     }


### PR DESCRIPTION
Otherwise, the subsequent `store`/`load` will fail (expecting a `Ptr`).