### PR TITLE
fix: basic wallet account compilation

### DIFF
--- a/frontend-wasm/src/miden_abi/transform.rs
+++ b/frontend-wasm/src/miden_abi/transform.rs
@@ -104,7 +104,7 @@ pub fn return_via_pointer(
             // expected to be +8 from the first and so on. So we need to
             // multiply the index by 8 so that the subsequent Rust code finds
             // the values in the expected locations.
-            let imm = Immediate::I32(idx as i32 * 8);
+            let imm = Immediate::U32(idx as u32 * 8);
             builder.ins().add_imm_checked(ptr_u32, imm, span)
         };
         let value_ty = builder.data_flow_graph().value_type(*value).clone();

--- a/hir/src/pass/rewrite.rs
+++ b/hir/src/pass/rewrite.rs
@@ -158,9 +158,9 @@ where
             if self.0.should_apply(&function, session) {
                 dirty = true;
                 self.0.apply(&mut function, analyses, session)?;
-            } else {
-                analyses.mark_all_preserved::<crate::Function>(&function.id);
+                analyses.invalidate::<crate::Function>(&function.id);
             }
+
             // Add the function back to the module
             //
             // We add it before the current position of the cursor


### PR DESCRIPTION
This PR applies some fixes that were causing the basic wallet account code from #186 to hit asserts in the backend. Once merged, the only remaining blockers are related to felts, stores of complex types, load/store reordering, and operand stack overflow handling.