### PR TITLE
Semantic test for calling stdlib's blake3 hash function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2847,6 +2847,7 @@ name = "miden-integration-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "blake3",
  "cargo-util",
  "cargo_metadata",
  "concat-idents",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ midenc-driver = { path = "midenc-driver" }
 midenc-session = { path = "midenc-session" }
 miden-integration-tests = { path = "tests/integration" }
 wat = "1.0.69"
+blake3 = "1.5"
 
 [patch.crates-io]
 thiserror = { git = "https://github.com/bitwalker/thiserror", branch = "no-std" }

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -39,3 +39,4 @@ proptest.workspace = true
 [dev-dependencies]
 miden-core.workspace = true
 concat-idents = "1.1"
+blake3.workspace = true

--- a/tests/integration/src/rust_masm_tests/abi_transform/stdlib.rs
+++ b/tests/integration/src/rust_masm_tests/abi_transform/stdlib.rs
@@ -1,34 +1,46 @@
 use core::panic;
 
 use expect_test::expect_file;
+use miden_core::utils::group_slice_elements;
+use miden_hir::Felt;
 use proptest::{
     arbitrary::any,
+    prop_assert_eq,
     test_runner::{TestError, TestRunner},
 };
 
-use crate::CompilerTest;
+use crate::{execute_vm, felt_conversion::TestFelt, CompilerTest};
 
 #[ignore = "until the VM stack overflow during the MASM generation is fixed"]
 #[test]
 fn test_blake3_hash() {
-    let main_fn = format!(
-        "(a: [u8; 32], b: [u8; 32]) -> [u8; 32] {{ miden_prelude::blake3_hash_2to1(a, b) }}"
-    );
+    let main_fn = "(a: [u8; 32], b: [u8; 32]) -> [u8; 32] { miden_prelude::blake3_hash_2to1(a, b) \
+                   }"
+    .to_string();
     let artifact_name = "abi_transform_stdlib_blake3_hash";
-    let mut test = CompilerTest::rust_fn_body_with_prelude(&artifact_name, &main_fn, true);
+    let mut test = CompilerTest::rust_fn_body_with_prelude(artifact_name, &main_fn, true);
     // Test expected compilation artifacts
     test.expect_wasm(expect_file![format!("../../../expected/{artifact_name}.wat")]);
     test.expect_ir(expect_file![format!("../../../expected/{artifact_name}.hir")]);
     test.expect_masm(expect_file![format!("../../../expected/{artifact_name}.masm")]);
-    // let ir_masm = test.ir_masm_program();
-    // let vm_program = test.vm_masm_program();
+    let vm_program = test.vm_masm_program();
 
     // Run the Rust and compiled MASM code against a bunch of random inputs and compare the results
-    let res =
-        TestRunner::default().run(&(any::<[u8; 32]>(), any::<[u8; 32]>()), move |(_a, _b)| {
-            todo!("test against rust");
-            // run_masm_vs_rust(rs_out, &vm_program, ir_masm.clone(), &args)
-        });
+    let res = TestRunner::default().run(&any::<[u8; 64]>(), move |ibytes| {
+        let hash_bytes = blake3::hash(&ibytes);
+        let rs_out = hash_bytes.as_bytes();
+        let rs_ofelts = group_slice_elements::<u8, 4>(rs_out)
+            .iter()
+            .map(|&bytes| u32::from_le_bytes(bytes).into())
+            .collect::<Vec<TestFelt>>();
+        let ifelts = group_slice_elements::<u8, 4>(&ibytes)
+            .iter()
+            .map(|&bytes| u32::from_le_bytes(bytes).into())
+            .collect::<Vec<Felt>>();
+        let vm_out = execute_vm(&vm_program, &ifelts);
+        prop_assert_eq!(rs_ofelts, vm_out, "VM output mismatch");
+        Ok(())
+    });
     match res {
         Err(TestError::Fail(_, value)) => {
             panic!("Found minimal(shrinked) failing case: {:?}", value);


### PR DESCRIPTION
This PR adds a semantic test (Rust vs. VM) for calling stdlib blake3 2-to-1 hash function.