### PR TITLE
[8/x] Avoid generating empty blocks for `if.true` op in MASM

### DIFF
--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs.masm
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs.masm
@@ -24,7 +24,7 @@ export."__rust_alloc_zeroed"
     eq.0
     neq.0
     if.true
-
+        push.0 drop
     else
         push.0 eq.0 assert
     end

--- a/tests/integration/src/rust_masm_tests/abi_transform/tx_kernel.rs
+++ b/tests/integration/src/rust_masm_tests/abi_transform/tx_kernel.rs
@@ -12,7 +12,7 @@ fn setup_log() {
         .try_init();
 }
 
-#[ignore = "until https://github.com/0xPolygonMiden/compiler/issues/207 is resolved"]
+#[ignore = "until https://github.com/0xPolygonMiden/compiler/issues/211 is resolved"]
 #[test]
 fn test_get_inputs() {
     // setup_log();


### PR DESCRIPTION
Close #207 

**This PR is stacked on the #210 and should be merged after it**

This PR adds a workaround to avoid generating empty `if.true` blocks in MASM when the IR block consists of the single `ret` instruction and the codegen does not generate any MASM ops for it (return value is already on the stack, etc.).