### PR TITLE
[10/x] Introduce `SKIP_RUST` env var to skip rust compilation in some integration tests

### DIFF
--- a/tests/integration/src/cargo_proj/mod.rs
+++ b/tests/integration/src/cargo_proj/mod.rs
@@ -44,6 +44,7 @@ pub fn panic_error(what: &str, err: impl Into<anyhow::Error>) -> ! {
 
 pub mod paths;
 use self::paths::CargoPathExt;
+use crate::compiler_test::skip_rust_compilation;
 
 /*
  *
@@ -204,6 +205,13 @@ impl ProjectBuilder {
 
     /// Creates the project.
     pub fn build(mut self) -> Project {
+        let last_path_component =
+            self.root.root().file_name().unwrap().to_string_lossy().to_string();
+        if skip_rust_compilation(&self.root(), &last_path_component) {
+            // Return the root directory without re-creating any files
+            return self.root;
+        }
+
         // First, clean the directory if it already exists
         self.rm_root();
 

--- a/tests/integration/src/rust_masm_tests/rust_sdk.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk.rs
@@ -6,12 +6,13 @@ use crate::{cargo_proj::project, compiler_test::sdk_crate_path, CompilerTest};
 
 #[test]
 fn account() {
+    let artifact_name = "miden_sdk_account_test";
     let mut test = CompilerTest::rust_source_cargo_lib(
         PathBuf::from("../rust-apps-wasm/rust-sdk/account-test"),
+        artifact_name,
         true,
         None,
     );
-    let artifact_name = test.source.artifact_name();
     test.expect_wasm(expect_file![format!(
         "../../expected/rust_sdk_account_test/{artifact_name}.wat"
     )]);
@@ -85,7 +86,7 @@ fn basic_wallet() {
         )
         .build();
 
-    let mut test = CompilerTest::rust_source_cargo_lib(proj.root(), true, None);
+    let mut test = CompilerTest::rust_source_cargo_lib(proj.root(), project_name, true, None);
     let artifact_name = test.source.artifact_name();
     test.expect_wasm(expect_file![format!("../../expected/{project_name}/{artifact_name}.wat")]);
     test.expect_ir(expect_file![format!("../../expected/{project_name}/{artifact_name}.hir")]);


### PR DESCRIPTION
Close #213 

**This PR is stacked on the #217 and should be merged after it**