### PR TITLE
[11/x] Use`FileName::as_str`for source file name to avoid enclosing virtual filenames in brackets

### DIFF
--- a/midenc-compile/src/stages/parse.rs
+++ b/midenc-compile/src/stages/parse.rs
@@ -44,7 +44,7 @@ impl Stage for ParseStage {
                     input,
                     session,
                     &WasmTranslationConfig {
-                        source_name: name.to_string().into(),
+                        source_name: name.as_str().unwrap().to_string().into(),
                         ..Default::default()
                     },
                 ),
@@ -52,7 +52,7 @@ impl Stage for ParseStage {
                     input,
                     session,
                     &WasmTranslationConfig {
-                        source_name: name.to_string().into(),
+                        source_name: name.as_str().unwrap().to_string().into(),
                         ..Default::default()
                     },
                 ),


### PR DESCRIPTION
**This PR is stacked on the #218 and should be merged after it**

Use `FileName::as_str` for source name in Wasm translation to avoid `<name>` (enclosed in brackets) which is produced by `FileName::to_string` since the brackets are illegal in MASM module ids. 