### PR TITLE
[8/x] Update the Miden VM deps  with  empty `if.true` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2613,8 +2613,8 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=0ac54125d5bd43160566736b2be3f5818fd84f69#0ac54125d5bd43160566736b2be3f5818fd84f69"
+version = "0.9.2"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=ddf536cd7157053f0940d7be41998b2a6546b4c1#ddf536cd7157053f0940d7be41998b2a6546b4c1"
 dependencies = [
  "miden-core",
  "winter-air",
@@ -2623,8 +2623,8 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=0ac54125d5bd43160566736b2be3f5818fd84f69#0ac54125d5bd43160566736b2be3f5818fd84f69"
+version = "0.9.2"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=ddf536cd7157053f0940d7be41998b2a6546b4c1#ddf536cd7157053f0940d7be41998b2a6546b4c1"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -2640,8 +2640,8 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=0ac54125d5bd43160566736b2be3f5818fd84f69#0ac54125d5bd43160566736b2be3f5818fd84f69"
+version = "0.9.1"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=ddf536cd7157053f0940d7be41998b2a6546b4c1#ddf536cd7157053f0940d7be41998b2a6546b4c1"
 dependencies = [
  "miden-crypto",
  "miden-formatting",
@@ -2653,8 +2653,7 @@ dependencies = [
 [[package]]
 name = "miden-crypto"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40dbd2701d7a0dd2ee9bb429388c21145a83e3228144ed086dfc04d676b8bc3a"
+source = "git+https://github.com/0xPolygonMiden/crypto?branch=next#b06cfa3c035ada8122a405a72d2e4b2ad1a89b47"
 dependencies = [
  "blake3",
  "cc",
@@ -2755,8 +2754,8 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=0ac54125d5bd43160566736b2be3f5818fd84f69#0ac54125d5bd43160566736b2be3f5818fd84f69"
+version = "0.9.2"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=ddf536cd7157053f0940d7be41998b2a6546b4c1#ddf536cd7157053f0940d7be41998b2a6546b4c1"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2766,8 +2765,8 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib"
-version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=0ac54125d5bd43160566736b2be3f5818fd84f69#0ac54125d5bd43160566736b2be3f5818fd84f69"
+version = "0.9.2"
+source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=ddf536cd7157053f0940d7be41998b2a6546b4c1#ddf536cd7157053f0940d7be41998b2a6546b4c1"
 dependencies = [
  "miden-assembly",
 ]
@@ -5689,9 +5688,9 @@ dependencies = [
 
 [[package]]
 name = "winter-air"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07390d3217bdd6410c1ef43f3d06510d3a424e7259b371fccbc7cd79a9c00a15"
+checksum = "b72f12b88ebb060b52c0e9aece9bb64a9fc38daf7ba689dd5ce63271b456c883"
 dependencies = [
  "libm",
  "winter-crypto",
@@ -5702,9 +5701,9 @@ dependencies = [
 
 [[package]]
 name = "winter-crypto"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aea508aa819e934c837f24bb706e69d890b9be2db82da39cde887e6f0a37246"
+checksum = "00fbb724d2d9fbfd3aa16ea27f5e461d4fe1d74b0c9e0ed1bf79e9e2a955f4d5"
 dependencies = [
  "blake3",
  "sha3",
@@ -5714,9 +5713,9 @@ dependencies = [
 
 [[package]]
 name = "winter-fri"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660f47c5c9f5872940ac07a724b1df426590dcffad26776e0528466f2e3095f8"
+checksum = "3ab6077cf4c23c0411f591f4ba29378e27f26acb8cef3c51cadd93daaf6080b3"
 dependencies = [
  "winter-crypto",
  "winter-math",
@@ -5725,32 +5724,44 @@ dependencies = [
 
 [[package]]
 name = "winter-math"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c91111b368b08c5a76009514e9b6d26af41fbb28604ea77a249282323b64d5"
+checksum = "004f85bb051ce986ec0b9a2bd90aaf81b83e3c67464becfdf7db31f14c1019ba"
 dependencies = [
  "winter-utils",
 ]
 
 [[package]]
-name = "winter-prover"
-version = "0.8.3"
+name = "winter-maybe-async"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170c1ef487df609625580156ea0350c500aeabb3f429dc88cfe800c4b7893edf"
+checksum = "7ce0f4161cdde50de809b3869c1cb083a09e92e949428ea28f04c0d64045875c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "winter-prover"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17e3dbae97050f58e01ed4f12906e247841575a0518632e052941a1c37468df"
 dependencies = [
  "tracing",
  "winter-air",
  "winter-crypto",
  "winter-fri",
  "winter-math",
+ "winter-maybe-async",
  "winter-utils",
 ]
 
 [[package]]
 name = "winter-utils"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6efccf6efa6fd0a80784f3894bc372ada67cc30d9c017fc907d4c0cdce86e7"
+checksum = "0568612a95bcae3c94fb14da2686f8279ca77723dbdf1e97cf3673798faf6485"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,11 +64,11 @@ thiserror = { version = "1.0", git = "https://github.com/bitwalker/thiserror", b
 toml = { version = "0.5", features = ["preserve_order"] }
 derive_more = "0.99"
 indexmap = "2.1"
-# 0ac54125 is the latest commit in 'next' that includes the assembler refactoring
-miden-assembly = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "0ac54125d5bd43160566736b2be3f5818fd84f69" }
-miden-core = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "0ac54125d5bd43160566736b2be3f5818fd84f69" }
-miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "0ac54125d5bd43160566736b2be3f5818fd84f69" }
-miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "0ac54125d5bd43160566736b2be3f5818fd84f69" }
+# ddf536cd7157053f0940d7be41998b2a6546b4c1 is the latest commit in 'next' that includes the `if.true` empty blocks support
+miden-assembly = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "ddf536cd7157053f0940d7be41998b2a6546b4c1" }
+miden-core = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "ddf536cd7157053f0940d7be41998b2a6546b4c1" }
+miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "ddf536cd7157053f0940d7be41998b2a6546b4c1" }
+miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "ddf536cd7157053f0940d7be41998b2a6546b4c1" }
 midenc-codegen-masm = { path = "codegen/masm" }
 miden-diagnostics = "0.1"
 midenc-hir= { path = "hir" }

--- a/hir/src/asm/builder.rs
+++ b/hir/src/asm/builder.rs
@@ -2138,7 +2138,8 @@ fn apply_op_stack_effects(
         | MasmOp::DebugMemoryRange(..)
         | MasmOp::DebugFrame
         | MasmOp::DebugFrameAt(_)
-        | MasmOp::DebugFrameRange(..) => (),
+        | MasmOp::DebugFrameRange(..)
+        | MasmOp::Nop => (),
     }
 }
 

--- a/hir/src/asm/builder.rs
+++ b/hir/src/asm/builder.rs
@@ -1855,7 +1855,7 @@ fn apply_op_stack_effects(
             assert!(stack.len() >= 8, "expected at least 8 elements on the stack for mtree_merge");
             stack.dropw();
         }
-        MasmOp::MtreeVerify => {
+        MasmOp::MtreeVerify | MasmOp::MtreeVerifyWithError(_) => {
             assert!(
                 stack.len() >= 10,
                 "expected at least 10 elements on the stack for mtree_verify"
@@ -2076,7 +2076,13 @@ fn apply_op_stack_effects(
         | MasmOp::U32WrappingAddImm(_)
         | MasmOp::U32WrappingSubImm(_)
         | MasmOp::U32WrappingMulImm(_)
-        | MasmOp::U32Not => {
+        | MasmOp::U32Not
+        | MasmOp::U32LtImm(_)
+        | MasmOp::U32LteImm(_)
+        | MasmOp::U32GtImm(_)
+        | MasmOp::U32GteImm(_)
+        | MasmOp::U32MinImm(_)
+        | MasmOp::U32MaxImm(_) => {
             let ty = stack.pop().expect("operand stack is empty");
             assert_compatible_u32_operand!(ty, op);
             stack.push(ty);

--- a/hir/src/asm/isa.rs
+++ b/hir/src/asm/isa.rs
@@ -824,6 +824,8 @@ pub enum MasmOp {
     Emit(u32),
     /// Emit a trace event with the given code
     Trace(u32),
+    /// No operation
+    Nop,
 }
 
 macro_rules! unwrap_imm {
@@ -1099,7 +1101,8 @@ impl MasmOp {
             | Self::DebugFrame
             | Self::DebugFrameAt(_)
             | Self::DebugFrameRange(..)
-            | Self::Breakpoint => 0,
+            | Self::Breakpoint
+            | Self::Nop => 0,
         }
     }
 
@@ -1404,6 +1407,18 @@ impl MasmOp {
             Instruction::Debug(DebugOptions::LocalInterval(start, end)) => {
                 Self::DebugFrameRange(unwrap_u16!(start), unwrap_u16!(end))
             }
+            Instruction::Nop => Self::Nop,
+            Instruction::LtImm(imm) => Self::LtImm(unwrap_imm!(imm)),
+            Instruction::LteImm(imm) => Self::LteImm(unwrap_imm!(imm)),
+            Instruction::GtImm(imm) => Self::GtImm(unwrap_imm!(imm)),
+            Instruction::GteImm(imm) => Self::GteImm(unwrap_imm!(imm)),
+            Instruction::U32LtImm(_) => todo!(),
+            Instruction::U32LteImm(_) => todo!(),
+            Instruction::U32GtImm(_) => todo!(),
+            Instruction::U32GteImm(_) => todo!(),
+            Instruction::U32MinImm(_) => todo!(),
+            Instruction::U32MaxImm(_) => todo!(),
+            Instruction::MTreeVerifyWithError(_) => todo!(),
         };
         smallvec![op]
     }
@@ -1750,6 +1765,7 @@ impl MasmOp {
             }
             Self::Emit(ev) => Instruction::Emit(ev.into()),
             Self::Trace(ev) => Instruction::Trace(ev.into()),
+            Self::Nop => Instruction::Nop,
         };
         smallvec![inst]
     }
@@ -1924,6 +1940,7 @@ impl fmt::Display for MasmOp {
             }
             Self::Emit(_) => f.write_str("emit"),
             Self::Trace(_) => f.write_str("trace"),
+            Self::Nop => f.write_str("nop"),
         }
     }
 }

--- a/hir/src/asm/isa.rs
+++ b/hir/src/asm/isa.rs
@@ -385,6 +385,16 @@ pub enum MasmOp {
     /// [V, d, i, R] => [V, d, i, R]
     /// ```
     MtreeVerify,
+    /// Verifies that a Merkle tree with root `R` opens to node `V` at depth `d` and index `i`.
+    ///
+    /// The Merkle tree with root `R` must be present in the advice provider or the operation
+    /// fails.
+    ///
+    /// ```ignore
+    /// [V, d, i, R] => [V, d, i, R]
+    /// ```
+    /// Raise the given error code if the verification fails
+    MtreeVerifyWithError(u32),
     /// Performs FRI layer folding by a factor of 4 for FRI protocol executed in a degree 2
     /// extension of the base field. Additionally, performs several computations which simplify
     /// FRI verification procedure.
@@ -782,26 +792,38 @@ pub enum MasmOp {
     ///
     /// This operation is unchecked, so the result is undefined if the operands are not valid u32
     U32Lt,
+    /// Same as above, but `b` is provided by the immediate
+    U32LtImm(u32),
     /// Pops `b, a` from the stack, and places 1 on the stack if `a <= b`, else 0
     ///
     /// This operation is unchecked, so the result is undefined if the operands are not valid u32
     U32Lte,
+    /// Same as above, but `b` is provided by the immediate
+    U32LteImm(u32),
     /// Pops `b, a` from the stack, and places 1 on the stack if `a > b`, else 0
     ///
     /// This operation is unchecked, so the result is undefined if the operands are not valid u32
     U32Gt,
+    /// Same as above, but `b` is provided by the immediate
+    U32GtImm(u32),
     /// Pops `b, a` from the stack, and places 1 on the stack if `a >= b`, else 0
     ///
     /// This operation is unchecked, so the result is undefined if the operands are not valid u32
     U32Gte,
+    /// Same as above, but `b` is provided by the immediate
+    U32GteImm(u32),
     /// Pops `b, a` from the stack, and places `a` back on the stack if `a < b`, else `b`
     ///
     /// This operation is unchecked, so the result is undefined if the operands are not valid u32
     U32Min,
+    /// Same as above, but `b` is provided by the immediate
+    U32MinImm(u32),
     /// Pops `b, a` from the stack, and places `a` back on the stack if `a > b`, else `b`
     ///
     /// This operation is unchecked, so the result is undefined if the operands are not valid u32
     U32Max,
+    /// Same as above, but `b` is provided by the immediate
+    U32MaxImm(u32),
     /// Trigger a breakpoint when this instruction is reached
     Breakpoint,
     /// Print out the contents of the stack
@@ -1013,7 +1035,7 @@ impl MasmOp {
             Self::MtreeGet => 9,
             Self::MtreeSet => 29,
             Self::MtreeMerge => 16,
-            Self::MtreeVerify => 1,
+            Self::MtreeVerify | Self::MtreeVerifyWithError(_) => 1,
             // This hasn't been measured, just a random guess due to the complexity
             Self::FriExt2Fold4 | Self::RCombBase => 50,
             Self::Ext2add => 5,
@@ -1074,11 +1096,17 @@ impl MasmOp {
             Self::U32Clo => 36,
             Self::U32Cto => 33,
             Self::U32Lt => 3,
+            Self::U32LtImm(_) => 4,
             Self::U32Lte => 5,
+            Self::U32LteImm(_) => 6,
             Self::U32Gt => 4,
+            Self::U32GtImm(_) => 5,
             Self::U32Gte => 4,
+            Self::U32GteImm(_) => 5,
             Self::U32Min => 8,
+            Self::U32MinImm(_) => 9,
             Self::U32Max => 9,
+            Self::U32MaxImm(_) => 10,
             // These instructions do not modify the VM state, so we place set their cost at 0 for
             // now
             Self::Emit(_)
@@ -1151,9 +1179,13 @@ impl MasmOp {
             Instruction::NeqImm(imm) => Self::NeqImm(unwrap_imm!(imm)),
             Instruction::Eqw => Self::Eqw,
             Instruction::Lt => Self::Lt,
+            Instruction::LtImm(imm) => Self::LtImm(unwrap_imm!(imm)),
             Instruction::Lte => Self::Lte,
+            Instruction::LteImm(imm) => Self::LteImm(unwrap_imm!(imm)),
             Instruction::Gt => Self::Gt,
+            Instruction::GtImm(imm) => Self::GtImm(unwrap_imm!(imm)),
             Instruction::Gte => Self::Gte,
+            Instruction::GteImm(imm) => Self::GteImm(unwrap_imm!(imm)),
             Instruction::IsOdd => Self::IsOdd,
             Instruction::Hash => Self::Hash,
             Instruction::HMerge => Self::Hmerge,
@@ -1162,6 +1194,9 @@ impl MasmOp {
             Instruction::MTreeSet => Self::MtreeSet,
             Instruction::MTreeMerge => Self::MtreeMerge,
             Instruction::MTreeVerify => Self::MtreeVerify,
+            Instruction::MTreeVerifyWithError(code) => {
+                Self::MtreeVerifyWithError(unwrap_u32!(code))
+            }
             Instruction::Ext2Add => Self::Ext2add,
             Instruction::Ext2Sub => Self::Ext2sub,
             Instruction::Ext2Mul => Self::Ext2mul,
@@ -1220,11 +1255,17 @@ impl MasmOp {
             Instruction::U32Clo => Self::U32Clo,
             Instruction::U32Cto => Self::U32Cto,
             Instruction::U32Lt => Self::U32Lt,
+            Instruction::U32LtImm(imm) => Self::U32LtImm(unwrap_u32!(imm)),
             Instruction::U32Lte => Self::U32Lte,
+            Instruction::U32LteImm(imm) => Self::U32LteImm(unwrap_u32!(imm)),
             Instruction::U32Gt => Self::U32Gt,
+            Instruction::U32GtImm(imm) => Self::U32GtImm(unwrap_u32!(imm)),
             Instruction::U32Gte => Self::U32Gte,
+            Instruction::U32GteImm(imm) => Self::U32GteImm(unwrap_u32!(imm)),
             Instruction::U32Min => Self::U32Min,
+            Instruction::U32MinImm(imm) => Self::U32MinImm(unwrap_u32!(imm)),
             Instruction::U32Max => Self::U32Max,
+            Instruction::U32MaxImm(imm) => Self::U32MaxImm(unwrap_u32!(imm)),
             Instruction::Drop => Self::Drop,
             Instruction::DropW => Self::Dropw,
             Instruction::PadW => Self::Padw,
@@ -1408,17 +1449,6 @@ impl MasmOp {
                 Self::DebugFrameRange(unwrap_u16!(start), unwrap_u16!(end))
             }
             Instruction::Nop => Self::Nop,
-            Instruction::LtImm(imm) => Self::LtImm(unwrap_imm!(imm)),
-            Instruction::LteImm(imm) => Self::LteImm(unwrap_imm!(imm)),
-            Instruction::GtImm(imm) => Self::GtImm(unwrap_imm!(imm)),
-            Instruction::GteImm(imm) => Self::GteImm(unwrap_imm!(imm)),
-            Instruction::U32LtImm(_) => todo!(),
-            Instruction::U32LteImm(_) => todo!(),
-            Instruction::U32GtImm(_) => todo!(),
-            Instruction::U32GteImm(_) => todo!(),
-            Instruction::U32MinImm(_) => todo!(),
-            Instruction::U32MaxImm(_) => todo!(),
-            Instruction::MTreeVerifyWithError(_) => todo!(),
         };
         smallvec![op]
     }
@@ -1677,6 +1707,7 @@ impl MasmOp {
             Self::MtreeSet => Instruction::MTreeSet,
             Self::MtreeMerge => Instruction::MTreeMerge,
             Self::MtreeVerify => Instruction::MTreeVerify,
+            Self::MtreeVerifyWithError(code) => Instruction::MTreeVerifyWithError(code.into()),
             Self::FriExt2Fold4 => Instruction::FriExt2Fold4,
             Self::RCombBase => Instruction::RCombBase,
             Self::U32Test => Instruction::U32Test,
@@ -1741,11 +1772,17 @@ impl MasmOp {
             Self::U32Clo => Instruction::U32Clo,
             Self::U32Cto => Instruction::U32Cto,
             Self::U32Lt => Instruction::U32Lt,
+            Self::U32LtImm(imm) => Instruction::U32LtImm(imm.into()),
             Self::U32Lte => Instruction::U32Lte,
+            Self::U32LteImm(imm) => Instruction::U32LteImm(imm.into()),
             Self::U32Gt => Instruction::U32Gt,
+            Self::U32GtImm(imm) => Instruction::U32GtImm(imm.into()),
             Self::U32Gte => Instruction::U32Gte,
+            Self::U32GteImm(imm) => Instruction::U32GteImm(imm.into()),
             Self::U32Min => Instruction::U32Min,
+            Self::U32MinImm(imm) => Instruction::U32MinImm(imm.into()),
             Self::U32Max => Instruction::U32Max,
+            Self::U32MaxImm(imm) => Instruction::U32MaxImm(imm.into()),
             Self::Breakpoint => Instruction::Breakpoint,
             Self::DebugStack => Instruction::Debug(DebugOptions::StackAll),
             Self::DebugStackN(n) => Instruction::Debug(DebugOptions::StackTop(n.into())),
@@ -1880,6 +1917,7 @@ impl fmt::Display for MasmOp {
             Self::MtreeSet => f.write_str("mtree_set"),
             Self::MtreeMerge => f.write_str("mtree_merge"),
             Self::MtreeVerify => f.write_str("mtree_verify"),
+            Self::MtreeVerifyWithError(code) => write!(f, "mtree_verify.err={code}"),
             Self::FriExt2Fold4 => f.write_str("fri_ext2fold4"),
             Self::RCombBase => f.write_str("rcomb_base"),
             Self::U32Test => f.write_str("u32test"),
@@ -1924,12 +1962,12 @@ impl fmt::Display for MasmOp {
             Self::U32Ctz => f.write_str("u32ctz"),
             Self::U32Clo => f.write_str("u32clo"),
             Self::U32Cto => f.write_str("u32cto"),
-            Self::U32Lt => f.write_str("u32lt"),
-            Self::U32Lte => f.write_str("u32lte"),
-            Self::U32Gt => f.write_str("u32gt"),
-            Self::U32Gte => f.write_str("u32gte"),
-            Self::U32Min => f.write_str("u32min"),
-            Self::U32Max => f.write_str("u32max"),
+            Self::U32Lt | Self::U32LtImm(_) => f.write_str("u32lt"),
+            Self::U32Lte | Self::U32LteImm(_) => f.write_str("u32lte"),
+            Self::U32Gt | Self::U32GtImm(_) => f.write_str("u32gt"),
+            Self::U32Gte | Self::U32GteImm(_) => f.write_str("u32gte"),
+            Self::U32Min | Self::U32MinImm(_) => f.write_str("u32min"),
+            Self::U32Max | Self::U32MaxImm(_) => f.write_str("u32max"),
             Self::Breakpoint => f.write_str("breakpoint"),
             Self::DebugStack | Self::DebugStackN(_) => f.write_str("debug.stack"),
             Self::DebugMemory | Self::DebugMemoryAt(_) | Self::DebugMemoryRange(..) => {

--- a/tests/integration/src/compiler_test.rs
+++ b/tests/integration/src/compiler_test.rs
@@ -609,7 +609,7 @@ fn masm_prog_from_modules(
     }
     if let Some(entrypoint) = entrypoint {
         let prog_source = masm_prog_source(user_ns_name, entrypoint);
-        assembler.assemble(prog_source)
+        assembler.assemble_program(prog_source)
     } else {
         todo!()
     }


### PR DESCRIPTION
**This PR is stacked on the #210 and should be merged after it**

This PR updates Miden VM crates to include empty `if.true` support introduced in 
https://github.com/0xPolygonMiden/miden-vm/pull/1360