### PR TITLE
[2/x] `CompilerTest` stubs generation for imported functions in MASM program

### DIFF
--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.hir
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.hir
@@ -1,6 +1,6 @@
 (component 
     ;; Modules
-    (module #abi_transform_tx_kernel_get_inputs
+    (module #abi_transform_tx_kernel_get_inputs_4
         ;; Constants
         (const (id 0) 0x00100000)
 

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
@@ -1,4 +1,16 @@
-# mod user_ns::abi_transform_tx_kernel_get_inputs
+# mod miden::note
+
+export.get_inputs
+    push.4294967295
+    push.1
+    push.0
+    push.4294967295
+    dup.4
+    mem_storew
+    push.4
+    end
+
+# mod user_ns::abi_transform_tx_kernel_get_inputs_4
 
 use.miden::note
 
@@ -3090,8 +3102,8 @@ export."alloc::raw_vec::capacity_overflow"
 end
 
 
-use.user_ns::abi_transform_tx_kernel_get_inputs
+use.user_ns::abi_transform_tx_kernel_get_inputs_4
 
 begin
-    exec.abi_transform_tx_kernel_get_inputs::entrypoint  
+    exec.abi_transform_tx_kernel_get_inputs_4::entrypoint  
 end

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.wat
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.wat
@@ -1,4 +1,4 @@
-(module $abi_transform_tx_kernel_get_inputs.wasm
+(module $abi_transform_tx_kernel_get_inputs_4.wasm
   (type (;0;) (func (param i32) (result i32)))
   (type (;1;) (func (param i32)))
   (type (;2;) (func (param i32 i32) (result i32)))


### PR DESCRIPTION
Close #223 

**This PR is stacked on the #222 and should be merged after it**