### PR TITLE
[3/x] Remove synthetic MASM namespace workaround for the module compiled from Rust

### DIFF
--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
@@ -10,7 +10,7 @@ export.get_inputs
     push.4
     end
 
-# mod user_ns::abi_transform_tx_kernel_get_inputs_4
+# mod abi_transform_tx_kernel_get_inputs_4
 
 use.miden::note
 
@@ -3102,8 +3102,6 @@ export."alloc::raw_vec::capacity_overflow"
 end
 
 
-use.user_ns::abi_transform_tx_kernel_get_inputs_4
-
 begin
-    exec.abi_transform_tx_kernel_get_inputs_4::entrypoint  
+    exec.::abi_transform_tx_kernel_get_inputs_4::entrypoint  
 end

--- a/tests/integration/expected/add_felt.masm
+++ b/tests/integration/expected/add_felt.masm
@@ -1,12 +1,10 @@
-# mod user_ns::add_felt
+# mod add_felt
 
 export.entrypoint
     swap.1 add
 end
 
 
-use.user_ns::add_felt
-
 begin
-    exec.add_felt::entrypoint  
+    exec.::add_felt::entrypoint  
 end

--- a/tests/integration/expected/add_i16.masm
+++ b/tests/integration/expected/add_i16.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_bbf5fdc0851222e92e718cc0af28212663b61bc643024537b3041e4528ea338c
+# mod test_rust_bbf5fdc0851222e92e718cc0af28212663b61bc643024537b3041e4528ea338c
 
 export.entrypoint
     u32wrapping_add
 end
 
 
-use.user_ns::test_rust_bbf5fdc0851222e92e718cc0af28212663b61bc643024537b3041e4528ea338c
-
 begin
-    exec.test_rust_bbf5fdc0851222e92e718cc0af28212663b61bc643024537b3041e4528ea338c::entrypoint  
+    exec.::test_rust_bbf5fdc0851222e92e718cc0af28212663b61bc643024537b3041e4528ea338c::entrypoint  
 end

--- a/tests/integration/expected/add_i32.masm
+++ b/tests/integration/expected/add_i32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_2e60443dc47eecaf44c0755d01375597814229ddd052f66a9a8f52569d4bee8b
+# mod test_rust_2e60443dc47eecaf44c0755d01375597814229ddd052f66a9a8f52569d4bee8b
 
 export.entrypoint
     u32wrapping_add
 end
 
 
-use.user_ns::test_rust_2e60443dc47eecaf44c0755d01375597814229ddd052f66a9a8f52569d4bee8b
-
 begin
-    exec.test_rust_2e60443dc47eecaf44c0755d01375597814229ddd052f66a9a8f52569d4bee8b::entrypoint  
+    exec.::test_rust_2e60443dc47eecaf44c0755d01375597814229ddd052f66a9a8f52569d4bee8b::entrypoint  
 end

--- a/tests/integration/expected/add_i8.masm
+++ b/tests/integration/expected/add_i8.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_aa4e8ec18774f7791634833f5a14b633e4c1a7d4ec8ae07ec95668a9f3fb05d6
+# mod test_rust_aa4e8ec18774f7791634833f5a14b633e4c1a7d4ec8ae07ec95668a9f3fb05d6
 
 export.entrypoint
     u32wrapping_add
 end
 
 
-use.user_ns::test_rust_aa4e8ec18774f7791634833f5a14b633e4c1a7d4ec8ae07ec95668a9f3fb05d6
-
 begin
-    exec.test_rust_aa4e8ec18774f7791634833f5a14b633e4c1a7d4ec8ae07ec95668a9f3fb05d6::entrypoint  
+    exec.::test_rust_aa4e8ec18774f7791634833f5a14b633e4c1a7d4ec8ae07ec95668a9f3fb05d6::entrypoint  
 end

--- a/tests/integration/expected/add_u16.masm
+++ b/tests/integration/expected/add_u16.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_10c9fc505476d6021538a9abdcf2c4d73bd1d8cc42c25993867649bb63b4319d
+# mod test_rust_10c9fc505476d6021538a9abdcf2c4d73bd1d8cc42c25993867649bb63b4319d
 
 export.entrypoint
     u32wrapping_add push.65535 u32and
 end
 
 
-use.user_ns::test_rust_10c9fc505476d6021538a9abdcf2c4d73bd1d8cc42c25993867649bb63b4319d
-
 begin
-    exec.test_rust_10c9fc505476d6021538a9abdcf2c4d73bd1d8cc42c25993867649bb63b4319d::entrypoint  
+    exec.::test_rust_10c9fc505476d6021538a9abdcf2c4d73bd1d8cc42c25993867649bb63b4319d::entrypoint  
 end

--- a/tests/integration/expected/add_u32.masm
+++ b/tests/integration/expected/add_u32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_d6a5f6b2fb9509a2986e40a5ab057ae035f5eeb6fb66c1c0bd59648ee4c31a35
+# mod test_rust_d6a5f6b2fb9509a2986e40a5ab057ae035f5eeb6fb66c1c0bd59648ee4c31a35
 
 export.entrypoint
     u32wrapping_add
 end
 
 
-use.user_ns::test_rust_d6a5f6b2fb9509a2986e40a5ab057ae035f5eeb6fb66c1c0bd59648ee4c31a35
-
 begin
-    exec.test_rust_d6a5f6b2fb9509a2986e40a5ab057ae035f5eeb6fb66c1c0bd59648ee4c31a35::entrypoint  
+    exec.::test_rust_d6a5f6b2fb9509a2986e40a5ab057ae035f5eeb6fb66c1c0bd59648ee4c31a35::entrypoint  
 end

--- a/tests/integration/expected/add_u8.masm
+++ b/tests/integration/expected/add_u8.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_4a87475b2f9d8d15ad35a776ff173dc1470f87cacd0a8312306b9896bb828aa3
+# mod test_rust_4a87475b2f9d8d15ad35a776ff173dc1470f87cacd0a8312306b9896bb828aa3
 
 export.entrypoint
     u32wrapping_add push.255 u32and
 end
 
 
-use.user_ns::test_rust_4a87475b2f9d8d15ad35a776ff173dc1470f87cacd0a8312306b9896bb828aa3
-
 begin
-    exec.test_rust_4a87475b2f9d8d15ad35a776ff173dc1470f87cacd0a8312306b9896bb828aa3::entrypoint  
+    exec.::test_rust_4a87475b2f9d8d15ad35a776ff173dc1470f87cacd0a8312306b9896bb828aa3::entrypoint  
 end

--- a/tests/integration/expected/and_bool.masm
+++ b/tests/integration/expected/and_bool.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_4ac99d1101f79650c02e85b18d774a8cfc696b791a33e4cbd07338faa6df2814
+# mod test_rust_4ac99d1101f79650c02e85b18d774a8cfc696b791a33e4cbd07338faa6df2814
 
 export.entrypoint
     swap.1 u32and
 end
 
 
-use.user_ns::test_rust_4ac99d1101f79650c02e85b18d774a8cfc696b791a33e4cbd07338faa6df2814
-
 begin
-    exec.test_rust_4ac99d1101f79650c02e85b18d774a8cfc696b791a33e4cbd07338faa6df2814::entrypoint  
+    exec.::test_rust_4ac99d1101f79650c02e85b18d774a8cfc696b791a33e4cbd07338faa6df2814::entrypoint  
 end

--- a/tests/integration/expected/and_i16.masm
+++ b/tests/integration/expected/and_i16.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_c7e9cce9483c4fd7983b386cae179d4a54022802e0d6b932bccd80235b921c40
+# mod test_rust_c7e9cce9483c4fd7983b386cae179d4a54022802e0d6b932bccd80235b921c40
 
 export.entrypoint
     u32and
 end
 
 
-use.user_ns::test_rust_c7e9cce9483c4fd7983b386cae179d4a54022802e0d6b932bccd80235b921c40
-
 begin
-    exec.test_rust_c7e9cce9483c4fd7983b386cae179d4a54022802e0d6b932bccd80235b921c40::entrypoint  
+    exec.::test_rust_c7e9cce9483c4fd7983b386cae179d4a54022802e0d6b932bccd80235b921c40::entrypoint  
 end

--- a/tests/integration/expected/and_i32.masm
+++ b/tests/integration/expected/and_i32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_8391b0d837d3b65b33c6b68ea552987952048935f4c45fadd58b81ea8ba141d9
+# mod test_rust_8391b0d837d3b65b33c6b68ea552987952048935f4c45fadd58b81ea8ba141d9
 
 export.entrypoint
     u32and
 end
 
 
-use.user_ns::test_rust_8391b0d837d3b65b33c6b68ea552987952048935f4c45fadd58b81ea8ba141d9
-
 begin
-    exec.test_rust_8391b0d837d3b65b33c6b68ea552987952048935f4c45fadd58b81ea8ba141d9::entrypoint  
+    exec.::test_rust_8391b0d837d3b65b33c6b68ea552987952048935f4c45fadd58b81ea8ba141d9::entrypoint  
 end

--- a/tests/integration/expected/and_i8.masm
+++ b/tests/integration/expected/and_i8.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_645dc02b90fa56981e2f5305f2d8f5067bb8cdc2eb91b610298ef135bd758d31
+# mod test_rust_645dc02b90fa56981e2f5305f2d8f5067bb8cdc2eb91b610298ef135bd758d31
 
 export.entrypoint
     u32and
 end
 
 
-use.user_ns::test_rust_645dc02b90fa56981e2f5305f2d8f5067bb8cdc2eb91b610298ef135bd758d31
-
 begin
-    exec.test_rust_645dc02b90fa56981e2f5305f2d8f5067bb8cdc2eb91b610298ef135bd758d31::entrypoint  
+    exec.::test_rust_645dc02b90fa56981e2f5305f2d8f5067bb8cdc2eb91b610298ef135bd758d31::entrypoint  
 end

--- a/tests/integration/expected/and_u16.masm
+++ b/tests/integration/expected/and_u16.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_552e799f48de5fcc388eaa5128c9842db9a9500f75f852887a429dbe8c67d810
+# mod test_rust_552e799f48de5fcc388eaa5128c9842db9a9500f75f852887a429dbe8c67d810
 
 export.entrypoint
     u32and
 end
 
 
-use.user_ns::test_rust_552e799f48de5fcc388eaa5128c9842db9a9500f75f852887a429dbe8c67d810
-
 begin
-    exec.test_rust_552e799f48de5fcc388eaa5128c9842db9a9500f75f852887a429dbe8c67d810::entrypoint  
+    exec.::test_rust_552e799f48de5fcc388eaa5128c9842db9a9500f75f852887a429dbe8c67d810::entrypoint  
 end

--- a/tests/integration/expected/and_u32.masm
+++ b/tests/integration/expected/and_u32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_03ecb06cdac4759a31c320b67e5a88995c8e5b0260bc540636a10106839a7c13
+# mod test_rust_03ecb06cdac4759a31c320b67e5a88995c8e5b0260bc540636a10106839a7c13
 
 export.entrypoint
     u32and
 end
 
 
-use.user_ns::test_rust_03ecb06cdac4759a31c320b67e5a88995c8e5b0260bc540636a10106839a7c13
-
 begin
-    exec.test_rust_03ecb06cdac4759a31c320b67e5a88995c8e5b0260bc540636a10106839a7c13::entrypoint  
+    exec.::test_rust_03ecb06cdac4759a31c320b67e5a88995c8e5b0260bc540636a10106839a7c13::entrypoint  
 end

--- a/tests/integration/expected/and_u8.masm
+++ b/tests/integration/expected/and_u8.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_dc5c0d94136b471b7115e3df5c99cd5b9ebfb25f4c88e0039211a30936a42650
+# mod test_rust_dc5c0d94136b471b7115e3df5c99cd5b9ebfb25f4c88e0039211a30936a42650
 
 export.entrypoint
     u32and
 end
 
 
-use.user_ns::test_rust_dc5c0d94136b471b7115e3df5c99cd5b9ebfb25f4c88e0039211a30936a42650
-
 begin
-    exec.test_rust_dc5c0d94136b471b7115e3df5c99cd5b9ebfb25f4c88e0039211a30936a42650::entrypoint  
+    exec.::test_rust_dc5c0d94136b471b7115e3df5c99cd5b9ebfb25f4c88e0039211a30936a42650::entrypoint  
 end

--- a/tests/integration/expected/div_felt.masm
+++ b/tests/integration/expected/div_felt.masm
@@ -1,12 +1,10 @@
-# mod user_ns::div_felt
+# mod div_felt
 
 export.entrypoint
     swap.1 div
 end
 
 
-use.user_ns::div_felt
-
 begin
-    exec.div_felt::entrypoint  
+    exec.::div_felt::entrypoint  
 end

--- a/tests/integration/expected/eq_felt.masm
+++ b/tests/integration/expected/eq_felt.masm
@@ -1,12 +1,10 @@
-# mod user_ns::eq_felt
+# mod eq_felt
 
 export.entrypoint
     swap.1 eq push.1 eq
 end
 
 
-use.user_ns::eq_felt
-
 begin
-    exec.eq_felt::entrypoint  
+    exec.::eq_felt::entrypoint  
 end

--- a/tests/integration/expected/eq_i16.masm
+++ b/tests/integration/expected/eq_i16.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_d3eecc0932c0745000688bf699bae5c588052144cdbc0bc7c4ab37c3cc14cd7b
+# mod test_rust_d3eecc0932c0745000688bf699bae5c588052144cdbc0bc7c4ab37c3cc14cd7b
 
 export.entrypoint
     swap.1 eq
 end
 
 
-use.user_ns::test_rust_d3eecc0932c0745000688bf699bae5c588052144cdbc0bc7c4ab37c3cc14cd7b
-
 begin
-    exec.test_rust_d3eecc0932c0745000688bf699bae5c588052144cdbc0bc7c4ab37c3cc14cd7b::entrypoint  
+    exec.::test_rust_d3eecc0932c0745000688bf699bae5c588052144cdbc0bc7c4ab37c3cc14cd7b::entrypoint  
 end

--- a/tests/integration/expected/eq_i32.masm
+++ b/tests/integration/expected/eq_i32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_535f5a5a2d649df390220a07008a31a5226ad26f1cf27c7849e47c754842ec03
+# mod test_rust_535f5a5a2d649df390220a07008a31a5226ad26f1cf27c7849e47c754842ec03
 
 export.entrypoint
     swap.1 eq
 end
 
 
-use.user_ns::test_rust_535f5a5a2d649df390220a07008a31a5226ad26f1cf27c7849e47c754842ec03
-
 begin
-    exec.test_rust_535f5a5a2d649df390220a07008a31a5226ad26f1cf27c7849e47c754842ec03::entrypoint  
+    exec.::test_rust_535f5a5a2d649df390220a07008a31a5226ad26f1cf27c7849e47c754842ec03::entrypoint  
 end

--- a/tests/integration/expected/eq_i64.masm
+++ b/tests/integration/expected/eq_i64.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_c0b1348123b7005d1a5f70ddc2c38a3fc27e908c3656adebf0eae90cdbc8959d
+# mod test_rust_c0b1348123b7005d1a5f70ddc2c38a3fc27e908c3656adebf0eae90cdbc8959d
 
 export.entrypoint
     movdn.3
@@ -11,8 +11,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_c0b1348123b7005d1a5f70ddc2c38a3fc27e908c3656adebf0eae90cdbc8959d
-
 begin
-    exec.test_rust_c0b1348123b7005d1a5f70ddc2c38a3fc27e908c3656adebf0eae90cdbc8959d::entrypoint  
+    exec.::test_rust_c0b1348123b7005d1a5f70ddc2c38a3fc27e908c3656adebf0eae90cdbc8959d::entrypoint  
 end

--- a/tests/integration/expected/eq_i8.masm
+++ b/tests/integration/expected/eq_i8.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_58aae86db503f25d519c45a178d348c9fa62ad89779c3a7beb32041962ccbd8a
+# mod test_rust_58aae86db503f25d519c45a178d348c9fa62ad89779c3a7beb32041962ccbd8a
 
 export.entrypoint
     swap.1 eq
 end
 
 
-use.user_ns::test_rust_58aae86db503f25d519c45a178d348c9fa62ad89779c3a7beb32041962ccbd8a
-
 begin
-    exec.test_rust_58aae86db503f25d519c45a178d348c9fa62ad89779c3a7beb32041962ccbd8a::entrypoint  
+    exec.::test_rust_58aae86db503f25d519c45a178d348c9fa62ad89779c3a7beb32041962ccbd8a::entrypoint  
 end

--- a/tests/integration/expected/eq_u16.masm
+++ b/tests/integration/expected/eq_u16.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_bf5c0ccc66e1188e428efe75b85c06065d267030df6b1c191b2ee935ea27795d
+# mod test_rust_bf5c0ccc66e1188e428efe75b85c06065d267030df6b1c191b2ee935ea27795d
 
 export.entrypoint
     swap.1 eq
 end
 
 
-use.user_ns::test_rust_bf5c0ccc66e1188e428efe75b85c06065d267030df6b1c191b2ee935ea27795d
-
 begin
-    exec.test_rust_bf5c0ccc66e1188e428efe75b85c06065d267030df6b1c191b2ee935ea27795d::entrypoint  
+    exec.::test_rust_bf5c0ccc66e1188e428efe75b85c06065d267030df6b1c191b2ee935ea27795d::entrypoint  
 end

--- a/tests/integration/expected/eq_u32.masm
+++ b/tests/integration/expected/eq_u32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_8fb01b80f31505a22343d7c26e3474f1160b5bf9f9048fa61561f108ac0be95e
+# mod test_rust_8fb01b80f31505a22343d7c26e3474f1160b5bf9f9048fa61561f108ac0be95e
 
 export.entrypoint
     swap.1 eq
 end
 
 
-use.user_ns::test_rust_8fb01b80f31505a22343d7c26e3474f1160b5bf9f9048fa61561f108ac0be95e
-
 begin
-    exec.test_rust_8fb01b80f31505a22343d7c26e3474f1160b5bf9f9048fa61561f108ac0be95e::entrypoint  
+    exec.::test_rust_8fb01b80f31505a22343d7c26e3474f1160b5bf9f9048fa61561f108ac0be95e::entrypoint  
 end

--- a/tests/integration/expected/eq_u64.masm
+++ b/tests/integration/expected/eq_u64.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_23a27398cbfb7447cb610e7b877565f4e43d633b55f98504051b93381d40740f
+# mod test_rust_23a27398cbfb7447cb610e7b877565f4e43d633b55f98504051b93381d40740f
 
 export.entrypoint
     movdn.3
@@ -11,8 +11,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_23a27398cbfb7447cb610e7b877565f4e43d633b55f98504051b93381d40740f
-
 begin
-    exec.test_rust_23a27398cbfb7447cb610e7b877565f4e43d633b55f98504051b93381d40740f::entrypoint  
+    exec.::test_rust_23a27398cbfb7447cb610e7b877565f4e43d633b55f98504051b93381d40740f::entrypoint  
 end

--- a/tests/integration/expected/eq_u8.masm
+++ b/tests/integration/expected/eq_u8.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_016edfcf5844ac44aa96bfe0cfac241307bf2ff2adbb955edec051f22a2332a9
+# mod test_rust_016edfcf5844ac44aa96bfe0cfac241307bf2ff2adbb955edec051f22a2332a9
 
 export.entrypoint
     swap.1 eq
 end
 
 
-use.user_ns::test_rust_016edfcf5844ac44aa96bfe0cfac241307bf2ff2adbb955edec051f22a2332a9
-
 begin
-    exec.test_rust_016edfcf5844ac44aa96bfe0cfac241307bf2ff2adbb955edec051f22a2332a9::entrypoint  
+    exec.::test_rust_016edfcf5844ac44aa96bfe0cfac241307bf2ff2adbb955edec051f22a2332a9::entrypoint  
 end

--- a/tests/integration/expected/fib.masm
+++ b/tests/integration/expected/fib.masm
@@ -1,4 +1,4 @@
-# mod user_ns::miden_integration_tests_rust_fib_wasm
+# mod miden_integration_tests_rust_fib_wasm
 
 export.fib
     push.0
@@ -31,8 +31,6 @@ export.fib
 end
 
 
-use.user_ns::miden_integration_tests_rust_fib_wasm
-
 begin
-    exec.miden_integration_tests_rust_fib_wasm::fib  
+    exec.::miden_integration_tests_rust_fib_wasm::fib  
 end

--- a/tests/integration/expected/ge_felt.masm
+++ b/tests/integration/expected/ge_felt.masm
@@ -1,12 +1,10 @@
-# mod user_ns::ge_felt
+# mod ge_felt
 
 export.entrypoint
     swap.1 gte push.0 neq
 end
 
 
-use.user_ns::ge_felt
-
 begin
-    exec.ge_felt::entrypoint  
+    exec.::ge_felt::entrypoint  
 end

--- a/tests/integration/expected/ge_u16.masm
+++ b/tests/integration/expected/ge_u16.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_76b95aeb59987e43311d2fb22a7021b58c09a51fe7457153d1a9986095f5038e
+# mod test_rust_76b95aeb59987e43311d2fb22a7021b58c09a51fe7457153d1a9986095f5038e
 
 export.entrypoint
     dup.0
@@ -16,8 +16,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_76b95aeb59987e43311d2fb22a7021b58c09a51fe7457153d1a9986095f5038e
-
 begin
-    exec.test_rust_76b95aeb59987e43311d2fb22a7021b58c09a51fe7457153d1a9986095f5038e::entrypoint  
+    exec.::test_rust_76b95aeb59987e43311d2fb22a7021b58c09a51fe7457153d1a9986095f5038e::entrypoint  
 end

--- a/tests/integration/expected/ge_u8.masm
+++ b/tests/integration/expected/ge_u8.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_54b0c7ea89a992ede15df4270d53ad3910db016fdef9484347e14e8583439818
+# mod test_rust_54b0c7ea89a992ede15df4270d53ad3910db016fdef9484347e14e8583439818
 
 export.entrypoint
     dup.0
@@ -16,8 +16,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_54b0c7ea89a992ede15df4270d53ad3910db016fdef9484347e14e8583439818
-
 begin
-    exec.test_rust_54b0c7ea89a992ede15df4270d53ad3910db016fdef9484347e14e8583439818::entrypoint  
+    exec.::test_rust_54b0c7ea89a992ede15df4270d53ad3910db016fdef9484347e14e8583439818::entrypoint  
 end

--- a/tests/integration/expected/gt_felt.masm
+++ b/tests/integration/expected/gt_felt.masm
@@ -1,12 +1,10 @@
-# mod user_ns::gt_felt
+# mod gt_felt
 
 export.entrypoint
     swap.1 gt push.0 neq
 end
 
 
-use.user_ns::gt_felt
-
 begin
-    exec.gt_felt::entrypoint  
+    exec.::gt_felt::entrypoint  
 end

--- a/tests/integration/expected/gt_u16.masm
+++ b/tests/integration/expected/gt_u16.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_1f3e71115fc0280c196e968bdc849a389f4cde61e22ba8a528fd4008c3dda439
+# mod test_rust_1f3e71115fc0280c196e968bdc849a389f4cde61e22ba8a528fd4008c3dda439
 
 export.entrypoint
     dup.0
@@ -16,8 +16,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_1f3e71115fc0280c196e968bdc849a389f4cde61e22ba8a528fd4008c3dda439
-
 begin
-    exec.test_rust_1f3e71115fc0280c196e968bdc849a389f4cde61e22ba8a528fd4008c3dda439::entrypoint  
+    exec.::test_rust_1f3e71115fc0280c196e968bdc849a389f4cde61e22ba8a528fd4008c3dda439::entrypoint  
 end

--- a/tests/integration/expected/gt_u8.masm
+++ b/tests/integration/expected/gt_u8.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_9ff23d66c653e992b6e1b92ca070ee51c8fb198f18a46cf1f931db5256d81673
+# mod test_rust_9ff23d66c653e992b6e1b92ca070ee51c8fb198f18a46cf1f931db5256d81673
 
 export.entrypoint
     dup.0
@@ -16,8 +16,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_9ff23d66c653e992b6e1b92ca070ee51c8fb198f18a46cf1f931db5256d81673
-
 begin
-    exec.test_rust_9ff23d66c653e992b6e1b92ca070ee51c8fb198f18a46cf1f931db5256d81673::entrypoint  
+    exec.::test_rust_9ff23d66c653e992b6e1b92ca070ee51c8fb198f18a46cf1f931db5256d81673::entrypoint  
 end

--- a/tests/integration/expected/le_felt.masm
+++ b/tests/integration/expected/le_felt.masm
@@ -1,12 +1,10 @@
-# mod user_ns::le_felt
+# mod le_felt
 
 export.entrypoint
     lte push.0 neq
 end
 
 
-use.user_ns::le_felt
-
 begin
-    exec.le_felt::entrypoint  
+    exec.::le_felt::entrypoint  
 end

--- a/tests/integration/expected/le_u16.masm
+++ b/tests/integration/expected/le_u16.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_ff0a06076c996bca51493fe83ecb25fcda9ae22252704c128b49117365264974
+# mod test_rust_ff0a06076c996bca51493fe83ecb25fcda9ae22252704c128b49117365264974
 
 export.entrypoint
     dup.0
@@ -16,8 +16,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_ff0a06076c996bca51493fe83ecb25fcda9ae22252704c128b49117365264974
-
 begin
-    exec.test_rust_ff0a06076c996bca51493fe83ecb25fcda9ae22252704c128b49117365264974::entrypoint  
+    exec.::test_rust_ff0a06076c996bca51493fe83ecb25fcda9ae22252704c128b49117365264974::entrypoint  
 end

--- a/tests/integration/expected/le_u8.masm
+++ b/tests/integration/expected/le_u8.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_90833d097291d3eaef34c669d42686006454d4265170e39f4f3da9191cdf4b91
+# mod test_rust_90833d097291d3eaef34c669d42686006454d4265170e39f4f3da9191cdf4b91
 
 export.entrypoint
     dup.0
@@ -16,8 +16,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_90833d097291d3eaef34c669d42686006454d4265170e39f4f3da9191cdf4b91
-
 begin
-    exec.test_rust_90833d097291d3eaef34c669d42686006454d4265170e39f4f3da9191cdf4b91::entrypoint  
+    exec.::test_rust_90833d097291d3eaef34c669d42686006454d4265170e39f4f3da9191cdf4b91::entrypoint  
 end

--- a/tests/integration/expected/lt_felt.masm
+++ b/tests/integration/expected/lt_felt.masm
@@ -1,12 +1,10 @@
-# mod user_ns::lt_felt
+# mod lt_felt
 
 export.entrypoint
     lt push.0 neq
 end
 
 
-use.user_ns::lt_felt
-
 begin
-    exec.lt_felt::entrypoint  
+    exec.::lt_felt::entrypoint  
 end

--- a/tests/integration/expected/lt_u16.masm
+++ b/tests/integration/expected/lt_u16.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_5c07628ec4d9ea05c0cb5402aea23aecccfbd786cb513f138b2395cb26c88212
+# mod test_rust_5c07628ec4d9ea05c0cb5402aea23aecccfbd786cb513f138b2395cb26c88212
 
 export.entrypoint
     dup.0
@@ -16,8 +16,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_5c07628ec4d9ea05c0cb5402aea23aecccfbd786cb513f138b2395cb26c88212
-
 begin
-    exec.test_rust_5c07628ec4d9ea05c0cb5402aea23aecccfbd786cb513f138b2395cb26c88212::entrypoint  
+    exec.::test_rust_5c07628ec4d9ea05c0cb5402aea23aecccfbd786cb513f138b2395cb26c88212::entrypoint  
 end

--- a/tests/integration/expected/lt_u8.masm
+++ b/tests/integration/expected/lt_u8.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_3af3eb760fd15a611df682ed67144a5abe767c638e3c0c928720d59e06e5a5ee
+# mod test_rust_3af3eb760fd15a611df682ed67144a5abe767c638e3c0c928720d59e06e5a5ee
 
 export.entrypoint
     dup.0
@@ -16,8 +16,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_3af3eb760fd15a611df682ed67144a5abe767c638e3c0c928720d59e06e5a5ee
-
 begin
-    exec.test_rust_3af3eb760fd15a611df682ed67144a5abe767c638e3c0c928720d59e06e5a5ee::entrypoint  
+    exec.::test_rust_3af3eb760fd15a611df682ed67144a5abe767c638e3c0c928720d59e06e5a5ee::entrypoint  
 end

--- a/tests/integration/expected/mul_felt.masm
+++ b/tests/integration/expected/mul_felt.masm
@@ -1,12 +1,10 @@
-# mod user_ns::mul_felt
+# mod mul_felt
 
 export.entrypoint
     swap.1 mul
 end
 
 
-use.user_ns::mul_felt
-
 begin
-    exec.mul_felt::entrypoint  
+    exec.::mul_felt::entrypoint  
 end

--- a/tests/integration/expected/neg_felt.masm
+++ b/tests/integration/expected/neg_felt.masm
@@ -1,12 +1,10 @@
-# mod user_ns::neg_felt
+# mod neg_felt
 
 export.entrypoint
     swap.1 sub
 end
 
 
-use.user_ns::neg_felt
-
 begin
-    exec.neg_felt::entrypoint  
+    exec.::neg_felt::entrypoint  
 end

--- a/tests/integration/expected/neg_i16.masm
+++ b/tests/integration/expected/neg_i16.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_8885ff83d4718aec39ee91baf1b6d9155897ac6940d8acb4ee8af80ac24d7630
+# mod test_rust_8885ff83d4718aec39ee91baf1b6d9155897ac6940d8acb4ee8af80ac24d7630
 
 export.entrypoint
     push.0 swap.1 u32wrapping_sub
 end
 
 
-use.user_ns::test_rust_8885ff83d4718aec39ee91baf1b6d9155897ac6940d8acb4ee8af80ac24d7630
-
 begin
-    exec.test_rust_8885ff83d4718aec39ee91baf1b6d9155897ac6940d8acb4ee8af80ac24d7630::entrypoint  
+    exec.::test_rust_8885ff83d4718aec39ee91baf1b6d9155897ac6940d8acb4ee8af80ac24d7630::entrypoint  
 end

--- a/tests/integration/expected/neg_i32.masm
+++ b/tests/integration/expected/neg_i32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_4d99fac9eee91dee5488ef87e46cd372efb54cac7088374c284c7fe1d592975b
+# mod test_rust_4d99fac9eee91dee5488ef87e46cd372efb54cac7088374c284c7fe1d592975b
 
 export.entrypoint
     push.0 swap.1 u32wrapping_sub
 end
 
 
-use.user_ns::test_rust_4d99fac9eee91dee5488ef87e46cd372efb54cac7088374c284c7fe1d592975b
-
 begin
-    exec.test_rust_4d99fac9eee91dee5488ef87e46cd372efb54cac7088374c284c7fe1d592975b::entrypoint  
+    exec.::test_rust_4d99fac9eee91dee5488ef87e46cd372efb54cac7088374c284c7fe1d592975b::entrypoint  
 end

--- a/tests/integration/expected/neg_i8.masm
+++ b/tests/integration/expected/neg_i8.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_a39cb19de351625b19b45683e68f0c391a8f9d3ac2c0b47dfe1db9e27887fc29
+# mod test_rust_a39cb19de351625b19b45683e68f0c391a8f9d3ac2c0b47dfe1db9e27887fc29
 
 export.entrypoint
     push.0 swap.1 u32wrapping_sub
 end
 
 
-use.user_ns::test_rust_a39cb19de351625b19b45683e68f0c391a8f9d3ac2c0b47dfe1db9e27887fc29
-
 begin
-    exec.test_rust_a39cb19de351625b19b45683e68f0c391a8f9d3ac2c0b47dfe1db9e27887fc29::entrypoint  
+    exec.::test_rust_a39cb19de351625b19b45683e68f0c391a8f9d3ac2c0b47dfe1db9e27887fc29::entrypoint  
 end

--- a/tests/integration/expected/not_bool.masm
+++ b/tests/integration/expected/not_bool.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_9eeb808d5b84e9923aca025d19ce8860aa1591ec14e265ab55978490184941f9
+# mod test_rust_9eeb808d5b84e9923aca025d19ce8860aa1591ec14e265ab55978490184941f9
 
 export.entrypoint
     push.1 u32xor
 end
 
 
-use.user_ns::test_rust_9eeb808d5b84e9923aca025d19ce8860aa1591ec14e265ab55978490184941f9
-
 begin
-    exec.test_rust_9eeb808d5b84e9923aca025d19ce8860aa1591ec14e265ab55978490184941f9::entrypoint  
+    exec.::test_rust_9eeb808d5b84e9923aca025d19ce8860aa1591ec14e265ab55978490184941f9::entrypoint  
 end

--- a/tests/integration/expected/not_i16.masm
+++ b/tests/integration/expected/not_i16.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_8fa57435a0704052eef5cf543da239dc56a277e303737da31ead024a9331a727
+# mod test_rust_8fa57435a0704052eef5cf543da239dc56a277e303737da31ead024a9331a727
 
 export.entrypoint
     push.4294967295 u32xor
 end
 
 
-use.user_ns::test_rust_8fa57435a0704052eef5cf543da239dc56a277e303737da31ead024a9331a727
-
 begin
-    exec.test_rust_8fa57435a0704052eef5cf543da239dc56a277e303737da31ead024a9331a727::entrypoint  
+    exec.::test_rust_8fa57435a0704052eef5cf543da239dc56a277e303737da31ead024a9331a727::entrypoint  
 end

--- a/tests/integration/expected/not_i32.masm
+++ b/tests/integration/expected/not_i32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_2025dc1efddce491d35a4bd97da58ce6432ab90aaa631eb386fc77f975594744
+# mod test_rust_2025dc1efddce491d35a4bd97da58ce6432ab90aaa631eb386fc77f975594744
 
 export.entrypoint
     push.4294967295 u32xor
 end
 
 
-use.user_ns::test_rust_2025dc1efddce491d35a4bd97da58ce6432ab90aaa631eb386fc77f975594744
-
 begin
-    exec.test_rust_2025dc1efddce491d35a4bd97da58ce6432ab90aaa631eb386fc77f975594744::entrypoint  
+    exec.::test_rust_2025dc1efddce491d35a4bd97da58ce6432ab90aaa631eb386fc77f975594744::entrypoint  
 end

--- a/tests/integration/expected/not_i8.masm
+++ b/tests/integration/expected/not_i8.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_3095798ff760882614d43aafa09c1c7941995bb5b9a48187009a712b0d3ac930
+# mod test_rust_3095798ff760882614d43aafa09c1c7941995bb5b9a48187009a712b0d3ac930
 
 export.entrypoint
     push.4294967295 u32xor
 end
 
 
-use.user_ns::test_rust_3095798ff760882614d43aafa09c1c7941995bb5b9a48187009a712b0d3ac930
-
 begin
-    exec.test_rust_3095798ff760882614d43aafa09c1c7941995bb5b9a48187009a712b0d3ac930::entrypoint  
+    exec.::test_rust_3095798ff760882614d43aafa09c1c7941995bb5b9a48187009a712b0d3ac930::entrypoint  
 end

--- a/tests/integration/expected/not_u16.masm
+++ b/tests/integration/expected/not_u16.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_de134871bf4e9b290991577707ea002a2485be8d7e8cec745b7e9faf22aff5dd
+# mod test_rust_de134871bf4e9b290991577707ea002a2485be8d7e8cec745b7e9faf22aff5dd
 
 export.entrypoint
     push.65535 u32xor
 end
 
 
-use.user_ns::test_rust_de134871bf4e9b290991577707ea002a2485be8d7e8cec745b7e9faf22aff5dd
-
 begin
-    exec.test_rust_de134871bf4e9b290991577707ea002a2485be8d7e8cec745b7e9faf22aff5dd::entrypoint  
+    exec.::test_rust_de134871bf4e9b290991577707ea002a2485be8d7e8cec745b7e9faf22aff5dd::entrypoint  
 end

--- a/tests/integration/expected/not_u32.masm
+++ b/tests/integration/expected/not_u32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_e7047e5fc0fbd81c45f586a2e1236121815ef43b08b645ca6cfa83914a40321c
+# mod test_rust_e7047e5fc0fbd81c45f586a2e1236121815ef43b08b645ca6cfa83914a40321c
 
 export.entrypoint
     push.4294967295 u32xor
 end
 
 
-use.user_ns::test_rust_e7047e5fc0fbd81c45f586a2e1236121815ef43b08b645ca6cfa83914a40321c
-
 begin
-    exec.test_rust_e7047e5fc0fbd81c45f586a2e1236121815ef43b08b645ca6cfa83914a40321c::entrypoint  
+    exec.::test_rust_e7047e5fc0fbd81c45f586a2e1236121815ef43b08b645ca6cfa83914a40321c::entrypoint  
 end

--- a/tests/integration/expected/not_u8.masm
+++ b/tests/integration/expected/not_u8.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_35b25eb77e4cb9a7ed55da7b9ee04431e564770fc0ccf796f4543d6e0f9e813f
+# mod test_rust_35b25eb77e4cb9a7ed55da7b9ee04431e564770fc0ccf796f4543d6e0f9e813f
 
 export.entrypoint
     push.255 u32xor
 end
 
 
-use.user_ns::test_rust_35b25eb77e4cb9a7ed55da7b9ee04431e564770fc0ccf796f4543d6e0f9e813f
-
 begin
-    exec.test_rust_35b25eb77e4cb9a7ed55da7b9ee04431e564770fc0ccf796f4543d6e0f9e813f::entrypoint  
+    exec.::test_rust_35b25eb77e4cb9a7ed55da7b9ee04431e564770fc0ccf796f4543d6e0f9e813f::entrypoint  
 end

--- a/tests/integration/expected/or_bool.masm
+++ b/tests/integration/expected/or_bool.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_b27aa658e891a67a41e3a9a972e49580fe9cb8844832b2b63b81e01624e5acca
+# mod test_rust_b27aa658e891a67a41e3a9a972e49580fe9cb8844832b2b63b81e01624e5acca
 
 export.entrypoint
     swap.1 u32or
 end
 
 
-use.user_ns::test_rust_b27aa658e891a67a41e3a9a972e49580fe9cb8844832b2b63b81e01624e5acca
-
 begin
-    exec.test_rust_b27aa658e891a67a41e3a9a972e49580fe9cb8844832b2b63b81e01624e5acca::entrypoint  
+    exec.::test_rust_b27aa658e891a67a41e3a9a972e49580fe9cb8844832b2b63b81e01624e5acca::entrypoint  
 end

--- a/tests/integration/expected/or_i16.masm
+++ b/tests/integration/expected/or_i16.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_8c8a3ab08866a8cdf13f461d225bc40cc694eab7818133d8e81630fc58c00003
+# mod test_rust_8c8a3ab08866a8cdf13f461d225bc40cc694eab7818133d8e81630fc58c00003
 
 export.entrypoint
     u32or
 end
 
 
-use.user_ns::test_rust_8c8a3ab08866a8cdf13f461d225bc40cc694eab7818133d8e81630fc58c00003
-
 begin
-    exec.test_rust_8c8a3ab08866a8cdf13f461d225bc40cc694eab7818133d8e81630fc58c00003::entrypoint  
+    exec.::test_rust_8c8a3ab08866a8cdf13f461d225bc40cc694eab7818133d8e81630fc58c00003::entrypoint  
 end

--- a/tests/integration/expected/or_i32.masm
+++ b/tests/integration/expected/or_i32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_ffcb4feca7e38ee8605b734c387b996462f7f0070d3e33c2a53fda99a685897e
+# mod test_rust_ffcb4feca7e38ee8605b734c387b996462f7f0070d3e33c2a53fda99a685897e
 
 export.entrypoint
     u32or
 end
 
 
-use.user_ns::test_rust_ffcb4feca7e38ee8605b734c387b996462f7f0070d3e33c2a53fda99a685897e
-
 begin
-    exec.test_rust_ffcb4feca7e38ee8605b734c387b996462f7f0070d3e33c2a53fda99a685897e::entrypoint  
+    exec.::test_rust_ffcb4feca7e38ee8605b734c387b996462f7f0070d3e33c2a53fda99a685897e::entrypoint  
 end

--- a/tests/integration/expected/or_i8.masm
+++ b/tests/integration/expected/or_i8.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_3c3c09a69dc74dba99e46fa37b6b592780b19270274db6be94fbda8283613174
+# mod test_rust_3c3c09a69dc74dba99e46fa37b6b592780b19270274db6be94fbda8283613174
 
 export.entrypoint
     u32or
 end
 
 
-use.user_ns::test_rust_3c3c09a69dc74dba99e46fa37b6b592780b19270274db6be94fbda8283613174
-
 begin
-    exec.test_rust_3c3c09a69dc74dba99e46fa37b6b592780b19270274db6be94fbda8283613174::entrypoint  
+    exec.::test_rust_3c3c09a69dc74dba99e46fa37b6b592780b19270274db6be94fbda8283613174::entrypoint  
 end

--- a/tests/integration/expected/or_u16.masm
+++ b/tests/integration/expected/or_u16.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_10d8c002ebbe90dc0a59554ee1570001dc61801e8d9f0ddf8b981a086284c00d
+# mod test_rust_10d8c002ebbe90dc0a59554ee1570001dc61801e8d9f0ddf8b981a086284c00d
 
 export.entrypoint
     u32or
 end
 
 
-use.user_ns::test_rust_10d8c002ebbe90dc0a59554ee1570001dc61801e8d9f0ddf8b981a086284c00d
-
 begin
-    exec.test_rust_10d8c002ebbe90dc0a59554ee1570001dc61801e8d9f0ddf8b981a086284c00d::entrypoint  
+    exec.::test_rust_10d8c002ebbe90dc0a59554ee1570001dc61801e8d9f0ddf8b981a086284c00d::entrypoint  
 end

--- a/tests/integration/expected/or_u32.masm
+++ b/tests/integration/expected/or_u32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_051fe51f50265dba6f2bf7289cceb8e7ed3693a0fa020cc6c2202f54677db6b4
+# mod test_rust_051fe51f50265dba6f2bf7289cceb8e7ed3693a0fa020cc6c2202f54677db6b4
 
 export.entrypoint
     u32or
 end
 
 
-use.user_ns::test_rust_051fe51f50265dba6f2bf7289cceb8e7ed3693a0fa020cc6c2202f54677db6b4
-
 begin
-    exec.test_rust_051fe51f50265dba6f2bf7289cceb8e7ed3693a0fa020cc6c2202f54677db6b4::entrypoint  
+    exec.::test_rust_051fe51f50265dba6f2bf7289cceb8e7ed3693a0fa020cc6c2202f54677db6b4::entrypoint  
 end

--- a/tests/integration/expected/or_u8.masm
+++ b/tests/integration/expected/or_u8.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_0e3d57c8c71f555a8cdba009047c4bf2655b2539ddd5bc24847e650a14566381
+# mod test_rust_0e3d57c8c71f555a8cdba009047c4bf2655b2539ddd5bc24847e650a14566381
 
 export.entrypoint
     u32or
 end
 
 
-use.user_ns::test_rust_0e3d57c8c71f555a8cdba009047c4bf2655b2539ddd5bc24847e650a14566381
-
 begin
-    exec.test_rust_0e3d57c8c71f555a8cdba009047c4bf2655b2539ddd5bc24847e650a14566381::entrypoint  
+    exec.::test_rust_0e3d57c8c71f555a8cdba009047c4bf2655b2539ddd5bc24847e650a14566381::entrypoint  
 end

--- a/tests/integration/expected/shl_i16.masm
+++ b/tests/integration/expected/shl_i16.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_0321dd193a3848fd9694d83145f19dfd509077216649a5c8574ca9ef1fad1279
+# mod test_rust_0321dd193a3848fd9694d83145f19dfd509077216649a5c8574ca9ef1fad1279
 
 export.entrypoint
     push.15
@@ -9,8 +9,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_0321dd193a3848fd9694d83145f19dfd509077216649a5c8574ca9ef1fad1279
-
 begin
-    exec.test_rust_0321dd193a3848fd9694d83145f19dfd509077216649a5c8574ca9ef1fad1279::entrypoint  
+    exec.::test_rust_0321dd193a3848fd9694d83145f19dfd509077216649a5c8574ca9ef1fad1279::entrypoint  
 end

--- a/tests/integration/expected/shl_i32.masm
+++ b/tests/integration/expected/shl_i32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_77347ac38c4f68c555c0f6c6fd4af8c580cac21fd98baf7c8bd8e0249991b718
+# mod test_rust_77347ac38c4f68c555c0f6c6fd4af8c580cac21fd98baf7c8bd8e0249991b718
 
 export.entrypoint
     swap.1 u32shl
 end
 
 
-use.user_ns::test_rust_77347ac38c4f68c555c0f6c6fd4af8c580cac21fd98baf7c8bd8e0249991b718
-
 begin
-    exec.test_rust_77347ac38c4f68c555c0f6c6fd4af8c580cac21fd98baf7c8bd8e0249991b718::entrypoint  
+    exec.::test_rust_77347ac38c4f68c555c0f6c6fd4af8c580cac21fd98baf7c8bd8e0249991b718::entrypoint  
 end

--- a/tests/integration/expected/shl_i8.masm
+++ b/tests/integration/expected/shl_i8.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_5c39989232aaeaed99257c5c5dd56de3164cb62fe893b1c4752946d9a8035626
+# mod test_rust_5c39989232aaeaed99257c5c5dd56de3164cb62fe893b1c4752946d9a8035626
 
 export.entrypoint
     push.7
@@ -9,8 +9,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_5c39989232aaeaed99257c5c5dd56de3164cb62fe893b1c4752946d9a8035626
-
 begin
-    exec.test_rust_5c39989232aaeaed99257c5c5dd56de3164cb62fe893b1c4752946d9a8035626::entrypoint  
+    exec.::test_rust_5c39989232aaeaed99257c5c5dd56de3164cb62fe893b1c4752946d9a8035626::entrypoint  
 end

--- a/tests/integration/expected/shl_u16.masm
+++ b/tests/integration/expected/shl_u16.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_12e1569e41153e52fb7cb3781dcfca47ee0548f6160a9e8e38b7734ffd45cb7e
+# mod test_rust_12e1569e41153e52fb7cb3781dcfca47ee0548f6160a9e8e38b7734ffd45cb7e
 
 export.entrypoint
     push.15
@@ -11,8 +11,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_12e1569e41153e52fb7cb3781dcfca47ee0548f6160a9e8e38b7734ffd45cb7e
-
 begin
-    exec.test_rust_12e1569e41153e52fb7cb3781dcfca47ee0548f6160a9e8e38b7734ffd45cb7e::entrypoint  
+    exec.::test_rust_12e1569e41153e52fb7cb3781dcfca47ee0548f6160a9e8e38b7734ffd45cb7e::entrypoint  
 end

--- a/tests/integration/expected/shl_u32.masm
+++ b/tests/integration/expected/shl_u32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_c3626bb8d040702290734d36fd1995f9bd099bbd60fea362c6a50e3386dab95b
+# mod test_rust_c3626bb8d040702290734d36fd1995f9bd099bbd60fea362c6a50e3386dab95b
 
 export.entrypoint
     swap.1 u32shl
 end
 
 
-use.user_ns::test_rust_c3626bb8d040702290734d36fd1995f9bd099bbd60fea362c6a50e3386dab95b
-
 begin
-    exec.test_rust_c3626bb8d040702290734d36fd1995f9bd099bbd60fea362c6a50e3386dab95b::entrypoint  
+    exec.::test_rust_c3626bb8d040702290734d36fd1995f9bd099bbd60fea362c6a50e3386dab95b::entrypoint  
 end

--- a/tests/integration/expected/shl_u8.masm
+++ b/tests/integration/expected/shl_u8.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_11ed47f38055f9bb6c854e44680e18c81be5e7220524472414d55982c663892d
+# mod test_rust_11ed47f38055f9bb6c854e44680e18c81be5e7220524472414d55982c663892d
 
 export.entrypoint
     push.7
@@ -11,8 +11,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_11ed47f38055f9bb6c854e44680e18c81be5e7220524472414d55982c663892d
-
 begin
-    exec.test_rust_11ed47f38055f9bb6c854e44680e18c81be5e7220524472414d55982c663892d::entrypoint  
+    exec.::test_rust_11ed47f38055f9bb6c854e44680e18c81be5e7220524472414d55982c663892d::entrypoint  
 end

--- a/tests/integration/expected/shr_u16.masm
+++ b/tests/integration/expected/shr_u16.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_0b3b019a1f9ca0666eeeeff0b69793030831994482d8a03491ea3289d29dd83b
+# mod test_rust_0b3b019a1f9ca0666eeeeff0b69793030831994482d8a03491ea3289d29dd83b
 
 export.entrypoint
     dup.0
@@ -24,8 +24,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_0b3b019a1f9ca0666eeeeff0b69793030831994482d8a03491ea3289d29dd83b
-
 begin
-    exec.test_rust_0b3b019a1f9ca0666eeeeff0b69793030831994482d8a03491ea3289d29dd83b::entrypoint  
+    exec.::test_rust_0b3b019a1f9ca0666eeeeff0b69793030831994482d8a03491ea3289d29dd83b::entrypoint  
 end

--- a/tests/integration/expected/shr_u8.masm
+++ b/tests/integration/expected/shr_u8.masm
@@ -1,4 +1,4 @@
-# mod user_ns::test_rust_0c960295b036bf3739ebef1e3e9ee68b7d941715927c576e8625d987a31dbbfe
+# mod test_rust_0c960295b036bf3739ebef1e3e9ee68b7d941715927c576e8625d987a31dbbfe
 
 export.entrypoint
     dup.0
@@ -24,8 +24,6 @@ export.entrypoint
 end
 
 
-use.user_ns::test_rust_0c960295b036bf3739ebef1e3e9ee68b7d941715927c576e8625d987a31dbbfe
-
 begin
-    exec.test_rust_0c960295b036bf3739ebef1e3e9ee68b7d941715927c576e8625d987a31dbbfe::entrypoint  
+    exec.::test_rust_0c960295b036bf3739ebef1e3e9ee68b7d941715927c576e8625d987a31dbbfe::entrypoint  
 end

--- a/tests/integration/expected/sub_felt.masm
+++ b/tests/integration/expected/sub_felt.masm
@@ -1,12 +1,10 @@
-# mod user_ns::sub_felt
+# mod sub_felt
 
 export.entrypoint
     swap.1 sub
 end
 
 
-use.user_ns::sub_felt
-
 begin
-    exec.sub_felt::entrypoint  
+    exec.::sub_felt::entrypoint  
 end

--- a/tests/integration/expected/sub_i16.masm
+++ b/tests/integration/expected/sub_i16.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_0bd9d85b7ff8d3866d324cd6d4ca05c25e67a2304dcd772858e426a99ba6ac7a
+# mod test_rust_0bd9d85b7ff8d3866d324cd6d4ca05c25e67a2304dcd772858e426a99ba6ac7a
 
 export.entrypoint
     swap.1 u32wrapping_sub
 end
 
 
-use.user_ns::test_rust_0bd9d85b7ff8d3866d324cd6d4ca05c25e67a2304dcd772858e426a99ba6ac7a
-
 begin
-    exec.test_rust_0bd9d85b7ff8d3866d324cd6d4ca05c25e67a2304dcd772858e426a99ba6ac7a::entrypoint  
+    exec.::test_rust_0bd9d85b7ff8d3866d324cd6d4ca05c25e67a2304dcd772858e426a99ba6ac7a::entrypoint  
 end

--- a/tests/integration/expected/sub_i32.masm
+++ b/tests/integration/expected/sub_i32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_6c95bc4ac3c970051b695c8b0d81ce4e464588966d9047a4db06a19a2885319c
+# mod test_rust_6c95bc4ac3c970051b695c8b0d81ce4e464588966d9047a4db06a19a2885319c
 
 export.entrypoint
     swap.1 u32wrapping_sub
 end
 
 
-use.user_ns::test_rust_6c95bc4ac3c970051b695c8b0d81ce4e464588966d9047a4db06a19a2885319c
-
 begin
-    exec.test_rust_6c95bc4ac3c970051b695c8b0d81ce4e464588966d9047a4db06a19a2885319c::entrypoint  
+    exec.::test_rust_6c95bc4ac3c970051b695c8b0d81ce4e464588966d9047a4db06a19a2885319c::entrypoint  
 end

--- a/tests/integration/expected/sub_i8.masm
+++ b/tests/integration/expected/sub_i8.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_47672a27266673dae49801c73b4791b5dd218b4cbca4677e7e9390d3988f3484
+# mod test_rust_47672a27266673dae49801c73b4791b5dd218b4cbca4677e7e9390d3988f3484
 
 export.entrypoint
     swap.1 u32wrapping_sub
 end
 
 
-use.user_ns::test_rust_47672a27266673dae49801c73b4791b5dd218b4cbca4677e7e9390d3988f3484
-
 begin
-    exec.test_rust_47672a27266673dae49801c73b4791b5dd218b4cbca4677e7e9390d3988f3484::entrypoint  
+    exec.::test_rust_47672a27266673dae49801c73b4791b5dd218b4cbca4677e7e9390d3988f3484::entrypoint  
 end

--- a/tests/integration/expected/sub_u16.masm
+++ b/tests/integration/expected/sub_u16.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_c0e8cc698fc282804a294a7ee5f65d91b6c6b89556c58494b84b1b928da26ac7
+# mod test_rust_c0e8cc698fc282804a294a7ee5f65d91b6c6b89556c58494b84b1b928da26ac7
 
 export.entrypoint
     swap.1 u32wrapping_sub push.65535 u32and
 end
 
 
-use.user_ns::test_rust_c0e8cc698fc282804a294a7ee5f65d91b6c6b89556c58494b84b1b928da26ac7
-
 begin
-    exec.test_rust_c0e8cc698fc282804a294a7ee5f65d91b6c6b89556c58494b84b1b928da26ac7::entrypoint  
+    exec.::test_rust_c0e8cc698fc282804a294a7ee5f65d91b6c6b89556c58494b84b1b928da26ac7::entrypoint  
 end

--- a/tests/integration/expected/sub_u32.masm
+++ b/tests/integration/expected/sub_u32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_caa1ad606ef14599034dee42dfda3f3b0e116720e1d8e83f024cc9fd2113e4b0
+# mod test_rust_caa1ad606ef14599034dee42dfda3f3b0e116720e1d8e83f024cc9fd2113e4b0
 
 export.entrypoint
     swap.1 u32wrapping_sub
 end
 
 
-use.user_ns::test_rust_caa1ad606ef14599034dee42dfda3f3b0e116720e1d8e83f024cc9fd2113e4b0
-
 begin
-    exec.test_rust_caa1ad606ef14599034dee42dfda3f3b0e116720e1d8e83f024cc9fd2113e4b0::entrypoint  
+    exec.::test_rust_caa1ad606ef14599034dee42dfda3f3b0e116720e1d8e83f024cc9fd2113e4b0::entrypoint  
 end

--- a/tests/integration/expected/sub_u8.masm
+++ b/tests/integration/expected/sub_u8.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_199edd7a9771d7f0d34a9bbc05730a9c8345e263f0285d6a3d4f49a010be4661
+# mod test_rust_199edd7a9771d7f0d34a9bbc05730a9c8345e263f0285d6a3d4f49a010be4661
 
 export.entrypoint
     swap.1 u32wrapping_sub push.255 u32and
 end
 
 
-use.user_ns::test_rust_199edd7a9771d7f0d34a9bbc05730a9c8345e263f0285d6a3d4f49a010be4661
-
 begin
-    exec.test_rust_199edd7a9771d7f0d34a9bbc05730a9c8345e263f0285d6a3d4f49a010be4661::entrypoint  
+    exec.::test_rust_199edd7a9771d7f0d34a9bbc05730a9c8345e263f0285d6a3d4f49a010be4661::entrypoint  
 end

--- a/tests/integration/expected/xor_bool.masm
+++ b/tests/integration/expected/xor_bool.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_dcd67ec43bbcd9107cffbbb7423564fd0a2cb122c842d7b8f810e5d557615869
+# mod test_rust_dcd67ec43bbcd9107cffbbb7423564fd0a2cb122c842d7b8f810e5d557615869
 
 export.entrypoint
     swap.1 u32xor
 end
 
 
-use.user_ns::test_rust_dcd67ec43bbcd9107cffbbb7423564fd0a2cb122c842d7b8f810e5d557615869
-
 begin
-    exec.test_rust_dcd67ec43bbcd9107cffbbb7423564fd0a2cb122c842d7b8f810e5d557615869::entrypoint  
+    exec.::test_rust_dcd67ec43bbcd9107cffbbb7423564fd0a2cb122c842d7b8f810e5d557615869::entrypoint  
 end

--- a/tests/integration/expected/xor_i16.masm
+++ b/tests/integration/expected/xor_i16.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_31340dea94d5815fdbeada64122d75ef52c31ef664b9bdb97f25dc50403c962e
+# mod test_rust_31340dea94d5815fdbeada64122d75ef52c31ef664b9bdb97f25dc50403c962e
 
 export.entrypoint
     u32xor
 end
 
 
-use.user_ns::test_rust_31340dea94d5815fdbeada64122d75ef52c31ef664b9bdb97f25dc50403c962e
-
 begin
-    exec.test_rust_31340dea94d5815fdbeada64122d75ef52c31ef664b9bdb97f25dc50403c962e::entrypoint  
+    exec.::test_rust_31340dea94d5815fdbeada64122d75ef52c31ef664b9bdb97f25dc50403c962e::entrypoint  
 end

--- a/tests/integration/expected/xor_i32.masm
+++ b/tests/integration/expected/xor_i32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_595d33f8d41bf8d0b48b19b9d0d717b2001169c6dacb943b6933b7ac892d670e
+# mod test_rust_595d33f8d41bf8d0b48b19b9d0d717b2001169c6dacb943b6933b7ac892d670e
 
 export.entrypoint
     u32xor
 end
 
 
-use.user_ns::test_rust_595d33f8d41bf8d0b48b19b9d0d717b2001169c6dacb943b6933b7ac892d670e
-
 begin
-    exec.test_rust_595d33f8d41bf8d0b48b19b9d0d717b2001169c6dacb943b6933b7ac892d670e::entrypoint  
+    exec.::test_rust_595d33f8d41bf8d0b48b19b9d0d717b2001169c6dacb943b6933b7ac892d670e::entrypoint  
 end

--- a/tests/integration/expected/xor_i8.masm
+++ b/tests/integration/expected/xor_i8.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_c64e2a982ef5596c6379542467e047153ae5c1824246ef4cbe06b327d51be74a
+# mod test_rust_c64e2a982ef5596c6379542467e047153ae5c1824246ef4cbe06b327d51be74a
 
 export.entrypoint
     u32xor
 end
 
 
-use.user_ns::test_rust_c64e2a982ef5596c6379542467e047153ae5c1824246ef4cbe06b327d51be74a
-
 begin
-    exec.test_rust_c64e2a982ef5596c6379542467e047153ae5c1824246ef4cbe06b327d51be74a::entrypoint  
+    exec.::test_rust_c64e2a982ef5596c6379542467e047153ae5c1824246ef4cbe06b327d51be74a::entrypoint  
 end

--- a/tests/integration/expected/xor_u16.masm
+++ b/tests/integration/expected/xor_u16.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_edfc84a713511234ff9afc4c89c4fd998413355e149a7e331eaec655163d9afe
+# mod test_rust_edfc84a713511234ff9afc4c89c4fd998413355e149a7e331eaec655163d9afe
 
 export.entrypoint
     u32xor
 end
 
 
-use.user_ns::test_rust_edfc84a713511234ff9afc4c89c4fd998413355e149a7e331eaec655163d9afe
-
 begin
-    exec.test_rust_edfc84a713511234ff9afc4c89c4fd998413355e149a7e331eaec655163d9afe::entrypoint  
+    exec.::test_rust_edfc84a713511234ff9afc4c89c4fd998413355e149a7e331eaec655163d9afe::entrypoint  
 end

--- a/tests/integration/expected/xor_u32.masm
+++ b/tests/integration/expected/xor_u32.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_972d35b4c4e5a4bf3450bff55d3407152f81ce2206ea8e96de43f1800f0f5f59
+# mod test_rust_972d35b4c4e5a4bf3450bff55d3407152f81ce2206ea8e96de43f1800f0f5f59
 
 export.entrypoint
     u32xor
 end
 
 
-use.user_ns::test_rust_972d35b4c4e5a4bf3450bff55d3407152f81ce2206ea8e96de43f1800f0f5f59
-
 begin
-    exec.test_rust_972d35b4c4e5a4bf3450bff55d3407152f81ce2206ea8e96de43f1800f0f5f59::entrypoint  
+    exec.::test_rust_972d35b4c4e5a4bf3450bff55d3407152f81ce2206ea8e96de43f1800f0f5f59::entrypoint  
 end

--- a/tests/integration/expected/xor_u8.masm
+++ b/tests/integration/expected/xor_u8.masm
@@ -1,12 +1,10 @@
-# mod user_ns::test_rust_3bc685af363b80b89b9cea6b01602a2b50a6c4a8978e24e239a9e9fac3fdccb4
+# mod test_rust_3bc685af363b80b89b9cea6b01602a2b50a6c4a8978e24e239a9e9fac3fdccb4
 
 export.entrypoint
     u32xor
 end
 
 
-use.user_ns::test_rust_3bc685af363b80b89b9cea6b01602a2b50a6c4a8978e24e239a9e9fac3fdccb4
-
 begin
-    exec.test_rust_3bc685af363b80b89b9cea6b01602a2b50a6c4a8978e24e239a9e9fac3fdccb4::entrypoint  
+    exec.::test_rust_3bc685af363b80b89b9cea6b01602a2b50a6c4a8978e24e239a9e9fac3fdccb4::entrypoint  
 end


### PR DESCRIPTION
Which was added as a workaround in #220 for the issue #208.

**This PR is stacked on the #224 and should be merged after it**