### PR TITLE
Build `expect-test` with release profile to speed up diffs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,3 +106,11 @@ opt-level = 3
 
 [profile.test.package.rand_chacha]
 opt-level = 3
+
+# Build `expect-test` with release optimizations even in dev mode to speed up the diffing
+[profile.dev.package.expect-test]
+opt-level = 3
+
+# Build `dissimilar` with release optimizations even in dev mode to speed up the diffing 
+[profile.dev.package.dissimilar]
+opt-level = 3


### PR DESCRIPTION
This PR fixes slow diffs for long texts in the expect tests.