### PR TITLE
Add Miden SDK crates release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,13 @@
-# Runs `release-plz release` only after the release PR is merged to the main branch 
-# see `release_always = false` in `release-plz.toml` 
-# Which publishes any unpublished crates.
+# Runs `release-plz release` only after the release PR (starts with `release-plz-`) 
+# is merged to the main branch. See `release_always = false` in `release-plz.toml` 
+# Publishes any unpublished crates when.
 # Does nothing if all crates are already published (i.e. have their versions on crates.io).
 # Does not create/update release PRs.
-# The crate version bumping and changelog generation is done manually via the `release-plz release_pr` CLI command.
-# Which creates the PR with the proposed changes and when the PR is merged this action will publish the crates.
+# The crate version bumping and changelog generation is done via the `release-plz update` CLI command.
+# Then manually create a release PR(starts with `release-plz-`) with the proposed changes and 
+# when the PR is merged this action will publish the crates.
+# See CONTRIBUTING.md for more details.
+
 name: release-plz
 
 on:
@@ -33,13 +36,21 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
         key: ${{ github.workflow }}-${{ github.job }}-toolchain-${{ env.CARGO_MAKE_TOOLCHAIN }}
-    - name: Run release-plz
+    - name: Publish Miden compiler crates
       uses: MarcoIeni/release-plz-action@v0.5
       with:
-        # Only run the `release` command. 
-        # The release PR is created manually via the `release-plz release_pr` CLI command.
-        # see https://release-plz.ieni.dev/docs/usage/release for more details
+        # Only run the `release` command that publishes any unpublished crates.
         command: release
+        # `manifest_path` is omitted because it defaults to the root directory
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    - name: Publish Miden SDK crates
+      uses: MarcoIeni/release-plz-action@v0.5
+      with:
+        # Only run the `release` command that publishes any unpublished crates.
+        command: release
+        manifest_path: sdk/Cargo.toml
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,22 +4,17 @@ TBD
 
 ## Release Process
 
-The release process for the Miden Compiler is managed using the `release-plz` tool. The following steps outline the process for creating a new release:
-
-1. Run `release-plz update` to update the crate versions and generate changelogs.
-2. Create a release PR naming the branch with `release-plz-` suffix (its important to use this suffix to trigger the crate publishing on CI in step 4).
-3. Review the changes in the release PR, commit edits if needed and merge it into the main branch.
-4. The CI will automatically run `release-plz release` after the release PR is merged to publish the new versions to crates.io.
-5. Set a git tag for the published crates to mark the release.
-
 ### Prerequisites
 
 Install `release-plz` CLI tool following the instructions [here](https://release-plz.ieni.dev/docs/usage/installation)
 
-### Release of the Miden Cargo Extension
+### Release of the Miden Compiler and Miden SDK crates
 
-Run the steps outlined above in the `Release Process` section in the repo root folder.
+The release process for the Miden Compiler and Miden SDK is managed using the `release-plz` tool. The following steps outline the process for creating a new release:
 
-### Release of the Miden SDK
-
-TBD
+1. Run `release-plz update` in the repo root folder to update the compiler crates versions and generate changelogs.
+2. Run `release-plz update` in the `sdk` folder to update the SDK crates versions and generate changelogs.
+3. Create a release PR naming the branch with the `release-plz-` suffix (its important to use this suffix to trigger the crate publishing on CI in step 4).
+4. Review the changes in the release PR, commit edits if needed and merge it into the main branch.
+5. The CI will automatically run `release-plz release` after the release PR is merged to publish the new versions to crates.io.
+6. Set a git tag for the published crates to mark the release.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,5 @@
 [workspace]
-# Only publish when the release PR is merged
+# Only publish when the release PR is merged (starts with `release-plz-`)
 # https://release-plz.ieni.dev/docs/config#the-release_always-field
 release_always = false
 # Does not create a git tag


### PR DESCRIPTION
Close #216 
Close #142 

This PR adds the Miden SDK crates publishing in the`release.yml` GA workflow and updates CONTRIBUTING.md.

After this PR is merged, I'm going to make and publish the first release for the compiler and SDK crates using the instructions in CONTRIBUTING.md.