### PR TITLE
[7/x] Fix memory cleanup in `Emulator::stop`

### DIFF
--- a/codegen/masm/src/emulator/mod.rs
+++ b/codegen/masm/src/emulator/mod.rs
@@ -570,7 +570,7 @@ impl Emulator {
     pub fn stop(&mut self) {
         self.callstack.clear();
         self.stack.clear();
-        self.memory.clear();
+        self.memory = vec![Self::EMPTY_WORD; self.memory.len()];
         self.hp = self.hp_start;
         self.lp = self.lp_start;
         self.step_over = None;


### PR DESCRIPTION
**This PR is stacked on the #233 and should be merged after it**