### PR TITLE
[8/x] Add `Emulator::print_trace` option to print the current stack and memory on every step

### DIFF
--- a/codegen/masm/src/codegen/emit/mem.rs
+++ b/codegen/masm/src/codegen/emit/mem.rs
@@ -49,7 +49,7 @@ impl<'a> OpEmitter<'a> {
         let ptr = self.stack.pop().expect("operand stack is empty");
         match ptr.ty() {
             Type::Ptr(_) => {
-                // Converet the pointer to a native pointer representation
+                // Convert the pointer to a native pointer representation
                 self.emit_native_ptr();
                 match &ty {
                     Type::I128 => self.load_quad_word(None),

--- a/codegen/masm/src/emulator/memory.rs
+++ b/codegen/masm/src/emulator/memory.rs
@@ -1,0 +1,59 @@
+use std::{
+    fmt::Debug,
+    ops::{Index, IndexMut},
+};
+
+use miden_core::FieldElement;
+use midenc_hir::Felt;
+use rustc_hash::FxHashSet;
+
+const EMPTY_WORD: [Felt; 4] = [Felt::ZERO; 4];
+
+pub struct Memory {
+    memory: Vec<[Felt; 4]>,
+    set_memory_addrs: FxHashSet<usize>,
+}
+
+impl Memory {
+    pub fn new(memory_size: usize) -> Self {
+        Self {
+            memory: vec![EMPTY_WORD; memory_size],
+            set_memory_addrs: Default::default(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.memory.len()
+    }
+
+    pub fn reset(&mut self) {
+        for addr in self.set_memory_addrs.iter() {
+            self.memory[*addr] = EMPTY_WORD;
+        }
+        self.set_memory_addrs = Default::default();
+    }
+}
+
+impl Index<usize> for Memory {
+    type Output = [Felt; 4];
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.memory[index]
+    }
+}
+
+impl IndexMut<usize> for Memory {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        self.set_memory_addrs.insert(index);
+        &mut self.memory[index]
+    }
+}
+
+impl Debug for Memory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for addr in self.set_memory_addrs.iter() {
+            write!(f, "{}: {:?}, ", addr, self[*addr])?;
+        }
+        Ok(())
+    }
+}

--- a/codegen/masm/src/emulator/memory.rs
+++ b/codegen/masm/src/emulator/memory.rs
@@ -1,17 +1,17 @@
 use std::{
+    collections::BTreeSet,
     fmt::Debug,
     ops::{Index, IndexMut},
 };
 
 use miden_core::FieldElement;
 use midenc_hir::Felt;
-use rustc_hash::FxHashSet;
 
 const EMPTY_WORD: [Felt; 4] = [Felt::ZERO; 4];
 
 pub struct Memory {
     memory: Vec<[Felt; 4]>,
-    set_memory_addrs: FxHashSet<usize>,
+    set_memory_addrs: BTreeSet<usize>,
 }
 
 impl Memory {

--- a/codegen/masm/src/emulator/mod.rs
+++ b/codegen/masm/src/emulator/mod.rs
@@ -1255,8 +1255,8 @@ impl Emulator {
         let ix_with_op = state.next();
         if let Some(ix_with_op) = ix_with_op {
             if self.print_trace {
-                eprintln!("stk: {}", self.stack.debug().pretty());
                 eprintln!("mem: {:?}", self.memory);
+                eprintln!("stk: {}", self.stack.debug());
                 eprintln!("op>: {:?}", ix_with_op.op);
             }
             match ix_with_op.op {

--- a/codegen/masm/src/tests.rs
+++ b/codegen/masm/src/tests.rs
@@ -36,13 +36,19 @@ struct TestByEmulationHarness {
 }
 #[allow(unused)]
 impl TestByEmulationHarness {
-    pub fn with_emulator_config(memory_size: usize, hp: usize, lp: usize) -> Self {
+    pub fn with_emulator_config(
+        memory_size: usize,
+        hp: usize,
+        lp: usize,
+        print_stack: bool,
+    ) -> Self {
         let mut harness = Self {
             context: TestContext::default(),
             emulator: Emulator::new(
                 memory_size.try_into().expect("invalid memory size"),
                 hp.try_into().expect("invalid address"),
                 lp.try_into().expect("invalid address"),
+                print_stack,
             ),
         };
         harness.set_cycle_budget(2000);

--- a/hir/src/asm/stack.rs
+++ b/hir/src/asm/stack.rs
@@ -458,6 +458,19 @@ impl<'a, E: StackElement, T: ?Sized + Stack<Element = E>> DebugStack<'a, T> {
         self.limit = Some(n);
         self
     }
+
+    pub fn pretty(&self) -> String {
+        let mut s = String::new();
+        for (i, value) in self.stack.stack().iter().rev().enumerate() {
+            if let Some(limit) = self.limit {
+                if i >= limit {
+                    break;
+                }
+            }
+            s.push_str(&format!("{:?} ", value.debug()));
+        }
+        s
+    }
 }
 impl<'a, E: StackElement, T: ?Sized + Stack<Element = E>> fmt::Debug for DebugStack<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/hir/src/asm/stack.rs
+++ b/hir/src/asm/stack.rs
@@ -458,19 +458,6 @@ impl<'a, E: StackElement, T: ?Sized + Stack<Element = E>> DebugStack<'a, T> {
         self.limit = Some(n);
         self
     }
-
-    pub fn pretty(&self) -> String {
-        let mut s = String::new();
-        for (i, value) in self.stack.stack().iter().rev().enumerate() {
-            if let Some(limit) = self.limit {
-                if i >= limit {
-                    break;
-                }
-            }
-            s.push_str(&format!("{:?} ", value.debug()));
-        }
-        s
-    }
 }
 impl<'a, E: StackElement, T: ?Sized + Stack<Element = E>> fmt::Debug for DebugStack<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -501,7 +488,22 @@ impl<'a, E: StackElement, T: ?Sized + Stack<Element = E>> fmt::Debug for DebugSt
             .finish()
     }
 }
-
+impl<'a, E: StackElement + fmt::Debug, T: ?Sized + Stack<Element = E>> fmt::Display
+    for DebugStack<'a, T>
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list()
+            .entries(
+                self.stack
+                    .stack()
+                    .iter()
+                    .rev()
+                    .enumerate()
+                    .take(self.limit.unwrap_or(self.stack.len())),
+            )
+            .finish()
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
**This PR is stacked on the #236 and should be merged after it**