### PR TITLE
feat(codegen): teach instruction scheduler about side effects

### DIFF
--- a/hir-analysis/src/dependency_graph.rs
+++ b/hir-analysis/src/dependency_graph.rs
@@ -663,6 +663,29 @@ impl DependencyGraph {
         self.nodes.contains(node)
     }
 
+    /// Returns true if there is a path to `b` from `a` in the graph.
+    pub fn is_reachable_from(&self, a: NodeId, b: NodeId) -> bool {
+        if !self.nodes.contains(&a) || !self.nodes.contains(&b) {
+            return false;
+        }
+
+        let mut visited = BTreeSet::default();
+        let mut worklist = std::collections::VecDeque::from([a]);
+        while let Some(node_id) = worklist.pop_front() {
+            if !visited.insert(node_id) {
+                continue;
+            }
+
+            if node_id == b {
+                return true;
+            }
+
+            worklist.extend(self.successor_ids(node_id));
+        }
+
+        false
+    }
+
     /// Add a dependency from `a` to `b`
     pub fn add_dependency(&mut self, a: NodeId, b: NodeId) {
         assert_ne!(a, b, "cannot add a self-referential dependency");

--- a/hir/src/instruction.rs
+++ b/hir/src/instruction.rs
@@ -499,6 +499,38 @@ impl Opcode {
         )
     }
 
+    pub fn is_assertion(&self) -> bool {
+        matches!(self, Self::Assert | Self::Assertz | Self::AssertEq)
+    }
+
+    pub fn reads_memory(&self) -> bool {
+        matches!(
+            self,
+            Self::MemGrow
+                | Self::MemCpy
+                | Self::MemSize
+                | Self::Load
+                | Self::Call
+                | Self::Syscall
+                | Self::InlineAsm
+                | Self::Reload
+        )
+    }
+
+    pub fn writes_memory(&self) -> bool {
+        matches!(
+            self,
+            Self::MemGrow
+                | Self::MemSet
+                | Self::MemCpy
+                | Self::Store
+                | Self::Call
+                | Self::Syscall
+                | Self::InlineAsm
+                | Self::Spill
+        )
+    }
+
     pub fn has_side_effects(&self) -> bool {
         match self {
             // These opcodes are all effectful

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
@@ -149,16 +149,16 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
             u32and
             eq.2147483648
             assertz
+            add.4
+            u32assert
             movup.3
             dup.0
             push.2147483648
             u32and
             eq.2147483648
             assertz
-            add.4
-            u32assert
             push.3
-            movup.4
+            movup.3
             swap.1
             u32and
             dup.2
@@ -171,11 +171,8 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
             movup.2
             u32div.16
             exec.::intrinsics::mem::store_sw
-            swap.1
-            u32mod.2
-            assertz.err=0
             push.3
-            movup.2
+            movup.3
             swap.1
             u32and
             dup.1
@@ -190,10 +187,18 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
             exec.::intrinsics::mem::store_sw
             u32mod.2
             assertz.err=0
+            u32mod.2
+            assertz.err=0
         else
             swap.1
             drop
-            dup.2
+            dup.0
+            dup.0
+            push.2147483648
+            u32and
+            eq.2147483648
+            assertz
+            swap.1
             dup.0
             push.2147483648
             u32and
@@ -213,83 +218,9 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
             u32and
             eq.2147483648
             assertz
-            movup.5
-            dup.0
-            push.2147483648
-            u32and
-            eq.2147483648
-            assertz
             add.4
             u32assert
-            dup.4
-            dup.0
-            push.2147483648
-            u32and
-            eq.2147483648
-            assertz
-            movup.5
-            dup.0
-            push.2147483648
-            u32and
-            eq.2147483648
-            assertz
-            dup.3
-            dup.0
-            u32mod.16
-            dup.0
-            u32mod.4
-            swap.1
-            u32div.4
-            movup.2
-            u32div.16
-            exec.::intrinsics::mem::load_sw
-            push.3
-            u32and
-            dup.6
-            dup.0
-            u32mod.16
-            dup.0
-            u32mod.4
-            swap.1
-            u32div.4
-            movup.2
-            u32div.16
-            exec.::intrinsics::mem::store_sw
-            movup.5
-            u32mod.2
-            assertz.err=0
             dup.2
-            dup.0
-            u32mod.16
-            dup.0
-            u32mod.4
-            swap.1
-            u32div.4
-            movup.2
-            u32div.16
-            exec.::intrinsics::mem::load_sw
-            push.3
-            u32and
-            dup.5
-            dup.0
-            u32mod.16
-            dup.0
-            u32mod.4
-            swap.1
-            u32div.4
-            movup.2
-            u32div.16
-            exec.::intrinsics::mem::store_sw
-            movup.4
-            u32mod.2
-            assertz.err=0
-            movup.3
-            u32mod.2
-            assertz.err=0
-            movup.2
-            u32mod.2
-            assertz.err=0
-            dup.0
             dup.0
             u32mod.16
             dup.0
@@ -302,10 +233,66 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
             push.3
             u32and
             push.4294967292
-            movup.4
+            movup.6
             swap.1
             u32and
             u32or
+            dup.4
+            dup.0
+            u32mod.16
+            dup.0
+            u32mod.4
+            swap.1
+            u32div.4
+            movup.2
+            u32div.16
+            exec.::intrinsics::mem::store_sw
+            dup.4
+            dup.0
+            push.2147483648
+            u32and
+            eq.2147483648
+            assertz
+            movup.5
+            dup.0
+            push.2147483648
+            u32and
+            eq.2147483648
+            assertz
+            dup.2
+            dup.0
+            u32mod.16
+            dup.0
+            u32mod.4
+            swap.1
+            u32div.4
+            movup.2
+            u32div.16
+            exec.::intrinsics::mem::load_sw
+            push.3
+            u32and
+            dup.4
+            dup.0
+            u32mod.16
+            dup.0
+            u32mod.4
+            swap.1
+            u32div.4
+            movup.2
+            u32div.16
+            exec.::intrinsics::mem::store_sw
+            dup.0
+            dup.0
+            u32mod.16
+            dup.0
+            u32mod.4
+            swap.1
+            u32div.4
+            movup.2
+            u32div.16
+            exec.::intrinsics::mem::load_sw
+            push.3
+            u32and
             dup.2
             dup.0
             u32mod.16
@@ -316,6 +303,16 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
             movup.2
             u32div.16
             exec.::intrinsics::mem::store_sw
+            swap.1
+            u32mod.2
+            assertz.err=0
+            movup.2
+            u32mod.2
+            assertz.err=0
+            u32mod.2
+            assertz.err=0
+            u32mod.2
+            assertz.err=0
             swap.1
             u32mod.2
             assertz.err=0
@@ -367,16 +364,16 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
                 u32and
                 eq.2147483648
                 assertz
+                add.4
+                u32assert
                 movup.3
                 dup.0
                 push.2147483648
                 u32and
                 eq.2147483648
                 assertz
-                add.4
-                u32assert
                 push.3
-                movup.4
+                movup.3
                 swap.1
                 u32and
                 dup.2
@@ -389,11 +386,8 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
                 movup.2
                 u32div.16
                 exec.::intrinsics::mem::store_sw
-                swap.1
-                u32mod.2
-                assertz.err=0
                 push.3
-                movup.2
+                movup.3
                 swap.1
                 u32and
                 dup.1
@@ -408,10 +402,18 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
                 exec.::intrinsics::mem::store_sw
                 u32mod.2
                 assertz.err=0
+                u32mod.2
+                assertz.err=0
             else
                 swap.1
                 drop
-                dup.2
+                dup.0
+                dup.0
+                push.2147483648
+                u32and
+                eq.2147483648
+                assertz
+                swap.1
                 dup.0
                 push.2147483648
                 u32and
@@ -431,83 +433,9 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
                 u32and
                 eq.2147483648
                 assertz
-                movup.5
-                dup.0
-                push.2147483648
-                u32and
-                eq.2147483648
-                assertz
                 add.4
                 u32assert
-                dup.4
-                dup.0
-                push.2147483648
-                u32and
-                eq.2147483648
-                assertz
-                movup.5
-                dup.0
-                push.2147483648
-                u32and
-                eq.2147483648
-                assertz
-                dup.3
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::load_sw
-                push.3
-                u32and
-                dup.6
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::store_sw
-                movup.5
-                u32mod.2
-                assertz.err=0
                 dup.2
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::load_sw
-                push.3
-                u32and
-                dup.5
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::store_sw
-                movup.4
-                u32mod.2
-                assertz.err=0
-                movup.3
-                u32mod.2
-                assertz.err=0
-                movup.2
-                u32mod.2
-                assertz.err=0
-                dup.0
                 dup.0
                 u32mod.16
                 dup.0
@@ -520,10 +448,66 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
                 push.3
                 u32and
                 push.4294967292
-                movup.4
+                movup.6
                 swap.1
                 u32and
                 u32or
+                dup.4
+                dup.0
+                u32mod.16
+                dup.0
+                u32mod.4
+                swap.1
+                u32div.4
+                movup.2
+                u32div.16
+                exec.::intrinsics::mem::store_sw
+                dup.4
+                dup.0
+                push.2147483648
+                u32and
+                eq.2147483648
+                assertz
+                movup.5
+                dup.0
+                push.2147483648
+                u32and
+                eq.2147483648
+                assertz
+                dup.2
+                dup.0
+                u32mod.16
+                dup.0
+                u32mod.4
+                swap.1
+                u32div.4
+                movup.2
+                u32div.16
+                exec.::intrinsics::mem::load_sw
+                push.3
+                u32and
+                dup.4
+                dup.0
+                u32mod.16
+                dup.0
+                u32mod.4
+                swap.1
+                u32div.4
+                movup.2
+                u32div.16
+                exec.::intrinsics::mem::store_sw
+                dup.0
+                dup.0
+                u32mod.16
+                dup.0
+                u32mod.4
+                swap.1
+                u32div.4
+                movup.2
+                u32div.16
+                exec.::intrinsics::mem::load_sw
+                push.3
+                u32and
                 dup.2
                 dup.0
                 u32mod.16
@@ -537,13 +521,23 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
                 swap.1
                 u32mod.2
                 assertz.err=0
+                movup.2
+                u32mod.2
+                assertz.err=0
+                u32mod.2
+                assertz.err=0
+                u32mod.2
+                assertz.err=0
+                swap.1
+                u32mod.2
+                assertz.err=0
                 u32mod.2
                 assertz.err=0
             end
         else
             swap.1
             drop
-            dup.1
+            dup.0
             dup.0
             push.2147483648
             u32and
@@ -557,7 +551,9 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
             u32and
             eq.2147483648
             assertz
-            dup.2
+            add.4
+            u32assert
+            movup.2
             dup.0
             push.2147483648
             u32and
@@ -565,39 +561,21 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
             assertz
             add.4
             u32assert
-            dup.4
-            dup.0
-            push.2147483648
-            u32and
-            eq.2147483648
-            assertz
-            add.4
-            u32assert
-            movup.4
-            dup.0
-            push.2147483648
-            u32and
-            eq.2147483648
-            assertz
-            add.4
-            u32assert
-            dup.4
-            u32mod.2
-            assertz.err=0
             dup.3
             dup.0
-            u32mod.16
+            push.2147483648
+            u32and
+            eq.2147483648
+            assertz
+            add.4
+            u32assert
+            dup.4
             dup.0
-            u32mod.4
-            swap.1
-            u32div.4
-            movup.2
-            u32div.16
-            exec.::intrinsics::mem::load_sw
-            movup.4
-            u32mod.2
-            assertz.err=0
-            dup.1
+            push.2147483648
+            u32and
+            eq.2147483648
+            assertz
+            dup.2
             dup.0
             u32mod.16
             dup.0
@@ -609,7 +587,7 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
             exec.::intrinsics::mem::load_sw
             push.3
             u32and
-            dup.3
+            dup.4
             dup.0
             u32mod.16
             dup.0
@@ -622,7 +600,7 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
             push.4294967292
             u32and
             u32or
-            dup.4
+            dup.5
             dup.0
             u32mod.16
             dup.0
@@ -632,13 +610,29 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
             movup.2
             u32div.16
             exec.::intrinsics::mem::store_sw
+            dup.1
+            u32mod.2
+            assertz.err=0
+            dup.0
+            dup.0
+            u32mod.16
+            dup.0
+            u32mod.4
+            swap.1
+            u32div.4
+            movup.2
+            u32div.16
+            exec.::intrinsics::mem::load_sw
+            swap.1
+            u32mod.2
+            assertz.err=0
+            movup.4
+            u32mod.2
+            assertz.err=0
             movup.3
             u32mod.2
             assertz.err=0
             movup.2
-            u32mod.2
-            assertz.err=0
-            swap.1
             u32mod.2
             assertz.err=0
             swap.1
@@ -666,16 +660,16 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
                 u32and
                 eq.2147483648
                 assertz
+                add.4
+                u32assert
                 movup.3
                 dup.0
                 push.2147483648
                 u32and
                 eq.2147483648
                 assertz
-                add.4
-                u32assert
                 push.3
-                movup.4
+                movup.3
                 swap.1
                 u32and
                 dup.2
@@ -688,11 +682,8 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
                 movup.2
                 u32div.16
                 exec.::intrinsics::mem::store_sw
-                swap.1
-                u32mod.2
-                assertz.err=0
                 push.3
-                movup.2
+                movup.3
                 swap.1
                 u32and
                 dup.1
@@ -707,10 +698,18 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
                 exec.::intrinsics::mem::store_sw
                 u32mod.2
                 assertz.err=0
+                u32mod.2
+                assertz.err=0
             else
                 swap.1
                 drop
-                dup.2
+                dup.0
+                dup.0
+                push.2147483648
+                u32and
+                eq.2147483648
+                assertz
+                swap.1
                 dup.0
                 push.2147483648
                 u32and
@@ -730,83 +729,9 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
                 u32and
                 eq.2147483648
                 assertz
-                movup.5
-                dup.0
-                push.2147483648
-                u32and
-                eq.2147483648
-                assertz
                 add.4
                 u32assert
-                dup.4
-                dup.0
-                push.2147483648
-                u32and
-                eq.2147483648
-                assertz
-                movup.5
-                dup.0
-                push.2147483648
-                u32and
-                eq.2147483648
-                assertz
-                dup.3
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::load_sw
-                push.3
-                u32and
-                dup.6
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::store_sw
-                movup.5
-                u32mod.2
-                assertz.err=0
                 dup.2
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::load_sw
-                push.3
-                u32and
-                dup.5
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::store_sw
-                movup.4
-                u32mod.2
-                assertz.err=0
-                movup.3
-                u32mod.2
-                assertz.err=0
-                movup.2
-                u32mod.2
-                assertz.err=0
-                dup.0
                 dup.0
                 u32mod.16
                 dup.0
@@ -819,10 +744,66 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
                 push.3
                 u32and
                 push.4294967292
-                movup.4
+                movup.6
                 swap.1
                 u32and
                 u32or
+                dup.4
+                dup.0
+                u32mod.16
+                dup.0
+                u32mod.4
+                swap.1
+                u32div.4
+                movup.2
+                u32div.16
+                exec.::intrinsics::mem::store_sw
+                dup.4
+                dup.0
+                push.2147483648
+                u32and
+                eq.2147483648
+                assertz
+                movup.5
+                dup.0
+                push.2147483648
+                u32and
+                eq.2147483648
+                assertz
+                dup.2
+                dup.0
+                u32mod.16
+                dup.0
+                u32mod.4
+                swap.1
+                u32div.4
+                movup.2
+                u32div.16
+                exec.::intrinsics::mem::load_sw
+                push.3
+                u32and
+                dup.4
+                dup.0
+                u32mod.16
+                dup.0
+                u32mod.4
+                swap.1
+                u32div.4
+                movup.2
+                u32div.16
+                exec.::intrinsics::mem::store_sw
+                dup.0
+                dup.0
+                u32mod.16
+                dup.0
+                u32mod.4
+                swap.1
+                u32div.4
+                movup.2
+                u32div.16
+                exec.::intrinsics::mem::load_sw
+                push.3
+                u32and
                 dup.2
                 dup.0
                 u32mod.16
@@ -833,6 +814,16 @@ export."wee_alloc::neighbors::Neighbors<T>::remove"
                 movup.2
                 u32div.16
                 exec.::intrinsics::mem::store_sw
+                swap.1
+                u32mod.2
+                assertz.err=0
+                movup.2
+                u32mod.2
+                assertz.err=0
+                u32mod.2
+                assertz.err=0
+                u32mod.2
+                assertz.err=0
                 swap.1
                 u32mod.2
                 assertz.err=0
@@ -887,13 +878,7 @@ export."<wee_alloc::LargeAllocPolicy as wee_alloc::AllocPolicy>::new_cell_for_fr
     if.true
         push.16
         u32shl
-        dup.2
         dup.0
-        push.2147483648
-        u32and
-        eq.2147483648
-        assertz
-        movup.3
         dup.0
         push.2147483648
         u32and
@@ -901,54 +886,36 @@ export."<wee_alloc::LargeAllocPolicy as wee_alloc::AllocPolicy>::new_cell_for_fr
         assertz
         add.4
         u32assert
-        dup.2
+        dup.1
         dup.0
         push.2147483648
         u32and
         eq.2147483648
         assertz
+        push.0.0
         dup.3
         dup.0
+        u32mod.16
+        dup.0
+        u32mod.4
+        swap.1
+        u32div.4
+        movup.2
+        u32div.16
+        exec.::intrinsics::mem::store_dw
+        dup.4
+        dup.0
         push.2147483648
         u32and
         eq.2147483648
         assertz
         add.4
         u32assert
-        push.0
-        dup.4
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
-        swap.1
-        u32div.4
-        movup.2
-        u32div.16
-        exec.::intrinsics::mem::store_sw
-        movup.3
-        u32mod.2
-        assertz.err=0
-        dup.2
-        dup.4
-        swap.1
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
-        swap.1
-        u32div.4
-        movup.2
-        u32div.16
-        exec.::intrinsics::mem::store_sw
-        movup.2
-        u32mod.2
-        assertz.err=0
         push.4294901760
-        movup.4
+        movup.5
         swap.1
         u32and
-        movup.3
+        dup.4
         swap.1
         u32wrapping_add
         push.2
@@ -963,41 +930,15 @@ export."<wee_alloc::LargeAllocPolicy as wee_alloc::AllocPolicy>::new_cell_for_fr
         movup.2
         u32div.16
         exec.::intrinsics::mem::store_sw
-        swap.1
-        u32mod.2
-        assertz.err=0
-        push.0.0
-        dup.2
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
-        swap.1
-        u32div.4
-        movup.2
-        u32div.16
-        exec.::intrinsics::mem::store_dw
-        u32mod.2
-        assertz.err=0
-    else
-        drop
-        drop
-        dup.0
+        movup.4
         dup.0
         push.2147483648
         u32and
         eq.2147483648
         assertz
+        dup.1
+        movup.5
         swap.1
-        dup.0
-        push.2147483648
-        u32and
-        eq.2147483648
-        assertz
-        add.4
-        u32assert
-        push.1
-        dup.2
         dup.0
         u32mod.16
         dup.0
@@ -1007,9 +948,6 @@ export."<wee_alloc::LargeAllocPolicy as wee_alloc::AllocPolicy>::new_cell_for_fr
         movup.2
         u32div.16
         exec.::intrinsics::mem::store_sw
-        swap.1
-        u32mod.2
-        assertz.err=0
         push.0
         dup.1
         dup.0
@@ -1021,6 +959,55 @@ export."<wee_alloc::LargeAllocPolicy as wee_alloc::AllocPolicy>::new_cell_for_fr
         movup.2
         u32div.16
         exec.::intrinsics::mem::store_sw
+        u32mod.2
+        assertz.err=0
+        u32mod.2
+        assertz.err=0
+        u32mod.2
+        assertz.err=0
+        u32mod.2
+        assertz.err=0
+    else
+        drop
+        drop
+        dup.0
+        dup.0
+        push.2147483648
+        u32and
+        eq.2147483648
+        assertz
+        add.4
+        u32assert
+        swap.1
+        dup.0
+        push.2147483648
+        u32and
+        eq.2147483648
+        assertz
+        push.0
+        dup.2
+        dup.0
+        u32mod.16
+        dup.0
+        u32mod.4
+        swap.1
+        u32div.4
+        movup.2
+        u32div.16
+        exec.::intrinsics::mem::store_sw
+        push.1
+        dup.1
+        dup.0
+        u32mod.16
+        dup.0
+        u32mod.4
+        swap.1
+        u32div.4
+        movup.2
+        u32div.16
+        exec.::intrinsics::mem::store_sw
+        u32mod.2
+        assertz.err=0
         u32mod.2
         assertz.err=0
     end
@@ -1104,7 +1091,7 @@ export."wee_alloc::alloc_first_fit"
                     u32and
                     eq.2147483648
                     assertz
-                    add.4
+                    add.8
                     u32assert
                     dup.2
                     dup.0
@@ -1112,16 +1099,13 @@ export."wee_alloc::alloc_first_fit"
                     u32and
                     eq.2147483648
                     assertz
-                    add.8
+                    add.4
                     u32assert
-                    dup.1
-                    u32mod.2
-                    assertz.err=0
                     push.4294967294
                     movup.3
                     swap.1
                     u32and
-                    dup.1
+                    dup.2
                     dup.0
                     u32mod.16
                     dup.0
@@ -1131,6 +1115,10 @@ export."wee_alloc::alloc_first_fit"
                     movup.2
                     u32div.16
                     exec.::intrinsics::mem::store_sw
+                    dup.0
+                    u32mod.2
+                    assertz.err=0
+                    swap.1
                     u32mod.2
                     assertz.err=0
                     dup.0
@@ -1240,7 +1228,7 @@ export."wee_alloc::alloc_first_fit"
                             neq.0
                             push.1
                         else
-                            dup.4
+                            dup.0
                             dup.0
                             push.2147483648
                             u32and
@@ -1252,28 +1240,13 @@ export."wee_alloc::alloc_first_fit"
                             u32and
                             eq.2147483648
                             assertz
-                            dup.2
+                            dup.6
                             dup.0
                             push.2147483648
                             u32and
                             eq.2147483648
                             assertz
-                            dup.2
-                            dup.4
-                            swap.1
-                            dup.0
-                            u32mod.16
-                            dup.0
-                            u32mod.4
-                            swap.1
-                            u32div.4
-                            movup.2
-                            u32div.16
-                            exec.::intrinsics::mem::store_sw
-                            movup.2
-                            u32mod.2
-                            assertz.err=0
-                            dup.0
+                            dup.1
                             dup.0
                             u32mod.16
                             dup.0
@@ -1285,7 +1258,7 @@ export."wee_alloc::alloc_first_fit"
                             exec.::intrinsics::mem::load_sw
                             push.2
                             u32or
-                            dup.2
+                            dup.3
                             dup.0
                             u32mod.16
                             dup.0
@@ -1295,6 +1268,20 @@ export."wee_alloc::alloc_first_fit"
                             movup.2
                             u32div.16
                             exec.::intrinsics::mem::store_sw
+                            dup.0
+                            dup.4
+                            swap.1
+                            dup.0
+                            u32mod.16
+                            dup.0
+                            u32mod.4
+                            swap.1
+                            u32div.4
+                            movup.2
+                            u32div.16
+                            exec.::intrinsics::mem::store_sw
+                            u32mod.2
+                            assertz.err=0
                             swap.1
                             u32mod.2
                             assertz.err=0
@@ -1401,7 +1388,7 @@ export."wee_alloc::alloc_first_fit"
                             neq.0
                             push.1
                         else
-                            dup.4
+                            dup.0
                             dup.0
                             push.2147483648
                             u32and
@@ -1413,28 +1400,13 @@ export."wee_alloc::alloc_first_fit"
                             u32and
                             eq.2147483648
                             assertz
-                            dup.2
+                            dup.6
                             dup.0
                             push.2147483648
                             u32and
                             eq.2147483648
                             assertz
-                            dup.2
-                            dup.4
-                            swap.1
-                            dup.0
-                            u32mod.16
-                            dup.0
-                            u32mod.4
-                            swap.1
-                            u32div.4
-                            movup.2
-                            u32div.16
-                            exec.::intrinsics::mem::store_sw
-                            movup.2
-                            u32mod.2
-                            assertz.err=0
-                            dup.0
+                            dup.1
                             dup.0
                             u32mod.16
                             dup.0
@@ -1446,7 +1418,7 @@ export."wee_alloc::alloc_first_fit"
                             exec.::intrinsics::mem::load_sw
                             push.2
                             u32or
-                            dup.2
+                            dup.3
                             dup.0
                             u32mod.16
                             dup.0
@@ -1456,6 +1428,20 @@ export."wee_alloc::alloc_first_fit"
                             movup.2
                             u32div.16
                             exec.::intrinsics::mem::store_sw
+                            dup.0
+                            dup.4
+                            swap.1
+                            dup.0
+                            u32mod.16
+                            dup.0
+                            u32mod.4
+                            swap.1
+                            u32div.4
+                            movup.2
+                            u32div.16
+                            exec.::intrinsics::mem::store_sw
+                            u32mod.2
+                            assertz.err=0
                             swap.1
                             u32mod.2
                             assertz.err=0
@@ -1599,7 +1585,7 @@ export."wee_alloc::alloc_first_fit"
                             dup.1
                             swap.1
                             u32wrapping_add
-                            dup.2
+                            swap.1
                             dup.0
                             push.2147483648
                             u32and
@@ -1611,28 +1597,47 @@ export."wee_alloc::alloc_first_fit"
                             u32and
                             eq.2147483648
                             assertz
-                            dup.4
-                            dup.0
-                            push.2147483648
-                            u32and
-                            eq.2147483648
-                            assertz
-                            dup.3
-                            dup.0
-                            push.2147483648
-                            u32and
-                            eq.2147483648
-                            assertz
-                            movup.5
-                            dup.0
-                            push.2147483648
-                            u32and
-                            eq.2147483648
-                            assertz
-                            dup.4
-                            u32mod.2
-                            assertz.err=0
+                            push.0
                             dup.2
+                            dup.0
+                            u32mod.16
+                            dup.0
+                            u32mod.4
+                            swap.1
+                            u32div.4
+                            movup.2
+                            u32div.16
+                            exec.::intrinsics::mem::store_sw
+                            dup.2
+                            dup.0
+                            push.2147483648
+                            u32and
+                            eq.2147483648
+                            assertz
+                            dup.4
+                            dup.0
+                            push.2147483648
+                            u32and
+                            eq.2147483648
+                            assertz
+                            push.0.0
+                            dup.4
+                            dup.0
+                            u32mod.16
+                            dup.0
+                            u32mod.4
+                            swap.1
+                            u32div.4
+                            movup.2
+                            u32div.16
+                            exec.::intrinsics::mem::store_dw
+                            dup.5
+                            dup.0
+                            push.2147483648
+                            u32and
+                            eq.2147483648
+                            assertz
+                            dup.1
                             dup.0
                             u32mod.16
                             dup.0
@@ -1644,23 +1649,6 @@ export."wee_alloc::alloc_first_fit"
                             exec.::intrinsics::mem::load_sw
                             push.4294967292
                             u32and
-                            dup.4
-                            dup.0
-                            u32mod.16
-                            dup.0
-                            u32mod.4
-                            swap.1
-                            u32div.4
-                            movup.2
-                            u32div.16
-                            exec.::intrinsics::mem::store_sw
-                            movup.3
-                            u32mod.2
-                            assertz.err=0
-                            movup.2
-                            u32mod.2
-                            assertz.err=0
-                            push.0.0
                             dup.3
                             dup.0
                             u32mod.16
@@ -1670,21 +1658,20 @@ export."wee_alloc::alloc_first_fit"
                             u32div.4
                             movup.2
                             u32div.16
-                            exec.::intrinsics::mem::store_dw
+                            exec.::intrinsics::mem::store_sw
+                            dup.0
+                            u32mod.2
+                            assertz.err=0
+                            movup.2
+                            u32mod.2
+                            assertz.err=0
                             swap.1
                             u32mod.2
                             assertz.err=0
-                            push.0
-                            dup.1
-                            dup.0
-                            u32mod.16
-                            dup.0
-                            u32mod.4
                             swap.1
-                            u32div.4
-                            movup.2
-                            u32div.16
-                            exec.::intrinsics::mem::store_sw
+                            u32mod.2
+                            assertz.err=0
+                            swap.1
                             u32mod.2
                             assertz.err=0
                             push.0
@@ -1705,45 +1692,7 @@ export."wee_alloc::alloc_first_fit"
                             neq.0
                             if.true
                                 drop
-                                dup.2
-                                dup.0
-                                push.2147483648
-                                u32and
-                                eq.2147483648
-                                assertz
-                                dup.3
-                                dup.0
-                                push.2147483648
-                                u32and
-                                eq.2147483648
-                                assertz
                                 dup.1
-                                dup.0
-                                u32mod.16
-                                dup.0
-                                u32mod.4
-                                swap.1
-                                u32div.4
-                                movup.2
-                                u32div.16
-                                exec.::intrinsics::mem::load_sw
-                                dup.5
-                                dup.0
-                                push.2147483648
-                                u32and
-                                eq.2147483648
-                                assertz
-                                add.8
-                                u32assert
-                                dup.6
-                                dup.0
-                                push.2147483648
-                                u32and
-                                eq.2147483648
-                                assertz
-                                add.8
-                                u32assert
-                                dup.6
                                 dup.0
                                 push.2147483648
                                 u32and
@@ -1751,15 +1700,28 @@ export."wee_alloc::alloc_first_fit"
                                 assertz
                                 add.4
                                 u32assert
-                                push.3
-                                dup.4
-                                swap.1
+                                dup.3
+                                dup.0
+                                push.2147483648
                                 u32and
-                                dup.8
-                                u32or
+                                eq.2147483648
+                                assertz
+                                add.8
+                                u32assert
+                                dup.4
+                                dup.0
+                                push.2147483648
+                                u32and
+                                eq.2147483648
+                                assertz
+                                add.8
+                                u32assert
                                 dup.5
-                                dup.1
                                 swap.1
+                                swap.4
+                                swap.1
+                                u32or
+                                dup.2
                                 dup.0
                                 u32mod.16
                                 dup.0
@@ -1769,13 +1731,13 @@ export."wee_alloc::alloc_first_fit"
                                 movup.2
                                 u32div.16
                                 exec.::intrinsics::mem::store_sw
-                                movup.5
-                                u32mod.2
-                                assertz.err=0
-                                movup.5
-                                u32mod.2
-                                assertz.err=0
-                                dup.2
+                                dup.4
+                                dup.0
+                                push.2147483648
+                                u32and
+                                eq.2147483648
+                                assertz
+                                dup.3
                                 dup.0
                                 u32mod.16
                                 dup.0
@@ -1787,7 +1749,7 @@ export."wee_alloc::alloc_first_fit"
                                 exec.::intrinsics::mem::load_sw
                                 push.4294967294
                                 u32and
-                                dup.4
+                                dup.2
                                 dup.0
                                 u32mod.16
                                 dup.0
@@ -1797,17 +1759,12 @@ export."wee_alloc::alloc_first_fit"
                                 movup.2
                                 u32div.16
                                 exec.::intrinsics::mem::store_sw
-                                movup.3
-                                u32mod.2
-                                assertz.err=0
-                                movup.2
-                                u32mod.2
-                                assertz.err=0
                                 dup.5
-                                swap.1
-                                swap.4
-                                swap.1
-                                u32or
+                                dup.0
+                                push.2147483648
+                                u32and
+                                eq.2147483648
+                                assertz
                                 dup.1
                                 dup.0
                                 u32mod.16
@@ -1817,14 +1774,47 @@ export."wee_alloc::alloc_first_fit"
                                 u32div.4
                                 movup.2
                                 u32div.16
+                                exec.::intrinsics::mem::load_sw
+                                push.3
+                                dup.1
+                                swap.1
+                                u32and
+                                dup.7
+                                u32or
+                                dup.2
+                                dup.1
+                                swap.1
+                                dup.0
+                                u32mod.16
+                                dup.0
+                                u32mod.4
+                                swap.1
+                                u32div.4
+                                movup.2
+                                u32div.16
                                 exec.::intrinsics::mem::store_sw
+                                movup.2
+                                u32mod.2
+                                assertz.err=0
+                                movup.2
+                                u32mod.2
+                                assertz.err=0
+                                movup.2
+                                u32mod.2
+                                assertz.err=0
+                                movup.3
+                                u32mod.2
+                                assertz.err=0
+                                movup.2
                                 u32mod.2
                                 assertz.err=0
                                 push.2
+                                movup.2
+                                swap.1
                                 u32and
                                 neq.0
                                 if.true
-                                    dup.1
+                                    movup.2
                                     dup.0
                                     push.2147483648
                                     u32and
@@ -1836,13 +1826,27 @@ export."wee_alloc::alloc_first_fit"
                                     u32and
                                     eq.2147483648
                                     assertz
-                                    movup.4
+                                    dup.3
                                     dup.0
                                     push.2147483648
                                     u32and
                                     eq.2147483648
                                     assertz
-                                    dup.1
+                                    push.4294967293
+                                    movup.4
+                                    swap.1
+                                    u32and
+                                    dup.3
+                                    dup.0
+                                    u32mod.16
+                                    dup.0
+                                    u32mod.4
+                                    swap.1
+                                    u32div.4
+                                    movup.2
+                                    u32div.16
+                                    exec.::intrinsics::mem::store_sw
+                                    dup.0
                                     dup.0
                                     u32mod.16
                                     dup.0
@@ -1856,7 +1860,7 @@ export."wee_alloc::alloc_first_fit"
                                     u32or
                                     push.1
                                     u32or
-                                    dup.3
+                                    dup.2
                                     dup.0
                                     u32mod.16
                                     dup.0
@@ -1866,26 +1870,11 @@ export."wee_alloc::alloc_first_fit"
                                     movup.2
                                     u32div.16
                                     exec.::intrinsics::mem::store_sw
-                                    movup.2
-                                    u32mod.2
-                                    assertz.err=0
                                     swap.1
                                     u32mod.2
                                     assertz.err=0
-                                    push.4294967293
-                                    movup.2
-                                    swap.1
-                                    u32and
-                                    dup.1
-                                    dup.0
-                                    u32mod.16
-                                    dup.0
-                                    u32mod.4
-                                    swap.1
-                                    u32div.4
-                                    movup.2
-                                    u32div.16
-                                    exec.::intrinsics::mem::store_sw
+                                    u32mod.2
+                                    assertz.err=0
                                     u32mod.2
                                     assertz.err=0
                                     push.8
@@ -1944,45 +1933,7 @@ export."wee_alloc::alloc_first_fit"
                                 neq.0
                                 if.true
                                     drop
-                                    dup.2
-                                    dup.0
-                                    push.2147483648
-                                    u32and
-                                    eq.2147483648
-                                    assertz
-                                    dup.3
-                                    dup.0
-                                    push.2147483648
-                                    u32and
-                                    eq.2147483648
-                                    assertz
                                     dup.1
-                                    dup.0
-                                    u32mod.16
-                                    dup.0
-                                    u32mod.4
-                                    swap.1
-                                    u32div.4
-                                    movup.2
-                                    u32div.16
-                                    exec.::intrinsics::mem::load_sw
-                                    dup.5
-                                    dup.0
-                                    push.2147483648
-                                    u32and
-                                    eq.2147483648
-                                    assertz
-                                    add.8
-                                    u32assert
-                                    dup.6
-                                    dup.0
-                                    push.2147483648
-                                    u32and
-                                    eq.2147483648
-                                    assertz
-                                    add.8
-                                    u32assert
-                                    dup.6
                                     dup.0
                                     push.2147483648
                                     u32and
@@ -1990,15 +1941,28 @@ export."wee_alloc::alloc_first_fit"
                                     assertz
                                     add.4
                                     u32assert
-                                    push.3
-                                    dup.4
-                                    swap.1
+                                    dup.3
+                                    dup.0
+                                    push.2147483648
                                     u32and
-                                    dup.8
-                                    u32or
+                                    eq.2147483648
+                                    assertz
+                                    add.8
+                                    u32assert
+                                    dup.4
+                                    dup.0
+                                    push.2147483648
+                                    u32and
+                                    eq.2147483648
+                                    assertz
+                                    add.8
+                                    u32assert
                                     dup.5
-                                    dup.1
                                     swap.1
+                                    swap.4
+                                    swap.1
+                                    u32or
+                                    dup.2
                                     dup.0
                                     u32mod.16
                                     dup.0
@@ -2008,13 +1972,13 @@ export."wee_alloc::alloc_first_fit"
                                     movup.2
                                     u32div.16
                                     exec.::intrinsics::mem::store_sw
-                                    movup.5
-                                    u32mod.2
-                                    assertz.err=0
-                                    movup.5
-                                    u32mod.2
-                                    assertz.err=0
-                                    dup.2
+                                    dup.4
+                                    dup.0
+                                    push.2147483648
+                                    u32and
+                                    eq.2147483648
+                                    assertz
+                                    dup.3
                                     dup.0
                                     u32mod.16
                                     dup.0
@@ -2026,7 +1990,7 @@ export."wee_alloc::alloc_first_fit"
                                     exec.::intrinsics::mem::load_sw
                                     push.4294967294
                                     u32and
-                                    dup.4
+                                    dup.2
                                     dup.0
                                     u32mod.16
                                     dup.0
@@ -2036,17 +2000,12 @@ export."wee_alloc::alloc_first_fit"
                                     movup.2
                                     u32div.16
                                     exec.::intrinsics::mem::store_sw
-                                    movup.3
-                                    u32mod.2
-                                    assertz.err=0
-                                    movup.2
-                                    u32mod.2
-                                    assertz.err=0
                                     dup.5
-                                    swap.1
-                                    swap.4
-                                    swap.1
-                                    u32or
+                                    dup.0
+                                    push.2147483648
+                                    u32and
+                                    eq.2147483648
+                                    assertz
                                     dup.1
                                     dup.0
                                     u32mod.16
@@ -2056,14 +2015,47 @@ export."wee_alloc::alloc_first_fit"
                                     u32div.4
                                     movup.2
                                     u32div.16
+                                    exec.::intrinsics::mem::load_sw
+                                    push.3
+                                    dup.1
+                                    swap.1
+                                    u32and
+                                    dup.7
+                                    u32or
+                                    dup.2
+                                    dup.1
+                                    swap.1
+                                    dup.0
+                                    u32mod.16
+                                    dup.0
+                                    u32mod.4
+                                    swap.1
+                                    u32div.4
+                                    movup.2
+                                    u32div.16
                                     exec.::intrinsics::mem::store_sw
+                                    movup.2
+                                    u32mod.2
+                                    assertz.err=0
+                                    movup.2
+                                    u32mod.2
+                                    assertz.err=0
+                                    movup.2
+                                    u32mod.2
+                                    assertz.err=0
+                                    movup.3
+                                    u32mod.2
+                                    assertz.err=0
+                                    movup.2
                                     u32mod.2
                                     assertz.err=0
                                     push.2
+                                    movup.2
+                                    swap.1
                                     u32and
                                     neq.0
                                     if.true
-                                        dup.1
+                                        movup.2
                                         dup.0
                                         push.2147483648
                                         u32and
@@ -2075,13 +2067,27 @@ export."wee_alloc::alloc_first_fit"
                                         u32and
                                         eq.2147483648
                                         assertz
-                                        movup.4
+                                        dup.3
                                         dup.0
                                         push.2147483648
                                         u32and
                                         eq.2147483648
                                         assertz
-                                        dup.1
+                                        push.4294967293
+                                        movup.4
+                                        swap.1
+                                        u32and
+                                        dup.3
+                                        dup.0
+                                        u32mod.16
+                                        dup.0
+                                        u32mod.4
+                                        swap.1
+                                        u32div.4
+                                        movup.2
+                                        u32div.16
+                                        exec.::intrinsics::mem::store_sw
+                                        dup.0
                                         dup.0
                                         u32mod.16
                                         dup.0
@@ -2095,7 +2101,7 @@ export."wee_alloc::alloc_first_fit"
                                         u32or
                                         push.1
                                         u32or
-                                        dup.3
+                                        dup.2
                                         dup.0
                                         u32mod.16
                                         dup.0
@@ -2105,26 +2111,11 @@ export."wee_alloc::alloc_first_fit"
                                         movup.2
                                         u32div.16
                                         exec.::intrinsics::mem::store_sw
-                                        movup.2
-                                        u32mod.2
-                                        assertz.err=0
                                         swap.1
                                         u32mod.2
                                         assertz.err=0
-                                        push.4294967293
-                                        movup.2
-                                        swap.1
-                                        u32and
-                                        dup.1
-                                        dup.0
-                                        u32mod.16
-                                        dup.0
-                                        u32mod.4
-                                        swap.1
-                                        u32div.4
-                                        movup.2
-                                        u32div.16
-                                        exec.::intrinsics::mem::store_sw
+                                        u32mod.2
+                                        assertz.err=0
                                         u32mod.2
                                         assertz.err=0
                                         push.8
@@ -2178,19 +2169,39 @@ export."wee_alloc::alloc_first_fit"
                                 else
                                     swap.1
                                     drop
+                                    dup.0
+                                    dup.0
+                                    push.2147483648
+                                    u32and
+                                    eq.2147483648
+                                    assertz
+                                    add.4
+                                    u32assert
+                                    swap.1
+                                    dup.0
+                                    push.2147483648
+                                    u32and
+                                    eq.2147483648
+                                    assertz
+                                    add.4
+                                    u32assert
                                     dup.2
                                     dup.0
                                     push.2147483648
                                     u32and
                                     eq.2147483648
                                     assertz
+                                    add.4
+                                    u32assert
                                     dup.3
                                     dup.0
                                     push.2147483648
                                     u32and
                                     eq.2147483648
                                     assertz
-                                    dup.1
+                                    add.4
+                                    u32assert
+                                    dup.2
                                     dup.0
                                     u32mod.16
                                     dup.0
@@ -2200,63 +2211,11 @@ export."wee_alloc::alloc_first_fit"
                                     movup.2
                                     u32div.16
                                     exec.::intrinsics::mem::load_sw
-                                    dup.5
-                                    dup.0
-                                    push.2147483648
-                                    u32and
-                                    eq.2147483648
-                                    assertz
-                                    add.8
-                                    u32assert
-                                    dup.6
-                                    dup.0
-                                    push.2147483648
-                                    u32and
-                                    eq.2147483648
-                                    assertz
-                                    add.8
-                                    u32assert
-                                    dup.6
-                                    dup.0
-                                    push.2147483648
-                                    u32and
-                                    eq.2147483648
-                                    assertz
-                                    add.4
-                                    u32assert
-                                    dup.7
-                                    dup.0
-                                    push.2147483648
-                                    u32and
-                                    eq.2147483648
-                                    assertz
-                                    add.4
-                                    u32assert
-                                    dup.7
-                                    dup.0
-                                    push.2147483648
-                                    u32and
-                                    eq.2147483648
-                                    assertz
-                                    add.4
-                                    u32assert
-                                    movup.8
-                                    dup.0
-                                    push.2147483648
-                                    u32and
-                                    eq.2147483648
-                                    assertz
-                                    add.4
-                                    u32assert
                                     push.3
-                                    dup.7
-                                    swap.1
                                     u32and
-                                    dup.10
+                                    dup.5
                                     u32or
-                                    dup.8
-                                    dup.1
-                                    swap.1
+                                    dup.4
                                     dup.0
                                     u32mod.16
                                     dup.0
@@ -2266,13 +2225,53 @@ export."wee_alloc::alloc_first_fit"
                                     movup.2
                                     u32div.16
                                     exec.::intrinsics::mem::store_sw
-                                    movup.8
-                                    u32mod.2
-                                    assertz.err=0
-                                    movup.8
-                                    u32mod.2
-                                    assertz.err=0
                                     dup.5
+                                    dup.0
+                                    push.2147483648
+                                    u32and
+                                    eq.2147483648
+                                    assertz
+                                    add.8
+                                    u32assert
+                                    dup.6
+                                    dup.0
+                                    push.2147483648
+                                    u32and
+                                    eq.2147483648
+                                    assertz
+                                    add.8
+                                    u32assert
+                                    dup.2
+                                    dup.0
+                                    u32mod.16
+                                    dup.0
+                                    u32mod.4
+                                    swap.1
+                                    u32div.4
+                                    movup.2
+                                    u32div.16
+                                    exec.::intrinsics::mem::load_sw
+                                    push.3
+                                    u32and
+                                    dup.8
+                                    u32or
+                                    dup.4
+                                    dup.0
+                                    u32mod.16
+                                    dup.0
+                                    u32mod.4
+                                    swap.1
+                                    u32div.4
+                                    movup.2
+                                    u32div.16
+                                    exec.::intrinsics::mem::store_sw
+                                    dup.7
+                                    dup.0
+                                    push.2147483648
+                                    u32and
+                                    eq.2147483648
+                                    assertz
+                                    dup.1
                                     dup.0
                                     u32mod.16
                                     dup.0
@@ -2284,22 +2283,6 @@ export."wee_alloc::alloc_first_fit"
                                     exec.::intrinsics::mem::load_sw
                                     push.4294967294
                                     u32and
-                                    dup.7
-                                    dup.0
-                                    u32mod.16
-                                    dup.0
-                                    u32mod.4
-                                    swap.1
-                                    u32div.4
-                                    movup.2
-                                    u32div.16
-                                    exec.::intrinsics::mem::store_sw
-                                    movup.6
-                                    u32mod.2
-                                    assertz.err=0
-                                    movup.5
-                                    u32mod.2
-                                    assertz.err=0
                                     dup.3
                                     dup.0
                                     u32mod.16
@@ -2309,27 +2292,13 @@ export."wee_alloc::alloc_first_fit"
                                     u32div.4
                                     movup.2
                                     u32div.16
-                                    exec.::intrinsics::mem::load_sw
-                                    push.3
-                                    u32and
-                                    dup.8
-                                    u32or
-                                    dup.5
-                                    dup.0
-                                    u32mod.16
-                                    dup.0
-                                    u32mod.4
-                                    swap.1
-                                    u32div.4
-                                    movup.2
-                                    u32div.16
                                     exec.::intrinsics::mem::store_sw
-                                    movup.4
-                                    u32mod.2
-                                    assertz.err=0
-                                    movup.3
-                                    u32mod.2
-                                    assertz.err=0
+                                    dup.8
+                                    dup.0
+                                    push.2147483648
+                                    u32and
+                                    eq.2147483648
+                                    assertz
                                     dup.1
                                     dup.0
                                     u32mod.16
@@ -2341,10 +2310,14 @@ export."wee_alloc::alloc_first_fit"
                                     u32div.16
                                     exec.::intrinsics::mem::load_sw
                                     push.3
+                                    dup.1
+                                    swap.1
                                     u32and
-                                    dup.5
+                                    dup.10
                                     u32or
-                                    dup.3
+                                    dup.2
+                                    dup.1
+                                    swap.1
                                     dup.0
                                     u32mod.16
                                     dup.0
@@ -2357,7 +2330,25 @@ export."wee_alloc::alloc_first_fit"
                                     movup.2
                                     u32mod.2
                                     assertz.err=0
-                                    swap.1
+                                    movup.2
+                                    u32mod.2
+                                    assertz.err=0
+                                    movup.3
+                                    u32mod.2
+                                    assertz.err=0
+                                    movup.2
+                                    u32mod.2
+                                    assertz.err=0
+                                    movup.3
+                                    u32mod.2
+                                    assertz.err=0
+                                    movup.2
+                                    u32mod.2
+                                    assertz.err=0
+                                    movup.3
+                                    u32mod.2
+                                    assertz.err=0
+                                    movup.2
                                     u32mod.2
                                     assertz.err=0
                                     push.2
@@ -2366,7 +2357,7 @@ export."wee_alloc::alloc_first_fit"
                                     u32and
                                     neq.0
                                     if.true
-                                        dup.1
+                                        movup.2
                                         dup.0
                                         push.2147483648
                                         u32and
@@ -2378,13 +2369,27 @@ export."wee_alloc::alloc_first_fit"
                                         u32and
                                         eq.2147483648
                                         assertz
-                                        movup.4
+                                        dup.3
                                         dup.0
                                         push.2147483648
                                         u32and
                                         eq.2147483648
                                         assertz
-                                        dup.1
+                                        push.4294967293
+                                        movup.4
+                                        swap.1
+                                        u32and
+                                        dup.3
+                                        dup.0
+                                        u32mod.16
+                                        dup.0
+                                        u32mod.4
+                                        swap.1
+                                        u32div.4
+                                        movup.2
+                                        u32div.16
+                                        exec.::intrinsics::mem::store_sw
+                                        dup.0
                                         dup.0
                                         u32mod.16
                                         dup.0
@@ -2398,7 +2403,7 @@ export."wee_alloc::alloc_first_fit"
                                         u32or
                                         push.1
                                         u32or
-                                        dup.3
+                                        dup.2
                                         dup.0
                                         u32mod.16
                                         dup.0
@@ -2408,26 +2413,11 @@ export."wee_alloc::alloc_first_fit"
                                         movup.2
                                         u32div.16
                                         exec.::intrinsics::mem::store_sw
-                                        movup.2
-                                        u32mod.2
-                                        assertz.err=0
                                         swap.1
                                         u32mod.2
                                         assertz.err=0
-                                        push.4294967293
-                                        movup.2
-                                        swap.1
-                                        u32and
-                                        dup.1
-                                        dup.0
-                                        u32mod.16
-                                        dup.0
-                                        u32mod.4
-                                        swap.1
-                                        u32div.4
-                                        movup.2
-                                        u32div.16
-                                        exec.::intrinsics::mem::store_sw
+                                        u32mod.2
+                                        assertz.err=0
                                         u32mod.2
                                         assertz.err=0
                                         push.8
@@ -2523,7 +2513,7 @@ export."wee_alloc::alloc_first_fit"
                                 drop
                                 movup.3
                                 drop
-                                dup.1
+                                movup.2
                                 dup.0
                                 push.2147483648
                                 u32and
@@ -2535,13 +2525,27 @@ export."wee_alloc::alloc_first_fit"
                                 u32and
                                 eq.2147483648
                                 assertz
-                                movup.4
+                                dup.3
                                 dup.0
                                 push.2147483648
                                 u32and
                                 eq.2147483648
                                 assertz
-                                dup.1
+                                push.4294967292
+                                movup.4
+                                swap.1
+                                u32and
+                                dup.3
+                                dup.0
+                                u32mod.16
+                                dup.0
+                                u32mod.4
+                                swap.1
+                                u32div.4
+                                movup.2
+                                u32div.16
+                                exec.::intrinsics::mem::store_sw
+                                dup.0
                                 dup.0
                                 u32mod.16
                                 dup.0
@@ -2553,7 +2557,7 @@ export."wee_alloc::alloc_first_fit"
                                 exec.::intrinsics::mem::load_sw
                                 push.1
                                 u32or
-                                dup.3
+                                dup.2
                                 dup.0
                                 u32mod.16
                                 dup.0
@@ -2563,26 +2567,11 @@ export."wee_alloc::alloc_first_fit"
                                 movup.2
                                 u32div.16
                                 exec.::intrinsics::mem::store_sw
-                                movup.2
-                                u32mod.2
-                                assertz.err=0
                                 swap.1
                                 u32mod.2
                                 assertz.err=0
-                                push.4294967292
-                                movup.2
-                                swap.1
-                                u32and
-                                dup.1
-                                dup.0
-                                u32mod.16
-                                dup.0
-                                u32mod.4
-                                swap.1
-                                u32div.4
-                                movup.2
-                                u32div.16
-                                exec.::intrinsics::mem::store_sw
+                                u32mod.2
+                                assertz.err=0
                                 u32mod.2
                                 assertz.err=0
                                 push.8
@@ -2717,14 +2706,14 @@ export."<wee_alloc::WeeAlloc as core::alloc::global::GlobalAlloc>::alloc"
             u32and
             eq.2147483648
             assertz
-            dup.0
-            u32mod.2
-            assertz.err=0
             dup.3
             dup.2
             dup.4
             dup.5
             exec."<wee_alloc::LargeAllocPolicy as wee_alloc::AllocPolicy>::new_cell_for_free_list"
+            dup.0
+            u32mod.2
+            assertz.err=0
             dup.0
             u32mod.16
             dup.0
@@ -2755,12 +2744,14 @@ export."<wee_alloc::WeeAlloc as core::alloc::global::GlobalAlloc>::alloc"
                 movup.2
                 u32div.16
                 exec.::intrinsics::mem::load_sw
-                movup.5
+                dup.0
                 dup.0
                 push.2147483648
                 u32and
                 eq.2147483648
                 assertz
+                add.8
+                u32assert
                 dup.4
                 dup.0
                 push.2147483648
@@ -2777,15 +2768,45 @@ export."<wee_alloc::WeeAlloc as core::alloc::global::GlobalAlloc>::alloc"
                 assertz
                 add.12
                 u32assert
+                dup.1
+                dup.0
+                u32mod.16
+                dup.0
+                u32mod.4
+                swap.1
+                u32div.4
+                movup.2
+                u32div.16
+                exec.::intrinsics::mem::load_sw
                 dup.3
+                dup.0
+                u32mod.16
+                dup.0
+                u32mod.4
+                swap.1
+                u32div.4
+                movup.2
+                u32div.16
+                exec.::intrinsics::mem::store_sw
+                dup.0
+                movup.4
+                swap.1
+                dup.0
+                u32mod.16
+                dup.0
+                u32mod.4
+                swap.1
+                u32div.4
+                movup.2
+                u32div.16
+                exec.::intrinsics::mem::store_sw
+                movup.7
                 dup.0
                 push.2147483648
                 u32and
                 eq.2147483648
                 assertz
-                add.8
-                u32assert
-                dup.7
+                dup.6
                 dup.0
                 push.2147483648
                 u32and
@@ -2793,82 +2814,54 @@ export."<wee_alloc::WeeAlloc as core::alloc::global::GlobalAlloc>::alloc"
                 assertz
                 add.12
                 u32assert
-                dup.3
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::load_sw
-                dup.5
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::store_sw
-                movup.4
-                u32mod.2
-                assertz.err=0
-                movup.3
-                u32mod.2
-                assertz.err=0
-                dup.2
-                movup.4
-                swap.1
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::store_sw
-                movup.2
-                u32mod.2
-                assertz.err=0
-                dup.0
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::load_sw
-                dup.2
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::store_sw
-                swap.1
-                u32mod.2
-                assertz.err=0
-                u32mod.2
-                assertz.err=0
-                u32mod.2
-                assertz.err=0
                 push.12
-                dup.2
+                dup.8
                 swap.1
                 u32wrapping_add
-                swap.2
-                swap.3
                 swap.1
+                swap.9
+                swap.1
+                swap.2
+                swap.7
                 exec."wee_alloc::alloc_first_fit"
+                dup.7
+                dup.0
+                u32mod.16
+                dup.0
+                u32mod.4
+                swap.1
+                u32div.4
+                movup.2
+                u32div.16
+                exec.::intrinsics::mem::load_sw
+                dup.6
+                dup.0
+                u32mod.16
+                dup.0
+                u32mod.4
+                swap.1
+                u32div.4
+                movup.2
+                u32div.16
+                exec.::intrinsics::mem::store_sw
+                movup.5
+                u32mod.2
+                assertz.err=0
+                movup.6
+                u32mod.2
+                assertz.err=0
+                swap.1
+                u32mod.2
+                assertz.err=0
+                movup.2
+                u32mod.2
+                assertz.err=0
+                swap.1
+                u32mod.2
+                assertz.err=0
+                swap.1
+                u32mod.2
+                assertz.err=0
                 dup.0
                 neq.0
                 if.true
@@ -2919,19 +2912,6 @@ export."<wee_alloc::WeeAlloc as core::alloc::global::GlobalAlloc>::alloc"
                 assertz
                 add.12
                 u32assert
-                push.16
-                movup.3
-                swap.1
-                u32wrapping_add
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
-                swap.1
-                u32div.4
-                movup.2
-                u32div.16
-                exec.::intrinsics::mem::store_sw
                 dup.0
                 dup.0
                 u32mod.16
@@ -2943,6 +2923,19 @@ export."<wee_alloc::WeeAlloc as core::alloc::global::GlobalAlloc>::alloc"
                 u32div.16
                 exec.::intrinsics::mem::load_sw
                 dup.2
+                dup.0
+                u32mod.16
+                dup.0
+                u32mod.4
+                swap.1
+                u32div.4
+                movup.2
+                u32div.16
+                exec.::intrinsics::mem::store_sw
+                push.16
+                movup.3
+                swap.1
+                u32wrapping_add
                 dup.0
                 u32mod.16
                 dup.0
@@ -2978,19 +2971,6 @@ export."<wee_alloc::WeeAlloc as core::alloc::global::GlobalAlloc>::alloc"
             assertz
             add.12
             u32assert
-            push.16
-            movup.3
-            swap.1
-            u32wrapping_add
-            dup.0
-            u32mod.16
-            dup.0
-            u32mod.4
-            swap.1
-            u32div.4
-            movup.2
-            u32div.16
-            exec.::intrinsics::mem::store_sw
             dup.0
             dup.0
             u32mod.16
@@ -3002,6 +2982,19 @@ export."<wee_alloc::WeeAlloc as core::alloc::global::GlobalAlloc>::alloc"
             u32div.16
             exec.::intrinsics::mem::load_sw
             dup.2
+            dup.0
+            u32mod.16
+            dup.0
+            u32mod.4
+            swap.1
+            u32div.4
+            movup.2
+            u32div.16
+            exec.::intrinsics::mem::store_sw
+            push.16
+            movup.3
+            swap.1
+            u32wrapping_add
             dup.0
             u32mod.16
             dup.0
@@ -3025,6 +3018,17 @@ export."miden_tx_kernel_sys::get_inputs"
     mem_load.0x00000000
     push.16
     u32wrapping_sub
+    dup.1
+    swap.1
+    dup.0
+    u32mod.16
+    dup.0
+    u32mod.4
+    swap.1
+    u32div.4
+    movup.2
+    u32div.16
+    exec.::intrinsics::mem::store_sw
     dup.0
     dup.0
     push.2147483648
@@ -3049,6 +3053,13 @@ export."miden_tx_kernel_sys::get_inputs"
     assertz
     add.12
     u32assert
+    push.0
+    push.256
+    push.4
+    dup.6
+    swap.1
+    u32wrapping_add
+    exec."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
     dup.2
     u32mod.2
     assertz.err=0
@@ -3078,24 +3089,6 @@ export."miden_tx_kernel_sys::get_inputs"
     movup.2
     u32mod.2
     assertz.err=0
-    push.0
-    push.256
-    push.4
-    dup.6
-    swap.1
-    u32wrapping_add
-    exec."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
-    dup.4
-    swap.1
-    dup.0
-    u32mod.16
-    dup.0
-    u32mod.4
-    swap.1
-    u32div.4
-    movup.2
-    u32div.16
-    exec.::intrinsics::mem::store_sw
     movup.2
     dup.0
     u32mod.16
@@ -3109,14 +3102,16 @@ export."miden_tx_kernel_sys::get_inputs"
     eq.0
     neq.0
     if.true
-        dup.0
-        exec.::miden::note::get_inputs
-        dup.5
+        dup.3
         dup.0
         push.2147483648
         u32and
         eq.2147483648
         assertz
+        add.8
+        u32assert
+        dup.1
+        exec.::miden::note::get_inputs
         dup.6
         dup.0
         push.2147483648
@@ -3125,16 +3120,49 @@ export."miden_tx_kernel_sys::get_inputs"
         assertz
         add.4
         u32assert
+        push.0
+        dup.4
+        dup.0
+        u32mod.16
+        dup.0
+        u32mod.4
+        swap.1
+        u32div.4
+        movup.2
+        u32div.16
+        exec.::intrinsics::mem::store_sw
         movup.7
         dup.0
         push.2147483648
         u32and
         eq.2147483648
         assertz
-        add.8
-        u32assert
+        dup.1
+        movup.6
+        swap.1
+        dup.0
+        u32mod.16
+        dup.0
+        u32mod.4
+        swap.1
+        u32div.4
+        movup.2
+        u32div.16
+        exec.::intrinsics::mem::store_sw
+        dup.0
+        movup.6
+        swap.1
+        dup.0
+        u32mod.16
+        dup.0
+        u32mod.4
+        swap.1
+        u32div.4
+        movup.2
+        u32div.16
+        exec.::intrinsics::mem::store_sw
         push.16
-        movup.8
+        movup.6
         swap.1
         u32wrapping_add
         dup.0
@@ -3146,47 +3174,11 @@ export."miden_tx_kernel_sys::get_inputs"
         movup.2
         u32div.16
         exec.::intrinsics::mem::store_sw
-        dup.2
-        movup.7
-        swap.1
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
-        swap.1
-        u32div.4
-        movup.2
-        u32div.16
-        exec.::intrinsics::mem::store_sw
-        movup.2
         u32mod.2
         assertz.err=0
-        dup.1
-        movup.5
-        swap.1
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
-        swap.1
-        u32div.4
-        movup.2
-        u32div.16
-        exec.::intrinsics::mem::store_sw
-        swap.1
         u32mod.2
         assertz.err=0
-        push.0
-        dup.1
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
-        swap.1
-        u32div.4
         movup.2
-        u32div.16
-        exec.::intrinsics::mem::store_sw
         u32mod.2
         assertz.err=0
         dropw
@@ -3251,6 +3243,8 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     u32and
                     eq.2147483648
                     assertz
+                    add.8
+                    u32assert
                     dup.2
                     dup.0
                     push.2147483648
@@ -3259,16 +3253,9 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     assertz
                     add.4
                     u32assert
+                    dup.1
                     movup.3
-                    dup.0
-                    push.2147483648
-                    u32and
-                    eq.2147483648
-                    assertz
-                    add.8
-                    u32assert
-                    push.1
-                    dup.3
+                    swap.1
                     dup.0
                     u32mod.16
                     dup.0
@@ -3279,8 +3266,11 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     u32div.16
                     exec.::intrinsics::mem::store_sw
                     movup.2
-                    u32mod.2
-                    assertz.err=0
+                    dup.0
+                    push.2147483648
+                    u32and
+                    eq.2147483648
+                    assertz
                     push.4
                     dup.2
                     dup.0
@@ -3292,12 +3282,8 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     movup.2
                     u32div.16
                     exec.::intrinsics::mem::store_sw
-                    swap.1
-                    u32mod.2
-                    assertz.err=0
-                    dup.0
-                    movup.2
-                    swap.1
+                    push.1
+                    dup.1
                     dup.0
                     u32mod.16
                     dup.0
@@ -3307,6 +3293,10 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     movup.2
                     u32div.16
                     exec.::intrinsics::mem::store_sw
+                    u32mod.2
+                    assertz.err=0
+                    u32mod.2
+                    assertz.err=0
                     u32mod.2
                     assertz.err=0
                 else
@@ -3318,6 +3308,8 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     u32and
                     eq.2147483648
                     assertz
+                    add.8
+                    u32assert
                     dup.2
                     dup.0
                     push.2147483648
@@ -3326,16 +3318,9 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     assertz
                     add.4
                     u32assert
+                    dup.1
                     movup.3
-                    dup.0
-                    push.2147483648
-                    u32and
-                    eq.2147483648
-                    assertz
-                    add.8
-                    u32assert
-                    push.0
-                    dup.3
+                    swap.1
                     dup.0
                     u32mod.16
                     dup.0
@@ -3346,8 +3331,11 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     u32div.16
                     exec.::intrinsics::mem::store_sw
                     movup.2
-                    u32mod.2
-                    assertz.err=0
+                    dup.0
+                    push.2147483648
+                    u32and
+                    eq.2147483648
+                    assertz
                     dup.1
                     movup.4
                     swap.1
@@ -3360,12 +3348,8 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     movup.2
                     u32div.16
                     exec.::intrinsics::mem::store_sw
-                    swap.1
-                    u32mod.2
-                    assertz.err=0
-                    dup.0
-                    movup.2
-                    swap.1
+                    push.0
+                    dup.1
                     dup.0
                     u32mod.16
                     dup.0
@@ -3375,6 +3359,10 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     movup.2
                     u32div.16
                     exec.::intrinsics::mem::store_sw
+                    u32mod.2
+                    assertz.err=0
+                    u32mod.2
+                    assertz.err=0
                     u32mod.2
                     assertz.err=0
                 end
@@ -3396,6 +3384,8 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     u32and
                     eq.2147483648
                     assertz
+                    add.8
+                    u32assert
                     dup.2
                     dup.0
                     push.2147483648
@@ -3404,16 +3394,9 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     assertz
                     add.4
                     u32assert
+                    dup.1
                     movup.3
-                    dup.0
-                    push.2147483648
-                    u32and
-                    eq.2147483648
-                    assertz
-                    add.8
-                    u32assert
-                    push.1
-                    dup.3
+                    swap.1
                     dup.0
                     u32mod.16
                     dup.0
@@ -3424,8 +3407,11 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     u32div.16
                     exec.::intrinsics::mem::store_sw
                     movup.2
-                    u32mod.2
-                    assertz.err=0
+                    dup.0
+                    push.2147483648
+                    u32and
+                    eq.2147483648
+                    assertz
                     push.4
                     dup.2
                     dup.0
@@ -3437,12 +3423,8 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     movup.2
                     u32div.16
                     exec.::intrinsics::mem::store_sw
-                    swap.1
-                    u32mod.2
-                    assertz.err=0
-                    dup.0
-                    movup.2
-                    swap.1
+                    push.1
+                    dup.1
                     dup.0
                     u32mod.16
                     dup.0
@@ -3452,6 +3434,10 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     movup.2
                     u32div.16
                     exec.::intrinsics::mem::store_sw
+                    u32mod.2
+                    assertz.err=0
+                    u32mod.2
+                    assertz.err=0
                     u32mod.2
                     assertz.err=0
                 else
@@ -3463,6 +3449,8 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     u32and
                     eq.2147483648
                     assertz
+                    add.8
+                    u32assert
                     dup.2
                     dup.0
                     push.2147483648
@@ -3471,16 +3459,9 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     assertz
                     add.4
                     u32assert
+                    dup.1
                     movup.3
-                    dup.0
-                    push.2147483648
-                    u32and
-                    eq.2147483648
-                    assertz
-                    add.8
-                    u32assert
-                    push.0
-                    dup.3
+                    swap.1
                     dup.0
                     u32mod.16
                     dup.0
@@ -3491,8 +3472,11 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     u32div.16
                     exec.::intrinsics::mem::store_sw
                     movup.2
-                    u32mod.2
-                    assertz.err=0
+                    dup.0
+                    push.2147483648
+                    u32and
+                    eq.2147483648
+                    assertz
                     dup.1
                     movup.4
                     swap.1
@@ -3505,12 +3489,8 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     movup.2
                     u32div.16
                     exec.::intrinsics::mem::store_sw
-                    swap.1
-                    u32mod.2
-                    assertz.err=0
-                    dup.0
-                    movup.2
-                    swap.1
+                    push.0
+                    dup.1
                     dup.0
                     u32mod.16
                     dup.0
@@ -3520,6 +3500,10 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
                     movup.2
                     u32div.16
                     exec.::intrinsics::mem::store_sw
+                    u32mod.2
+                    assertz.err=0
+                    u32mod.2
+                    assertz.err=0
                     u32mod.2
                     assertz.err=0
                 end
@@ -3534,15 +3518,15 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
             u32and
             eq.2147483648
             assertz
+            add.4
+            u32assert
             swap.1
             dup.0
             push.2147483648
             u32and
             eq.2147483648
             assertz
-            add.4
-            u32assert
-            push.1
+            push.0
             dup.2
             dup.0
             u32mod.16
@@ -3553,10 +3537,7 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
             movup.2
             u32div.16
             exec.::intrinsics::mem::store_sw
-            swap.1
-            u32mod.2
-            assertz.err=0
-            push.0
+            push.1
             dup.1
             dup.0
             u32mod.16
@@ -3567,6 +3548,8 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
             movup.2
             u32div.16
             exec.::intrinsics::mem::store_sw
+            u32mod.2
+            assertz.err=0
             u32mod.2
             assertz.err=0
         end
@@ -3580,30 +3563,16 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
         u32and
         eq.2147483648
         assertz
+        add.4
+        u32assert
         swap.1
         dup.0
         push.2147483648
         u32and
         eq.2147483648
         assertz
-        add.4
-        u32assert
-        push.0
-        dup.2
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
-        swap.1
-        u32div.4
-        movup.2
-        u32div.16
-        exec.::intrinsics::mem::store_sw
-        swap.1
-        u32mod.2
-        assertz.err=0
         push.4.0
-        dup.2
+        dup.3
         dup.0
         u32mod.16
         dup.0
@@ -3613,6 +3582,19 @@ export."alloc::raw_vec::RawVec<T,A>::try_allocate_in"
         movup.2
         u32div.16
         exec.::intrinsics::mem::store_dw
+        push.0
+        dup.1
+        dup.0
+        u32mod.16
+        dup.0
+        u32mod.4
+        swap.1
+        u32div.4
+        movup.2
+        u32div.16
+        exec.::intrinsics::mem::store_sw
+        u32mod.2
+        assertz.err=0
         u32mod.2
         assertz.err=0
     end


### PR DESCRIPTION
Our instruction scheduler is based on a block-local data dependency graph that is decomposed into a structure we call a treegraph. The topological ordering of nodes in the treegraph, determines the order in which expression trees in a block will be scheduled.

This necessarily led to the need for some notion of control dependencies: first to ensure that the block terminator was always the last thing scheduled; then to handle instructions with no results that had side effects, as our dead-code elimination pass would remove nodes from the dependency graph which appeared dead, and control dependencies ensured that they were both kept live, and scheduled late in the block.

One thing we didn't handle however, was implicit control dependencies, manifested in the relationship between instructions with side effects - loads and stores, calls to side-effectful functions, etc. If there was no path between them in the dependency graph, they could be reordered relative to one another, which can cause all kinds of weird behavior in the final program. Consider moving a write to memory after a read which expects to observe that write - not good.

This commit refines our existing control dependency handling a bit, by ensuring that within a block, memory reads and writes form implicit control dependencies on other instructions which could affect the state of the world it sees. Memory reads implicitly depend on any writes which appear earlier in the block, ensuring that the writes can't be moved past the read. Memory writes implicitly depend on both previous writes _and_ reads - we don't want to reorder stores relative to each other, and we don't want to move a store above a load, potentially affecting the value observed by that load.

We don't yet have good tests to really determine how drastic of an affect this has on the scheduler, but the one expect test affected by this change (and included in this commit), demonstrates that it does more faithfully preserve the original program order in HIR. For now these extra edges in the dependency graph are placed very conservatively, which reduces the opportunities for the scheduler to place instructions as optimally as possible. We'll need to introduce some static analyses that will let us reason more precisely about the relationships between certain loads/stores, and to determine if a function call actually has memory effects (or other side effects, such as the advice provider); these would let us remove some edges, and bring back optimization opportunities.

Closes #191 

---

@greenhat I've based this on my branch in #241, so we'll want to merge that one first.