### PR TITLE
Disable tag creation on release PR merging(`release` command)

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,6 +2,9 @@
 # Only publish when the release PR is merged (starts with `release-plz-`)
 # https://release-plz.ieni.dev/docs/config#the-release_always-field
 release_always = false
+# Do not create a github release
+# https://release-plz.ieni.dev/docs/config#the-git_release_enable-field
+git_release_enable = false  
 # Does not create a git tag
 # https://release-plz.ieni.dev/docs/config#the-git_tag_enable-field
 git_tag_enable = false


### PR DESCRIPTION
Ref #246 

Disables the git tag creation when publishing crates.