### PR TITLE
Release v0.0.1 (take 4): Initial release of the compiler and SDK crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ name: release-plz
 on:
   push:
     branches:
-      - main
+      - next # TODO: switch to main after testing the publish workflow
 
 env:
   CARGO_MAKE_TOOLCHAIN: nightly-2024-05-07

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,10 +2731,11 @@ dependencies = [
 [[package]]
 name = "miden-air"
 version = "0.10.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=b4e1f3abf84c0c982b3a0ff83bb7568d2ba7ee88#b4e1f3abf84c0c982b3a0ff83bb7568d2ba7ee88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d25e229d9d1f1598de2939477884a4162776ea124d95f1349c2427325b9e53"
 dependencies = [
  "miden-core",
- "thiserror",
+ "miden-thiserror",
  "winter-air",
  "winter-prover",
 ]
@@ -2742,43 +2743,46 @@ dependencies = [
 [[package]]
 name = "miden-assembly"
 version = "0.10.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=b4e1f3abf84c0c982b3a0ff83bb7568d2ba7ee88#b4e1f3abf84c0c982b3a0ff83bb7568d2ba7ee88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221e820d4f6ff61b7618805dd8835a871828bd3f67f09aee3e1a50233d67be2e"
 dependencies = [
  "aho-corasick",
  "lalrpop",
  "lalrpop-util",
  "miden-core",
- "miette 7.1.0",
- "rustc_version 0.2.3",
+ "miden-miette",
+ "miden-thiserror",
+ "rustc_version 0.4.0",
  "smallvec",
- "thiserror",
  "tracing",
  "unicode-width",
 ]
 
 [[package]]
 name = "miden-core"
-version = "0.10.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=b4e1f3abf84c0c982b3a0ff83bb7568d2ba7ee88#b4e1f3abf84c0c982b3a0ff83bb7568d2ba7ee88"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92def4a24d566e58be40c62f1730d234e1a328678a2c846a591fecd9e77971b0"
 dependencies = [
  "lock_api",
  "loom",
  "memchr",
  "miden-crypto",
  "miden-formatting",
- "miette 7.1.0",
+ "miden-miette",
+ "miden-thiserror",
  "num-derive",
  "num-traits",
  "parking_lot",
- "thiserror",
  "winter-math",
  "winter-utils",
 ]
 
 [[package]]
 name = "miden-crypto"
-version = "0.9.3"
-source = "git+https://github.com/0xPolygonMiden/crypto?branch=next#b06cfa3c035ada8122a405a72d2e4b2ad1a89b47"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6fad06fc3af260ed3c4235821daa2132813d993f96d446856036ae97e9606dd"
 dependencies = [
  "blake3",
  "cc",
@@ -2869,6 +2873,48 @@ name = "miden-integration-tests-rust-fib"
 version = "0.0.0"
 
 [[package]]
+name = "miden-miette"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c532250422d933f15b148fb81e4522a5d649c178ab420d0d596c86228da35570"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "futures",
+ "indenter",
+ "lazy_static",
+ "miden-miette-derive",
+ "miden-thiserror",
+ "owo-colors",
+ "regex",
+ "rustc_version 0.2.3",
+ "rustversion",
+ "serde_json",
+ "spin",
+ "strip-ansi-escapes",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "syn 2.0.72",
+ "terminal_size",
+ "textwrap",
+ "trybuild",
+ "unicode-width",
+]
+
+[[package]]
+name = "miden-miette-derive"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc759f0a2947acae217a2f32f722105cacc57d17d5f93bc16362142943a4edd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "miden-parsing"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2881,7 +2927,8 @@ dependencies = [
 [[package]]
 name = "miden-processor"
 version = "0.10.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=b4e1f3abf84c0c982b3a0ff83bb7568d2ba7ee88#b4e1f3abf84c0c982b3a0ff83bb7568d2ba7ee88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fbd977bd66fc5f28cfd12b6780a82f17de4531aaa16b43d68d54c46fa5f9e49"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2892,9 +2939,30 @@ dependencies = [
 [[package]]
 name = "miden-stdlib"
 version = "0.10.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=b4e1f3abf84c0c982b3a0ff83bb7568d2ba7ee88#b4e1f3abf84c0c982b3a0ff83bb7568d2ba7ee88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2262c928634816598db588da8ff6f2b56e0251edbd94e75b986e82dcbee5af3e"
 dependencies = [
  "miden-assembly",
+]
+
+[[package]]
+name = "miden-thiserror"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183ff8de338956ecfde3a38573241eb7a6f3d44d73866c210e5629c07fa00253"
+dependencies = [
+ "miden-thiserror-impl",
+]
+
+[[package]]
+name = "miden-thiserror-impl"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee4176a0f2e7d29d2a8ee7e60b6deb14ce67a20e94c3e2c7275cdb8804e1862"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3098,39 +3166,9 @@ version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
 dependencies = [
- "miette-derive 5.10.0",
+ "miette-derive",
  "once_cell",
  "thiserror",
- "unicode-width",
-]
-
-[[package]]
-name = "miette"
-version = "7.1.0"
-source = "git+https://github.com/bitwalker/miette?branch=no-std#e918fbde6c9853fe5e0db8e8e05bf7fbc8d2cc15"
-dependencies = [
- "backtrace",
- "backtrace-ext",
- "cfg-if",
- "futures",
- "indenter",
- "lazy_static",
- "miette-derive 7.1.0",
- "owo-colors",
- "regex",
- "rustc_version 0.2.3",
- "rustversion",
- "serde_json",
- "spin",
- "strip-ansi-escapes",
- "supports-color",
- "supports-hyperlinks",
- "supports-unicode",
- "syn 2.0.72",
- "terminal_size",
- "textwrap",
- "thiserror",
- "trybuild",
  "unicode-width",
 ]
 
@@ -3139,16 +3177,6 @@ name = "miette-derive"
 version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "miette-derive"
-version = "7.1.0"
-source = "git+https://github.com/bitwalker/miette?branch=no-std#e918fbde6c9853fe5e0db8e8e05bf7fbc8d2cc15"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3915,7 +3943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b823de344848e011658ac981009100818b322421676740546f8b52ed5249428"
 dependencies = [
  "logos",
- "miette 5.10.0",
+ "miette",
  "once_cell",
  "prost",
  "prost-types",
@@ -3937,7 +3965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06a5aacd1f6147ceac5e3896e0c766187dc6a9645f3b93ec821fabbaf821b887"
 dependencies = [
  "bytes",
- "miette 5.10.0",
+ "miette",
  "prost",
  "prost-reflect",
  "prost-types",
@@ -3952,7 +3980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30fc6d0af2dec2c39da31eb02cc78cbc05b843b04f30ad78ccc6e8a342ec5518"
 dependencies = [
  "logos",
- "miette 5.10.0",
+ "miette",
  "prost-types",
  "thiserror",
 ]
@@ -6314,3 +6342,8 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[patch.unused]]
+name = "miette"
+version = "7.1.0"
+source = "git+https://github.com/bitwalker/miette?branch=no-std#e918fbde6c9853fe5e0db8e8e05bf7fbc8d2cc15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,10 +68,10 @@ thiserror = { version = "1.0", git = "https://github.com/bitwalker/thiserror", b
 toml = { version = "0.8", features = ["preserve_order"] }
 derive_more = "0.99"
 indexmap = "2.2"
-miden-assembly = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "b4e1f3abf84c0c982b3a0ff83bb7568d2ba7ee88" }
-miden-core = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "b4e1f3abf84c0c982b3a0ff83bb7568d2ba7ee88" }
-miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "b4e1f3abf84c0c982b3a0ff83bb7568d2ba7ee88" }
-miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "b4e1f3abf84c0c982b3a0ff83bb7568d2ba7ee88" }
+miden-assembly = { version = "0.10" }
+miden-core = { version = "0.10" }
+miden-processor = { version = "0.10" }
+miden-stdlib = { version = "0.10" }
 midenc-codegen-masm = { path = "codegen/masm" }
 miden-diagnostics = "0.1"
 midenc-hir = { version = "0.0.1", path = "hir" }

--- a/codegen/masm/src/lib.rs
+++ b/codegen/masm/src/lib.rs
@@ -9,7 +9,7 @@ mod masm;
 #[cfg(test)]
 mod tests;
 
-use miden_assembly::library::CompiledLibrary;
+use miden_assembly::library::Library as CompiledLibrary;
 use midenc_hir::{
     self as hir,
     diagnostics::Report,

--- a/codegen/masm/src/masm/program.rs
+++ b/codegen/masm/src/masm/program.rs
@@ -3,7 +3,7 @@ use std::{fmt, path::Path, sync::Arc};
 use hir::{Signature, Symbol};
 use miden_assembly::{
     ast::{ModuleKind, ProcedureName},
-    library::{CompiledLibrary, KernelLibrary},
+    library::{KernelLibrary, Library as CompiledLibrary},
     LibraryNamespace,
 };
 use miden_core::crypto::hash::Rpo256;
@@ -328,7 +328,7 @@ impl Program {
 
         // Link extra libraries
         for library in self.library.libraries.iter() {
-            assembler.add_compiled_library(library)?;
+            assembler.add_library(library)?;
         }
 
         // Assemble library
@@ -519,7 +519,7 @@ impl Library {
 
         // Link extra libraries
         for library in self.libraries.iter() {
-            assembler.add_compiled_library(library)?;
+            assembler.add_library(library)?;
         }
 
         // Assemble library

--- a/hir/src/program/linker.rs
+++ b/hir/src/program/linker.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
 };
 
-use miden_assembly::library::CompiledLibrary;
+use miden_assembly::library::Library as CompiledLibrary;
 use petgraph::{prelude::DiGraphMap, Direction};
 
 use crate::{

--- a/hir/src/program/mod.rs
+++ b/hir/src/program/mod.rs
@@ -4,7 +4,7 @@ use alloc::collections::BTreeMap;
 use core::ops::{Deref, DerefMut};
 
 use intrusive_collections::RBTree;
-use miden_assembly::library::CompiledLibrary;
+use miden_assembly::library::Library as CompiledLibrary;
 use miden_core::crypto::hash::RpoDigest;
 
 pub use self::linker::Linker;

--- a/midenc-session/src/libs.rs
+++ b/midenc-session/src/libs.rs
@@ -5,7 +5,7 @@ use std::{
     str::FromStr,
 };
 
-use miden_assembly::{library::CompiledLibrary, LibraryNamespace};
+use miden_assembly::{library::Library as CompiledLibrary, LibraryNamespace};
 use miden_stdlib::StdLibrary;
 
 use crate::{

--- a/tests/integration/src/exec_vm.rs
+++ b/tests/integration/src/exec_vm.rs
@@ -3,7 +3,7 @@ use std::{
     rc::Rc,
 };
 
-use miden_assembly::library::CompiledLibrary;
+use miden_assembly::library::Library as CompiledLibrary;
 use miden_core::{Program, StackInputs};
 use miden_processor::{AdviceInputs, DefaultHost, ExecutionError, MastForest, Process};
 use midenc_hir::Felt;


### PR DESCRIPTION
Ref #246 

Well, the release PR against the main branch is not going to work since the VM v0.10 has MSRV 1.80 and some breaking API changes. Let's test the publishing from the next branch.

In this PR, I set the release CI job to run on merges to the `next` branch. We'll revert this after publish testing is complete.

After this PR is merged, the release CI job will publish all the unpublished crates.