### PR TITLE
Release v0.0.1 (take 5): Initial release of the compiler and SDK crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # Runs `release-plz release` only after the release PR (starts with `release-plz-`) 
-# is merged to the main branch. See `release_always = false` in `release-plz.toml` 
+# is merged to the next branch. See `release_always = false` in `release-plz.toml` 
 # Publishes any unpublished crates when.
 # Does nothing if all crates are already published (i.e. have their versions on crates.io).
 # Does not create/update release PRs.
@@ -13,7 +13,7 @@ name: release-plz
 on:
   push:
     branches:
-      - main
+      - next
 
 env:
   CARGO_MAKE_TOOLCHAIN: nightly-2024-05-07

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,7 @@ Install `release-plz` CLI tool following the instructions [here](https://release
 The release process for the Miden Compiler and Miden SDK is managed using the `release-plz` tool. The following steps outline the process for creating a new release:
 
 1. Run `release-plz update` in the repo root folder to update the compiler crates versions and generate changelogs.
-2. Run `release-plz update` in the `sdk` folder to update the SDK crates versions and generate changelogs.
-3. Create a release PR naming the branch with the `release-plz-` suffix (its important to use this suffix to trigger the crate publishing on CI in step 4).
-4. Review the changes in the release PR, commit edits if needed and merge it into the main branch.
-5. The CI will automatically run `release-plz release` after the release PR is merged to publish the new versions to crates.io.
-6. Set a git tag for the published crates to mark the release.
+2. Create a release PR naming the branch with the `release-plz-` suffix (its important to use this suffix to trigger the crate publishing on CI in step 4).
+3. Review the changes in the release PR, commit edits if needed and merge it into the main branch.
+4. The CI will automatically run `release-plz release` after the release PR is merged to publish the new versions to crates.io.
+5. Set a git tag for the published crates to mark the release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,6 +3040,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-sdk"
+version = "0.0.1"
+dependencies = [
+ "miden-base-sys",
+ "miden-stdlib-sys",
+]
+
+[[package]]
 name = "miden-stdlib"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-debug"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "clap",
  "crossterm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,7 +2856,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "miden-assembly",
  "miden-stdlib-sys",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-debug"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "clap",
  "crossterm",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-macros"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -3292,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-session"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "atty",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ midenc-codegen-masm = { path = "codegen/masm" }
 miden-diagnostics = "0.1"
 midenc-hir = { version = "0.0.1", path = "hir" }
 midenc-hir-analysis = { version = "0.0.1", path = "hir-analysis" }
-midenc-hir-macros = { version = "0.0.1", path = "hir-macros" }
+midenc-hir-macros = { version = "0.0.2", path = "hir-macros" }
 midenc-hir-symbol = { version = "0.0.1", path = "hir-symbol" }
 midenc-hir-transform = { version = "0.0.1", path = "hir-transform" }
 midenc-hir-type = { version = "0.0.1", path = "hir-type" }
@@ -95,8 +95,8 @@ miden-parsing = "0.1"
 midenc-frontend-wasm = { version = "0.0.1", path = "frontend-wasm" }
 midenc-compile = { version = "0.0.1", path = "midenc-compile" }
 midenc-driver = { version = "0.0.1", path = "midenc-driver" }
-midenc-debug = { version = "0.0.0", path = "midenc-debug" }
-midenc-session = { version = "0.0.1", path = "midenc-session" }
+midenc-debug = { version = "0.0.1", path = "midenc-debug" }
+midenc-session = { version = "0.0.2", path = "midenc-session" }
 miden-integration-tests = { version = "0.0.0", path = "tests/integration" }
 wat = "1.0.69"
 blake3 = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ miden-parsing = "0.1"
 midenc-frontend-wasm = { version = "0.0.1", path = "frontend-wasm" }
 midenc-compile = { version = "0.0.1", path = "midenc-compile" }
 midenc-driver = { version = "0.0.1", path = "midenc-driver" }
-midenc-debug = { version = "0.0.1", path = "midenc-debug" }
+midenc-debug = { version = "0.0.0", path = "midenc-debug" }
 midenc-session = { version = "0.0.1", path = "midenc-session" }
 miden-integration-tests = { version = "0.0.0", path = "tests/integration" }
 wat = "1.0.69"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "codegen/*",
+    "frontend-wasm",
     "hir",
     "hir-analysis",
     "hir-macros",
@@ -13,14 +14,12 @@ members = [
     "midenc-debug",
     "midenc-driver",
     "midenc-session",
-    "sdk/base-sys",
-    "sdk/stdlib-sys",
-    "sdk/sdk",
+    "sdk/*",
     "tools/*",
-    "frontend-wasm",
     "tests/integration",
 ]
 exclude = [
+    "sdk/.cargo",
     "tests/rust-apps/fib",
     "tests/rust-apps-wasm",
     "cargo-ext/tests/data",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ members = [
     "midenc-driver",
     "midenc-session",
     "sdk/base-sys",
+    "sdk/stdlib-sys",
+    "sdk/sdk",
     "tools/*",
     "frontend-wasm",
     "tests/integration",

--- a/hir-macros/CHANGELOG.md
+++ b/hir-macros/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-macros-v0.0.1...midenc-hir-macros-v0.0.2) - 2024-08-16
+
+### Fixed
+- *(cli)* improve help output, hide plumbing flags
+
+### Other
+- unify diagnostics infa between compiler, assembler, vm
+
 ## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-macros-v0.0.0...midenc-hir-macros-v0.0.1) - 2024-07-25
 
 ### Other

--- a/hir-macros/Cargo.toml
+++ b/hir-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir-macros"
 description = "Provides proc macro support for Miden IR"
-version = "0.0.1"
+version = "0.0.2"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/midenc-debug/CHANGELOG.md
+++ b/midenc-debug/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-debug-v0.0.0...midenc-debug-v0.0.1) - 2024-08-16
+
+### Other
+- set `midenc-debug` version to `0.0.0` to be in sync with crates.io
+- clean up naming in midenc-debug
+- rename midenc-runner to midenc-debug
+- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- a few minor improvements
+- set up mdbook deploy
+- add guides for compiling rust->masm
+- add mdbook skeleton
+- provide some initial usage instructions
+- Initial commit

--- a/midenc-debug/Cargo.toml
+++ b/midenc-debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-debug"
 description = "An interactive debugger for Miden VM programs"
-version = "0.0.1"
+version = "0.0.0"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/midenc-debug/Cargo.toml
+++ b/midenc-debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-debug"
 description = "An interactive debugger for Miden VM programs"
-version = "0.0.0"
+version = "0.0.1"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/midenc-session/CHANGELOG.md
+++ b/midenc-session/CHANGELOG.md
@@ -6,6 +6,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-session-v0.0.1...midenc-session-v0.0.2) - 2024-08-16
+
+### Added
+- *(codegen)* propagate source spans from hir to masm
+
+### Fixed
+- add tx kernel library with stubs and link it on `-l miden`
+- infer link libraries from target env
+- tweak session init handling of outputs
+- various tests, cli bugs, vm test executor, test builder api
+- *(cli)* improve help output, hide plumbing flags
+- clap error formatting, unused deps
+
+### Other
+- delete `miden-tx-kernel-sys` crate and move the code to `miden-base-sys`
+- rename `midenc-tx-kernel` to `miden-base-sys` and move it to
+- update to miden v0.10.3
+- update to miden v0.10.2
+- improve behavior of frontend config
+- clean up driver init and output config
+- fix various clippy warnings, bug in wasm br_table lowering, expect output
+- move miden-vm deps to latest commit included in 0.10 releasef
+- support compiled libraries, linker flags
+- update to latest miden vm patchset
+- unify diagnostics infa between compiler, assembler, vm
+- unify compilation, rodata init, test harness
+
 ## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-session-v0.0.0...midenc-session-v0.0.1) - 2024-07-18
 
 ### Added

--- a/midenc-session/Cargo.toml
+++ b/midenc-session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-session"
 description = "Session management for the Midenc compiler"
-version = "0.0.1"
+version = "0.0.2"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -23,5 +23,5 @@ miden-stdlib.workspace = true
 miden-diagnostics.workspace = true
 midenc-hir-symbol.workspace = true
 midenc-hir-macros.workspace = true
-miden-base-sys = { version = "0.0.0", path = "../sdk/base-sys", features = ["masl-lib"] }
+miden-base-sys = { version = "0.0.1", path = "../sdk/base-sys", features = ["masl-lib"] }
 thiserror.workspace = true

--- a/sdk/base-sys/CHANGELOG.md
+++ b/sdk/base-sys/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/miden-base-sys-v0.0.0...miden-base-sys-v0.0.1) - 2024-08-16
+
+### Fixed
+- fix the build after VM v0.10.3 update
+
+### Other
+- delete `miden-tx-kernel-sys` crate and move the code to `miden-base-sys`
+- build the MASL for the tx kernel stubs in `build.rs` and
+- rename `midenc-tx-kernel` to `miden-base-sys` and move it to
+- fix typos ([#243](https://github.com/0xPolygonMiden/compiler/pull/243))
+- a few minor improvements
+- set up mdbook deploy
+- add guides for compiling rust->masm
+- add mdbook skeleton
+- provide some initial usage instructions
+- Initial commit

--- a/sdk/base-sys/Cargo.toml
+++ b/sdk/base-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-base-sys"
 description = "Miden rollup Rust bingings and MASM library"
-version = "0.0.0"
+version = "0.0.1"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Ref #246 

This PR when merged will trigger the CI job to publish all the unpublished crates to crates.io.

Also in this PR:
- switch release PRs to be branched from the `next` branch instead of `main`, i.e. merging a release PR to `next` will trigger the publishing process;
- add `miden-sdk` and `miden-stdlib-sys` crates to the workspace.