### PR TITLE
chore: update cargo extension to use new project template v0.3.0 (our alloc)

### DIFF
--- a/tools/cargo-miden/src/new_project.rs
+++ b/tools/cargo-miden/src/new_project.rs
@@ -74,7 +74,7 @@ impl NewCommand {
             },
             None => TemplatePath {
                 git: Some("https://github.com/0xPolygonMiden/rust-templates".into()),
-                tag: Some("v0.2.0".into()),
+                tag: Some("v0.3.0".into()),
                 auto_path: Some("account".into()),
                 ..Default::default()
             },


### PR DESCRIPTION
Close #282 

PR in `rust-templates` - https://github.com/0xPolygonMiden/rust-templates/pull/5