### PR TITLE
[1/2] chore: remove separate SDK crates publishing on CI since they are now published as a part of the workspace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,3 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-    - name: Publish Miden SDK crates
-      uses: MarcoIeni/release-plz-action@v0.5
-      with:
-        # Only run the `release` command that publishes any unpublished crates.
-        command: release
-        manifest_path: sdk/Cargo.toml
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Install `release-plz` CLI tool following the instructions [here](https://release
 
 The release process for the Miden Compiler and Miden SDK is managed using the `release-plz` tool. The following steps outline the process for creating a new release:
 
-1. Run `release-plz update` in the repo root folder to update the compiler crates versions and generate changelogs.
+1. Run `release-plz update` in the repo root folder to update the crates versions and generate changelogs.
 2. Create a release PR naming the branch with the `release-plz-` suffix (its important to use this suffix to trigger the crate publishing on CI in step 4).
 3. Review the changes in the release PR, commit edits if needed and merge it into the main branch.
 4. The CI will automatically run `release-plz release` after the release PR is merged to publish the new versions to crates.io.


### PR DESCRIPTION
This should fix `release-plz` CI job failing on every merge to the `next` branch.