### PR TITLE
fix: `cargo release` by adding `help` feature to `clap` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ clap = { version = "4.1", default-features = false, features = [
     "derive",
     "std",
     "env",
+    "help",
 ] }
 cranelift-entity = "0.108"
 cranelift-bforest = "0.108"


### PR DESCRIPTION
Since `cargo build` seems to ignore `default-features` on the workspace level and enables default features for inherited dependencies. `cargo release` OTOH seems to behave correctly and does not ignore `default-features` on the workspace level, and the build fails due to `Command::help_template` is hidden behind the `help` feature.

This PR fixes the https://github.com/0xPolygonMiden/compiler/actions/runs/10604566214/job/29391504068 build error during the `cargo release`
