### PR TITLE
Release v0.0.4 (take 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-miden"
-version = "0.0.2"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "cargo-component",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "miden-assembly",
  "miden-stdlib-sys",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk"
-version = "0.0.2"
+version = "0.0.4"
 dependencies = [
  "miden-base-sys",
  "miden-sdk-alloc",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.0.2"
+version = "0.0.4"
 
 [[package]]
 name = "miden-stdlib"
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.0.3"
+version = "0.0.4"
 
 [[package]]
 name = "miden-thiserror"
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "midenc"
-version = "0.0.2"
+version = "0.0.4"
 dependencies = [
  "env_logger 0.11.5",
  "human-panic",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-codegen-masm"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "bitcode",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-compile"
-version = "0.0.1"
+version = "0.0.4"
 dependencies = [
  "clap",
  "either",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-debug"
-version = "0.0.2"
+version = "0.0.4"
 dependencies = [
  "clap",
  "crossterm",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-driver"
-version = "0.0.1"
+version = "0.0.4"
 dependencies = [
  "clap",
  "log",
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm"
-version = "0.0.2"
+version = "0.0.4"
 dependencies = [
  "addr2line 0.24.1",
  "anyhow",
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir"
-version = "0.0.2"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-analysis"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "cranelift-bforest",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-macros"
-version = "0.0.2"
+version = "0.0.4"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-symbol"
-version = "0.0.2"
+version = "0.0.4"
 dependencies = [
  "Inflector",
  "bitcode",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-transform"
-version = "0.0.2"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "inventory",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "serde",
  "serde_repr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,24 +85,24 @@ derive_more = "0.99"
 indexmap = "2.2"
 miden-assembly = { version = "0.10.3" }
 miden-core = { version = "0.10.3" }
+miden-parsing = "0.1"
 miden-processor = { version = "0.10.3" }
 miden-stdlib = { version = "0.10.3", features = ["with-debug-info"] }
 #miden-assembly = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "828557c28ca1d159bfe42195e7ea73256ce4aa06" }
 #miden-core = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "828557c28ca1d159bfe42195e7ea73256ce4aa06" }
 #miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "828557c28ca1d159bfe42195e7ea73256ce4aa06" }
 #miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "828557c28ca1d159bfe42195e7ea73256ce4aa06" }
-midenc-codegen-masm = { version = "0.0.3", path = "codegen/masm" }
-midenc-hir = { version = "0.0.2", path = "hir" }
-midenc-hir-analysis = { version = "0.0.3", path = "hir-analysis" }
-midenc-hir-macros = { version = "0.0.2", path = "hir-macros" }
-midenc-hir-symbol = { version = "0.0.2", path = "hir-symbol" }
-midenc-hir-transform = { version = "0.0.2", path = "hir-transform" }
-midenc-hir-type = { version = "0.0.3", path = "hir-type" }
-miden-parsing = "0.1"
-midenc-frontend-wasm = { version = "0.0.2", path = "frontend-wasm" }
-midenc-compile = { version = "0.0.1", path = "midenc-compile" }
-midenc-driver = { version = "0.0.1", path = "midenc-driver" }
-midenc-debug = { version = "0.0.2", path = "midenc-debug" }
+midenc-codegen-masm = { version = "0.0.4", path = "codegen/masm" }
+midenc-hir = { version = "0.0.4", path = "hir" }
+midenc-hir-analysis = { version = "0.0.4", path = "hir-analysis" }
+midenc-hir-macros = { version = "0.0.4", path = "hir-macros" }
+midenc-hir-symbol = { version = "0.0.4", path = "hir-symbol" }
+midenc-hir-transform = { version = "0.0.4", path = "hir-transform" }
+midenc-hir-type = { version = "0.0.4", path = "hir-type" }
+midenc-frontend-wasm = { version = "0.0.4", path = "frontend-wasm" }
+midenc-compile = { version = "0.0.4", path = "midenc-compile" }
+midenc-driver = { version = "0.0.4", path = "midenc-driver" }
+midenc-debug = { version = "0.0.4", path = "midenc-debug" }
 midenc-session = { version = "0.0.4", path = "midenc-session" }
 miden-integration-tests = { version = "0.0.0", path = "tests/integration" }
 wat = "1.0.69"

--- a/codegen/masm/Cargo.toml
+++ b/codegen/masm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-codegen-masm"
 description = "Miden Assembly backend for the Miden compiler"
-version = "0.0.3"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/frontend-wasm/Cargo.toml
+++ b/frontend-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-frontend-wasm"
 description = "Wasm frontend for the Miden compiler"
-version = "0.0.2"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/hir-analysis/Cargo.toml
+++ b/hir-analysis/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir-analysis"
 description = "Analysis passes and utilties for Miden HIR"
-version = "0.0.3"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/hir-macros/Cargo.toml
+++ b/hir-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir-macros"
 description = "Provides proc macro support for Miden IR"
-version = "0.0.2"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/hir-symbol/Cargo.toml
+++ b/hir-symbol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir-symbol"
 description = "String interning for the Miden compiler"
-version = "0.0.2"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/hir-transform/Cargo.toml
+++ b/hir-transform/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir-transform"
 description = "Transformation passes and utilities for Miden HIR"
-version = "0.0.2"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/hir-type/Cargo.toml
+++ b/hir-type/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir-type"
 description = "Type system and utilities for Miden HIR"
-version = "0.0.3"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/hir/Cargo.toml
+++ b/hir/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir"
 description = "High-level Intermediate Representation for Miden Assembly"
-version = "0.0.2"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/midenc-compile/Cargo.toml
+++ b/midenc-compile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-compile"
 description = "The compiler frontend for Miden"
-version = "0.0.1"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/midenc-debug/Cargo.toml
+++ b/midenc-debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-debug"
 description = "An interactive debugger for Miden VM programs"
-version = "0.0.2"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/midenc-driver/Cargo.toml
+++ b/midenc-driver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-driver"
 description = "The driver for midenc, the Miden compiler"
-version = "0.0.1"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/midenc-session/Cargo.toml
+++ b/midenc-session/Cargo.toml
@@ -27,7 +27,7 @@ miden-core.workspace = true
 miden-stdlib.workspace = true
 midenc-hir-symbol.workspace = true
 midenc-hir-macros.workspace = true
-miden-base-sys = { version = "0.0.3", path = "../sdk/base-sys", features = [
+miden-base-sys = { version = "0.0.4", path = "../sdk/base-sys", features = [
     "masl-lib",
 ] }
 parking_lot = { workspace = true, optional = true }

--- a/midenc/Cargo.toml
+++ b/midenc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc"
 description = "The compiler frontend/executable for Miden"
-version = "0.0.2"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sdk/alloc/Cargo.toml
+++ b/sdk/alloc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-sdk-alloc"
 description = "A simple bump allocator for Miden SDK programs"
-version = "0.0.2"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sdk/base-sys/Cargo.toml
+++ b/sdk/base-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-base-sys"
 description = "Miden rollup Rust bingings and MASM library"
-version = "0.0.3"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ edition.workspace = true
 
 [dependencies]
 miden-assembly.workspace = true
-miden-stdlib-sys = { version = "0.0.3", path = "../stdlib-sys", optional = true }
+miden-stdlib-sys = { version = "0.0.4", path = "../stdlib-sys", optional = true }
 
 [build-dependencies]
 miden-assembly.workspace = true

--- a/sdk/sdk/Cargo.toml
+++ b/sdk/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-sdk"
 description = "Miden SDK"
-version = "0.0.2"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -15,6 +15,6 @@ edition.workspace = true
 crate-type = ["rlib"]
 
 [dependencies]
-miden-sdk-alloc = { version = "0.0.2", path = "../alloc" }
-miden-stdlib-sys = { version = "0.0.3", path = "../stdlib-sys" }
-miden-base-sys = { version = "0.0.3", path = "../base-sys", features = ["bindings"] }
+miden-sdk-alloc = { version = "0.0.4", path = "../alloc" }
+miden-stdlib-sys = { version = "0.0.4", path = "../stdlib-sys" }
+miden-base-sys = { version = "0.0.4", path = "../base-sys", features = ["bindings"] }

--- a/sdk/stdlib-sys/Cargo.toml
+++ b/sdk/stdlib-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-stdlib-sys"
 description = "Low-level Rust bindings for the Miden standard library"
-version = "0.0.3"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/tests/rust-apps-wasm/rust-sdk/account-test/Cargo.lock
+++ b/tests/rust-apps-wasm/rust-sdk/account-test/Cargo.lock
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.0.1"
+version = "0.0.4"
 dependencies = [
  "miden-assembly",
  "miden-stdlib-sys",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk"
-version = "0.0.1"
+version = "0.0.4"
 dependencies = [
  "miden-base-sys",
  "miden-sdk-alloc",
@@ -667,11 +667,11 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.0.1"
+version = "0.0.4"
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.0.1"
+version = "0.0.4"
 
 [[package]]
 name = "miden-thiserror"

--- a/tools/cargo-miden/Cargo.toml
+++ b/tools/cargo-miden/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-miden"
 description = "A cargo extension to build Miden projects"
-version = "0.0.2"
+version = "0.0.4"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Ref #296 

This is a release PR (CI job will publish all unpublished crate versions).

This PR bumps all crate versions to `v0.0.4` as a fix to #296 