### PR TITLE
chore: switch all crates to a single workspace version (0.0.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "miden-integration-tests"
-version = "0.0.0"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.0.0"
+version = "0.0.5"
 rust-version = "1.78"
 authors = ["Miden contributors"]
 description = "An intermediate representation and compiler for Miden Assembly"

--- a/codegen/masm/Cargo.toml
+++ b/codegen/masm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-codegen-masm"
 description = "Miden Assembly backend for the Miden compiler"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/frontend-wasm/Cargo.toml
+++ b/frontend-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-frontend-wasm"
 description = "Wasm frontend for the Miden compiler"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/hir-analysis/Cargo.toml
+++ b/hir-analysis/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir-analysis"
 description = "Analysis passes and utilties for Miden HIR"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/hir-macros/Cargo.toml
+++ b/hir-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir-macros"
 description = "Provides proc macro support for Miden IR"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/hir-symbol/Cargo.toml
+++ b/hir-symbol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir-symbol"
 description = "String interning for the Miden compiler"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/hir-transform/Cargo.toml
+++ b/hir-transform/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir-transform"
 description = "Transformation passes and utilities for Miden HIR"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/hir-type/Cargo.toml
+++ b/hir-type/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir-type"
 description = "Type system and utilities for Miden HIR"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/hir/Cargo.toml
+++ b/hir/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir"
 description = "High-level Intermediate Representation for Miden Assembly"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/midenc-compile/Cargo.toml
+++ b/midenc-compile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-compile"
 description = "The compiler frontend for Miden"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/midenc-debug/Cargo.toml
+++ b/midenc-debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-debug"
 description = "An interactive debugger for Miden VM programs"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/midenc-driver/Cargo.toml
+++ b/midenc-driver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-driver"
 description = "The driver for midenc, the Miden compiler"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/midenc-session/Cargo.toml
+++ b/midenc-session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-session"
 description = "Session management for the Midenc compiler"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/midenc/Cargo.toml
+++ b/midenc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc"
 description = "The compiler frontend/executable for Miden"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sdk/alloc/Cargo.toml
+++ b/sdk/alloc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-sdk-alloc"
 description = "A simple bump allocator for Miden SDK programs"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sdk/base-sys/Cargo.toml
+++ b/sdk/base-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-base-sys"
 description = "Miden rollup Rust bingings and MASM library"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sdk/sdk/Cargo.toml
+++ b/sdk/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-sdk"
 description = "Miden SDK"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sdk/stdlib-sys/Cargo.toml
+++ b/sdk/stdlib-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-stdlib-sys"
 description = "Low-level Rust bindings for the Miden standard library"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/tools/cargo-miden/Cargo.toml
+++ b/tools/cargo-miden/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-miden"
 description = "A cargo extension to build Miden projects"
-version = "0.0.5"
+version.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Ref #296 

This PR switches the member crates to use the single `workspace.package.version` instead of specifying a separate version for each member crate.

See the https://github.com/0xPolygonMiden/compiler/issues/296#issuecomment-2326343060 for details.
