### PR TITLE
release: 0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-miden"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "cargo-component",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "miden-assembly",
  "miden-stdlib-sys",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "miden-integration-tests"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "miden-base-sys",
  "miden-sdk-alloc",
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.0.5"
+version = "0.0.6"
 
 [[package]]
 name = "miden-stdlib"
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.0.5"
+version = "0.0.6"
 
 [[package]]
 name = "miden-thiserror"
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "midenc"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "env_logger 0.11.5",
  "human-panic",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-codegen-masm"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "bitcode",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-compile"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "clap",
  "either",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-debug"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "clap",
  "crossterm",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-driver"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "clap",
  "log",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "addr2line 0.24.1",
  "anyhow",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-analysis"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "cranelift-bforest",
@@ -3213,7 +3213,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-macros"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-symbol"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "Inflector",
  "rustc-hash",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-transform"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "inventory",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "serde",
  "serde_repr",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-session"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "clap",
  "inventory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.0.5"
+version = "0.0.6"
 rust-version = "1.80"
 authors = ["Miden contributors"]
 description = "An intermediate representation and compiler for Miden Assembly"
@@ -92,18 +92,18 @@ miden-stdlib = { version = "0.10.3", features = ["with-debug-info"] }
 #miden-core = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "828557c28ca1d159bfe42195e7ea73256ce4aa06" }
 #miden-processor = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "828557c28ca1d159bfe42195e7ea73256ce4aa06" }
 #miden-stdlib = { git = "https://github.com/0xPolygonMiden/miden-vm", rev = "828557c28ca1d159bfe42195e7ea73256ce4aa06" }
-midenc-codegen-masm = { version = "0.0.5", path = "codegen/masm" }
-midenc-hir = { version = "0.0.5", path = "hir" }
-midenc-hir-analysis = { version = "0.0.5", path = "hir-analysis" }
-midenc-hir-macros = { version = "0.0.5", path = "hir-macros" }
-midenc-hir-symbol = { version = "0.0.5", path = "hir-symbol" }
-midenc-hir-transform = { version = "0.0.5", path = "hir-transform" }
-midenc-hir-type = { version = "0.0.5", path = "hir-type" }
-midenc-frontend-wasm = { version = "0.0.5", path = "frontend-wasm" }
-midenc-compile = { version = "0.0.5", path = "midenc-compile" }
-midenc-driver = { version = "0.0.5", path = "midenc-driver" }
-midenc-debug = { version = "0.0.5", path = "midenc-debug" }
-midenc-session = { version = "0.0.5", path = "midenc-session" }
+midenc-codegen-masm = { version = "0.0.6", path = "codegen/masm" }
+midenc-hir = { version = "0.0.6", path = "hir" }
+midenc-hir-analysis = { version = "0.0.6", path = "hir-analysis" }
+midenc-hir-macros = { version = "0.0.6", path = "hir-macros" }
+midenc-hir-symbol = { version = "0.0.6", path = "hir-symbol" }
+midenc-hir-transform = { version = "0.0.6", path = "hir-transform" }
+midenc-hir-type = { version = "0.0.6", path = "hir-type" }
+midenc-frontend-wasm = { version = "0.0.6", path = "frontend-wasm" }
+midenc-compile = { version = "0.0.6", path = "midenc-compile" }
+midenc-driver = { version = "0.0.6", path = "midenc-driver" }
+midenc-debug = { version = "0.0.6", path = "midenc-debug" }
+midenc-session = { version = "0.0.6", path = "midenc-session" }
 miden-integration-tests = { version = "0.0.0", path = "tests/integration" }
 wat = "1.0.69"
 blake3 = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = [
 
 [workspace.package]
 version = "0.0.5"
-rust-version = "1.78"
+rust-version = "1.80"
 authors = ["Miden contributors"]
 description = "An intermediate representation and compiler for Miden Assembly"
 repository = "https://github.com/0xPolygonMiden/compiler"

--- a/codegen/masm/CHANGELOG.md
+++ b/codegen/masm/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/midenc-codegen-masm-v0.0.5...midenc-codegen-masm-v0.0.6) - 2024-09-06
+
+### Other
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/midenc-codegen-masm-v0.0.2...midenc-codegen-masm-v0.0.3) - 2024-08-30
 
 ### Fixed

--- a/frontend-wasm/CHANGELOG.md
+++ b/frontend-wasm/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/midenc-frontend-wasm-v0.0.5...midenc-frontend-wasm-v0.0.6) - 2024-09-06
+
+### Other
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-frontend-wasm-v0.0.1...midenc-frontend-wasm-v0.0.2) - 2024-08-30
 
 ### Fixed

--- a/hir-analysis/CHANGELOG.md
+++ b/hir-analysis/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/midenc-hir-analysis-v0.0.5...midenc-hir-analysis-v0.0.6) - 2024-09-06
+
+### Other
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-analysis-v0.0.2...midenc-hir-analysis-v0.0.3) - 2024-08-30
 
 ### Other

--- a/hir-macros/CHANGELOG.md
+++ b/hir-macros/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/midenc-hir-macros-v0.0.5...midenc-hir-macros-v0.0.6) - 2024-09-06
+
+### Other
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-macros-v0.0.1...midenc-hir-macros-v0.0.2) - 2024-08-16
 
 ### Fixed

--- a/hir-symbol/CHANGELOG.md
+++ b/hir-symbol/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/midenc-hir-symbol-v0.0.5...midenc-hir-symbol-v0.0.6) - 2024-09-06
+
+### Other
+- clean up unused deps
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-symbol-v0.0.1...midenc-hir-symbol-v0.0.2) - 2024-08-28
 
 ### Added

--- a/hir-transform/CHANGELOG.md
+++ b/hir-transform/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/midenc-hir-transform-v0.0.5...midenc-hir-transform-v0.0.6) - 2024-09-06
+
+### Other
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-transform-v0.0.1...midenc-hir-transform-v0.0.2) - 2024-08-28
 
 ### Fixed

--- a/hir-type/CHANGELOG.md
+++ b/hir-type/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/midenc-hir-type-v0.0.5...midenc-hir-type-v0.0.6) - 2024-09-06
+
+### Other
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-type-v0.0.2...midenc-hir-type-v0.0.3) - 2024-08-30
 
 ### Fixed

--- a/hir/CHANGELOG.md
+++ b/hir/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/midenc-hir-v0.0.5...midenc-hir-v0.0.6) - 2024-09-06
+
+### Other
+- clean up unused deps
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-hir-v0.0.1...midenc-hir-v0.0.2) - 2024-08-28
 
 ### Added

--- a/midenc-compile/CHANGELOG.md
+++ b/midenc-compile/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/midenc-compile-v0.0.5...midenc-compile-v0.0.6) - 2024-09-06
+
+### Fixed
+- *(driver)* ensure mast/masl outputs are emitted on request
+
+### Other
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-compile-v0.0.0...midenc-compile-v0.0.1) - 2024-07-18
 
 ### Added

--- a/midenc-debug/CHANGELOG.md
+++ b/midenc-debug/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/midenc-debug-v0.0.5...midenc-debug-v0.0.6) - 2024-09-06
+
+### Added
+- implement 'midenc run' command
+
+### Other
+- revisit/update documentation and guides
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-debug-v0.0.1...midenc-debug-v0.0.2) - 2024-08-30
 
 ### Fixed

--- a/midenc-driver/CHANGELOG.md
+++ b/midenc-driver/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/midenc-driver-v0.0.5...midenc-driver-v0.0.6) - 2024-09-06
+
+### Added
+- implement 'midenc run' command
+
+### Other
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.1](https://github.com/0xPolygonMiden/compiler/compare/midenc-driver-v0.0.0...midenc-driver-v0.0.1) - 2024-07-18
 
 ### Added

--- a/midenc-session/CHANGELOG.md
+++ b/midenc-session/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/midenc-session-v0.0.5...midenc-session-v0.0.6) - 2024-09-06
+
+### Fixed
+- *(driver)* incorrect extension for masl output type
+
+### Other
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.4](https://github.com/0xPolygonMiden/compiler/compare/midenc-session-v0.0.3...midenc-session-v0.0.4) - 2024-08-30
 
 ### Other

--- a/midenc-session/Cargo.toml
+++ b/midenc-session/Cargo.toml
@@ -27,7 +27,7 @@ miden-core.workspace = true
 miden-stdlib.workspace = true
 midenc-hir-symbol.workspace = true
 midenc-hir-macros.workspace = true
-miden-base-sys = { version = "0.0.5", path = "../sdk/base-sys", features = [
+miden-base-sys = { version = "0.0.6", path = "../sdk/base-sys", features = [
     "masl-lib",
 ] }
 parking_lot = { workspace = true, optional = true }

--- a/midenc/CHANGELOG.md
+++ b/midenc/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/midenc-v0.0.5...midenc-v0.0.6) - 2024-09-06
+
+### Other
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/midenc-v0.0.1...midenc-v0.0.2) - 2024-08-30
 
 ### Other

--- a/sdk/alloc/CHANGELOG.md
+++ b/sdk/alloc/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/miden-sdk-alloc-v0.0.5...miden-sdk-alloc-v0.0.6) - 2024-09-06
+
+### Other
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/miden-sdk-alloc-v0.0.1...miden-sdk-alloc-v0.0.2) - 2024-08-30
 
 ### Other

--- a/sdk/base-sys/CHANGELOG.md
+++ b/sdk/base-sys/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/miden-base-sys-v0.0.5...miden-base-sys-v0.0.6) - 2024-09-06
+
+### Other
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/miden-base-sys-v0.0.2...miden-base-sys-v0.0.3) - 2024-08-30
 
 ### Other

--- a/sdk/base-sys/Cargo.toml
+++ b/sdk/base-sys/Cargo.toml
@@ -15,7 +15,7 @@ edition.workspace = true
 
 [dependencies]
 miden-assembly.workspace = true
-miden-stdlib-sys = { version = "0.0.5", path = "../stdlib-sys", optional = true }
+miden-stdlib-sys = { version = "0.0.6", path = "../stdlib-sys", optional = true }
 
 [build-dependencies]
 miden-assembly.workspace = true

--- a/sdk/sdk/CHANGELOG.md
+++ b/sdk/sdk/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/miden-sdk-v0.0.5...miden-sdk-v0.0.6) - 2024-09-06
+
+### Other
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/miden-sdk-v0.0.1...miden-sdk-v0.0.2) - 2024-08-30
 
 ### Other

--- a/sdk/sdk/Cargo.toml
+++ b/sdk/sdk/Cargo.toml
@@ -15,6 +15,6 @@ edition.workspace = true
 crate-type = ["rlib"]
 
 [dependencies]
-miden-sdk-alloc = { version = "0.0.5", path = "../alloc" }
-miden-stdlib-sys = { version = "0.0.5", path = "../stdlib-sys" }
-miden-base-sys = { version = "0.0.5", path = "../base-sys", features = ["bindings"] }
+miden-sdk-alloc = { version = "0.0.6", path = "../alloc" }
+miden-stdlib-sys = { version = "0.0.6", path = "../stdlib-sys" }
+miden-base-sys = { version = "0.0.6", path = "../base-sys", features = ["bindings"] }

--- a/sdk/stdlib-sys/CHANGELOG.md
+++ b/sdk/stdlib-sys/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/miden-stdlib-sys-v0.0.5...miden-stdlib-sys-v0.0.6) - 2024-09-06
+
+### Other
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.3](https://github.com/0xPolygonMiden/compiler/compare/miden-stdlib-sys-v0.0.2...miden-stdlib-sys-v0.0.3) - 2024-08-30
 
 ### Fixed

--- a/tools/cargo-miden/CHANGELOG.md
+++ b/tools/cargo-miden/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/0xpolygonmiden/compiler/compare/cargo-miden-v0.0.5...cargo-miden-v0.0.6) - 2024-09-06
+
+### Other
+- fix mkdocs warnings, move cargo-miden README to docs.
+- clean up unused deps
+- switch all crates to a single workspace version (0.0.5)
+
 ## [0.0.2](https://github.com/0xPolygonMiden/compiler/compare/cargo-miden-v0.0.1...cargo-miden-v0.0.2) - 2024-08-30
 
 ### Other


### PR DESCRIPTION
Publish 0.0.6 to crates.io, with recent fixes to the initial 0.0.5 release. This is my first time running the release process myself, but so far so good, all that remains is for our release automation to do the rest.

@bobbinth Same deal as the last PR, if you have a moment and can sign off, that'd be great - but it's not a big deal. The updated docs depend on some things in this release, but as they haven't been published yet, we can certainly wait until @greenhat is online for this one