### PR TITLE
chore: add `CompilerTestInputType::CargoMiden` and use `cargo-miden` build it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,6 +2906,7 @@ version = "0.0.6"
 dependencies = [
  "anyhow",
  "blake3",
+ "cargo-miden",
  "cargo-util",
  "cargo_metadata",
  "concat-idents",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ midenc-compile = { version = "0.0.6", path = "midenc-compile" }
 midenc-driver = { version = "0.0.6", path = "midenc-driver" }
 midenc-debug = { version = "0.0.6", path = "midenc-debug" }
 midenc-session = { version = "0.0.6", path = "midenc-session" }
+cargo-miden = { version = "0.0.6", path = "tools/cargo-miden" }
 miden-integration-tests = { version = "0.0.0", path = "tests/integration" }
 wat = "1.0.69"
 blake3 = "1.5"

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -31,6 +31,7 @@ midenc-codegen-masm.workspace = true
 midenc-session.workspace = true
 midenc-compile.workspace = true
 midenc-debug.workspace = true
+cargo-miden.workspace = true
 wasmprinter = "0.2.80"
 proptest.workspace = true
 sha2 = "0.10"

--- a/tools/cargo-miden/src/lib.rs
+++ b/tools/cargo-miden/src/lib.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use cargo_component::load_metadata;
-use cargo_component_core::terminal::Terminal;
 use clap::{CommandFactory, Parser};
 use config::CargoArguments;
 use midenc_session::diagnostics::Report;
@@ -14,6 +13,9 @@ pub mod config;
 mod new_project;
 mod run_cargo_command;
 mod target;
+
+// re-export cargo-component's terminal module
+pub use cargo_component_core::terminal;
 
 fn version() -> &'static str {
     option_env!("CARGO_VERSION_INFO").unwrap_or(env!("CARGO_PKG_VERSION"))
@@ -80,7 +82,7 @@ where
     None
 }
 
-pub fn run<T>(args: T, terminal: &Terminal) -> Result<Vec<PathBuf>, Report>
+pub fn run<T>(args: T, terminal: &terminal::Terminal) -> Result<Vec<PathBuf>, Report>
 where
     T: Iterator<Item = String>,
 {


### PR DESCRIPTION
Close #312

The `CompilerInputTestType::CargoComponent` will be removed, and all relevant tests will be switched to the `CargoMiden` variant after the #90 and #308 are implemented.