### PR TITLE
Switch cargo-miden to v0.4.0 of the new project template with `dev` profile to fix the #323 compilation issue

### DIFF
--- a/tools/cargo-miden/src/new_project.rs
+++ b/tools/cargo-miden/src/new_project.rs
@@ -74,7 +74,7 @@ impl NewCommand {
             },
             None => TemplatePath {
                 git: Some("https://github.com/0xPolygonMiden/rust-templates".into()),
-                tag: Some("v0.3.0".into()),
+                tag: Some("v0.4.0".into()),
                 auto_path: Some("account".into()),
                 ..Default::default()
             },

--- a/tools/cargo-miden/tests/build.rs
+++ b/tools/cargo-miden/tests/build.rs
@@ -48,12 +48,26 @@ fn build_new_project_from_template() {
     assert!(new_project_path.exists());
     assert_eq!(new_project_path, expected_new_project_dir.canonicalize().unwrap());
     env::set_current_dir(&new_project_path).unwrap();
-    let args = ["cargo", "miden", "build", "--release"].iter().map(|s| s.to_string());
-    let outputs = run(args).expect("Failed to compile");
+
+    // build with the dev profile
+    let args = ["cargo", "miden", "build"].iter().map(|s| s.to_string());
+    let outputs = run(args).expect("Failed to compile with the dev profile");
+    assert_eq!(outputs.len(), 1);
     let expected_masm_path = outputs.first().unwrap();
     dbg!(&expected_masm_path);
-    // eprintln!("{}", String::from_utf8(fs::read(expected_masm_path).unwrap()).unwrap());
     assert!(expected_masm_path.exists());
+    assert!(expected_masm_path.to_str().unwrap().contains("/debug/"));
+    assert!(expected_masm_path.metadata().unwrap().len() > 0);
+    // assert_eq!(expected_masm_path.metadata().unwrap().len(), 0);
+
+    // build with the release profile
+    let args = ["cargo", "miden", "build", "--release"].iter().map(|s| s.to_string());
+    let outputs = run(args).expect("Failed to compile with the release profile");
+    assert_eq!(outputs.len(), 1);
+    let expected_masm_path = outputs.first().unwrap();
+    dbg!(&expected_masm_path);
+    assert!(expected_masm_path.exists());
+    assert!(expected_masm_path.to_str().unwrap().contains("/release/"));
     assert!(expected_masm_path.metadata().unwrap().len() > 0);
 
     env::set_current_dir(restore_dir).unwrap();


### PR DESCRIPTION
Close #323 

rust-templates PR - https://github.com/0xPolygonMiden/rust-templates/pull/6

This PR also adds a test to build the new project with `dev` profile.