### PR TITLE
chore: remove `miden-assembly` dependency from `sdk/base-sys` for `bindings` feature

### DIFF
--- a/sdk/base-sys/Cargo.toml
+++ b/sdk/base-sys/Cargo.toml
@@ -14,11 +14,11 @@ readme.workspace = true
 edition.workspace = true
 
 [dependencies]
-miden-assembly.workspace = true
+miden-assembly = { workspace = true, optional = true }
 miden-stdlib-sys = { version = "0.0.6", path = "../stdlib-sys", optional = true }
 
 [build-dependencies]
-miden-assembly.workspace = true
+miden-assembly = { workspace = true, optional = true }
 
 [features]
 default = []
@@ -26,4 +26,4 @@ default = []
 # User facing Rust bindings
 "bindings" = ["dep:miden-stdlib-sys"]
 # MASL library for Miden rollup (tx kernel, etc.) used by the compiler in the link phase
-"masl-lib" = []
+"masl-lib" = ["dep:miden-assembly"]

--- a/sdk/base-sys/build.rs
+++ b/sdk/base-sys/build.rs
@@ -1,12 +1,11 @@
-use std::{env, path::Path, sync::Arc};
-
-use miden_assembly::{
-    diagnostics::{IntoDiagnostic, Result},
-    Assembler, Library as CompiledLibrary, LibraryNamespace,
-};
-
 /// Read and parse the contents from `./masm/*` and compile it to MASL.
-fn main() -> Result<()> {
+#[cfg(feature = "masl-lib")]
+fn main() {
+    use std::{env, path::Path, sync::Arc};
+
+    use miden_assembly::{
+        diagnostics::IntoDiagnostic, Assembler, Library as CompiledLibrary, LibraryNamespace,
+    };
     // re-build the `[OUT_DIR]/assets/` file iff something in the `./masm` directory
     // or its builder changed:
     println!("cargo:rerun-if-changed=masm");
@@ -19,12 +18,13 @@ fn main() -> Result<()> {
 
     let tx_asm_dir = Path::new(manifest_dir).join("masm").join("tx");
     let asm = Assembler::new(source_manager);
-    let txlib = CompiledLibrary::from_dir(tx_asm_dir, namespace, asm)?;
+    let txlib = CompiledLibrary::from_dir(tx_asm_dir, namespace, asm).unwrap();
     let tx_masl_path = build_dir
         .join("assets")
         .join("tx")
         .with_extension(CompiledLibrary::LIBRARY_EXTENSION);
-    txlib.write_to_file(tx_masl_path).into_diagnostic()?;
-
-    Ok(())
+    txlib.write_to_file(tx_masl_path).into_diagnostic().unwrap();
 }
+
+#[cfg(not(feature = "masl-lib"))]
+fn main() {}


### PR DESCRIPTION
Use `miden-assembly` dependency only when building MASL library.