### PR TITLE
Implement CondBr, Br, Loop translations; add `fib` test  

### DIFF
--- a/dialects/hir/src/builders/function.rs
+++ b/dialects/hir/src/builders/function.rs
@@ -1027,8 +1027,10 @@ pub trait InstBuilder: InstBuilderBase {
         Ok(op.borrow().result().as_value_ref())
     }
 
-    fn neq_imm(mut self, cond: ValueRef, i32: Immediate, span: SourceSpan) -> ValueRef {
-        todo!()
+    fn neq_imm(mut self, cond: ValueRef, imm: i32, span: SourceSpan) -> Result<ValueRef, Report> {
+        let op_builder = self.builder_mut().create::<crate::ops::NeqImm, _>(span);
+        let op = op_builder(cond, imm)?;
+        Ok(op.borrow().result().as_value_ref())
     }
 
     /// Compares two integers and returns the minimum value

--- a/dialects/hir/src/builders/function.rs
+++ b/dialects/hir/src/builders/function.rs
@@ -1,5 +1,5 @@
 use midenc_hir2::{
-    dialects::builtin::*, AsCallableSymbolRef, Block, BlockRef, Builder, Immediate, Listener,
+    dialects::builtin::*, AsCallableSymbolRef, Block, BlockRef, Builder, Felt, Immediate, Listener,
     OpBuilder, Overflow, Region, RegionRef, Report, SourceSpan, Type, UnsafeIntrusiveEntityRef,
     Usable, ValueRef,
 };
@@ -194,39 +194,76 @@ pub trait InstBuilder: InstBuilderBase {
         op_builder(lhs, rhs)
     }
 
-    fn u32(mut self, value: u32, span: SourceSpan) -> Result<ValueRef, Report> {
-        let op_builder = self.builder_mut().create::<crate::ops::Constant, _>(span);
-        let constant = op_builder(Immediate::U32(value))?;
-        Ok(constant.borrow().result().as_value_ref())
-    }
-
-    //signed_integer_literal!(1, bool);
-    //integer_literal!(8);
-    //integer_literal!(16);
-    //integer_literal!(32);
-    //integer_literal!(64);
-    //integer_literal!(128);
-
     /*
-    fn felt(self, i: Felt, span: SourceSpan) -> Value {
-        into_first_result!(self.UnaryImm(Opcode::ImmFelt, Type::Felt, Immediate::Felt(i), span))
-    }
-
-    fn f64(self, f: f64, span: SourceSpan) -> Value {
-        into_first_result!(self.UnaryImm(Opcode::ImmF64, Type::F64, Immediate::F64(f), span))
-    }
-
     fn character(self, c: char, span: SourceSpan) -> Value {
         self.i32((c as u32) as i32, span)
     }
     */
 
+    fn i1(mut self, value: bool, span: SourceSpan) -> ValueRef {
+        let op_builder = self.builder_mut().create::<crate::ops::Constant, _>(span);
+        let constant = op_builder(Immediate::I1(value)).unwrap();
+        constant.borrow().result().as_value_ref()
+    }
+
+    fn i8(mut self, value: i8, span: SourceSpan) -> ValueRef {
+        let op_builder = self.builder_mut().create::<crate::ops::Constant, _>(span);
+        let constant = op_builder(Immediate::I8(value)).unwrap();
+        constant.borrow().result().as_value_ref()
+    }
+
+    fn i16(mut self, value: i16, span: SourceSpan) -> ValueRef {
+        let op_builder = self.builder_mut().create::<crate::ops::Constant, _>(span);
+        let constant = op_builder(Immediate::I16(value)).unwrap();
+        constant.borrow().result().as_value_ref()
+    }
+
     fn i32(mut self, value: i32, span: SourceSpan) -> ValueRef {
-        todo!()
+        let op_builder = self.builder_mut().create::<crate::ops::Constant, _>(span);
+        let constant = op_builder(Immediate::I32(value)).unwrap();
+        constant.borrow().result().as_value_ref()
     }
 
     fn i64(mut self, value: i64, span: SourceSpan) -> ValueRef {
-        todo!()
+        let op_builder = self.builder_mut().create::<crate::ops::Constant, _>(span);
+        let constant = op_builder(Immediate::I64(value)).unwrap();
+        constant.borrow().result().as_value_ref()
+    }
+
+    fn u8(mut self, value: u8, span: SourceSpan) -> ValueRef {
+        let op_builder = self.builder_mut().create::<crate::ops::Constant, _>(span);
+        let constant = op_builder(Immediate::U8(value)).unwrap();
+        constant.borrow().result().as_value_ref()
+    }
+
+    fn u16(mut self, value: u16, span: SourceSpan) -> ValueRef {
+        let op_builder = self.builder_mut().create::<crate::ops::Constant, _>(span);
+        let constant = op_builder(Immediate::U16(value)).unwrap();
+        constant.borrow().result().as_value_ref()
+    }
+
+    fn u32(mut self, value: u32, span: SourceSpan) -> ValueRef {
+        let op_builder = self.builder_mut().create::<crate::ops::Constant, _>(span);
+        let constant = op_builder(Immediate::U32(value)).unwrap();
+        constant.borrow().result().as_value_ref()
+    }
+
+    fn u64(mut self, value: u64, span: SourceSpan) -> ValueRef {
+        let op_builder = self.builder_mut().create::<crate::ops::Constant, _>(span);
+        let constant = op_builder(Immediate::U64(value)).unwrap();
+        constant.borrow().result().as_value_ref()
+    }
+
+    fn f64(mut self, value: f64, span: SourceSpan) -> ValueRef {
+        let op_builder = self.builder_mut().create::<crate::ops::Constant, _>(span);
+        let constant = op_builder(Immediate::F64(value)).unwrap();
+        constant.borrow().result().as_value_ref()
+    }
+
+    fn felt(mut self, value: Felt, span: SourceSpan) -> ValueRef {
+        let op_builder = self.builder_mut().create::<crate::ops::Constant, _>(span);
+        let constant = op_builder(Immediate::Felt(value)).unwrap();
+        constant.borrow().result().as_value_ref()
     }
 
     /// Grow the global heap by `num_pages` pages, in 64kb units.

--- a/dialects/hir/src/lib.rs
+++ b/dialects/hir/src/lib.rs
@@ -161,6 +161,7 @@ impl DialectRegistration for HirDialect {
         info.register_operation::<ops::Rotr>();
         info.register_operation::<ops::Eq>();
         info.register_operation::<ops::Neq>();
+        info.register_operation::<ops::NeqImm>();
         info.register_operation::<ops::Gt>();
         info.register_operation::<ops::Gte>();
         info.register_operation::<ops::Lt>();

--- a/dialects/hir/src/ops/binary.rs
+++ b/dialects/hir/src/ops/binary.rs
@@ -573,6 +573,22 @@ pub struct Neq {
 
 infer_return_ty_for_binary_op!(Neq as Type::I1);
 
+/// Inequality comparison with immediate
+#[operation(
+    dialect = HirDialect,
+    implements(InferTypeOpInterface)
+)]
+pub struct NeqImm {
+    #[operand]
+    lhs: AnyInteger,
+    #[attr]
+    rhs: i32,
+    #[result]
+    result: Bool,
+}
+
+infer_return_ty_for_binary_op!(NeqImm as Type::I1);
+
 /// Greater-than comparison
 #[operation(
     dialect = HirDialect,

--- a/frontend-wasm/src/module/func_translator.rs
+++ b/frontend-wasm/src/module/func_translator.rs
@@ -68,10 +68,7 @@ impl FuncTranslator {
 
         // Set up the translation state with a single pushed control block representing the whole
         // function and its return values.
-        dbg!(builder.current_block());
         let exit_block = builder.create_block();
-        dbg!(&exit_block);
-        dbg!(builder.current_block());
         builder.append_block_params_for_function_returns(exit_block);
         self.state.initialize(builder.signature(), exit_block);
 

--- a/frontend-wasm/src/module/function_builder_ext.rs
+++ b/frontend-wasm/src/module/function_builder_ext.rs
@@ -139,11 +139,6 @@ impl<'a, 'b, 'c> FunctionBuilderExt<'a, 'b, 'c> {
         // First we check that the previous block has been filled.
 
         let is_unreachable = self.is_unreachable();
-        dbg!(self.inner.current_block());
-        dbg!(block);
-        dbg!(is_unreachable);
-        dbg!(self.is_pristine(self.inner.current_block()));
-        dbg!(self.is_filled(self.inner.current_block()));
         debug_assert!(
             is_unreachable
                 || self.is_pristine(self.inner.current_block())
@@ -343,8 +338,6 @@ impl<'a, 'b, 'c> FunctionBuilderExt<'a, 'b, 'c> {
     /// Returns `true` if and only if a terminator instruction has been inserted since the
     /// last call to `switch_to_block`.
     fn is_filled(&self, block: Block) -> bool {
-        dbg!(block);
-        dbg!(&self.func_ctx.status);
         self.func_ctx.status[block] == BlockStatus::Filled
     }
 

--- a/frontend-wasm/src/ssa.rs
+++ b/frontend-wasm/src/ssa.rs
@@ -197,10 +197,8 @@ impl SSABuilder {
         ty: Type,
         mut block: Block,
     ) {
-        dbg!(var);
         // First, try Local Value Numbering (Algorithm 1 in the paper).
         // If the variable already has a known Value in this block, use that.
-        // dbg!(&self.variables);
         if let Some(val) = self.variables[var][block].expand() {
             self.results.push(val);
             return;
@@ -283,7 +281,6 @@ impl SSABuilder {
 
         // We've promised to return the most recent block where `var` was defined, but we didn't
         // find a usable definition. So create one.
-        dbg!(&var, &block, &ty);
         let val = dfg.append_block_param(block, ty, SourceSpan::default());
         var_defs[block] = PackedOption::from(val);
 

--- a/frontend-wasm2/src/code_translator/mod.rs
+++ b/frontend-wasm2/src/code_translator/mod.rs
@@ -122,7 +122,7 @@ pub fn translate_operator(
             // if cond is not 0, return arg1, else return arg2
             // https://www.w3.org/TR/wasm-core-1/#-hrefsyntax-instr-parametricmathsfselect%E2%91%A0
             // cond is expected to be an i32
-            let cond_i1 = builder.ins().neq_imm(cond, Immediate::I32(0), span);
+            let cond_i1 = builder.ins().neq_imm(cond, 0, span)?;
             state.push1(builder.ins().select(cond_i1, arg1, arg2, span)?);
         }
         Operator::TypedSelect { ty } => {
@@ -134,12 +134,13 @@ pub fn translate_operator(
                     state.push1(builder.ins().select(cond, arg1, arg2, span)?);
                 }
                 wasmparser::ValType::I32 => {
-                    let cond = builder.ins().neq_imm(cond, Immediate::I32(0), span);
+                    let cond = builder.ins().neq_imm(cond, 0, span)?;
                     state.push1(builder.ins().select(cond, arg1, arg2, span)?);
                 }
                 wasmparser::ValType::I64 => {
-                    let cond = builder.ins().neq_imm(cond, Immediate::I64(0), span);
-                    state.push1(builder.ins().select(cond, arg1, arg2, span)?);
+                    todo!()
+                    // let cond = builder.ins().neq_imm(cond, Immediate::I64(0), span);
+                    // state.push1(builder.ins().select(cond, arg1, arg2, span)?);
                 }
                 ty => panic!("unsupported value type for 'select': {ty}"),
             };
@@ -784,7 +785,7 @@ fn translate_br_if(
     let else_dest = next_block;
     let else_args = vec![];
     // cond is expected to be a i32 value
-    let cond_i1 = builder.ins().neq_imm(cond, Immediate::I32(0), span);
+    let cond_i1 = builder.ins().neq_imm(cond, 0, span)?;
     builder.ins().cond_br(cond_i1, then_dest, then_args, else_dest, else_args, span);
     builder.seal_block(next_block); // The only predecessor is the current block.
     builder.switch_to_block(next_block);

--- a/frontend-wasm2/src/code_translator/mod.rs
+++ b/frontend-wasm2/src/code_translator/mod.rs
@@ -751,23 +751,22 @@ fn translate_br(
     builder: &mut FunctionBuilderExt,
     span: SourceSpan,
 ) {
-    todo!()
-    // let i = state.control_stack.len() - 1 - (*relative_depth as usize);
-    // let (return_count, br_destination) = {
-    //     let frame = &mut state.control_stack[i];
-    //     // We signal that all the code that follows until the next End is unreachable
-    //     frame.set_branched_to_exit();
-    //     let return_count = if frame.is_loop() {
-    //         frame.num_param_values()
-    //     } else {
-    //         frame.num_return_values()
-    //     };
-    //     (return_count, frame.br_destination())
-    // };
-    // let destination_args = state.peekn_mut(return_count);
-    // builder.ins().br(br_destination, destination_args, span);
-    // state.popn(return_count);
-    // state.reachable = false;
+    let i = state.control_stack.len() - 1 - (*relative_depth as usize);
+    let (return_count, br_destination) = {
+        let frame = &mut state.control_stack[i];
+        // We signal that all the code that follows until the next End is unreachable
+        frame.set_branched_to_exit();
+        let return_count = if frame.is_loop() {
+            frame.num_param_values()
+        } else {
+            frame.num_return_values()
+        };
+        (return_count, frame.br_destination())
+    };
+    let destination_args = state.peekn_mut(return_count).to_vec();
+    builder.ins().br(br_destination, destination_args, span);
+    state.popn(return_count);
+    state.reachable = false;
 }
 
 fn translate_br_if(
@@ -898,7 +897,6 @@ fn translate_end(
     // block and have already been translated) and modify the value stack to use the
     // possible `Block`'s arguments values.
     let frame = state.control_stack.pop().unwrap();
-    // dbg!(&frame);
     let next_block = frame.following_code();
     let return_count = frame.num_return_values();
     let return_args = state.peekn_mut(return_count);

--- a/frontend-wasm2/src/module/build_ir.rs
+++ b/frontend-wasm2/src/module/build_ir.rs
@@ -74,7 +74,6 @@ pub fn translate_module_as_component(
         .unwrap();
     let mut cb = ComponentBuilder::new(component_ref);
     let module_name = parsed_module.module.name().as_str();
-    dbg!(&module_name);
     let mut module_ref = cb.define_module(Ident::from(module_name)).unwrap().borrow_mut();
     let module = module_ref.as_mut().downcast_mut::<Module>().unwrap();
 
@@ -162,7 +161,6 @@ pub fn build_ir_module(
             Visibility::Internal
         };
         let sig = ir_func_sig(&ir_func_type, CallConv::SystemV, visibility);
-        dbg!(&func_name);
         let mut function_ref = module_builder
             .define_function(Ident::from(func_name), sig)
             .unwrap()

--- a/frontend-wasm2/src/module/func_translation_state.rs
+++ b/frontend-wasm2/src/module/func_translation_state.rs
@@ -296,13 +296,15 @@ impl FuncTranslationState {
         builder: &mut FunctionBuilderExt,
         span: SourceSpan,
     ) -> ValueRef {
-        todo!()
-        // let val = self.stack.pop().expect("attempted to pop a value from an empty stack");
-        // if builder.data_flow_graph().value_type(val) != &ty {
-        //     builder.ins().bitcast(val, ty, span)
-        // } else {
-        //     val
-        // }
+        let val = self.stack.pop().expect("attempted to pop a value from an empty stack");
+        if val.borrow().ty() != &ty {
+            builder
+                .ins()
+                .bitcast(val, ty.clone(), span)
+                .unwrap_or_else(|_| panic!("failed to bitcast {:?} to {:?}", val, ty))
+        } else {
+            val
+        }
     }
 
     /// Peek at the top of the stack without popping it.

--- a/frontend-wasm2/src/module/func_translation_state.rs
+++ b/frontend-wasm2/src/module/func_translation_state.rs
@@ -7,7 +7,7 @@
 
 use midenc_dialect_hir::InstBuilder;
 use midenc_hir::{diagnostics::SourceSpan, Block, Inst};
-use midenc_hir2::{BlockRef, Signature, ValueRef};
+use midenc_hir2::{BlockRef, OperationRef, Signature, ValueRef};
 use midenc_hir_type::Type;
 
 use super::function_builder_ext::FunctionBuilderExt;
@@ -25,7 +25,7 @@ pub enum ElseData {
         /// If we discover that we need an `else` block, this is the jump
         /// instruction that needs to be fixed up to point to the new `else`
         /// block rather than the destination block after the `if...end`.
-        branch_inst: Inst,
+        branch_inst: OperationRef,
 
         /// The placeholder block we're replacing.
         placeholder: BlockRef,

--- a/frontend-wasm2/src/module/func_translation_state.rs
+++ b/frontend-wasm2/src/module/func_translation_state.rs
@@ -416,7 +416,6 @@ impl FuncTranslationState {
         num_result_types: usize,
     ) {
         debug_assert!(num_param_types <= self.stack.len());
-        dbg!(&following_code);
         self.control_stack.push(ControlStackFrame::Block {
             destination: following_code,
             original_stack_size: self.stack.len() - num_param_types,

--- a/frontend-wasm2/src/module/func_translator.rs
+++ b/frontend-wasm2/src/module/func_translator.rs
@@ -67,20 +67,14 @@ impl FuncTranslator {
     ) -> WasmResult<()> {
         let mut builder = FunctionBuilderExt::new(func, self.func_ctx.clone());
 
-        dbg!(builder.current_block());
         let entry_block = builder.current_block();
-        dbg!(builder.current_block());
-        dbg!(&entry_block);
         builder.seal_block(entry_block); // Declare all predecessors known.
 
         let num_params = declare_parameters(&mut builder, entry_block);
 
         // Set up the translation state with a single pushed control block representing the whole
         // function and its return values.
-        dbg!(builder.current_block());
         let exit_block = builder.create_block();
-        dbg!(&exit_block);
-        dbg!(builder.current_block());
         builder.append_block_params_for_function_returns(exit_block);
         self.state.initialize(builder.signature(), exit_block);
 

--- a/frontend-wasm2/src/module/function_builder_ext.rs
+++ b/frontend-wasm2/src/module/function_builder_ext.rs
@@ -183,6 +183,10 @@ impl<'c> FunctionBuilderExt<'c> {
         block
     }
 
+    pub fn create_detached_block(&mut self) -> BlockRef {
+        self.inner.builder().context().create_block()
+    }
+
     /// Append parameters to the given `Block` corresponding to the function
     /// return values. This can be used to set up the block parameters for a
     /// function exit block.

--- a/frontend-wasm2/src/module/function_builder_ext.rs
+++ b/frontend-wasm2/src/module/function_builder_ext.rs
@@ -200,7 +200,6 @@ impl<'c> FunctionBuilderExt<'c> {
 
         #[allow(clippy::unnecessary_to_owned)]
         for argtyp in self.signature().results().to_vec() {
-            dbg!(&argtyp.ty);
             self.inner.append_block_param(block, argtyp.ty.clone(), SourceSpan::default());
         }
     }
@@ -215,11 +214,6 @@ impl<'c> FunctionBuilderExt<'c> {
     pub fn switch_to_block(&mut self, block: BlockRef) {
         // First we check that the previous block has been filled.
         let is_unreachable = self.is_unreachable();
-        dbg!(self.inner.current_block());
-        dbg!(block);
-        dbg!(is_unreachable);
-        dbg!(self.is_pristine(&self.inner.current_block()));
-        dbg!(self.is_filled(&self.inner.current_block()));
         debug_assert!(
             is_unreachable
                 || self.is_pristine(&self.inner.current_block())
@@ -415,12 +409,9 @@ impl<'c> FunctionBuilderExt<'c> {
     /// The entry block of a function is never unreachable.
     pub fn is_unreachable(&self) -> bool {
         let is_entry = self.inner.current_block() == self.inner.entry_block();
-        dbg!(is_entry);
         let func_ctx = self.func_ctx.borrow();
         let is_sealed = func_ctx.ssa.is_sealed(self.inner.current_block());
-        dbg!(is_sealed);
         let has_no_predecessors = !func_ctx.ssa.has_any_predecessors(self.inner.current_block());
-        dbg!(has_no_predecessors);
         !is_entry && is_sealed && has_no_predecessors
     }
 

--- a/frontend-wasm2/src/ssa.rs
+++ b/frontend-wasm2/src/ssa.rs
@@ -244,7 +244,7 @@ impl SSABuilder {
         // any of the blocks before `from`.
         //
         // So in either case there is no definition in these blocks yet and we can blindly set one.
-        let var_defs = self.variables.get_mut(&var).unwrap();
+        let var_defs = self.variables.entry(var).or_default();
         while block != from {
             debug_assert!(var_defs[&block].is_none());
             var_defs.insert(block, Some(val));
@@ -284,9 +284,9 @@ impl SSABuilder {
                 break;
             }
             block = pred;
-            if let Some(val) = var_defs[&block] {
-                self.results.push(val);
-                return (val, block);
+            if let Some(val) = var_defs.entry(block).or_default() {
+                self.results.push(*val);
+                return (*val, block);
             }
         }
 

--- a/frontend-wasm2/src/ssa.rs
+++ b/frontend-wasm2/src/ssa.rs
@@ -210,16 +210,12 @@ impl SSABuilder {
     ///
     /// This function sets up state for `run_state_machine()` but does not execute it.
     fn use_var_nonlocal(&mut self, var: Variable, ty: Type, mut block: BlockRef) {
-        dbg!(var);
         // First, try Local Value Numbering (Algorithm 1 in the paper).
         // If the variable already has a known Value in this block, use that.
-        dbg!(&block);
-        // dbg!(&self.variables);
         if let Some(val) = self.variables.entry(var).or_default().entry(block).or_default() {
             self.results.push(*val);
             return;
         }
-        // dbg!(&self.variables);
 
         // Otherwise, use Global Value Numbering (Algorithm 2 in the paper).
         // This resolves the Value with respect to its predecessors.
@@ -293,7 +289,6 @@ impl SSABuilder {
         // We've promised to return the most recent block where `var` was defined, but we didn't
         // find a usable definition. So create one.
 
-        dbg!(&var, &block, &ty);
         let val = self.context.append_block_argument(block, ty, SourceSpan::default());
         var_defs.insert(block, Some(val));
 
@@ -302,13 +297,11 @@ impl SSABuilder {
         // problems with doing that. First, we need to keep a fixed bound on stack depth, so we
         // can't actually recurse; instead we defer to `run_state_machine`. Second, if we don't
         // know all our predecessors yet, we have to defer this work until the block gets sealed.
-        match self.ssa_blocks.get_mut(&block).unwrap().sealed {
+        match &mut self.ssa_blocks.get_mut(&block).unwrap().sealed {
             // Once all the `calls` added here complete, this leaves either `val` or an equivalent
             // definition on the `results` stack.
             Sealed::Yes => self.begin_predecessors_lookup(val, block),
-            Sealed::No {
-                mut undef_variables,
-            } => {
+            Sealed::No { undef_variables } => {
                 undef_variables.push(var, &mut self.variable_pool);
                 self.results.push(val);
             }
@@ -384,12 +377,12 @@ impl SSABuilder {
         // only if necessary.
         let mut undef_variables = match self.ssa_blocks.entry_ref(&block) {
             EntryRef::Occupied(mut entry) => {
-                let undef_variables = match entry.get().sealed {
+                let old_sealed = entry.get().sealed.clone();
+                entry.get_mut().sealed = Sealed::Yes;
+                match old_sealed {
                     Sealed::No { undef_variables } => undef_variables,
                     Sealed::Yes => return,
-                };
-                entry.get_mut().sealed = Sealed::Yes;
-                undef_variables
+                }
             }
             EntryRef::Vacant(_) => {
                 self.ssa_blocks.insert(
@@ -486,9 +479,7 @@ impl SSABuilder {
                 "you have declared a non-branch instruction as a predecessor to a block!"
             );
 
-            let ty = val.borrow().ty().clone();
-            dbg!(&dest_block, &ty);
-            self.context.append_block_argument(dest_block, ty, val.borrow().span());
+            self.context.append_branch_destination_argument(branch, dest_block, val);
         }
         sentinel
     }

--- a/frontend-wasm2/src/translation_utils.rs
+++ b/frontend-wasm2/src/translation_utils.rs
@@ -1,8 +1,9 @@
 //! Helper functions and structures for the translation.
 
+use midenc_dialect_hir::InstBuilder;
 use midenc_hir::{
     diagnostics::{DiagnosticsHandler, SourceSpan},
-    AbiParam, CallConv, Felt, FieldElement, InstBuilder, Linkage, Signature, Value,
+    AbiParam, CallConv, Felt, FieldElement, Linkage, Signature, Value,
 };
 use midenc_hir2::ValueRef;
 use midenc_hir_type::{FunctionType, Type};
@@ -108,33 +109,32 @@ pub fn emit_zero(
     builder: &mut FunctionBuilderExt,
     diagnostics: &DiagnosticsHandler,
 ) -> WasmResult<ValueRef> {
-    todo!()
-    // Ok(match ty {
-    //     Type::I1 => builder.ins().i1(false, SourceSpan::default()),
-    //     Type::I8 => builder.ins().i8(0, SourceSpan::default()),
-    //     Type::I16 => builder.ins().i16(0, SourceSpan::default()),
-    //     Type::I32 => builder.ins().i32(0, SourceSpan::default()),
-    //     Type::I64 => builder.ins().i64(0, SourceSpan::default()),
-    //     Type::U8 => builder.ins().u8(0, SourceSpan::default()),
-    //     Type::U16 => builder.ins().u16(0, SourceSpan::default()),
-    //     Type::U32 => builder.ins().u32(0, SourceSpan::default()),
-    //     Type::U64 => builder.ins().u64(0, SourceSpan::default()),
-    //     Type::F64 => builder.ins().f64(0.0, SourceSpan::default()),
-    //     Type::Felt => builder.ins().felt(Felt::ZERO, SourceSpan::default()),
-    //     Type::I128
-    //     | Type::U128
-    //     | Type::U256
-    //     | Type::Ptr(_)
-    //     | Type::NativePtr(..)
-    //     | Type::Struct(_)
-    //     | Type::Array(..)
-    //     | Type::List(_)
-    //     | Type::Unknown
-    //     | Type::Unit
-    //     | Type::Never => {
-    //         unsupported_diag!(diagnostics, "cannot emit zero value for type: {:?}", ty);
-    //     }
-    // })
+    Ok(match ty {
+        Type::I1 => builder.ins().i1(false, SourceSpan::default()),
+        Type::I8 => builder.ins().i8(0, SourceSpan::default()),
+        Type::I16 => builder.ins().i16(0, SourceSpan::default()),
+        Type::I32 => builder.ins().i32(0, SourceSpan::default()),
+        Type::I64 => builder.ins().i64(0, SourceSpan::default()),
+        Type::U8 => builder.ins().u8(0, SourceSpan::default()),
+        Type::U16 => builder.ins().u16(0, SourceSpan::default()),
+        Type::U32 => builder.ins().u32(0, SourceSpan::default()),
+        Type::U64 => builder.ins().u64(0, SourceSpan::default()),
+        Type::F64 => builder.ins().f64(0.0, SourceSpan::default()),
+        Type::Felt => builder.ins().felt(Felt::ZERO, SourceSpan::default()),
+        Type::I128
+        | Type::U128
+        | Type::U256
+        | Type::Ptr(_)
+        | Type::NativePtr(..)
+        | Type::Struct(_)
+        | Type::Array(..)
+        | Type::List(_)
+        | Type::Unknown
+        | Type::Unit
+        | Type::Never => {
+            unsupported_diag!(diagnostics, "cannot emit zero value for type: {:?}", ty);
+        }
+    })
 }
 
 pub fn sig_from_func_type(

--- a/hir2/src/dialects/builtin/ops/function.rs
+++ b/hir2/src/dialects/builtin/ops/function.rs
@@ -70,7 +70,6 @@ impl Function {
             .as_operation()
             .context()
             .create_block_with_params(signature.params().iter().map(|p| p.ty.clone()));
-        dbg!(&block);
         let mut body = self.body_mut();
         body.push_back(block);
         Block::on_inserted_into_parent(block, body.as_region_ref());

--- a/hir2/src/ir/print.rs
+++ b/hir2/src/ir/print.rs
@@ -204,9 +204,10 @@ impl PrettyPrint for OperationPrinter<'_> {
                         if i > 0 {
                             doc + const_text(", ") + display(succ.block.borrow().block)
                         } else {
-                            doc + display(succ.block.borrow().block) + const_text(" ")
+                            doc + display(succ.block.borrow().block)
                         }
                     });
+                    doc += const_text(" ");
                 }
 
                 let operands = self.op.operands();

--- a/tests/integration/expected/fib_hir2.hir
+++ b/tests/integration/expected/fib_hir2.hir
@@ -1,0 +1,27 @@
+builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+
+    builtin.module  #[name = #miden_integration_tests_rust_fib_wasm] #[visibility = public] {
+
+        builtin.function public @fib(v0: i32) -> i32 {
+        ^block2(v0: i32):
+            v2 = hir.constant 0 : i32;
+            v3 = hir.constant 0 : i32;
+            v4 = hir.constant 1 : i32;
+            hir.br block4 v4, v0, v3;
+        ^block3(v1: i32):
+
+        ^block4(v6: i32, v7: i32, v9: i32):
+            v8 = hir.neq_imm v7 : i1 #[rhs = 0];
+            hir.cond_br block6, block7 v8;
+        ^block5(v5: i32):
+
+        ^block6:
+            v10 = hir.constant -1 : i32;
+            v11 = hir.add v7, v10 : i32 #[overflow = wrapping];
+            v12 = hir.add v9, v6 : i32 #[overflow = wrapping];
+            hir.br block4 v12, v11, v6;
+        ^block7:
+            hir.ret v9;
+        };
+    };
+};

--- a/tests/integration/expected/fib_hir2.wat
+++ b/tests/integration/expected/fib_hir2.wat
@@ -1,0 +1,39 @@
+(module $miden_integration_tests_rust_fib_wasm.wasm
+  (type (;0;) (func (param i32) (result i32)))
+  (func $fib (;0;) (type 0) (param i32) (result i32)
+    (local i32 i32 i32)
+    i32.const 0
+    local.set 1
+    i32.const 1
+    local.set 2
+    loop (result i32) ;; label = @1
+      local.get 2
+      local.set 3
+      block ;; label = @2
+        local.get 0
+        br_if 0 (;@2;)
+        local.get 1
+        return
+      end
+      local.get 0
+      i32.const -1
+      i32.add
+      local.set 0
+      local.get 1
+      local.get 3
+      i32.add
+      local.set 2
+      local.get 3
+      local.set 1
+      br 0 (;@1;)
+    end
+  )
+  (memory (;0;) 16)
+  (global $__stack_pointer (;0;) (mut i32) i32.const 1048576)
+  (global (;1;) i32 i32.const 1048576)
+  (global (;2;) i32 i32.const 1048576)
+  (export "memory" (memory 0))
+  (export "fib" (func $fib))
+  (export "__data_end" (global 1))
+  (export "__heap_base" (global 2))
+)

--- a/tests/integration/src/rust_masm_tests/apps.rs
+++ b/tests/integration/src/rust_masm_tests/apps.rs
@@ -38,3 +38,37 @@ fn fib() {
         })
         .unwrap();
 }
+
+#[test]
+fn fib_hir2() {
+    let mut test = CompilerTest::rust_source_cargo("fib", "fib_hir2", "fib");
+    let artifact_name = test.artifact_name().to_string();
+    test.expect_wasm(expect_file![format!("../../expected/{artifact_name}.wat")]);
+    test.expect_ir2(expect_file![format!("../../expected/{artifact_name}.hir")]);
+
+    /*
+        test.expect_masm(expect_file!["../../expected/fib.masm"]);
+        // let ir_masm = test.ir_masm_program();
+        let package = test.compiled_package();
+
+        // Run the Rust and compiled MASM code against a bunch of random inputs and compare the results
+        TestRunner::default()
+            .run(&(1u32..30), move |a| {
+                let rust_out = miden_integration_tests_rust_fib::fib(a);
+                let mut args = Vec::<Felt>::default();
+                PushToStack::try_push(&a, &mut args);
+
+                let exec = Executor::for_package(&package, args, &test.session)
+                    .map_err(|err| TestCaseError::fail(err.to_string()))?;
+                let output: u32 = exec.execute_into(&package.unwrap_program(), &test.session);
+                dbg!(output);
+                prop_assert_eq!(rust_out, output);
+                // args.reverse();
+                // let emul_out: u32 =
+                //     execute_emulator(ir_masm.clone(), &args).first().unwrap().clone().into();
+                // prop_assert_eq!(rust_out, emul_out);
+                Ok(())
+            })
+            .unwrap();
+    */
+}


### PR DESCRIPTION
Ref #363 

**This PR is based on the #367**

This PR implements `CondBr`, `Br` and `Loop` ops along with the missing parts in the `SSABuilder` to successfully translate `fib` test code (see `fib_hir2` test).