### PR TITLE
[1/x] frontend: Local function calls translation

### DIFF
--- a/dialects/hir/src/builders/function.rs
+++ b/dialects/hir/src/builders/function.rs
@@ -1,7 +1,7 @@
 use midenc_hir2::{
     dialects::builtin::*, AsCallableSymbolRef, Block, BlockRef, Builder, Felt, Immediate, Listener,
-    OpBuilder, Overflow, Region, RegionRef, Report, SourceSpan, Type, UnsafeIntrusiveEntityRef,
-    Usable, ValueRef,
+    OpBuilder, Overflow, Region, RegionRef, Report, Signature, SourceSpan, Type,
+    UnsafeIntrusiveEntityRef, Usable, ValueRef,
 };
 
 use crate::*;
@@ -1052,6 +1052,7 @@ pub trait InstBuilder: InstBuilderBase {
     fn exec<C, A>(
         mut self,
         callee: C,
+        signature: Signature,
         args: A,
         span: SourceSpan,
     ) -> Result<UnsafeIntrusiveEntityRef<crate::ops::Exec>, Report>
@@ -1059,13 +1060,14 @@ pub trait InstBuilder: InstBuilderBase {
         C: AsCallableSymbolRef,
         A: IntoIterator<Item = ValueRef>,
     {
-        let op_builder = self.builder_mut().create::<crate::ops::Exec, (C, A)>(span);
-        op_builder(callee, args)
+        let op_builder = self.builder_mut().create::<crate::ops::Exec, (C, Signature, A)>(span);
+        op_builder(callee, signature, args)
     }
 
     fn call<C, A>(
         mut self,
         callee: C,
+        signature: Signature,
         args: A,
         span: SourceSpan,
     ) -> Result<UnsafeIntrusiveEntityRef<crate::ops::Call>, Report>
@@ -1073,8 +1075,8 @@ pub trait InstBuilder: InstBuilderBase {
         C: AsCallableSymbolRef,
         A: IntoIterator<Item = ValueRef>,
     {
-        let op_builder = self.builder_mut().create::<crate::ops::Call, (C, A)>(span);
-        op_builder(callee, args)
+        let op_builder = self.builder_mut().create::<crate::ops::Call, (C, Signature, A)>(span);
+        op_builder(callee, signature, args)
     }
 
     fn select(

--- a/dialects/hir/src/ops/invoke.rs
+++ b/dialects/hir/src/ops/invoke.rs
@@ -4,7 +4,7 @@ use crate::HirDialect;
 
 #[operation(
     dialect = HirDialect,
-    implements(CallOpInterface)
+    implements(CallOpInterface, InferTypeOpInterface)
 )]
 pub struct Exec {
     #[symbol(callable)]

--- a/dialects/hir/src/ops/invoke.rs
+++ b/dialects/hir/src/ops/invoke.rs
@@ -111,7 +111,7 @@ impl CallOpInterface for Exec {
 // any types which are invalid for cross-context calls
 #[operation(
     dialect = HirDialect,
-    implements(CallOpInterface)
+    implements(CallOpInterface, InferTypeOpInterface)
 )]
 pub struct Call {
     #[symbol(callable)]

--- a/dialects/hir/src/ops/invoke.rs
+++ b/dialects/hir/src/ops/invoke.rs
@@ -9,53 +9,22 @@ use crate::HirDialect;
 pub struct Exec {
     #[symbol(callable)]
     callee: SymbolPath,
+    #[attr]
+    signature: Signature,
     #[operands]
     arguments: AnyType,
 }
 
 impl InferTypeOpInterface for Exec {
     fn infer_return_types(&mut self, context: &Context) -> Result<(), Report> {
-        use midenc_session::diagnostics::Severity;
-
         let span = self.span();
         let owner = self.as_operation().as_operation_ref();
-        if let Some(symbol) = self.resolve() {
-            let symbol = symbol.borrow();
-            if let Some(callable) =
-                symbol.as_symbol_operation().as_trait::<dyn CallableOpInterface>()
-            {
-                let signature = callable.signature();
-                for (i, result) in signature.results().iter().enumerate() {
-                    let value = context.make_result(span, result.ty.clone(), owner, i as u8);
-                    self.op.results.push(value);
-                }
-
-                Ok(())
-            } else {
-                Err(context
-                    .session
-                    .diagnostics
-                    .diagnostic(Severity::Error)
-                    .with_message("invalid operation")
-                    .with_primary_label(
-                        span,
-                        "invalid callee: does not implement CallableOpInterface",
-                    )
-                    .with_secondary_label(
-                        symbol.as_symbol_operation().span,
-                        "symbol refers to this definition",
-                    )
-                    .into_report())
-            }
-        } else {
-            Err(context
-                .session
-                .diagnostics
-                .diagnostic(Severity::Error)
-                .with_message("invalid operation")
-                .with_primary_label(span, "invalid callee: symbol is undefined")
-                .into_report())
+        let signature = self.signature().clone();
+        for (i, result) in signature.results().iter().enumerate() {
+            let value = context.make_result(span, result.ty.clone(), owner, i as u8);
+            self.op.results.push(value);
         }
+        Ok(())
     }
 }
 
@@ -116,53 +85,22 @@ impl CallOpInterface for Exec {
 pub struct Call {
     #[symbol(callable)]
     callee: SymbolPath,
+    #[attr]
+    signature: Signature,
     #[operands]
     arguments: AnyType,
 }
 
 impl InferTypeOpInterface for Call {
     fn infer_return_types(&mut self, context: &Context) -> Result<(), Report> {
-        use midenc_session::diagnostics::Severity;
-
         let span = self.span();
         let owner = self.as_operation().as_operation_ref();
-        if let Some(symbol) = self.resolve() {
-            let symbol = symbol.borrow();
-            if let Some(callable) =
-                symbol.as_symbol_operation().as_trait::<dyn CallableOpInterface>()
-            {
-                let signature = callable.signature();
-                for (i, result) in signature.results().iter().enumerate() {
-                    let value = context.make_result(span, result.ty.clone(), owner, i as u8);
-                    self.op.results.push(value);
-                }
-
-                Ok(())
-            } else {
-                Err(context
-                    .session
-                    .diagnostics
-                    .diagnostic(Severity::Error)
-                    .with_message("invalid operation")
-                    .with_primary_label(
-                        span,
-                        "invalid callee: does not implement CallableOpInterface",
-                    )
-                    .with_secondary_label(
-                        symbol.as_symbol_operation().span,
-                        "symbol refers to this definition",
-                    )
-                    .into_report())
-            }
-        } else {
-            Err(context
-                .session
-                .diagnostics
-                .diagnostic(Severity::Error)
-                .with_message("invalid operation")
-                .with_primary_label(span, "invalid callee: symbol is undefined")
-                .into_report())
+        let signature = self.signature().clone();
+        for (i, result) in signature.results().iter().enumerate() {
+            let value = context.make_result(span, result.ty.clone(), owner, i as u8);
+            self.op.results.push(value);
         }
+        Ok(())
     }
 }
 

--- a/frontend-wasm2/src/code_translator/mod.rs
+++ b/frontend-wasm2/src/code_translator/mod.rs
@@ -21,8 +21,8 @@ use midenc_hir::{
     Type::*,
 };
 use midenc_hir2::{
-    dialects::builtin::Function, BlockRef, CallableOpInterface, Immediate,
-    UnsafeIntrusiveEntityRef, ValueRef,
+    dialects::builtin::Function, traits::InferTypeOpInterface, BlockRef, CallableOpInterface,
+    Immediate, UnsafeIntrusiveEntityRef, ValueRef,
 };
 use wasmparser::{MemArg, Operator};
 
@@ -701,9 +701,7 @@ fn translate_call(
     //     );
     //     func_state.popn(num_wasm_args);
     //     func_state.pushn(&results);
-    // } else {
-    // no transformation needed
-    // let callee = func_id.downcast_ref::<Function>();
+    // } else { code below }
 
     let exec = builder.ins().exec(func_ref, args.to_vec(), span)?;
     let borrow = exec.borrow();
@@ -712,9 +710,7 @@ fn translate_call(
     func_state.popn(num_args);
     let result_vals: Vec<ValueRef> =
         results.iter().map(|op_res| op_res.borrow().as_value_ref()).collect();
-    dbg!(&result_vals);
     func_state.pushn(&result_vals);
-    // };
     Ok(())
 }
 

--- a/frontend-wasm2/src/code_translator/mod.rs
+++ b/frontend-wasm2/src/code_translator/mod.rs
@@ -676,7 +676,8 @@ fn translate_call(
     diagnostics: &DiagnosticsHandler,
 ) -> WasmResult<()> {
     let func_ref = module_state.get_direct_func(function_index, diagnostics)?;
-    let num_args = func_ref.borrow().signature().params().len();
+    let sig = func_ref.borrow().signature().clone();
+    let num_args = sig.params().len();
     let args = func_state.peekn(num_args);
     // if is_miden_intrinsics_module(func_id.module.as_symbol()) {
     //     let results = convert_intrinsics_call(func_id, args, builder, span);
@@ -703,10 +704,9 @@ fn translate_call(
     //     func_state.pushn(&results);
     // } else { code below }
 
-    let exec = builder.ins().exec(func_ref, args.to_vec(), span)?;
+    let exec = builder.ins().exec(func_ref, sig, args.to_vec(), span)?;
     let borrow = exec.borrow();
     let results = borrow.as_ref().results();
-    dbg!(&results);
     func_state.popn(num_args);
     let result_vals: Vec<ValueRef> =
         results.iter().map(|op_res| op_res.borrow().as_value_ref()).collect();

--- a/frontend-wasm2/src/code_translator/tests.rs
+++ b/frontend-wasm2/src/code_translator/tests.rs
@@ -69,7 +69,7 @@ fn memory_grow() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i32;
                 v1 = hir.bitcast v0 : ? #[ty = u32];
@@ -90,7 +90,7 @@ fn memory_size() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.mem_size  : ?;
                 hir.br block3 ;
@@ -111,7 +111,7 @@ fn memory_copy() {
             memory.copy
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 20 : i32;
                 v1 = hir.constant 10 : i32;
@@ -139,7 +139,7 @@ fn i32_load8_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.bitcast v0 : ? #[ty = u32];
@@ -163,7 +163,7 @@ fn i32_load16_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.bitcast v0 : ? #[ty = u32];
@@ -190,7 +190,7 @@ fn i32_load8_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.bitcast v0 : ? #[ty = u32];
@@ -214,7 +214,7 @@ fn i32_load16_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.bitcast v0 : ? #[ty = u32];
@@ -241,7 +241,7 @@ fn i64_load8_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.bitcast v0 : ? #[ty = u32];
@@ -265,7 +265,7 @@ fn i64_load16_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.bitcast v0 : ? #[ty = u32];
@@ -292,7 +292,7 @@ fn i64_load8_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.bitcast v0 : ? #[ty = u32];
@@ -316,7 +316,7 @@ fn i64_load16_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.bitcast v0 : ? #[ty = u32];
@@ -343,7 +343,7 @@ fn i64_load32_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.bitcast v0 : ? #[ty = u32];
@@ -370,7 +370,7 @@ fn i64_load32_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.bitcast v0 : ? #[ty = u32];
@@ -397,7 +397,7 @@ fn i32_load() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.bitcast v0 : ? #[ty = u32];
@@ -423,7 +423,7 @@ fn i64_load() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.bitcast v0 : ? #[ty = u32];
@@ -449,7 +449,7 @@ fn i32_store() {
             i32.store
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.constant 1 : i32;
@@ -476,7 +476,7 @@ fn i64_store() {
             i64.store
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.constant 1 : i64;
@@ -503,7 +503,7 @@ fn i32_store8() {
             i32.store8
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.constant 1 : i32;
@@ -529,7 +529,7 @@ fn i32_store16() {
             i32.store16
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.constant 1 : i32;
@@ -558,7 +558,7 @@ fn i64_store32() {
             i64.store32
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.constant 1 : i64;
@@ -586,7 +586,7 @@ fn i32_const() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i32;
                 hir.br block3 ;
@@ -605,7 +605,7 @@ fn i64_const() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i64;
                 hir.br block3 ;
@@ -625,7 +625,7 @@ fn i32_popcnt() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i32;
                 v1 = hir.popcnt v0 : ?;
@@ -647,7 +647,7 @@ fn i32_clz() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i32;
                 v1 = hir.clz v0 : ?;
@@ -669,7 +669,7 @@ fn i64_clz() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i64;
                 v1 = hir.clz v0 : ?;
@@ -691,7 +691,7 @@ fn i32_ctz() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i32;
                 v1 = hir.ctz v0 : ?;
@@ -713,7 +713,7 @@ fn i64_ctz() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i64;
                 v1 = hir.ctz v0 : ?;
@@ -735,7 +735,7 @@ fn i64_extend_i32_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i32;
                 v1 = hir.sext v0 : ? #[ty = i64];
@@ -756,7 +756,7 @@ fn i64_extend_i32_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i32;
                 v1 = hir.bitcast v0 : ? #[ty = u32];
@@ -779,7 +779,7 @@ fn i32_wrap_i64() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i64;
                 v1 = hir.trunc v0 : ? #[ty = i32];
@@ -801,7 +801,7 @@ fn i32_add() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 3 : i32;
                 v1 = hir.constant 1 : i32;
@@ -824,7 +824,7 @@ fn i64_add() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 3 : i64;
                 v1 = hir.constant 1 : i64;
@@ -847,7 +847,7 @@ fn i32_and() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -870,7 +870,7 @@ fn i64_and() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -893,7 +893,7 @@ fn i32_or() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -916,7 +916,7 @@ fn i64_or() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -939,7 +939,7 @@ fn i32_sub() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 3 : i32;
                 v1 = hir.constant 1 : i32;
@@ -962,7 +962,7 @@ fn i64_sub() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 3 : i64;
                 v1 = hir.constant 1 : i64;
@@ -985,7 +985,7 @@ fn i32_xor() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1008,7 +1008,7 @@ fn i64_xor() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1031,7 +1031,7 @@ fn i32_shl() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1055,7 +1055,7 @@ fn i64_shl() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1079,7 +1079,7 @@ fn i32_shr_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1105,7 +1105,7 @@ fn i64_shr_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1131,7 +1131,7 @@ fn i32_shr_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1155,7 +1155,7 @@ fn i64_shr_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1179,7 +1179,7 @@ fn i32_rotl() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1203,7 +1203,7 @@ fn i64_rotl() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1227,7 +1227,7 @@ fn i32_rotr() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1251,7 +1251,7 @@ fn i64_rotr() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1275,7 +1275,7 @@ fn i32_mul() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1298,7 +1298,7 @@ fn i64_mul() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1321,7 +1321,7 @@ fn i32_div_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1347,7 +1347,7 @@ fn i64_div_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1373,7 +1373,7 @@ fn i32_div_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1396,7 +1396,7 @@ fn i64_div_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1419,7 +1419,7 @@ fn i32_rem_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1445,7 +1445,7 @@ fn i64_rem_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1471,7 +1471,7 @@ fn i32_rem_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1494,7 +1494,7 @@ fn i64_rem_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1517,7 +1517,7 @@ fn i32_lt_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1543,7 +1543,7 @@ fn i64_lt_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1569,7 +1569,7 @@ fn i32_lt_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1593,7 +1593,7 @@ fn i64_lt_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1617,7 +1617,7 @@ fn i32_le_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1643,7 +1643,7 @@ fn i64_le_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1669,7 +1669,7 @@ fn i32_le_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1693,7 +1693,7 @@ fn i64_le_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1717,7 +1717,7 @@ fn i32_gt_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1743,7 +1743,7 @@ fn i64_gt_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1769,7 +1769,7 @@ fn i32_gt_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1793,7 +1793,7 @@ fn i64_gt_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1817,7 +1817,7 @@ fn i32_ge_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1843,7 +1843,7 @@ fn i64_ge_u() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1869,7 +1869,7 @@ fn i32_ge_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1893,7 +1893,7 @@ fn i64_ge_s() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -1916,7 +1916,7 @@ fn i32_eqz() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 0 : i32;
@@ -1939,7 +1939,7 @@ fn i64_eqz() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 0 : i64;
@@ -1963,7 +1963,7 @@ fn i32_eq() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -1987,7 +1987,7 @@ fn i64_eq() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -2011,7 +2011,7 @@ fn i32_ne() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
@@ -2035,7 +2035,7 @@ fn i64_ne() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
@@ -2060,7 +2060,7 @@ fn select_i32() {
             drop
         "#,
         expect![[r#"
-            builtin.function internal @test_wrapper() {
+            builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 3 : i64;
                 v1 = hir.constant 7 : i64;

--- a/frontend-wasm2/src/code_translator/tests.rs
+++ b/frontend-wasm2/src/code_translator/tests.rs
@@ -30,7 +30,6 @@ fn check_op(wat_op: &str, expected_ir: expect_test::Expect) {
     let wasm = wat::parse_str(wat).unwrap();
     let component_ref = translate(&wasm, &WasmTranslationConfig::default(), context.clone())
         .map_err(|e| {
-            let labels = e.labels().unwrap().collect::<Vec<midenc_hir::diagnostics::LabeledSpan>>();
             if let Some(labels) = e.labels() {
                 for label in labels {
                     eprintln!("{}", label.label().unwrap());

--- a/frontend-wasm2/src/module/build_ir.rs
+++ b/frontend-wasm2/src/module/build_ir.rs
@@ -55,13 +55,6 @@ pub fn translate_module_as_component(
     }
     let module_types = module_types_builder.finish();
 
-    let mut module_state = ModuleTranslationState::new(
-        &parsed_module.module,
-        &module_types,
-        vec![],
-        &context.session.diagnostics,
-    );
-
     // TODO: get proper ns and name (from exported interfaces?)
     let ns = Ident::from("root_ns");
     let name = Ident::from("root");
@@ -74,10 +67,17 @@ pub fn translate_module_as_component(
         .unwrap();
     let mut cb = ComponentBuilder::new(component_ref);
     let module_name = parsed_module.module.name().as_str();
-    let mut module_ref = cb.define_module(Ident::from(module_name)).unwrap().borrow_mut();
-    let module = module_ref.as_mut().downcast_mut::<Module>().unwrap();
+    let mut module_ref = cb.define_module(Ident::from(module_name)).unwrap();
 
-    build_ir_module(&mut parsed_module, &module_types, &mut module_state, config, context, module)?;
+    let mut module_builder = ModuleBuilder::new(module_ref);
+    let mut module_state = ModuleTranslationState::new(
+        &parsed_module.module,
+        &mut module_builder,
+        &module_types,
+        vec![],
+        &context.session.diagnostics,
+    );
+    build_ir_module(&mut parsed_module, &module_types, &mut module_state, config, context)?;
 
     // TODO: translate core module imports (create empty Components?)
     //
@@ -111,14 +111,12 @@ pub fn build_ir_module(
     module_state: &mut ModuleTranslationState,
     _config: &WasmTranslationConfig,
     context: Rc<Context>,
-    module_ref: &mut Module,
 ) -> WasmResult<()> {
     let memory_size = parsed_module
         .module
         .memories
         .get(MemoryIndex::from_u32(0))
         .map(|mem| mem.minimum as u32);
-    let mut module_builder = ModuleBuilder::new(module_ref);
     // if let Some(memory_size) = memory_size {
     // module_builder.with_reserved_memory_pages(memory_size);
     // }
@@ -161,9 +159,12 @@ pub fn build_ir_module(
             Visibility::Internal
         };
         let sig = ir_func_sig(&ir_func_type, CallConv::SystemV, visibility);
-        let mut function_ref = module_builder
-            .define_function(Ident::from(func_name), sig)
-            .unwrap()
+        let mut function_ref = module_state
+            .module_builder
+            .get_function(func_name)
+            .unwrap_or_else(|| {
+                panic!("cannot build {func_name} function, since it is not defined in the module.")
+            })
             .borrow_mut();
         let func = function_ref.as_mut().downcast_mut::<Function>().unwrap();
         // let mut module_func_builder = module_builder.function(func_name.as_str(), sig.clone())?;

--- a/frontend-wasm2/src/module/instance.rs
+++ b/frontend-wasm2/src/module/instance.rs
@@ -1,4 +1,5 @@
-use midenc_hir::{ComponentImport, FunctionIdent};
+use midenc_hir::ComponentImport;
+use midenc_hir2::FunctionIdent;
 
 /// Represents module argument that is used to instantiate a module.
 #[derive(Debug, Clone)]

--- a/frontend-wasm2/src/translation_utils.rs
+++ b/frontend-wasm2/src/translation_utils.rs
@@ -1,12 +1,11 @@
 //! Helper functions and structures for the translation.
 
+use miden_core::{Felt, FieldElement};
 use midenc_dialect_hir::InstBuilder;
-use midenc_hir::{
-    diagnostics::{DiagnosticsHandler, SourceSpan},
-    AbiParam, CallConv, Felt, FieldElement, Linkage, Signature, Value,
-};
-use midenc_hir2::ValueRef;
+use midenc_hir::SourceSpan;
+use midenc_hir2::{AbiParam, CallConv, Signature, ValueRef, Visibility};
 use midenc_hir_type::{FunctionType, Type};
+use midenc_session::DiagnosticsHandler;
 
 use crate::{
     error::WasmResult, module::function_builder_ext::FunctionBuilderExt, unsupported_diag,
@@ -140,12 +139,12 @@ pub fn emit_zero(
 pub fn sig_from_func_type(
     func_type: &FunctionType,
     call_conv: CallConv,
-    linkage: Linkage,
+    visibility: Visibility,
 ) -> Signature {
     Signature {
         params: func_type.params.iter().map(|ty| AbiParam::new(ty.clone())).collect(),
         results: func_type.results.iter().map(|ty| AbiParam::new(ty.clone())).collect(),
         cc: call_conv,
-        linkage,
+        visibility,
     }
 }

--- a/hir2/src/dialects/builtin/ops/function.rs
+++ b/hir2/src/dialects/builtin/ops/function.rs
@@ -111,6 +111,11 @@ impl Function {
         self.locals.push(ty);
         LocalId::new(id)
     }
+
+    #[inline(always)]
+    pub fn as_function_ref(&self) -> FunctionRef {
+        unsafe { FunctionRef::from_raw(self) }
+    }
 }
 
 impl RegionKindInterface for Function {

--- a/hir2/src/ir/symbols/table.rs
+++ b/hir2/src/ir/symbols/table.rs
@@ -292,7 +292,7 @@ impl SymbolMap {
     /// NOTE: If `symbol` is already in the map with `name`, this is a no-op.
     pub fn insert(&mut self, name: SymbolName, mut symbol: SymbolRef) -> SymbolName {
         // Add the symbol to the symbol map
-        let sym = symbol.borrow();
+        // let sym = symbol.borrow();
         match self.symbols.try_insert(name, symbol) {
             Ok(_) => {
                 symbol.borrow_mut().set_name(name);
@@ -313,7 +313,7 @@ impl SymbolMap {
                 let uniqued = generate_symbol_name(name, &mut self.uniquing_count, |name| {
                     !self.symbols.contains_key(name)
                 });
-                drop(sym);
+                // drop(sym);
                 symbol.borrow_mut().set_name(uniqued);
                 // TODO: visit uses? symbol should be unused AFAICT
                 self.symbols.insert(uniqued, symbol);

--- a/tests/integration/expected/function_call_hir2.hir
+++ b/tests/integration/expected/function_call_hir2.hir
@@ -1,0 +1,20 @@
+builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+
+    builtin.module  #[name = #function_call_hir2] #[visibility = public] {
+
+        builtin.function public @add(v0: i32, v1: i32) -> i32 {
+        ^block2(v0: i32, v1: i32):
+            v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
+            hir.br block3 v3;
+        ^block3(v2: i32):
+            hir.ret v2;
+        };
+        builtin.function public @entrypoint(v4: i32, v5: i32) -> i32 {
+        ^block4(v4: i32, v5: i32):
+            v7 = hir.exec v4, v5 : i32 #[callee = root/function_call_hir2/add] #[signature = (param i32) (param i32) (result i32)];
+            hir.br block5 v7;
+        ^block5(v6: i32):
+            hir.ret v6;
+        };
+    };
+};

--- a/tests/integration/expected/function_call_hir2.wat
+++ b/tests/integration/expected/function_call_hir2.wat
@@ -1,0 +1,18 @@
+(module $function_call_hir2.wasm
+  (type (;0;) (func (param i32 i32) (result i32)))
+  (func $add (;0;) (type 0) (param i32 i32) (result i32)
+    local.get 1
+    local.get 0
+    i32.add
+  )
+  (func $entrypoint (;1;) (type 0) (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    call $add
+  )
+  (memory (;0;) 16)
+  (global $__stack_pointer (;0;) (mut i32) i32.const 1048576)
+  (export "memory" (memory 0))
+  (export "add" (func $add))
+  (export "entrypoint" (func $entrypoint))
+)

--- a/tests/integration/src/cargo_proj/mod.rs
+++ b/tests/integration/src/cargo_proj/mod.rs
@@ -251,14 +251,23 @@ impl ProjectBuilder {
     }
 
     fn skip_rust_compilation(&self, artifact_name: &str) -> bool {
-        let computed_artifact_path = self
+        let computed_artifact_path_wuu = self
             .root()
             .join("target")
             .join("wasm32-unknown-unknown")
             .join("release")
             .join(artifact_name)
             .with_extension("wasm");
-        if std::env::var("SKIP_RUST").is_ok() && computed_artifact_path.exists() {
+        let computed_artifact_path_ww = self
+            .root()
+            .join("target")
+            .join("wasm32-wasip1")
+            .join("release")
+            .join(artifact_name)
+            .with_extension("wasm");
+        if std::env::var("SKIP_RUST").is_ok()
+            && (computed_artifact_path_wuu.exists() || computed_artifact_path_ww.exists())
+        {
             eprintln!("Skipping Rust compilation");
             true
         } else {

--- a/tests/integration/src/rust_masm_tests/apps.rs
+++ b/tests/integration/src/rust_masm_tests/apps.rs
@@ -2,10 +2,11 @@ use std::collections::VecDeque;
 
 use expect_test::expect_file;
 use midenc_debug::{Executor, PopFromStack, PushToStack};
+use midenc_frontend_wasm::WasmTranslationConfig;
 use midenc_hir::Felt;
 use proptest::{prelude::*, test_runner::TestRunner};
 
-use crate::CompilerTest;
+use crate::{cargo_proj::project, CompilerTest, CompilerTestBuilder};
 
 #[test]
 fn fib() {
@@ -71,4 +72,78 @@ fn fib_hir2() {
             })
             .unwrap();
     */
+}
+
+#[test]
+fn function_call_hir2() {
+    let name = "function_call_hir2";
+    let cargo_proj = project(name)
+        .file(
+            "Cargo.toml",
+            format!(
+                r#"
+                [package]
+                name = "{name}"
+                version = "0.0.1"
+                edition = "2021"
+                authors = []
+
+                [lib]
+                crate-type = ["cdylib"]
+
+                [profile.release]
+                # optimize the output for size
+                opt-level = "z"
+                panic = "abort"
+
+                [profile.dev]
+                panic = "abort"
+                opt-level = 1
+                debug-assertions = true
+                overflow-checks = false
+                debug = true
+            "#,
+            )
+            .as_str(),
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+                #![no_std]
+
+                // Global allocator to use heap memory in no-std environment
+                // #[global_allocator]
+                // static ALLOC: miden::BumpAlloc = miden::BumpAlloc::new();
+
+                // Required for no-std crates
+                #[panic_handler]
+                fn my_panic(_info: &core::panic::PanicInfo) -> ! {
+                    loop {}
+                }
+
+                // use miden::Felt;
+
+                #[no_mangle]
+                #[inline(never)]
+                pub fn add(a: u32, b: u32) -> u32 {
+                    a + b
+                }
+
+                #[no_mangle]
+                pub fn entrypoint(a: u32, b: u32) -> u32 {
+                    add(a, b)
+                }
+            "#,
+        )
+        .build();
+    let mut test = CompilerTestBuilder::rust_source_cargo_miden(
+        cargo_proj.root(),
+        WasmTranslationConfig::default(),
+        [],
+    )
+    .build();
+
+    let artifact_name = name;
+    test.expect_wasm(expect_file![format!("../../expected/{artifact_name}.wat")]);
+    test.expect_ir2(expect_file![format!("../../expected/{artifact_name}.hir")]);
 }


### PR DESCRIPTION
#363 

This PR adds:
- Declare the module's functions before the first function's body translation;
- Add the defined function to the module's symbol table;
- Lookup the function in the module's symbol table when translating a function call.
