### PR TITLE
[2/x] fix: handle empty regions in `NoRegionArguments` verification

### DIFF
--- a/hir2/src/dialects/builtin/ops/component.rs
+++ b/hir2/src/dialects/builtin/ops/component.rs
@@ -7,8 +7,8 @@ use crate::{
     derive::operation,
     dialects::builtin::BuiltinDialect,
     traits::{
-        GraphRegionNoTerminator, HasOnlyGraphRegion, IsolatedFromAbove, NoTerminator, SingleBlock,
-        SingleRegion,
+        GraphRegionNoTerminator, HasOnlyGraphRegion, IsolatedFromAbove, NoRegionArguments,
+        NoTerminator, SingleBlock, SingleRegion,
     },
     version::Version,
     Ident, Operation, RegionKind, RegionKindInterface, Symbol, SymbolManager, SymbolManagerMut,
@@ -64,7 +64,7 @@ pub type ComponentRef = UnsafeIntrusiveEntityRef<Component>;
     traits(
         SingleRegion,
         SingleBlock,
-        // NoRegionArguments,
+        NoRegionArguments,
         NoTerminator,
         HasOnlyGraphRegion,
         GraphRegionNoTerminator,

--- a/hir2/src/dialects/builtin/ops/module.rs
+++ b/hir2/src/dialects/builtin/ops/module.rs
@@ -2,8 +2,8 @@ use crate::{
     derive::operation,
     dialects::builtin::BuiltinDialect,
     traits::{
-        GraphRegionNoTerminator, HasOnlyGraphRegion, IsolatedFromAbove, NoTerminator, SingleBlock,
-        SingleRegion,
+        GraphRegionNoTerminator, HasOnlyGraphRegion, IsolatedFromAbove, NoRegionArguments,
+        NoTerminator, SingleBlock, SingleRegion,
     },
     Ident, Operation, RegionKind, RegionKindInterface, Symbol, SymbolManager, SymbolManagerMut,
     SymbolMap, SymbolName, SymbolRef, SymbolTable, SymbolUseList, UnsafeIntrusiveEntityRef, Usable,
@@ -52,7 +52,7 @@ pub type ModuleRef = UnsafeIntrusiveEntityRef<Module>;
     traits(
         SingleRegion,
         SingleBlock,
-        // NoRegionArguments,
+        NoRegionArguments,
         NoTerminator,
         HasOnlyGraphRegion,
         GraphRegionNoTerminator,

--- a/hir2/src/ir/traits.rs
+++ b/hir2/src/ir/traits.rs
@@ -231,6 +231,9 @@ derive! {
     verify {
         fn no_region_arguments(op: &Operation, context: &Context) -> Result<(), Report> {
             for region in op.regions().iter() {
+                if region.is_empty() {
+                    continue
+                }
                 if region.entry().has_arguments() {
                     return Err(context
                         .session


### PR DESCRIPTION
**This PR is stacked on the #381 and should be merged after it**