### PR TITLE
[1/x] fix: restore op type constraint verification, fix `zext` vs `sext` usage in the frontend

### DIFF
--- a/dialects/hir/src/ops/cast.rs
+++ b/dialects/hir/src/ops/cast.rs
@@ -32,8 +32,9 @@ pub enum CastKind {
  */
 
 #[operation(
-     dialect = HirDialect,
-     traits(UnaryOp)
+    dialect = HirDialect,
+    traits(UnaryOp),
+    implements(InferTypeOpInterface)
  )]
 pub struct PtrToInt {
     #[operand]
@@ -54,7 +55,8 @@ impl InferTypeOpInterface for PtrToInt {
 
 #[operation(
     dialect = HirDialect,
-    traits(UnaryOp)
+    traits(UnaryOp),
+    implements(InferTypeOpInterface)
 )]
 pub struct IntToPtr {
     #[operand]
@@ -75,7 +77,8 @@ impl InferTypeOpInterface for IntToPtr {
 
 #[operation(
     dialect = HirDialect,
-    traits(UnaryOp)
+    traits(UnaryOp),
+    implements(InferTypeOpInterface)
 )]
 pub struct Cast {
     #[operand]
@@ -96,7 +99,8 @@ impl InferTypeOpInterface for Cast {
 
 #[operation(
     dialect = HirDialect,
-    traits(UnaryOp)
+    traits(UnaryOp),
+    implements(InferTypeOpInterface)
 )]
 pub struct Bitcast {
     #[operand]
@@ -117,7 +121,8 @@ impl InferTypeOpInterface for Bitcast {
 
 #[operation(
     dialect = HirDialect,
-    traits(UnaryOp)
+    traits(UnaryOp),
+    implements(InferTypeOpInterface)
 )]
 pub struct Trunc {
     #[operand]
@@ -138,7 +143,8 @@ impl InferTypeOpInterface for Trunc {
 
 #[operation(
     dialect = HirDialect,
-    traits(UnaryOp)
+    traits(UnaryOp),
+    implements(InferTypeOpInterface)
 )]
 pub struct Zext {
     #[operand]
@@ -159,7 +165,8 @@ impl InferTypeOpInterface for Zext {
 
 #[operation(
     dialect = HirDialect,
-    traits(UnaryOp)
+    traits(UnaryOp),
+    implements(InferTypeOpInterface)
 )]
 pub struct Sext {
     #[operand]

--- a/dialects/hir/src/ops/primop.rs
+++ b/dialects/hir/src/ops/primop.rs
@@ -4,7 +4,8 @@ use crate::HirDialect;
 
 #[operation(
     dialect = HirDialect,
-    traits(HasSideEffects, MemoryRead, MemoryWrite, SameOperandsAndResultType)
+    traits(HasSideEffects, MemoryRead, MemoryWrite, SameOperandsAndResultType),
+    implements(InferTypeOpInterface)
 )]
 pub struct MemGrow {
     #[operand]
@@ -15,14 +16,15 @@ pub struct MemGrow {
 
 impl InferTypeOpInterface for MemGrow {
     fn infer_return_types(&mut self, _context: &Context) -> Result<(), Report> {
-        self.result_mut().set_type(Type::I32);
+        self.result_mut().set_type(Type::U32);
         Ok(())
     }
 }
 
 #[operation(
     dialect = HirDialect,
-    traits(HasSideEffects, MemoryRead)
+    traits(HasSideEffects, MemoryRead),
+    implements(InferTypeOpInterface)
 )]
 pub struct MemSize {
     #[result]
@@ -31,7 +33,7 @@ pub struct MemSize {
 
 impl InferTypeOpInterface for MemSize {
     fn infer_return_types(&mut self, _context: &Context) -> Result<(), Report> {
-        self.result_mut().set_type(Type::I32);
+        self.result_mut().set_type(Type::U32);
         Ok(())
     }
 }

--- a/dialects/hir/src/ops/unary.rs
+++ b/dialects/hir/src/ops/unary.rs
@@ -28,7 +28,8 @@ macro_rules! infer_return_ty_for_unary_op {
 /// Increment
 #[operation (
         dialect = HirDialect,
-        traits(UnaryOp, SameOperandsAndResultType)
+        traits(UnaryOp, SameOperandsAndResultType),
+        implements(InferTypeOpInterface)
     )]
 pub struct Incr {
     #[operand]
@@ -42,7 +43,8 @@ infer_return_ty_for_unary_op!(Incr);
 /// Negation
 #[operation (
         dialect = HirDialect,
-        traits(UnaryOp, SameOperandsAndResultType)
+        traits(UnaryOp, SameOperandsAndResultType),
+        implements(InferTypeOpInterface)
     )]
 pub struct Neg {
     #[operand]
@@ -56,7 +58,8 @@ infer_return_ty_for_unary_op!(Neg);
 /// Modular inverse
 #[operation (
         dialect = HirDialect,
-        traits(UnaryOp, SameOperandsAndResultType)
+        traits(UnaryOp, SameOperandsAndResultType),
+        implements(InferTypeOpInterface)
     )]
 pub struct Inv {
     #[operand]
@@ -70,7 +73,8 @@ infer_return_ty_for_unary_op!(Inv);
 /// log2(operand)
 #[operation (
         dialect = HirDialect,
-        traits(UnaryOp, SameOperandsAndResultType)
+        traits(UnaryOp, SameOperandsAndResultType),
+        implements(InferTypeOpInterface)
     )]
 pub struct Ilog2 {
     #[operand]
@@ -84,7 +88,8 @@ infer_return_ty_for_unary_op!(Ilog2);
 /// pow2(operand)
 #[operation (
         dialect = HirDialect,
-        traits(UnaryOp, SameOperandsAndResultType)
+        traits(UnaryOp, SameOperandsAndResultType),
+        implements(InferTypeOpInterface)
     )]
 pub struct Pow2 {
     #[operand]
@@ -98,7 +103,9 @@ infer_return_ty_for_unary_op!(Pow2);
 /// Logical NOT
 #[operation (
         dialect = HirDialect,
-        traits(UnaryOp, SameOperandsAndResultType)
+        traits(UnaryOp, SameOperandsAndResultType),
+        implements(InferTypeOpInterface)
+
     )]
 pub struct Not {
     #[operand]
@@ -112,7 +119,8 @@ infer_return_ty_for_unary_op!(Not);
 /// Bitwise NOT
 #[operation (
         dialect = HirDialect,
-        traits(UnaryOp, SameOperandsAndResultType)
+        traits(UnaryOp, SameOperandsAndResultType),
+        implements(InferTypeOpInterface)
     )]
 pub struct Bnot {
     #[operand]
@@ -126,7 +134,8 @@ infer_return_ty_for_unary_op!(Bnot);
 /// is_odd(operand)
 #[operation (
         dialect = HirDialect,
-        traits(UnaryOp)
+        traits(UnaryOp),
+        implements(InferTypeOpInterface)
     )]
 pub struct IsOdd {
     #[operand]
@@ -140,7 +149,8 @@ infer_return_ty_for_unary_op!(IsOdd as Type::I1);
 /// Count of non-zero bits (population count)
 #[operation (
         dialect = HirDialect,
-        traits(UnaryOp)
+        traits(UnaryOp),
+        implements(InferTypeOpInterface)
     )]
 pub struct Popcnt {
     #[operand]
@@ -154,7 +164,8 @@ infer_return_ty_for_unary_op!(Popcnt as Type::U32);
 /// Count Leading Zeros
 #[operation (
         dialect = HirDialect,
-        traits(UnaryOp)
+        traits(UnaryOp),
+        implements(InferTypeOpInterface)
     )]
 pub struct Clz {
     #[operand]
@@ -168,7 +179,8 @@ infer_return_ty_for_unary_op!(Clz as Type::U32);
 /// Count Trailing Zeros
 #[operation (
         dialect = HirDialect,
-        traits(UnaryOp)
+        traits(UnaryOp),
+        implements(InferTypeOpInterface)
     )]
 pub struct Ctz {
     #[operand]
@@ -182,7 +194,8 @@ infer_return_ty_for_unary_op!(Ctz as Type::U32);
 /// Count Leading Ones
 #[operation (
         dialect = HirDialect,
-        traits(UnaryOp)
+        traits(UnaryOp),
+        implements(InferTypeOpInterface)
     )]
 pub struct Clo {
     #[operand]
@@ -196,7 +209,8 @@ infer_return_ty_for_unary_op!(Clo as Type::U32);
 /// Count Trailing Ones
 #[operation (
         dialect = HirDialect,
-        traits(UnaryOp)
+        traits(UnaryOp),
+        implements(InferTypeOpInterface)
     )]
 pub struct Cto {
     #[operand]

--- a/frontend-wasm2/src/code_translator/mod.rs
+++ b/frontend-wasm2/src/code_translator/mod.rs
@@ -224,10 +224,10 @@ pub fn translate_operator(
         }
         /******************************* Load instructions ***********************************/
         Operator::I32Load8U { memarg } => {
-            translate_load_zext(U8, I32, memarg, state, builder, span)?;
+            translate_load_zext(U8, U32, memarg, state, builder, span)?;
         }
         Operator::I32Load16U { memarg } => {
-            translate_load_zext(U16, I32, memarg, state, builder, span)?;
+            translate_load_zext(U16, U32, memarg, state, builder, span)?;
         }
         Operator::I32Load8S { memarg } => {
             translate_load_sext(I8, I32, memarg, state, builder, span)?;
@@ -236,10 +236,10 @@ pub fn translate_operator(
             translate_load_sext(I16, I32, memarg, state, builder, span)?;
         }
         Operator::I64Load8U { memarg } => {
-            translate_load_zext(U8, I64, memarg, state, builder, span)?;
+            translate_load_zext(U8, U64, memarg, state, builder, span)?;
         }
         Operator::I64Load16U { memarg } => {
-            translate_load_zext(U16, I64, memarg, state, builder, span)?;
+            translate_load_zext(U16, U64, memarg, state, builder, span)?;
         }
         Operator::I64Load8S { memarg } => {
             translate_load_sext(I8, I64, memarg, state, builder, span)?;
@@ -251,7 +251,7 @@ pub fn translate_operator(
             translate_load_sext(I32, I64, memarg, state, builder, span)?;
         }
         Operator::I64Load32U { memarg } => {
-            translate_load_zext(U32, I64, memarg, state, builder, span)?;
+            translate_load_zext(U32, U64, memarg, state, builder, span)?;
         }
         Operator::I32Load { memarg } => translate_load(I32, memarg, state, builder, span)?,
         Operator::I64Load { memarg } => translate_load(I64, memarg, state, builder, span)?,
@@ -444,109 +444,109 @@ pub fn translate_operator(
         Operator::I32LtU => {
             let (arg0, arg1) = state.pop2_bitcasted(U32, builder, span)?;
             let val = builder.ins().lt(arg0, arg1, span)?;
-            state.push1(builder.ins().sext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I64LtU => {
             let (arg0, arg1) = state.pop2_bitcasted(U64, builder, span)?;
             let val = builder.ins().lt(arg0, arg1, span)?;
-            state.push1(builder.ins().sext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I32LtS => {
             let (arg0, arg1) = state.pop2();
             let val = builder.ins().lt(arg0, arg1, span)?;
-            state.push1(builder.ins().sext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I64LtS => {
             let (arg0, arg1) = state.pop2();
             let val = builder.ins().lt(arg0, arg1, span)?;
-            state.push1(builder.ins().sext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I32LeU => {
             let (arg0, arg1) = state.pop2_bitcasted(U32, builder, span)?;
             let val = builder.ins().lte(arg0, arg1, span)?;
-            state.push1(builder.ins().sext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I64LeU => {
             let (arg0, arg1) = state.pop2_bitcasted(U64, builder, span)?;
             let val = builder.ins().lte(arg0, arg1, span)?;
-            state.push1(builder.ins().sext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I32LeS => {
             let (arg0, arg1) = state.pop2();
             let val = builder.ins().lte(arg0, arg1, span)?;
-            state.push1(builder.ins().sext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I64LeS => {
             let (arg0, arg1) = state.pop2();
             let val = builder.ins().lte(arg0, arg1, span)?;
-            state.push1(builder.ins().sext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I32GtU => {
             let (arg0, arg1) = state.pop2_bitcasted(U32, builder, span)?;
             let val = builder.ins().gt(arg0, arg1, span)?;
-            state.push1(builder.ins().sext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I64GtU => {
             let (arg0, arg1) = state.pop2_bitcasted(U64, builder, span)?;
             let val = builder.ins().gt(arg0, arg1, span)?;
-            state.push1(builder.ins().sext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I32GtS | Operator::I64GtS => {
             let (arg0, arg1) = state.pop2();
             let val = builder.ins().gt(arg0, arg1, span)?;
-            state.push1(builder.ins().zext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I32GeU => {
             let (arg0, arg1) = state.pop2_bitcasted(U32, builder, span)?;
             let val = builder.ins().gte(arg0, arg1, span)?;
-            state.push1(builder.ins().zext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I64GeU => {
             let (arg0, arg1) = state.pop2_bitcasted(U64, builder, span)?;
             let val = builder.ins().gte(arg0, arg1, span)?;
-            state.push1(builder.ins().zext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I32GeS => {
             let (arg0, arg1) = state.pop2();
             let val = builder.ins().gte(arg0, arg1, span)?;
-            state.push1(builder.ins().zext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I64GeS => {
             let (arg0, arg1) = state.pop2();
             let val = builder.ins().gte(arg0, arg1, span)?;
-            state.push1(builder.ins().zext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I32Eqz => {
             let arg = state.pop1();
             let imm = builder.ins().imm(Immediate::I32(0), span);
             let val = builder.ins().eq(arg, imm, span)?;
-            state.push1(builder.ins().zext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I64Eqz => {
             let arg = state.pop1();
             let imm = builder.ins().imm(Immediate::I64(0), span);
             let val = builder.ins().eq(arg, imm, span)?;
-            state.push1(builder.ins().zext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I32Eq => {
             let (arg0, arg1) = state.pop2();
             let val = builder.ins().eq(arg0, arg1, span)?;
-            state.push1(builder.ins().zext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I64Eq => {
             let (arg0, arg1) = state.pop2();
             let val = builder.ins().eq(arg0, arg1, span)?;
-            state.push1(builder.ins().zext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I32Ne => {
             let (arg0, arg1) = state.pop2();
             let val = builder.ins().neq(arg0, arg1, span)?;
-            state.push1(builder.ins().zext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         Operator::I64Ne => {
             let (arg0, arg1) = state.pop2();
             let val = builder.ins().neq(arg0, arg1, span)?;
-            state.push1(builder.ins().zext(val, I32, span)?);
+            state.push1(builder.ins().zext(val, U32, span)?);
         }
         op => {
             unsupported_diag!(diagnostics, "Wasm op {:?} is not supported", op);
@@ -596,8 +596,8 @@ fn translate_load_zext(
     let addr_int = state.pop1();
     let addr = prepare_addr(addr_int, &ptr_ty, Some(memarg), builder, span)?;
     let val = builder.ins().load(addr, span)?;
-    let sext_val = builder.ins().zext(val, zext_ty, span)?;
-    state.push1(sext_val);
+    let zext_val = builder.ins().zext(val, zext_ty, span)?;
+    state.push1(zext_val);
     Ok(())
 }
 

--- a/frontend-wasm2/src/code_translator/tests.rs
+++ b/frontend-wasm2/src/code_translator/tests.rs
@@ -72,8 +72,8 @@ fn memory_grow() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i32;
-                v1 = hir.bitcast v0 : ? #[ty = u32];
-                v2 = hir.mem_grow v1 : ?;
+                v1 = hir.bitcast v0 : u32 #[ty = u32];
+                v2 = hir.mem_grow v1 : u32;
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -92,7 +92,7 @@ fn memory_size() {
         expect![[r#"
             builtin.function public @test_wrapper() {
             ^block2:
-                v0 = hir.mem_size  : ?;
+                v0 = hir.mem_size  : u32;
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -116,11 +116,11 @@ fn memory_copy() {
                 v0 = hir.constant 20 : i32;
                 v1 = hir.constant 10 : i32;
                 v2 = hir.constant 1 : i32;
-                v3 = hir.bitcast v2 : ? #[ty = u32];
-                v4 = hir.bitcast v0 : ? #[ty = u32];
-                v5 = hir.int_to_ptr v4 : ? #[ty = (ptr u8)];
-                v6 = hir.bitcast v1 : ? #[ty = u32];
-                v7 = hir.int_to_ptr v6 : ? #[ty = (ptr u8)];
+                v3 = hir.bitcast v2 : u32 #[ty = u32];
+                v4 = hir.bitcast v0 : u32 #[ty = u32];
+                v5 = hir.int_to_ptr v4 : (ptr u8) #[ty = (ptr u8)];
+                v6 = hir.bitcast v1 : u32 #[ty = u32];
+                v7 = hir.int_to_ptr v6 : (ptr u8) #[ty = (ptr u8)];
                 hir.mem_cpy v7, v5, v3;
                 hir.br block3 ;
             ^block3:
@@ -142,10 +142,10 @@ fn i32_load8_u() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
-                v1 = hir.bitcast v0 : ? #[ty = u32];
-                v2 = hir.int_to_ptr v1 : ? #[ty = (ptr u8)];
-                v3 = hir.load v2 : ?;
-                v4 = hir.zext v3 : ? #[ty = i32];
+                v1 = hir.bitcast v0 : u32 #[ty = u32];
+                v2 = hir.int_to_ptr v1 : (ptr u8) #[ty = (ptr u8)];
+                v3 = hir.load v2 : u8;
+                v4 = hir.zext v3 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -166,13 +166,13 @@ fn i32_load16_u() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
-                v1 = hir.bitcast v0 : ? #[ty = u32];
+                v1 = hir.bitcast v0 : u32 #[ty = u32];
                 v2 = hir.constant 2 : u32;
-                v3 = hir.mod v1, v2 : ?;
+                v3 = hir.mod v1, v2 : u32;
                 hir.assertz v3 #[code = 250];
-                v4 = hir.int_to_ptr v1 : ? #[ty = (ptr u16)];
-                v5 = hir.load v4 : ?;
-                v6 = hir.zext v5 : ? #[ty = i32];
+                v4 = hir.int_to_ptr v1 : (ptr u16) #[ty = (ptr u16)];
+                v5 = hir.load v4 : u16;
+                v6 = hir.zext v5 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -193,10 +193,10 @@ fn i32_load8_s() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
-                v1 = hir.bitcast v0 : ? #[ty = u32];
-                v2 = hir.int_to_ptr v1 : ? #[ty = (ptr i8)];
-                v3 = hir.load v2 : ?;
-                v4 = hir.sext v3 : ? #[ty = i32];
+                v1 = hir.bitcast v0 : u32 #[ty = u32];
+                v2 = hir.int_to_ptr v1 : (ptr i8) #[ty = (ptr i8)];
+                v3 = hir.load v2 : i8;
+                v4 = hir.sext v3 : i32 #[ty = i32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -217,13 +217,13 @@ fn i32_load16_s() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
-                v1 = hir.bitcast v0 : ? #[ty = u32];
+                v1 = hir.bitcast v0 : u32 #[ty = u32];
                 v2 = hir.constant 2 : u32;
-                v3 = hir.mod v1, v2 : ?;
+                v3 = hir.mod v1, v2 : u32;
                 hir.assertz v3 #[code = 250];
-                v4 = hir.int_to_ptr v1 : ? #[ty = (ptr i16)];
-                v5 = hir.load v4 : ?;
-                v6 = hir.sext v5 : ? #[ty = i32];
+                v4 = hir.int_to_ptr v1 : (ptr i16) #[ty = (ptr i16)];
+                v5 = hir.load v4 : i16;
+                v6 = hir.sext v5 : i32 #[ty = i32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -244,10 +244,10 @@ fn i64_load8_u() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
-                v1 = hir.bitcast v0 : ? #[ty = u32];
-                v2 = hir.int_to_ptr v1 : ? #[ty = (ptr u8)];
-                v3 = hir.load v2 : ?;
-                v4 = hir.zext v3 : ? #[ty = i64];
+                v1 = hir.bitcast v0 : u32 #[ty = u32];
+                v2 = hir.int_to_ptr v1 : (ptr u8) #[ty = (ptr u8)];
+                v3 = hir.load v2 : u8;
+                v4 = hir.zext v3 : u64 #[ty = u64];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -268,13 +268,13 @@ fn i64_load16_u() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
-                v1 = hir.bitcast v0 : ? #[ty = u32];
+                v1 = hir.bitcast v0 : u32 #[ty = u32];
                 v2 = hir.constant 2 : u32;
-                v3 = hir.mod v1, v2 : ?;
+                v3 = hir.mod v1, v2 : u32;
                 hir.assertz v3 #[code = 250];
-                v4 = hir.int_to_ptr v1 : ? #[ty = (ptr u16)];
-                v5 = hir.load v4 : ?;
-                v6 = hir.zext v5 : ? #[ty = i64];
+                v4 = hir.int_to_ptr v1 : (ptr u16) #[ty = (ptr u16)];
+                v5 = hir.load v4 : u16;
+                v6 = hir.zext v5 : u64 #[ty = u64];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -295,10 +295,10 @@ fn i64_load8_s() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
-                v1 = hir.bitcast v0 : ? #[ty = u32];
-                v2 = hir.int_to_ptr v1 : ? #[ty = (ptr i8)];
-                v3 = hir.load v2 : ?;
-                v4 = hir.sext v3 : ? #[ty = i64];
+                v1 = hir.bitcast v0 : u32 #[ty = u32];
+                v2 = hir.int_to_ptr v1 : (ptr i8) #[ty = (ptr i8)];
+                v3 = hir.load v2 : i8;
+                v4 = hir.sext v3 : i64 #[ty = i64];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -319,13 +319,13 @@ fn i64_load16_s() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
-                v1 = hir.bitcast v0 : ? #[ty = u32];
+                v1 = hir.bitcast v0 : u32 #[ty = u32];
                 v2 = hir.constant 2 : u32;
-                v3 = hir.mod v1, v2 : ?;
+                v3 = hir.mod v1, v2 : u32;
                 hir.assertz v3 #[code = 250];
-                v4 = hir.int_to_ptr v1 : ? #[ty = (ptr i16)];
-                v5 = hir.load v4 : ?;
-                v6 = hir.sext v5 : ? #[ty = i64];
+                v4 = hir.int_to_ptr v1 : (ptr i16) #[ty = (ptr i16)];
+                v5 = hir.load v4 : i16;
+                v6 = hir.sext v5 : i64 #[ty = i64];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -346,13 +346,13 @@ fn i64_load32_s() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
-                v1 = hir.bitcast v0 : ? #[ty = u32];
+                v1 = hir.bitcast v0 : u32 #[ty = u32];
                 v2 = hir.constant 4 : u32;
-                v3 = hir.mod v1, v2 : ?;
+                v3 = hir.mod v1, v2 : u32;
                 hir.assertz v3 #[code = 250];
-                v4 = hir.int_to_ptr v1 : ? #[ty = (ptr i32)];
-                v5 = hir.load v4 : ?;
-                v6 = hir.sext v5 : ? #[ty = i64];
+                v4 = hir.int_to_ptr v1 : (ptr i32) #[ty = (ptr i32)];
+                v5 = hir.load v4 : i32;
+                v6 = hir.sext v5 : i64 #[ty = i64];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -373,13 +373,13 @@ fn i64_load32_u() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
-                v1 = hir.bitcast v0 : ? #[ty = u32];
+                v1 = hir.bitcast v0 : u32 #[ty = u32];
                 v2 = hir.constant 4 : u32;
-                v3 = hir.mod v1, v2 : ?;
+                v3 = hir.mod v1, v2 : u32;
                 hir.assertz v3 #[code = 250];
-                v4 = hir.int_to_ptr v1 : ? #[ty = (ptr u32)];
-                v5 = hir.load v4 : ?;
-                v6 = hir.zext v5 : ? #[ty = i64];
+                v4 = hir.int_to_ptr v1 : (ptr u32) #[ty = (ptr u32)];
+                v5 = hir.load v4 : u32;
+                v6 = hir.zext v5 : u64 #[ty = u64];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -400,12 +400,12 @@ fn i32_load() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
-                v1 = hir.bitcast v0 : ? #[ty = u32];
+                v1 = hir.bitcast v0 : u32 #[ty = u32];
                 v2 = hir.constant 4 : u32;
-                v3 = hir.mod v1, v2 : ?;
+                v3 = hir.mod v1, v2 : u32;
                 hir.assertz v3 #[code = 250];
-                v4 = hir.int_to_ptr v1 : ? #[ty = (ptr i32)];
-                v5 = hir.load v4 : ?;
+                v4 = hir.int_to_ptr v1 : (ptr i32) #[ty = (ptr i32)];
+                v5 = hir.load v4 : i32;
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -426,12 +426,12 @@ fn i64_load() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
-                v1 = hir.bitcast v0 : ? #[ty = u32];
+                v1 = hir.bitcast v0 : u32 #[ty = u32];
                 v2 = hir.constant 8 : u32;
-                v3 = hir.mod v1, v2 : ?;
+                v3 = hir.mod v1, v2 : u32;
                 hir.assertz v3 #[code = 250];
-                v4 = hir.int_to_ptr v1 : ? #[ty = (ptr i64)];
-                v5 = hir.load v4 : ?;
+                v4 = hir.int_to_ptr v1 : (ptr i64) #[ty = (ptr i64)];
+                v5 = hir.load v4 : i64;
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -453,11 +453,11 @@ fn i32_store() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.constant 1 : i32;
-                v2 = hir.bitcast v0 : ? #[ty = u32];
+                v2 = hir.bitcast v0 : u32 #[ty = u32];
                 v3 = hir.constant 4 : u32;
-                v4 = hir.mod v2, v3 : ?;
+                v4 = hir.mod v2, v3 : u32;
                 hir.assertz v4 #[code = 250];
-                v5 = hir.int_to_ptr v2 : ? #[ty = (ptr i32)];
+                v5 = hir.int_to_ptr v2 : (ptr i32) #[ty = (ptr i32)];
                 hir.store v5, v1;
                 hir.br block3 ;
             ^block3:
@@ -480,11 +480,11 @@ fn i64_store() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.constant 1 : i64;
-                v2 = hir.bitcast v0 : ? #[ty = u32];
+                v2 = hir.bitcast v0 : u32 #[ty = u32];
                 v3 = hir.constant 8 : u32;
-                v4 = hir.mod v2, v3 : ?;
+                v4 = hir.mod v2, v3 : u32;
                 hir.assertz v4 #[code = 250];
-                v5 = hir.int_to_ptr v2 : ? #[ty = (ptr i64)];
+                v5 = hir.int_to_ptr v2 : (ptr i64) #[ty = (ptr i64)];
                 hir.store v5, v1;
                 hir.br block3 ;
             ^block3:
@@ -507,10 +507,10 @@ fn i32_store8() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.constant 1 : i32;
-                v2 = hir.bitcast v1 : ? #[ty = u32];
-                v3 = hir.trunc v2 : ? #[ty = u8];
-                v4 = hir.bitcast v0 : ? #[ty = u32];
-                v5 = hir.int_to_ptr v4 : ? #[ty = (ptr u8)];
+                v2 = hir.bitcast v1 : u32 #[ty = u32];
+                v3 = hir.trunc v2 : u8 #[ty = u8];
+                v4 = hir.bitcast v0 : u32 #[ty = u32];
+                v5 = hir.int_to_ptr v4 : (ptr u8) #[ty = (ptr u8)];
                 hir.store v5, v3;
                 hir.br block3 ;
             ^block3:
@@ -533,13 +533,13 @@ fn i32_store16() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.constant 1 : i32;
-                v2 = hir.bitcast v1 : ? #[ty = u32];
-                v3 = hir.trunc v2 : ? #[ty = u16];
-                v4 = hir.bitcast v0 : ? #[ty = u32];
+                v2 = hir.bitcast v1 : u32 #[ty = u32];
+                v3 = hir.trunc v2 : u16 #[ty = u16];
+                v4 = hir.bitcast v0 : u32 #[ty = u32];
                 v5 = hir.constant 2 : u32;
-                v6 = hir.mod v4, v5 : ?;
+                v6 = hir.mod v4, v5 : u32;
                 hir.assertz v6 #[code = 250];
-                v7 = hir.int_to_ptr v4 : ? #[ty = (ptr u16)];
+                v7 = hir.int_to_ptr v4 : (ptr u16) #[ty = (ptr u16)];
                 hir.store v7, v3;
                 hir.br block3 ;
             ^block3:
@@ -562,13 +562,13 @@ fn i64_store32() {
             ^block2:
                 v0 = hir.constant 1024 : i32;
                 v1 = hir.constant 1 : i64;
-                v2 = hir.bitcast v1 : ? #[ty = u64];
-                v3 = hir.trunc v2 : ? #[ty = u32];
-                v4 = hir.bitcast v0 : ? #[ty = u32];
+                v2 = hir.bitcast v1 : u64 #[ty = u64];
+                v3 = hir.trunc v2 : u32 #[ty = u32];
+                v4 = hir.bitcast v0 : u32 #[ty = u32];
                 v5 = hir.constant 4 : u32;
-                v6 = hir.mod v4, v5 : ?;
+                v6 = hir.mod v4, v5 : u32;
                 hir.assertz v6 #[code = 250];
-                v7 = hir.int_to_ptr v4 : ? #[ty = (ptr u32)];
+                v7 = hir.int_to_ptr v4 : (ptr u32) #[ty = (ptr u32)];
                 hir.store v7, v3;
                 hir.br block3 ;
             ^block3:
@@ -628,8 +628,8 @@ fn i32_popcnt() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i32;
-                v1 = hir.popcnt v0 : ?;
-                v2 = hir.bitcast v1 : ? #[ty = i32];
+                v1 = hir.popcnt v0 : u32;
+                v2 = hir.bitcast v1 : i32 #[ty = i32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -650,8 +650,8 @@ fn i32_clz() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i32;
-                v1 = hir.clz v0 : ?;
-                v2 = hir.bitcast v1 : ? #[ty = i32];
+                v1 = hir.clz v0 : u32;
+                v2 = hir.bitcast v1 : i32 #[ty = i32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -672,8 +672,8 @@ fn i64_clz() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i64;
-                v1 = hir.clz v0 : ?;
-                v2 = hir.bitcast v1 : ? #[ty = i32];
+                v1 = hir.clz v0 : u32;
+                v2 = hir.bitcast v1 : i32 #[ty = i32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -694,8 +694,8 @@ fn i32_ctz() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i32;
-                v1 = hir.ctz v0 : ?;
-                v2 = hir.bitcast v1 : ? #[ty = i32];
+                v1 = hir.ctz v0 : u32;
+                v2 = hir.bitcast v1 : i32 #[ty = i32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -716,8 +716,8 @@ fn i64_ctz() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i64;
-                v1 = hir.ctz v0 : ?;
-                v2 = hir.bitcast v1 : ? #[ty = i32];
+                v1 = hir.ctz v0 : u32;
+                v2 = hir.bitcast v1 : i32 #[ty = i32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -738,7 +738,7 @@ fn i64_extend_i32_s() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i32;
-                v1 = hir.sext v0 : ? #[ty = i64];
+                v1 = hir.sext v0 : i64 #[ty = i64];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -759,9 +759,9 @@ fn i64_extend_i32_u() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i32;
-                v1 = hir.bitcast v0 : ? #[ty = u32];
-                v2 = hir.zext v1 : ? #[ty = u64];
-                v3 = hir.bitcast v2 : ? #[ty = i64];
+                v1 = hir.bitcast v0 : u32 #[ty = u32];
+                v2 = hir.zext v1 : u64 #[ty = u64];
+                v3 = hir.bitcast v2 : i64 #[ty = i64];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -782,7 +782,7 @@ fn i32_wrap_i64() {
             builtin.function public @test_wrapper() {
             ^block2:
                 v0 = hir.constant 1 : i64;
-                v1 = hir.trunc v0 : ? #[ty = i32];
+                v1 = hir.trunc v0 : i32 #[ty = i32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1035,7 +1035,7 @@ fn i32_shl() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
-                v2 = hir.bitcast v1 : ? #[ty = u32];
+                v2 = hir.bitcast v1 : u32 #[ty = u32];
                 v3 = hir.shl v0, v2 : i32;
                 hir.br block3 ;
             ^block3:
@@ -1059,7 +1059,7 @@ fn i64_shl() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
-                v2 = hir.cast v1 : ? #[ty = u32];
+                v2 = hir.cast v1 : u32 #[ty = u32];
                 v3 = hir.shl v0, v2 : i64;
                 hir.br block3 ;
             ^block3:
@@ -1083,10 +1083,10 @@ fn i32_shr_u() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
-                v2 = hir.bitcast v0 : ? #[ty = u32];
-                v3 = hir.bitcast v1 : ? #[ty = u32];
-                v4 = hir.shr v2, v3 : ?;
-                v5 = hir.bitcast v4 : ? #[ty = i32];
+                v2 = hir.bitcast v0 : u32 #[ty = u32];
+                v3 = hir.bitcast v1 : u32 #[ty = u32];
+                v4 = hir.shr v2, v3 : u32;
+                v5 = hir.bitcast v4 : i32 #[ty = i32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1109,10 +1109,10 @@ fn i64_shr_u() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
-                v2 = hir.bitcast v0 : ? #[ty = u64];
-                v3 = hir.cast v1 : ? #[ty = u32];
-                v4 = hir.shr v2, v3 : ?;
-                v5 = hir.bitcast v4 : ? #[ty = i64];
+                v2 = hir.bitcast v0 : u64 #[ty = u64];
+                v3 = hir.cast v1 : u32 #[ty = u32];
+                v4 = hir.shr v2, v3 : u64;
+                v5 = hir.bitcast v4 : i64 #[ty = i64];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1135,7 +1135,7 @@ fn i32_shr_s() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
-                v2 = hir.bitcast v1 : ? #[ty = u32];
+                v2 = hir.bitcast v1 : u32 #[ty = u32];
                 v3 = hir.shr v0, v2 : i32;
                 hir.br block3 ;
             ^block3:
@@ -1159,7 +1159,7 @@ fn i64_shr_s() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
-                v2 = hir.cast v1 : ? #[ty = u32];
+                v2 = hir.cast v1 : u32 #[ty = u32];
                 v3 = hir.shr v0, v2 : i64;
                 hir.br block3 ;
             ^block3:
@@ -1183,7 +1183,7 @@ fn i32_rotl() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
-                v2 = hir.bitcast v1 : ? #[ty = u32];
+                v2 = hir.bitcast v1 : u32 #[ty = u32];
                 v3 = hir.rotl v0, v2 : i32;
                 hir.br block3 ;
             ^block3:
@@ -1207,7 +1207,7 @@ fn i64_rotl() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
-                v2 = hir.cast v1 : ? #[ty = u32];
+                v2 = hir.cast v1 : u32 #[ty = u32];
                 v3 = hir.rotl v0, v2 : i64;
                 hir.br block3 ;
             ^block3:
@@ -1231,7 +1231,7 @@ fn i32_rotr() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
-                v2 = hir.bitcast v1 : ? #[ty = u32];
+                v2 = hir.bitcast v1 : u32 #[ty = u32];
                 v3 = hir.rotr v0, v2 : i32;
                 hir.br block3 ;
             ^block3:
@@ -1255,7 +1255,7 @@ fn i64_rotr() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
-                v2 = hir.cast v1 : ? #[ty = u32];
+                v2 = hir.cast v1 : u32 #[ty = u32];
                 v3 = hir.rotr v0, v2 : i64;
                 hir.br block3 ;
             ^block3:
@@ -1325,10 +1325,10 @@ fn i32_div_u() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
-                v2 = hir.bitcast v0 : ? #[ty = u32];
-                v3 = hir.bitcast v1 : ? #[ty = u32];
-                v4 = hir.div v2, v3 : ?;
-                v5 = hir.bitcast v4 : ? #[ty = i32];
+                v2 = hir.bitcast v0 : u32 #[ty = u32];
+                v3 = hir.bitcast v1 : u32 #[ty = u32];
+                v4 = hir.div v2, v3 : u32;
+                v5 = hir.bitcast v4 : i32 #[ty = i32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1351,10 +1351,10 @@ fn i64_div_u() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
-                v2 = hir.bitcast v0 : ? #[ty = u64];
-                v3 = hir.bitcast v1 : ? #[ty = u64];
-                v4 = hir.div v2, v3 : ?;
-                v5 = hir.bitcast v4 : ? #[ty = i64];
+                v2 = hir.bitcast v0 : u64 #[ty = u64];
+                v3 = hir.bitcast v1 : u64 #[ty = u64];
+                v4 = hir.div v2, v3 : u64;
+                v5 = hir.bitcast v4 : i64 #[ty = i64];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1423,10 +1423,10 @@ fn i32_rem_u() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
-                v2 = hir.bitcast v0 : ? #[ty = u32];
-                v3 = hir.bitcast v1 : ? #[ty = u32];
-                v4 = hir.mod v2, v3 : ?;
-                v5 = hir.bitcast v4 : ? #[ty = i32];
+                v2 = hir.bitcast v0 : u32 #[ty = u32];
+                v3 = hir.bitcast v1 : u32 #[ty = u32];
+                v4 = hir.mod v2, v3 : u32;
+                v5 = hir.bitcast v4 : i32 #[ty = i32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1449,10 +1449,10 @@ fn i64_rem_u() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
-                v2 = hir.bitcast v0 : ? #[ty = u64];
-                v3 = hir.bitcast v1 : ? #[ty = u64];
-                v4 = hir.mod v2, v3 : ?;
-                v5 = hir.bitcast v4 : ? #[ty = i64];
+                v2 = hir.bitcast v0 : u64 #[ty = u64];
+                v3 = hir.bitcast v1 : u64 #[ty = u64];
+                v4 = hir.mod v2, v3 : u64;
+                v5 = hir.bitcast v4 : i64 #[ty = i64];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1521,10 +1521,10 @@ fn i32_lt_u() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
-                v2 = hir.bitcast v0 : ? #[ty = u32];
-                v3 = hir.bitcast v1 : ? #[ty = u32];
+                v2 = hir.bitcast v0 : u32 #[ty = u32];
+                v3 = hir.bitcast v1 : u32 #[ty = u32];
                 v4 = hir.lt v2, v3 : i1;
-                v5 = hir.sext v4 : ? #[ty = i32];
+                v5 = hir.zext v4 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1547,10 +1547,10 @@ fn i64_lt_u() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
-                v2 = hir.bitcast v0 : ? #[ty = u64];
-                v3 = hir.bitcast v1 : ? #[ty = u64];
+                v2 = hir.bitcast v0 : u64 #[ty = u64];
+                v3 = hir.bitcast v1 : u64 #[ty = u64];
                 v4 = hir.lt v2, v3 : i1;
-                v5 = hir.sext v4 : ? #[ty = i32];
+                v5 = hir.zext v4 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1574,7 +1574,7 @@ fn i32_lt_s() {
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
                 v2 = hir.lt v0, v1 : i1;
-                v3 = hir.sext v2 : ? #[ty = i32];
+                v3 = hir.zext v2 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1598,7 +1598,7 @@ fn i64_lt_s() {
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
                 v2 = hir.lt v0, v1 : i1;
-                v3 = hir.sext v2 : ? #[ty = i32];
+                v3 = hir.zext v2 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1621,10 +1621,10 @@ fn i32_le_u() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
-                v2 = hir.bitcast v0 : ? #[ty = u32];
-                v3 = hir.bitcast v1 : ? #[ty = u32];
+                v2 = hir.bitcast v0 : u32 #[ty = u32];
+                v3 = hir.bitcast v1 : u32 #[ty = u32];
                 v4 = hir.lte v2, v3 : i1;
-                v5 = hir.sext v4 : ? #[ty = i32];
+                v5 = hir.zext v4 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1647,10 +1647,10 @@ fn i64_le_u() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
-                v2 = hir.bitcast v0 : ? #[ty = u64];
-                v3 = hir.bitcast v1 : ? #[ty = u64];
+                v2 = hir.bitcast v0 : u64 #[ty = u64];
+                v3 = hir.bitcast v1 : u64 #[ty = u64];
                 v4 = hir.lte v2, v3 : i1;
-                v5 = hir.sext v4 : ? #[ty = i32];
+                v5 = hir.zext v4 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1674,7 +1674,7 @@ fn i32_le_s() {
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
                 v2 = hir.lte v0, v1 : i1;
-                v3 = hir.sext v2 : ? #[ty = i32];
+                v3 = hir.zext v2 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1698,7 +1698,7 @@ fn i64_le_s() {
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
                 v2 = hir.lte v0, v1 : i1;
-                v3 = hir.sext v2 : ? #[ty = i32];
+                v3 = hir.zext v2 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1721,10 +1721,10 @@ fn i32_gt_u() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
-                v2 = hir.bitcast v0 : ? #[ty = u32];
-                v3 = hir.bitcast v1 : ? #[ty = u32];
+                v2 = hir.bitcast v0 : u32 #[ty = u32];
+                v3 = hir.bitcast v1 : u32 #[ty = u32];
                 v4 = hir.gt v2, v3 : i1;
-                v5 = hir.sext v4 : ? #[ty = i32];
+                v5 = hir.zext v4 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1747,10 +1747,10 @@ fn i64_gt_u() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
-                v2 = hir.bitcast v0 : ? #[ty = u64];
-                v3 = hir.bitcast v1 : ? #[ty = u64];
+                v2 = hir.bitcast v0 : u64 #[ty = u64];
+                v3 = hir.bitcast v1 : u64 #[ty = u64];
                 v4 = hir.gt v2, v3 : i1;
-                v5 = hir.sext v4 : ? #[ty = i32];
+                v5 = hir.zext v4 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1774,7 +1774,7 @@ fn i32_gt_s() {
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
                 v2 = hir.gt v0, v1 : i1;
-                v3 = hir.zext v2 : ? #[ty = i32];
+                v3 = hir.zext v2 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1798,7 +1798,7 @@ fn i64_gt_s() {
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
                 v2 = hir.gt v0, v1 : i1;
-                v3 = hir.zext v2 : ? #[ty = i32];
+                v3 = hir.zext v2 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1821,10 +1821,10 @@ fn i32_ge_u() {
             ^block2:
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
-                v2 = hir.bitcast v0 : ? #[ty = u32];
-                v3 = hir.bitcast v1 : ? #[ty = u32];
+                v2 = hir.bitcast v0 : u32 #[ty = u32];
+                v3 = hir.bitcast v1 : u32 #[ty = u32];
                 v4 = hir.gte v2, v3 : i1;
-                v5 = hir.zext v4 : ? #[ty = i32];
+                v5 = hir.zext v4 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1847,10 +1847,10 @@ fn i64_ge_u() {
             ^block2:
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
-                v2 = hir.bitcast v0 : ? #[ty = u64];
-                v3 = hir.bitcast v1 : ? #[ty = u64];
+                v2 = hir.bitcast v0 : u64 #[ty = u64];
+                v3 = hir.bitcast v1 : u64 #[ty = u64];
                 v4 = hir.gte v2, v3 : i1;
-                v5 = hir.zext v4 : ? #[ty = i32];
+                v5 = hir.zext v4 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1874,7 +1874,7 @@ fn i32_ge_s() {
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
                 v2 = hir.gte v0, v1 : i1;
-                v3 = hir.zext v2 : ? #[ty = i32];
+                v3 = hir.zext v2 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1898,7 +1898,7 @@ fn i64_ge_s() {
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
                 v2 = hir.gte v0, v1 : i1;
-                v3 = hir.zext v2 : ? #[ty = i32];
+                v3 = hir.zext v2 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1921,7 +1921,7 @@ fn i32_eqz() {
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 0 : i32;
                 v2 = hir.eq v0, v1 : i1;
-                v3 = hir.zext v2 : ? #[ty = i32];
+                v3 = hir.zext v2 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1944,7 +1944,7 @@ fn i64_eqz() {
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 0 : i64;
                 v2 = hir.eq v0, v1 : i1;
-                v3 = hir.zext v2 : ? #[ty = i32];
+                v3 = hir.zext v2 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1968,7 +1968,7 @@ fn i32_eq() {
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
                 v2 = hir.eq v0, v1 : i1;
-                v3 = hir.zext v2 : ? #[ty = i32];
+                v3 = hir.zext v2 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -1992,7 +1992,7 @@ fn i64_eq() {
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
                 v2 = hir.eq v0, v1 : i1;
-                v3 = hir.zext v2 : ? #[ty = i32];
+                v3 = hir.zext v2 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -2016,7 +2016,7 @@ fn i32_ne() {
                 v0 = hir.constant 2 : i32;
                 v1 = hir.constant 1 : i32;
                 v2 = hir.neq v0, v1 : i1;
-                v3 = hir.zext v2 : ? #[ty = i32];
+                v3 = hir.zext v2 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
@@ -2040,7 +2040,7 @@ fn i64_ne() {
                 v0 = hir.constant 2 : i64;
                 v1 = hir.constant 1 : i64;
                 v2 = hir.neq v0, v1 : i1;
-                v3 = hir.zext v2 : ? #[ty = i32];
+                v3 = hir.zext v2 : u32 #[ty = u32];
                 hir.br block3 ;
             ^block3:
                 hir.ret ;

--- a/hir-macros/src/operation.rs
+++ b/hir-macros/src/operation.rs
@@ -427,8 +427,8 @@ impl quote::ToTokens for WithOperands<'_> {
                         operands[0].name.span(),
                     ));
                     let operand_name = operands.iter().map(|o| &o.name).collect::<Vec<_>>();
-                    let _operand_constraint = operands.iter().map(|o| &o.constraint);
-                    let _constraint_violation = operands.iter().map(|o| {
+                    let operand_constraint = operands.iter().map(|o| &o.constraint);
+                    let constraint_violation = operands.iter().map(|o| {
                         syn::Lit::Str(syn::LitStr::new(
                             &format!("type constraint violation for '{}'", &o.name),
                             o.name.span(),
@@ -439,28 +439,28 @@ impl quote::ToTokens for WithOperands<'_> {
                             {
                                 let value = #operand_name.borrow();
                                 let value_ty = value.ty();
-                                // if !<#operand_constraint as ::midenc_hir2::traits::TypeConstraint>::matches(value_ty) {
-                                //     let expected = <#operand_constraint as ::midenc_hir2::traits::TypeConstraint>::description();
-                                //     return Err(builder.context()
-                                //         .session
-                                //         .diagnostics
-                                //         .diagnostic(::midenc_session::diagnostics::Severity::Error)
-                                //         .with_message("invalid operand")
-                                //         .with_primary_label(span, #constraint_violation)
-                                //         .with_secondary_label(value.span(), ::alloc::format!("this value has type '{value_ty}', but expected '{expected}'"))
-                                //         .into_report());
-                                // }
+                                if !<#operand_constraint as ::midenc_hir2::traits::TypeConstraint>::matches(value_ty) {
+                                    let expected = <#operand_constraint as ::midenc_hir2::traits::TypeConstraint>::description();
+                                    return Err(builder.context()
+                                        .session
+                                        .diagnostics
+                                        .diagnostic(::midenc_session::diagnostics::Severity::Error)
+                                        .with_message("invalid operand")
+                                        .with_primary_label(span, #constraint_violation)
+                                        .with_secondary_label(value.span(), ::alloc::format!("this value has type '{value_ty}', but expected '{expected}'"))
+                                        .into_report());
+                                }
                             }
                         )*
                         op_builder.with_operands_in_group(#group_index, [#(#operand_name),*]);
                     });
                 }
-                OpOperandGroup::Named(group_name, _group_constraint) => {
+                OpOperandGroup::Named(group_name, group_constraint) => {
                     let group_index = syn::Lit::Int(syn::LitInt::new(
                         &format!("{group_index}usize"),
                         group_name.span(),
                     ));
-                    let _constraint_violation = syn::Lit::Str(syn::LitStr::new(
+                    let constraint_violation = syn::Lit::Str(syn::LitStr::new(
                         &format!("type constraint violation for operand in '{group_name}'"),
                         group_name.span(),
                     ));
@@ -469,17 +469,17 @@ impl quote::ToTokens for WithOperands<'_> {
                         for operand in #group_name.iter() {
                             let value = operand.borrow();
                             let value_ty = value.ty();
-                            // if !<#group_constraint as ::midenc_hir2::traits::TypeConstraint>::matches(value_ty) {
-                            //     let expected = <#group_constraint as ::midenc_hir2::traits::TypeConstraint>::description();
-                            //     return Err(builder.context()
-                            //         .session
-                            //         .diagnostics
-                            //         .diagnostic(::midenc_session::diagnostics::Severity::Error)
-                            //         .with_message("invalid operand")
-                            //         .with_primary_label(span, #constraint_violation)
-                            //         .with_secondary_label(value.span(), ::alloc::format!("this value has type '{value_ty}', but expected '{expected}'"))
-                            //         .into_report());
-                            // }
+                            if !<#group_constraint as ::midenc_hir2::traits::TypeConstraint>::matches(value_ty) {
+                                let expected = <#group_constraint as ::midenc_hir2::traits::TypeConstraint>::description();
+                                return Err(builder.context()
+                                    .session
+                                    .diagnostics
+                                    .diagnostic(::midenc_session::diagnostics::Severity::Error)
+                                    .with_message("invalid operand")
+                                    .with_primary_label(span, #constraint_violation)
+                                    .with_secondary_label(value.span(), ::alloc::format!("this value has type '{value_ty}', but expected '{expected}'"))
+                                    .into_report());
+                            }
                         }
                         op_builder.with_operands_in_group(#group_index, #group_name);
                     });
@@ -567,8 +567,8 @@ impl quote::ToTokens for BuildOp<'_> {
                     OpResultGroup::Unnamed(results) => {
                         let verify_result = results.iter().map(|result| {
                             let result_name = &result.name;
-                            let _result_constraint = &result.constraint;
-                            let _constraint_violation = syn::Lit::Str(syn::LitStr::new(
+                            let result_constraint = &result.constraint;
+                            let constraint_violation = syn::Lit::Str(syn::LitStr::new(
                                 &format!("type constraint violation for result '{result_name}'"),
                                 result_name.span(),
                             ));
@@ -576,17 +576,17 @@ impl quote::ToTokens for BuildOp<'_> {
                                 {
                                     let op_result = op.#result_name();
                                     let value_ty = op_result.ty();
-                                    // if !<#result_constraint as ::midenc_hir2::traits::TypeConstraint>::matches(value_ty) {
-                                    //     let expected = <#result_constraint as ::midenc_hir2::traits::TypeConstraint>::description();
-                                    //     return Err(builder.context()
-                                    //         .session
-                                    //         .diagnostics
-                                    //         .diagnostic(::midenc_session::diagnostics::Severity::Error)
-                                    //         .with_message(::alloc::format!("invalid operation {}", op.name()))
-                                    //         .with_primary_label(span, #constraint_violation)
-                                    //         .with_secondary_label(op_result.span(), ::alloc::format!("this value has type '{value_ty}', but expected '{expected}'"))
-                                    //         .into_report());
-                                    // }
+                                    if !<#result_constraint as ::midenc_hir2::traits::TypeConstraint>::matches(value_ty) {
+                                        let expected = <#result_constraint as ::midenc_hir2::traits::TypeConstraint>::description();
+                                        return Err(builder.context()
+                                            .session
+                                            .diagnostics
+                                            .diagnostic(::midenc_session::diagnostics::Severity::Error)
+                                            .with_message(::alloc::format!("invalid operation {}", op.name()))
+                                            .with_primary_label(span, #constraint_violation)
+                                            .with_secondary_label(op_result.span(), ::alloc::format!("this value has type '{value_ty}', but expected '{expected}'"))
+                                            .into_report());
+                                    }
                                 }
                             }
                         });

--- a/hir2/src/dialects/builtin/ops/global_variable.rs
+++ b/hir2/src/dialects/builtin/ops/global_variable.rs
@@ -2,8 +2,8 @@ use crate::{
     derive::operation,
     dialects::builtin::BuiltinDialect,
     traits::{
-        ConstantLike, InferTypeOpInterface, IsolatedFromAbove, NoRegionArguments, SingleBlock,
-        SingleRegion,
+        ConstantLike, InferTypeOpInterface, IsolatedFromAbove, NoRegionArguments, PointerOf,
+        SingleBlock, SingleRegion, UInt8,
     },
     AsSymbolRef, Context, Ident, Operation, Report, Spanned, Symbol, SymbolName, SymbolRef,
     SymbolUseList, Type, UnsafeIntrusiveEntityRef, Usable, Value, Visibility,


### PR DESCRIPTION
Close #378 