### PR TITLE
[2/x] frontend: translate Wasm data segments

### DIFF
--- a/hir2/src/dialects/builtin/ops/segment.rs
+++ b/hir2/src/dialects/builtin/ops/segment.rs
@@ -34,7 +34,6 @@ pub type SegmentRef = UnsafeIntrusiveEntityRef<Segment>;
 #[operation(
     dialect = BuiltinDialect,
     traits(
-        SingleRegion,
         SingleBlock,
         NoRegionArguments,
         IsolatedFromAbove,

--- a/tests/integration/expected/types/array.hir
+++ b/tests/integration/expected/types/array.hir
@@ -1,73 +1,69 @@
-(component 
-    ;; Modules
-    (module #test_rust_d63291a98b435c53f58385d5782fb46f0b0b78bee8e860843e7223106d66f7d6
-        ;; Data Segments
-        (data (mut) (offset 1048576) 0x0100000002000000030000000400000005000000060000000700000008000000090000000a000000)
+builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        ;; Constants
-        (const (id 0) 0x00100000)
-        (const (id 1) 0x00100028)
-        (const (id 2) 0x00100030)
+    builtin.module  #[name = #test_rust_d63291a98b435c53f58385d5782fb46f0b0b78bee8e860843e7223106d66f7d6] #[visibility = public] {
 
-        ;; Global Variables
-        (global (export #__stack_pointer) (id 0) (type i32) (const 0))
-        (global (export #gv1) (id 1) (type i32) (const 1))
-        (global (export #gv2) (id 2) (type i32) (const 2))
+        builtin.function public @sum_arr(v0: i32, v1: i32) -> i32 {
+        ^block5(v0: i32, v1: i32):
+            v3 = hir.constant 0 : i32;
+            v4 = hir.constant 0 : i32;
+            v5 = hir.constant 0 : i32;
+            v6 = hir.eq v1, v5 : i1;
+            v7 = hir.zext v6 : u32 #[ty = u32];
+            v8 = hir.bitcast v7 : i32 #[ty = i32];
+            v9 = hir.constant 0 : i32;
+            v10 = hir.neq v8, v9 : i1;
+            hir.cond_br block7, block8 v10, v4;
+        ^block6(v2: i32):
+            hir.ret v2;
+        ^block7(v26: i32):
+            hir.br block6 v26;
+        ^block8:
+            hir.br block9 v0, v4, v1;
+        ^block9(v11: i32, v17: i32, v21: i32):
+            v12 = hir.bitcast v11 : u32 #[ty = u32];
+            v13 = hir.constant 4 : u32;
+            v14 = hir.mod v12, v13 : u32;
+            hir.assertz v14 #[code = 250];
+            v15 = hir.int_to_ptr v12 : (ptr i32) #[ty = (ptr i32)];
+            v16 = hir.load v15 : i32;
+            v18 = hir.add v16, v17 : i32 #[overflow = wrapping];
+            v19 = hir.constant 4 : i32;
+            v20 = hir.add v11, v19 : i32 #[overflow = wrapping];
+            v22 = hir.constant -1 : i32;
+            v23 = hir.add v21, v22 : i32 #[overflow = wrapping];
+            v24 = hir.constant 0 : i32;
+            v25 = hir.neq v23, v24 : i1;
+            hir.cond_br block9, block11 v25, v20, v18, v23;
+        ^block10:
+            hir.br block7 v18;
+        ^block11:
+            hir.br block10 ;
+        };
+        builtin.function public @__main() -> i32 {
+        ^block12:
+            v28 = hir.constant 1048576 : i32;
+            v29 = hir.constant 5 : i32;
+            v30 = hir.exec v28, v29 : i32 #[callee = root/test_rust_d63291a98b435c53f58385d5782fb46f0b0b78bee8e860843e7223106d66f7d6/sum_arr] #[signature = (param i32) (param i32) (result i32)];
+            v31 = hir.constant 1048596 : i32;
+            v32 = hir.constant 5 : i32;
+            v33 = hir.exec v31, v32 : i32 #[callee = root/test_rust_d63291a98b435c53f58385d5782fb46f0b0b78bee8e860843e7223106d66f7d6/sum_arr] #[signature = (param i32) (param i32) (result i32)];
+            v34 = hir.add v30, v33 : i32 #[overflow = wrapping];
+            hir.br block13 v34;
+        ^block13(v27: i32):
+            hir.ret v27;
+        };
+        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-        ;; Functions
-        (func (export #sum_arr) (param i32) (param i32) (result i32)
-            (block 0 (param v0 i32) (param v1 i32)
-                (let (v3 i32) (const.i32 0))
-                (let (v4 i32) (const.i32 0))
-                (let (v5 i1) (eq v1 0))
-                (let (v6 i32) (zext v5))
-                (let (v7 i1) (neq v6 0))
-                (condbr v7 (block 2 v4) (block 3)))
+            hir.ret_imm  #[value = 1048576];
+        };
+        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            (block 1 (param v2 i32)
-                (ret v2))
+            hir.ret_imm  #[value = 1048616];
+        };
+        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
 
-            (block 2 (param v21 i32)
-                (br (block 1 v21)))
-
-            (block 3
-                (br (block 4 v0 v4 v1)))
-
-            (block 4 (param v8 i32) (param v13 i32) (param v17 i32)
-                (let (v9 u32) (bitcast v8))
-                (let (v10 u32) (mod.unchecked v9 4))
-                (assertz 250 v10)
-                (let (v11 (ptr i32)) (inttoptr v9))
-                (let (v12 i32) (load v11))
-                (let (v14 i32) (add.wrapping v12 v13))
-                (let (v15 i32) (const.i32 4))
-                (let (v16 i32) (add.wrapping v8 v15))
-                (let (v18 i32) (const.i32 -1))
-                (let (v19 i32) (add.wrapping v17 v18))
-                (let (v20 i1) (neq v19 0))
-                (condbr v20 (block 4 v16 v14 v19) (block 6)))
-
-            (block 5
-                (br (block 2 v14)))
-
-            (block 6
-                (br (block 5)))
-        )
-
-        (func (export #__main) (result i32)
-            (block 0
-                (let (v1 i32) (const.i32 1048576))
-                (let (v2 i32) (const.i32 5))
-                (let (v3 i32) (exec #sum_arr v1 v2))
-                (let (v4 i32) (const.i32 1048596))
-                (let (v5 i32) (const.i32 5))
-                (let (v6 i32) (exec #sum_arr v4 v5))
-                (let (v7 i32) (add.wrapping v3 v6))
-                (br (block 1 v7)))
-
-            (block 1 (param v0 i32)
-                (ret v0))
-        )
-    )
-
-)
+            hir.ret_imm  #[value = 1048624];
+        };
+        builtin.segment  #[data = 0000000a000000090000000800000007000000060000000500000004000000030000000200000001] #[offset = 1048576] #[readonly = false];
+    };
+};

--- a/tests/integration/src/rust_masm_tests/types.rs
+++ b/tests/integration/src/rust_masm_tests/types.rs
@@ -15,7 +15,7 @@ fn test_enum() {
 fn test_array() {
     let mut test = CompilerTest::rust_source_program(include_str!("types_src/array.rs"));
     test.expect_wasm(expect_file!["../../expected/types/array.wat"]);
-    test.expect_ir(expect_file!["../../expected/types/array.hir"]);
+    test.expect_ir2(expect_file!["../../expected/types/array.hir"]);
     test.expect_masm(expect_file!["../../expected/types/array.masm"]);
 
     assert!(


### PR DESCRIPTION
#363 

**This PR is stacked on #386 and should be merged after it**

This PR adds the Wasm data segment translation. See the `test_array` test for an example.