### PR TITLE
[3/x] frontend: translate `BrTable` Wasm op

### DIFF
--- a/dialects/hir/src/builders/function.rs
+++ b/dialects/hir/src/builders/function.rs
@@ -1121,11 +1121,23 @@ pub trait InstBuilder: InstBuilderBase {
         op_builder(cond, then_dest, then_args, else_dest, else_args)
     }
 
-    // fn switch(self, arg: ValueRef, span: SourceSpan) -> SwitchBuilder<'f, Self> {
-    //     todo!()
-    //     // require_integer!(self, arg, Type::U32);
-    //     // SwitchBuilder::new(self, arg, span)
-    // }
+    fn switch<TCases, TFallbackArgs>(
+        mut self,
+        selector: ValueRef,
+        cases: TCases,
+        fallback: BlockRef,
+        fallback_args: TFallbackArgs,
+        span: SourceSpan,
+    ) -> Result<UnsafeIntrusiveEntityRef<crate::ops::Switch>, Report>
+    where
+        TCases: IntoIterator<Item = SwitchCase>,
+        TFallbackArgs: IntoIterator<Item = ::midenc_hir2::ValueRef>,
+    {
+        let op_builder = self
+            .builder_mut()
+            .create::<crate::ops::Switch, (_, TCases, _, TFallbackArgs)>(span);
+        op_builder(selector, cases, fallback, fallback_args)
+    }
 
     fn ret(
         mut self,

--- a/tests/integration/expected/types/enum.hir
+++ b/tests/integration/expected/types/enum.hir
@@ -1,64 +1,56 @@
-(component 
-    ;; Modules
-    (module #test_rust_f0bb65319ffababec660ada9dd2dd5f137503f60cf9c37332d6f7e171f275824
-        ;; Constants
-        (const (id 0) 0x00100000)
+builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        ;; Global Variables
-        (global (export #__stack_pointer) (id 0) (type i32) (const 0))
-        (global (export #gv1) (id 1) (type i32) (const 0))
-        (global (export #gv2) (id 2) (type i32) (const 0))
+    builtin.module  #[name = #test_rust_f0bb65319ffababec660ada9dd2dd5f137503f60cf9c37332d6f7e171f275824] #[visibility = public] {
 
-        ;; Functions
-        (func (export #match_enum)
-              (param i32) (param i32) (param i32) (result i32)
-            (block 0 (param v0 i32) (param v1 i32) (param v2 i32)
-                (let (v4 i32) (const.i32 255))
-                (let (v5 i32) (band v2 v4))
-                (let (v6 u32) (cast v5))
-                (switchv6
-                    (0 . (block 4))
-                    (1 . (block 3))
-                    (2 . (block 2))
-                    (_ . (block 4))))
+        builtin.function public @match_enum(v0: i32, v1: i32, v2: i32) -> i32 {
+        ^block5(v0: i32, v1: i32, v2: i32):
+            v4 = hir.constant 255 : i32;
+            v5 = hir.band v2, v4 : i32;
+            v6 = hir.cast v5 : u32 #[ty = u32];
+            hir.switch block9, block8, block7, block9 v6;
+        ^block6(v3: i32):
+            hir.ret v3;
+        ^block7:
+            v9 = hir.mul v1, v0 : i32 #[overflow = wrapping];
+            hir.br block6 v9;
+        ^block8:
+            v8 = hir.sub v0, v1 : i32 #[overflow = wrapping];
+            hir.ret v8;
+        ^block9:
+            v7 = hir.add v1, v0 : i32 #[overflow = wrapping];
+            hir.ret v7;
+        };
+        builtin.function public @__main() -> i32 {
+        ^block10:
+            v11 = hir.constant 3 : i32;
+            v12 = hir.constant 5 : i32;
+            v13 = hir.constant 0 : i32;
+            v14 = hir.exec v11, v12, v13 : i32 #[callee = root/test_rust_f0bb65319ffababec660ada9dd2dd5f137503f60cf9c37332d6f7e171f275824/match_enum] #[signature = (param i32) (param i32) (param i32) (result i32)];
+            v15 = hir.constant 3 : i32;
+            v16 = hir.constant 5 : i32;
+            v17 = hir.constant 1 : i32;
+            v18 = hir.exec v15, v16, v17 : i32 #[callee = root/test_rust_f0bb65319ffababec660ada9dd2dd5f137503f60cf9c37332d6f7e171f275824/match_enum] #[signature = (param i32) (param i32) (param i32) (result i32)];
+            v19 = hir.add v14, v18 : i32 #[overflow = wrapping];
+            v20 = hir.constant 3 : i32;
+            v21 = hir.constant 5 : i32;
+            v22 = hir.constant 2 : i32;
+            v23 = hir.exec v20, v21, v22 : i32 #[callee = root/test_rust_f0bb65319ffababec660ada9dd2dd5f137503f60cf9c37332d6f7e171f275824/match_enum] #[signature = (param i32) (param i32) (param i32) (result i32)];
+            v24 = hir.add v19, v23 : i32 #[overflow = wrapping];
+            hir.br block11 v24;
+        ^block11(v10: i32):
+            hir.ret v10;
+        };
+        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            (block 1 (param v3 i32)
-                (ret v3))
+            hir.ret_imm  #[value = 1048576];
+        };
+        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            (block 2
-                (let (v9 i32) (mul.wrapping v1 v0))
-                (br (block 1 v9)))
+            hir.ret_imm  #[value = 1048576];
+        };
+        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
 
-            (block 3
-                (let (v8 i32) (sub.wrapping v0 v1))
-                (ret v8))
-
-            (block 4
-                (let (v7 i32) (add.wrapping v1 v0))
-                (ret v7))
-        )
-
-        (func (export #__main) (result i32)
-            (block 0
-                (let (v1 i32) (const.i32 3))
-                (let (v2 i32) (const.i32 5))
-                (let (v3 i32) (const.i32 0))
-                (let (v4 i32) (exec #match_enum v1 v2 v3))
-                (let (v5 i32) (const.i32 3))
-                (let (v6 i32) (const.i32 5))
-                (let (v7 i32) (const.i32 1))
-                (let (v8 i32) (exec #match_enum v5 v6 v7))
-                (let (v9 i32) (add.wrapping v4 v8))
-                (let (v10 i32) (const.i32 3))
-                (let (v11 i32) (const.i32 5))
-                (let (v12 i32) (const.i32 2))
-                (let (v13 i32) (exec #match_enum v10 v11 v12))
-                (let (v14 i32) (add.wrapping v9 v13))
-                (br (block 1 v14)))
-
-            (block 1 (param v0 i32)
-                (ret v0))
-        )
-    )
-
-)
+            hir.ret_imm  #[value = 1048576];
+        };
+    };
+};

--- a/tests/integration/src/rust_masm_tests/types.rs
+++ b/tests/integration/src/rust_masm_tests/types.rs
@@ -6,7 +6,7 @@ use crate::CompilerTest;
 fn test_enum() {
     let mut test = CompilerTest::rust_source_program(include_str!("types_src/enum.rs"));
     test.expect_wasm(expect_file!["../../expected/types/enum.wat"]);
-    test.expect_ir(expect_file!["../../expected/types/enum.hir"]);
+    test.expect_ir2(expect_file!["../../expected/types/enum.hir"]);
     // uncomment when https://github.com/0xPolygonMiden/compiler/issues/281 is fixed
     // test.expect_masm(expect_file!["../../expected/types/enum.masm"]);
 }


### PR DESCRIPTION
#363 

**This PR is stacked on the #387 and should be merged after it**

This PR adds translation for the `br_table` Wasm op. See `test_enum` test for the example.