### PR TITLE
Add `--program` flag for `cargo miden new` command and make it the default for new projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,7 @@ dependencies = [
  "clap",
  "env_logger 0.11.5",
  "log",
+ "miden-package",
  "midenc-compile",
  "midenc-session",
  "parse_arg",

--- a/docs/usage/cargo-miden.md
+++ b/docs/usage/cargo-miden.md
@@ -18,10 +18,16 @@ a template to spin up a new Miden project in Rust, and takes care of orchestrati
     NOTE: You can also use the latest nightly, but the specific nightly shown here is known to
     work.
 
-To install the extension, simply run the following in your shell:
+To install the extension, clone the compiler repo first:
 
 ```bash
-cargo +nightly-2025-01-16 install cargo-miden
+git clone https://github.com/0xpolygonmiden/compiler
+```
+
+Then, run the following in your shell in the cloned repo folder:
+
+```bash
+cargo install --path tools/cargo-miden --locked
 ```
 
 This will take a minute to compile, but once complete, you can run `cargo help miden` or just
@@ -42,7 +48,7 @@ crate named `foo`, generated from our Miden project template.
 
 The template we use sets things up so that you can pretty much just build and run. Since the
 toolchain depends on Rust's native WebAssembly target, it is set up just like a minimal WebAssembly
-crate, with some additional tweaks for Miden specfically.
+crate, with some additional tweaks for Miden specifically.
 
 Out of the box, you will get a Rust crate that depends on the Miden SDK, and sets the global
 allocator to a simple bump allocator we provide as part of the SDK, and is well suited for most
@@ -52,13 +58,32 @@ As there is no panic infrastructure, `panic = "abort"` is set, and the panic han
 to use the native WebAssembly `unreachable` intrinsic, so the compiler will strip out all of the
 usual panic formatting code.
 
-### Compiling to Miden Assembly
+### Compiling to Miden package
 
-Now that you've created your project, compiling it to Miden Assembly is as easy as running the
+Now that you've created your project, compiling it to Miden package is as easy as running the
 following command from the root of the project directory:
 
 ```bash
 cargo miden build --release
 ```
 
-This will emit the compiled artifacts to `target/miden`.
+This will emit the compiled artifacts to `target/miden/release/foo.masp`.
+
+
+### Running a compiled Miden VM program
+
+
+!!! warning
+
+    To run the compiled Miden VM program you need to have `midenc` installed. See [`midenc` docs](/docs/usage/midenc.md) for the installation instructions.
+
+
+The compiled Miden VM program can be run from the Miden package with the following:
+
+```bash
+midenc run target/miden/release/foo.masp
+```
+
+
+
+

--- a/docs/usage/cargo-miden.md
+++ b/docs/usage/cargo-miden.md
@@ -81,8 +81,10 @@ This will emit the compiled artifacts to `target/miden/release/foo.masp`.
 The compiled Miden VM program can be run from the Miden package with the following:
 
 ```bash
-midenc run target/miden/release/foo.masp
+midenc run target/miden/release/foo.masp --inputs some_inputs.toml
 ```
+
+See `midenc run --help` for the inputs file format.
 
 
 

--- a/docs/usage/cargo-miden.md
+++ b/docs/usage/cargo-miden.md
@@ -12,7 +12,7 @@ a template to spin up a new Miden project in Rust, and takes care of orchestrati
     make sure you have it installed first:
 
     ```bash
-    rustup toolchain install nightly-2024-08-06
+    rustup toolchain install nightly-2025-01-16
     ```
 
     NOTE: You can also use the latest nightly, but the specific nightly shown here is known to
@@ -21,7 +21,7 @@ a template to spin up a new Miden project in Rust, and takes care of orchestrati
 To install the extension, simply run the following in your shell:
 
 ```bash
-cargo +nightly-2024-08-06 install cargo-miden
+cargo +nightly-2025-01-16 install cargo-miden
 ```
 
 This will take a minute to compile, but once complete, you can run `cargo help miden` or just

--- a/docs/usage/midenc.md
+++ b/docs/usage/midenc.md
@@ -12,7 +12,7 @@ hands dirty.
 ## Installation
 
 First, you'll need to have Rust installed, with the nightly toolchain (currently we're building
-against the `nightly-2024-08-06` toolchain, but we regularly update this).
+against the `nightly-2025-01-16` toolchain, but we regularly update this).
 
 Then, simply install `midenc` using Cargo in one of the following ways:
 

--- a/docs/usage/midenc.md
+++ b/docs/usage/midenc.md
@@ -11,26 +11,32 @@ hands dirty.
 
 ## Installation
 
-First, you'll need to have Rust installed, with the nightly toolchain (currently we're building
-against the `nightly-2025-01-16` toolchain, but we regularly update this).
 
-Then, simply install `midenc` using Cargo in one of the following ways:
+!!! warning
 
-    # From crates.io:
-    cargo +nightly install midenc
+    Currently, `midenc` (and as a result, `cargo-miden`), requires the nightly Rust toolchain, so
+    make sure you have it installed first:
 
-    # If you have cloned the git repo, and are in the project root:
-    cargo make install
+    ```bash
+    rustup toolchain install nightly-2025-01-16
+    ```
 
-    # If you have Rust installed, but have not cloned the git repo:
-    cargo install --git https://github.com/0xpolygonmiden/compiler midenc
+    NOTE: You can also use the latest nightly, but the specific nightly shown here is known to
+    work.
 
 
-!!! advice
+To install the `midenc`, clone the compiler repo first:
 
-    This installation method relies on Cargo-managed binaries being in your shell `PATH`,
-    which is almost always the case, but if you have disabled this functionality, you'll need
-    to add `midenc` to your `PATH` manually.
+```bash
+git clone https://github.com/0xpolygonmiden/compiler
+```
+
+Then, run the following in your shell in the cloned repo folder:
+
+```bash
+cargo install --path midenc --locked
+```
+
 
 ## Usage
 

--- a/midenc-driver/src/midenc.rs
+++ b/midenc-driver/src/midenc.rs
@@ -47,6 +47,13 @@ enum Commands {
         /// Program inputs are stack and advice provider values which the program can
         /// access during execution. The inputs file is a TOML file which describes
         /// what the inputs are, or where to source them from.
+        ///
+        /// Example:
+        ///
+        /// [inputs]
+        ///
+        /// stack = [1, 2, 0x3]
+        ///
         #[arg(long, value_name = "FILE")]
         inputs: Option<debugger::DebuggerConfig>,
         /// Number of outputs on the operand stack to print

--- a/tests/integration/src/rust_masm_tests/rust_sdk.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk.rs
@@ -159,6 +159,7 @@ fn rust_sdk_cross_ctx_note() {
         "build",
         "--manifest-path",
         "../rust-apps-wasm/rust-sdk/cross-ctx-account/Cargo.toml",
+        "--lib",
         "--release",
         // Use the target dir of this test's cargo project to avoid issues running tests in parallel
         // i.e. avoid using the same target dir as the basic-wallet test (see above)

--- a/tools/cargo-miden/Cargo.toml
+++ b/tools/cargo-miden/Cargo.toml
@@ -41,3 +41,4 @@ tokio.workspace = true
 cargo-config2 = "0.1.24"
 
 [dev-dependencies]
+miden-package.workspace = true

--- a/tools/cargo-miden/src/commands/new_project.rs
+++ b/tools/cargo-miden/src/commands/new_project.rs
@@ -4,6 +4,8 @@ use anyhow::Context;
 use cargo_generate::{GenerateArgs, TemplatePath};
 use clap::Args;
 
+const TEMPLATES_REPO_TAG: &str = "v0.6.0";
+
 // This should have been an enum but I could not bend `clap` to expose variants as flags
 /// Project template
 #[derive(Clone, Args)]
@@ -12,10 +14,10 @@ pub struct ProjectTemplate {
     #[clap(long, group = "template", conflicts_with_all(["account", "note"]))]
     program: bool,
     /// Miden rollup account
-    #[clap(long, group = "template", conflicts_with_all(["program", "note"]))]
+    #[clap(hide(true), long, group = "template", conflicts_with_all(["program", "note"]))]
     account: bool,
     /// Miden rollup note script
-    #[clap(long, group = "template", conflicts_with_all(["program", "account"]))]
+    #[clap(hide(true), long, group = "template", conflicts_with_all(["program", "account"]))]
     note: bool,
 }
 
@@ -48,11 +50,7 @@ impl ProjectTemplate {
 
 impl Default for ProjectTemplate {
     fn default() -> Self {
-        Self {
-            program: false,
-            account: true,
-            note: false,
-        }
+        Self::program()
     }
 }
 
@@ -65,7 +63,7 @@ impl fmt::Display for ProjectTemplate {
         } else if self.note {
             write!(f, "note")
         } else {
-            write!(f, "account")
+            panic!("Invalid project template, at least one variant must be set")
         }
     }
 }
@@ -147,7 +145,7 @@ impl NewCommand {
                 };
                 TemplatePath {
                     git: Some("https://github.com/0xPolygonMiden/rust-templates".into()),
-                    tag: Some("v0.6.0".into()),
+                    tag: Some(TEMPLATES_REPO_TAG.into()),
                     auto_path: Some(project_kind_str),
                     ..Default::default()
                 }

--- a/tools/cargo-miden/src/commands/new_project.rs
+++ b/tools/cargo-miden/src/commands/new_project.rs
@@ -1,27 +1,96 @@
-use std::path::PathBuf;
+use std::{fmt, path::PathBuf};
 
 use anyhow::Context;
 use cargo_generate::{GenerateArgs, TemplatePath};
 use clap::Args;
 
+// This should have been an enum but I could not bend `clap` to expose variants as flags
+/// Project template
+#[derive(Clone, Args)]
+pub struct ProjectTemplate {
+    /// Rust program
+    #[clap(long, group = "template", conflicts_with_all(["account", "note"]))]
+    program: bool,
+    /// Miden rollup account
+    #[clap(long, group = "template", conflicts_with_all(["program", "note"]))]
+    account: bool,
+    /// Miden rollup note script
+    #[clap(long, group = "template", conflicts_with_all(["program", "account"]))]
+    note: bool,
+}
+
+#[allow(unused)]
+impl ProjectTemplate {
+    pub fn program() -> Self {
+        Self {
+            program: true,
+            account: false,
+            note: false,
+        }
+    }
+
+    pub fn account() -> Self {
+        Self {
+            program: false,
+            account: true,
+            note: false,
+        }
+    }
+
+    pub fn note() -> Self {
+        Self {
+            program: false,
+            account: false,
+            note: true,
+        }
+    }
+}
+
+impl Default for ProjectTemplate {
+    fn default() -> Self {
+        Self {
+            program: false,
+            account: true,
+            note: false,
+        }
+    }
+}
+
+impl fmt::Display for ProjectTemplate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.program {
+            write!(f, "program")
+        } else if self.account {
+            write!(f, "account")
+        } else if self.note {
+            write!(f, "note")
+        } else {
+            write!(f, "account")
+        }
+    }
+}
+
 /// Create a new Miden project at <path>
 #[derive(Args)]
 #[clap(disable_version_flag = true)]
 pub struct NewCommand {
-    /// The path for the generated package.
+    /// The path for the generated package (the directory name is used for project name)
     #[clap()]
     pub path: PathBuf,
+    /// The template name to use to generate the package
+    #[clap(flatten)]
+    pub template: Option<ProjectTemplate>,
     /// The path to the template to use to generate the package
-    #[clap(long, hide(true))]
+    #[clap(long, conflicts_with("template"))]
     pub template_path: Option<PathBuf>,
     /// Use a locally cloned compiler in the generated package
-    #[clap(long, conflicts_with_all(["compiler_rev", "compiler_branch"]))]
+    #[clap(long, hide(true), conflicts_with_all(["compiler_rev", "compiler_branch"]))]
     pub compiler_path: Option<PathBuf>,
     /// Use a specific revision of the compiler in the generated package
-    #[clap(long, conflicts_with("compiler_branch"))]
+    #[clap(long, hide(true), conflicts_with("compiler_branch"))]
     pub compiler_rev: Option<String>,
     /// Use a specific branch of the compiler in the generated package
-    #[clap(long)]
+    #[clap(long, hide(true))]
     pub compiler_branch: Option<String>,
 }
 
@@ -69,15 +138,20 @@ impl NewCommand {
         let template_path = match self.template_path.as_ref() {
             Some(template_path) => TemplatePath {
                 path: Some(template_path.display().to_string()),
-                subfolder: Some("account".into()),
                 ..Default::default()
             },
-            None => TemplatePath {
-                git: Some("https://github.com/0xPolygonMiden/rust-templates".into()),
-                tag: Some("v0.5.0".into()),
-                auto_path: Some("account".into()),
-                ..Default::default()
-            },
+            None => {
+                let project_kind_str = match self.template {
+                    Some(kind) => kind.to_string(),
+                    None => ProjectTemplate::default().to_string(),
+                };
+                TemplatePath {
+                    git: Some("https://github.com/0xPolygonMiden/rust-templates".into()),
+                    tag: Some("v0.6.0".into()),
+                    auto_path: Some(project_kind_str),
+                    ..Default::default()
+                }
+            }
         };
 
         let destination = self

--- a/tools/cargo-miden/src/compile_masm.rs
+++ b/tools/cargo-miden/src/compile_masm.rs
@@ -37,7 +37,7 @@ pub fn wasm_to_masm(
         output_folder.join(masm_file_name).with_extension(OutputType::Masp.extension());
     let project_type = if is_bin { "--exe" } else { "--lib" };
     let entrypoint_opt = format!("--entrypoint={masm_file_name}::entrypoint");
-    let args: Vec<&std::ffi::OsStr> = vec![
+    let mut args: Vec<&std::ffi::OsStr> = vec![
         "--output-dir".as_ref(),
         output_folder.as_os_str(),
         "-o".as_ref(),
@@ -46,8 +46,12 @@ pub fn wasm_to_masm(
         "--verbose".as_ref(),
         "--target".as_ref(),
         "rollup".as_ref(),
-        entrypoint_opt.as_ref(),
     ];
+
+    if is_bin {
+        args.push(entrypoint_opt.as_ref());
+    }
+
     let session = Rc::new(Compiler::new_session([input], None, args));
     midenc_compile::compile(session.clone())?;
     Ok(output_file)

--- a/tools/cargo-miden/src/compile_masm.rs
+++ b/tools/cargo-miden/src/compile_masm.rs
@@ -28,10 +28,15 @@ pub fn wasm_to_masm(
     let input = InputFile::from_path(wasm_file_path)
         .into_diagnostic()
         .wrap_err("Invalid input file")?;
-    let output_file = output_folder
-        .join(wasm_file_path.file_stem().expect("invalid wasm file path: no file stem"))
-        .with_extension(OutputType::Masp.extension());
+    let masm_file_name = wasm_file_path
+        .file_stem()
+        .expect("invalid wasm file path: no file stem")
+        .to_str()
+        .unwrap();
+    let output_file =
+        output_folder.join(masm_file_name).with_extension(OutputType::Masp.extension());
     let project_type = if is_bin { "--exe" } else { "--lib" };
+    let entrypoint_opt = format!("--entrypoint={masm_file_name}::entrypoint");
     let args: Vec<&std::ffi::OsStr> = vec![
         "--output-dir".as_ref(),
         output_folder.as_os_str(),
@@ -41,6 +46,7 @@ pub fn wasm_to_masm(
         "--verbose".as_ref(),
         "--target".as_ref(),
         "rollup".as_ref(),
+        entrypoint_opt.as_ref(),
     ];
     let session = Rc::new(Compiler::new_session([input], None, args));
     midenc_compile::compile(session.clone())?;

--- a/tools/cargo-miden/src/lib.rs
+++ b/tools/cargo-miden/src/lib.rs
@@ -205,7 +205,7 @@ where
                 .collect();
             }
 
-            let mut spawn_args: Vec<_> = args.into_iter().collect();
+            let mut spawn_args: Vec<_> = args.clone().into_iter().collect();
             spawn_args.extend_from_slice(
                 &[
                     "-Z",
@@ -270,8 +270,9 @@ where
 
                     let mut outputs = Vec::new();
                     for wasm in wasm_outputs {
-                        // so far, we only support the Miden VM programs
-                        let is_bin = true;
+                        // so far, we only support the Miden VM programs, unless `--lib` is
+                        // specified (in our integration tests)
+                        let is_bin = !args.contains(&"--lib".to_string());
                         let output = wasm_to_masm(&wasm, miden_out_dir.as_std_path(), is_bin)
                             .map_err(|e| anyhow::anyhow!("{e}"))?;
                         outputs.push(output);

--- a/tools/cargo-miden/src/lib.rs
+++ b/tools/cargo-miden/src/lib.rs
@@ -270,7 +270,8 @@ where
 
                     let mut outputs = Vec::new();
                     for wasm in wasm_outputs {
-                        let is_bin = false;
+                        // so far, we only support the Miden VM programs
+                        let is_bin = true;
                         let output = wasm_to_masm(&wasm, miden_out_dir.as_std_path(), is_bin)
                             .map_err(|e| anyhow::anyhow!("{e}"))?;
                         outputs.push(output);

--- a/tools/cargo-miden/src/lib.rs
+++ b/tools/cargo-miden/src/lib.rs
@@ -104,7 +104,8 @@ pub fn run<T>(args: T, build_output_type: OutputType) -> anyhow::Result<Vec<Path
 where
     T: Iterator<Item = String>,
 {
-    let args = args.skip_while(|arg| arg == "cargo").collect::<Vec<_>>();
+    // The first argument is the cargo-miden binary path
+    let args = args.skip_while(|arg| arg != "miden").collect::<Vec<_>>();
     let subcommand = detect_subcommand(args.clone());
 
     let outputs = match subcommand.as_deref() {


### PR DESCRIPTION
Close #371 

This PR adds the `--program` flag and makes it the default for `cargo miden new` command. The entrypoint function name is hard-coded and is `entrypoint` which is highlighted in its comments in the project template.

The Miden VM new project template is added in https://github.com/0xPolygonMiden/rust-templates/pull/8 , tagged with `v0.6.0` which is used in this PR.

Besides, `--program` the `--account` and `--note` flags are also added, but made hidden until their implementation is restored after the new IR migration.
