### PR TITLE
frontend: translate `mem::intrinsics::heap_base`

### DIFF
--- a/frontend-wasm2/src/miden_abi/mod.rs
+++ b/frontend-wasm2/src/miden_abi/mod.rs
@@ -2,7 +2,8 @@ pub(crate) mod stdlib;
 pub(crate) mod transform;
 pub(crate) mod tx_kernel;
 
-use midenc_hir::{FunctionIdent, FunctionType, FxHashMap, Ident, Symbol};
+use midenc_hir::{FunctionType, FxHashMap, Symbol};
+use midenc_hir2::{FunctionIdent, Ident};
 use tx_kernel::note;
 
 use crate::intrinsics;

--- a/frontend-wasm2/src/module/build_ir.rs
+++ b/frontend-wasm2/src/module/build_ir.rs
@@ -74,6 +74,7 @@ pub fn translate_module_as_component(
     let mut module_state = ModuleTranslationState::new(
         &parsed_module.module,
         &mut module_builder,
+        &mut cb,
         &module_types,
         vec![],
         &context.session.diagnostics,

--- a/hir2/src/ir/symbols/table.rs
+++ b/hir2/src/ir/symbols/table.rs
@@ -118,7 +118,7 @@ impl dyn SymbolTable {
 /// In most circumstances, you will want to interact with this via [SymbolManager] or
 /// [SymbolManagerMut], as the operations provided here are mostly low-level plumbing, and thus
 /// incomplete without functionality provided by higher-level abstractions.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SymbolMap {
     /// A low-level mapping of symbols to operations found in this table
     symbols: FxHashMap<SymbolName, SymbolRef>,

--- a/tests/integration/expected/mem_intrinsics_heap_base.hir
+++ b/tests/integration/expected/mem_intrinsics_heap_base.hir
@@ -1,0 +1,201 @@
+builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+
+    builtin.module  #[name = #mem_intrinsics_heap_base] #[visibility = public] {
+
+        builtin.function public @entrypoint(v0: i32, v1: i32) {
+        ^block4(v0: i32, v1: i32):
+            v2 = hir.constant 0 : i32;
+            v3 = hir.constant 0 : i32;
+            v4 = hir.bitcast v3 : u32 #[ty = u32];
+            v5 = hir.constant 1048580 : u32;
+            v6 = hir.add v4, v5 : u32 #[overflow = checked];
+            v7 = hir.int_to_ptr v6 : (ptr u8) #[ty = (ptr u8)];
+            v8 = hir.load v7 : u8;
+            v9 = hir.zext v8 : u32 #[ty = u32];
+            v10 = hir.constant 4 : i32;
+            v11 = hir.constant 4 : i32;
+            v12 = hir.exec v10, v11 : i32 #[callee = root/mem_intrinsics_heap_base/__rust_alloc] #[signature = (param i32) (param i32) (result i32)];
+            v13 = hir.constant 0 : i32;
+            v14 = hir.neq v12, v13 : i1;
+            hir.cond_br block6, block7 v14;
+        ^block5:
+            hir.ret ;
+        ^block6:
+            v17 = hir.constant 1 : i32;
+            v18 = hir.bitcast v0 : u32 #[ty = u32];
+            v19 = hir.constant 8 : u32;
+            v20 = hir.add v18, v19 : u32 #[overflow = checked];
+            v21 = hir.constant 4 : u32;
+            v22 = hir.mod v20, v21 : u32;
+            hir.assertz v22 #[code = 250];
+            v23 = hir.int_to_ptr v20 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v23, v17;
+            v24 = hir.bitcast v0 : u32 #[ty = u32];
+            v25 = hir.constant 4 : u32;
+            v26 = hir.add v24, v25 : u32 #[overflow = checked];
+            v27 = hir.constant 4 : u32;
+            v28 = hir.mod v26, v27 : u32;
+            hir.assertz v28 #[code = 250];
+            v29 = hir.int_to_ptr v26 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v29, v12;
+            v30 = hir.constant 1 : i32;
+            v31 = hir.bitcast v0 : u32 #[ty = u32];
+            v32 = hir.constant 4 : u32;
+            v33 = hir.mod v31, v32 : u32;
+            hir.assertz v33 #[code = 250];
+            v34 = hir.int_to_ptr v31 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v34, v30;
+            v35 = hir.constant 1 : i32;
+            v36 = hir.bitcast v35 : u32 #[ty = u32];
+            v37 = hir.shl v1, v36 : i32;
+            v38 = hir.bitcast v12 : u32 #[ty = u32];
+            v39 = hir.constant 4 : u32;
+            v40 = hir.mod v38, v39 : u32;
+            hir.assertz v40 #[code = 250];
+            v41 = hir.int_to_ptr v38 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v41, v37;
+            hir.br block5 ;
+        ^block7:
+            v15 = hir.constant 4 : i32;
+            v16 = hir.constant 4 : i32;
+            hir.exec v15, v16 #[callee = root/mem_intrinsics_heap_base/alloc::alloc::handle_alloc_error] #[signature = (param i32) (param i32)];
+            hir.unreachable ;
+        };
+        builtin.function public @__rust_alloc(v42: i32, v43: i32) -> i32 {
+        ^block8(v42: i32, v43: i32):
+            v45 = hir.constant 1048576 : i32;
+            v46 = hir.exec v45, v43, v42 : i32 #[callee = root/mem_intrinsics_heap_base/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc] #[signature = (param i32) (param i32) (param i32) (result i32)];
+            hir.br block9 v46;
+        ^block9(v44: i32):
+            hir.ret v44;
+        };
+        builtin.function public @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v47: i32, v48: i32, v49: i32) -> i32 {
+        ^block10(v47: i32, v48: i32, v49: i32):
+            v51 = hir.constant 0 : i32;
+            v52 = hir.constant 32 : i32;
+            v53 = hir.constant 32 : i32;
+            v54 = hir.bitcast v48 : u32 #[ty = u32];
+            v55 = hir.bitcast v53 : u32 #[ty = u32];
+            v56 = hir.gt v54, v55 : i1;
+            v57 = hir.zext v56 : u32 #[ty = u32];
+            v58 = hir.constant 0 : i32;
+            v59 = hir.neq v57, v58 : i1;
+            v60 = hir.select v59, v48, v52 : i32;
+            v61 = hir.popcnt v60 : u32;
+            v62 = hir.bitcast v61 : i32 #[ty = i32];
+            v63 = hir.constant 1 : i32;
+            v64 = hir.neq v62, v63 : i1;
+            v65 = hir.zext v64 : u32 #[ty = u32];
+            v66 = hir.bitcast v65 : i32 #[ty = i32];
+            v67 = hir.constant 0 : i32;
+            v68 = hir.neq v66, v67 : i1;
+            hir.cond_br block12, block13 v68;
+        ^block11(v50: i32):
+
+        ^block12:
+            hir.unreachable ;
+        ^block13:
+            v69 = hir.constant -2147483648 : i32;
+            v70 = hir.exec v48, v60 : i32 #[callee = root/mem_intrinsics_heap_base/core::ptr::alignment::Alignment::max] #[signature = (param i32) (param i32) (result i32)];
+            v71 = hir.sub v69, v70 : i32 #[overflow = wrapping];
+            v72 = hir.bitcast v71 : u32 #[ty = u32];
+            v73 = hir.bitcast v49 : u32 #[ty = u32];
+            v74 = hir.lt v72, v73 : i1;
+            v75 = hir.zext v74 : u32 #[ty = u32];
+            v76 = hir.bitcast v75 : i32 #[ty = i32];
+            v77 = hir.constant 0 : i32;
+            v78 = hir.neq v76, v77 : i1;
+            hir.cond_br block12, block14 v78;
+        ^block14:
+            v79 = hir.constant 0 : i32;
+            v80 = hir.add v49, v70 : i32 #[overflow = wrapping];
+            v81 = hir.constant -1 : i32;
+            v82 = hir.add v80, v81 : i32 #[overflow = wrapping];
+            v83 = hir.constant 0 : i32;
+            v84 = hir.sub v83, v70 : i32 #[overflow = wrapping];
+            v85 = hir.band v82, v84 : i32;
+            v86 = hir.bitcast v47 : u32 #[ty = u32];
+            v87 = hir.constant 4 : u32;
+            v88 = hir.mod v86, v87 : u32;
+            hir.assertz v88 #[code = 250];
+            v89 = hir.int_to_ptr v86 : (ptr i32) #[ty = (ptr i32)];
+            v90 = hir.load v89 : i32;
+            v91 = hir.constant 0 : i32;
+            v92 = hir.neq v90, v91 : i1;
+            hir.cond_br block15, block16 v92, v47, v85, v70, v79;
+        ^block15(v105: i32, v112: i32, v125: i32, v128: i32):
+            v104 = hir.constant 268435456 : i32;
+            v106 = hir.bitcast v105 : u32 #[ty = u32];
+            v107 = hir.constant 4 : u32;
+            v108 = hir.mod v106, v107 : u32;
+            hir.assertz v108 #[code = 250];
+            v109 = hir.int_to_ptr v106 : (ptr i32) #[ty = (ptr i32)];
+            v110 = hir.load v109 : i32;
+            v111 = hir.sub v104, v110 : i32 #[overflow = wrapping];
+            v113 = hir.bitcast v111 : u32 #[ty = u32];
+            v114 = hir.bitcast v112 : u32 #[ty = u32];
+            v115 = hir.lt v113, v114 : i1;
+            v116 = hir.zext v115 : u32 #[ty = u32];
+            v117 = hir.bitcast v116 : i32 #[ty = i32];
+            v118 = hir.constant 0 : i32;
+            v119 = hir.neq v117, v118 : i1;
+            hir.cond_br block17, block18 v119, v128;
+        ^block16:
+            v93 = hir.exec  : i32 #[callee = root/intrinsics::mem/heap_base] #[signature = (result i32)];
+            v94 = hir.mem_size  : u32;
+            v95 = hir.constant 16 : i32;
+            v96 = hir.bitcast v95 : u32 #[ty = u32];
+            v97 = hir.shl v94, v96 : u32;
+            v98 = hir.bitcast v97 : i32 #[ty = i32];
+            v99 = hir.add v93, v98 : i32 #[overflow = wrapping];
+            v100 = hir.bitcast v47 : u32 #[ty = u32];
+            v101 = hir.constant 4 : u32;
+            v102 = hir.mod v100, v101 : u32;
+            hir.assertz v102 #[code = 250];
+            v103 = hir.int_to_ptr v100 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v103, v99;
+            hir.br block15 v47, v85, v70, v79;
+        ^block17(v127: i32):
+            hir.ret v127;
+        ^block18:
+            v120 = hir.add v110, v112 : i32 #[overflow = wrapping];
+            v121 = hir.bitcast v105 : u32 #[ty = u32];
+            v122 = hir.constant 4 : u32;
+            v123 = hir.mod v121, v122 : u32;
+            hir.assertz v123 #[code = 250];
+            v124 = hir.int_to_ptr v121 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v124, v120;
+            v126 = hir.add v110, v125 : i32 #[overflow = wrapping];
+            hir.br block17 v126;
+        };
+        builtin.function public @alloc::alloc::handle_alloc_error(v129: i32, v130: i32) {
+        ^block19(v129: i32, v130: i32):
+            hir.unreachable ;
+        ^block20:
+
+        };
+        builtin.function public @core::ptr::alignment::Alignment::max(v131: i32, v132: i32) -> i32 {
+        ^block21(v131: i32, v132: i32):
+            v134 = hir.bitcast v131 : u32 #[ty = u32];
+            v135 = hir.bitcast v132 : u32 #[ty = u32];
+            v136 = hir.gt v134, v135 : i1;
+            v137 = hir.zext v136 : u32 #[ty = u32];
+            v138 = hir.constant 0 : i32;
+            v139 = hir.neq v137, v138 : i1;
+            v140 = hir.select v139, v131, v132 : i32;
+            hir.br block22 v140;
+        ^block22(v133: i32):
+            hir.ret v133;
+        };
+        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+            hir.ret_imm  #[value = 1048576];
+        };
+    };
+    builtin.module  #[name = #intrinsics::mem] #[visibility = public] {
+
+        builtin.function public @heap_base(result i32) {
+
+        };
+    };
+};

--- a/tests/integration/expected/mem_intrinsics_heap_base.wat
+++ b/tests/integration/expected/mem_intrinsics_heap_base.wat
@@ -1,0 +1,131 @@
+(module $mem_intrinsics_heap_base.wasm
+  (type (;0;) (func (result i32)))
+  (type (;1;) (func (param i32 i32)))
+  (type (;2;) (func (param i32 i32) (result i32)))
+  (type (;3;) (func (param i32 i32 i32) (result i32)))
+  (import "miden:core-import/intrinsics-mem@1.0.0" "heap-base" (func $miden_sdk_alloc::heap_base (;0;) (type 0)))
+  (func $entrypoint (;1;) (type 1) (param i32 i32)
+    (local i32)
+    i32.const 0
+    i32.load8_u offset=1048580
+    drop
+    block ;; label = @1
+      i32.const 4
+      i32.const 4
+      call $__rust_alloc
+      local.tee 2
+      br_if 0 (;@1;)
+      i32.const 4
+      i32.const 4
+      call $alloc::alloc::handle_alloc_error
+      unreachable
+    end
+    local.get 0
+    i32.const 1
+    i32.store offset=8
+    local.get 0
+    local.get 2
+    i32.store offset=4
+    local.get 0
+    i32.const 1
+    i32.store
+    local.get 2
+    local.get 1
+    i32.const 1
+    i32.shl
+    i32.store
+  )
+  (func $__rust_alloc (;2;) (type 2) (param i32 i32) (result i32)
+    i32.const 1048576
+    local.get 1
+    local.get 0
+    call $<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
+  )
+  (func $<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc (;3;) (type 3) (param i32 i32 i32) (result i32)
+    (local i32 i32)
+    block ;; label = @1
+      local.get 1
+      i32.const 32
+      local.get 1
+      i32.const 32
+      i32.gt_u
+      select
+      local.tee 3
+      i32.popcnt
+      i32.const 1
+      i32.ne
+      br_if 0 (;@1;)
+      i32.const -2147483648
+      local.get 1
+      local.get 3
+      call $core::ptr::alignment::Alignment::max
+      local.tee 1
+      i32.sub
+      local.get 2
+      i32.lt_u
+      br_if 0 (;@1;)
+      i32.const 0
+      local.set 3
+      local.get 2
+      local.get 1
+      i32.add
+      i32.const -1
+      i32.add
+      i32.const 0
+      local.get 1
+      i32.sub
+      i32.and
+      local.set 2
+      block ;; label = @2
+        local.get 0
+        i32.load
+        br_if 0 (;@2;)
+        local.get 0
+        call $miden_sdk_alloc::heap_base
+        memory.size
+        i32.const 16
+        i32.shl
+        i32.add
+        i32.store
+      end
+      block ;; label = @2
+        i32.const 268435456
+        local.get 0
+        i32.load
+        local.tee 4
+        i32.sub
+        local.get 2
+        i32.lt_u
+        br_if 0 (;@2;)
+        local.get 0
+        local.get 4
+        local.get 2
+        i32.add
+        i32.store
+        local.get 4
+        local.get 1
+        i32.add
+        local.set 3
+      end
+      local.get 3
+      return
+    end
+    unreachable
+  )
+  (func $alloc::alloc::handle_alloc_error (;4;) (type 1) (param i32 i32)
+    unreachable
+  )
+  (func $core::ptr::alignment::Alignment::max (;5;) (type 2) (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    local.get 0
+    local.get 1
+    i32.gt_u
+    select
+  )
+  (table (;0;) 1 1 funcref)
+  (memory (;0;) 17)
+  (global $__stack_pointer (;0;) (mut i32) i32.const 1048576)
+  (export "memory" (memory 0))
+  (export "entrypoint" (func $entrypoint))
+)

--- a/tests/integration/src/compiler_test.rs
+++ b/tests/integration/src/compiler_test.rs
@@ -1204,7 +1204,7 @@ fn stdlib_sys_crate_path() -> PathBuf {
     cwd.parent().unwrap().parent().unwrap().join("sdk").join("stdlib-sys")
 }
 
-fn sdk_alloc_crate_path() -> PathBuf {
+pub fn sdk_alloc_crate_path() -> PathBuf {
     let cwd = std::env::current_dir().unwrap();
     cwd.parent().unwrap().parent().unwrap().join("sdk").join("alloc")
 }


### PR DESCRIPTION
Close #396 

This PR add translation for `mem::intrinsics::heap_base` by creating a module(`mem::intrinsics`) with an "empty" function (`heap_base`) since the real function implementation is linked at the codegen. 