### PR TITLE
[1/x] feature(frontend): implement felt intrinsics

### DIFF
--- a/frontend-wasm2/src/intrinsics/felt.rs
+++ b/frontend-wasm2/src/intrinsics/felt.rs
@@ -1,9 +1,9 @@
 use std::vec;
 
-use midenc_hir::{FunctionIdent, InstBuilder, SourceSpan, Type::*, Value};
-use midenc_hir2::ValueRef;
+use midenc_dialect_hir::InstBuilder;
+use midenc_hir2::{FunctionIdent, SourceSpan, Type, ValueRef};
 
-use crate::module::function_builder_ext::FunctionBuilderExt;
+use crate::{error::WasmResult, module::function_builder_ext::FunctionBuilderExt};
 
 pub(crate) const MODULE_ID: &str = "intrinsics::felt";
 
@@ -13,121 +13,120 @@ pub(crate) fn convert_felt_intrinsics(
     args: &[ValueRef],
     builder: &mut FunctionBuilderExt<'_>,
     span: SourceSpan,
-) -> Vec<ValueRef> {
-    todo!()
-    // match func_id.function.as_symbol().as_str() {
-    //     // Conversion operations
-    //     "from_u64_unchecked" => {
-    //         assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
-    //         let inst = builder.ins().cast(args[0], Felt, span);
-    //         vec![inst]
-    //     }
-    //     "from_u32" => {
-    //         assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
-    //         let inst = builder.ins().bitcast(args[0], Felt, span);
-    //         vec![inst]
-    //     }
-    //     "as_u64" => {
-    //         assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
-    //         // we're casting to i64 instead of u64 because Wasm doesn't have u64
-    //         // and this value will be used in Wasm ops or local vars that expect i64
-    //         let inst = builder.ins().cast(args[0], I64, span);
-    //         vec![inst]
-    //     }
-    //     // Arithmetic operations
-    //     "add" => {
-    //         assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
-    //         let inst = builder.ins().add_unchecked(args[0], args[1], span);
-    //         vec![inst]
-    //     }
-    //     "sub" => {
-    //         assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
-    //         let inst = builder.ins().sub_unchecked(args[0], args[1], span);
-    //         vec![inst]
-    //     }
-    //     "mul" => {
-    //         assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
-    //         let inst = builder.ins().mul_unchecked(args[0], args[1], span);
-    //         vec![inst]
-    //     }
-    //     "div" => {
-    //         assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
-    //         let inst = builder.ins().div_unchecked(args[0], args[1], span);
-    //         vec![inst]
-    //     }
-    //     "neg" => {
-    //         assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
-    //         let inst = builder.ins().neg(args[0], span);
-    //         vec![inst]
-    //     }
-    //     "inv" => {
-    //         assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
-    //         let inst = builder.ins().inv(args[0], span);
-    //         vec![inst]
-    //     }
-    //     "pow2" => {
-    //         assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
-    //         let inst = builder.ins().pow2(args[0], span);
-    //         vec![inst]
-    //     }
-    //     "exp" => {
-    //         assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
-    //         let inst = builder.ins().exp(args[0], args[1], span);
-    //         vec![inst]
-    //     }
-    //     // Comparison operations
-    //     "eq" => {
-    //         assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
-    //         let inst = builder.ins().eq(args[0], args[1], span);
-    //         let cast = builder.ins().cast(inst, I32, span);
-    //         vec![cast]
-    //     }
-    //     "gt" => {
-    //         assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
-    //         let inst = builder.ins().gt(args[0], args[1], span);
-    //         let cast = builder.ins().cast(inst, I32, span);
-    //         vec![cast]
-    //     }
-    //     "ge" => {
-    //         assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
-    //         let inst = builder.ins().gte(args[0], args[1], span);
-    //         let cast = builder.ins().cast(inst, I32, span);
-    //         vec![cast]
-    //     }
-    //     "lt" => {
-    //         assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
-    //         let inst = builder.ins().lt(args[0], args[1], span);
-    //         let cast = builder.ins().cast(inst, I32, span);
-    //         vec![cast]
-    //     }
-    //     "le" => {
-    //         assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
-    //         let inst = builder.ins().lte(args[0], args[1], span);
-    //         let cast = builder.ins().cast(inst, I32, span);
-    //         vec![cast]
-    //     }
-    //     "is_odd" => {
-    //         assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
-    //         let inst = builder.ins().is_odd(args[0], span);
-    //         let cast = builder.ins().cast(inst, I32, span);
-    //         vec![cast]
-    //     }
-    //     // Assert operations
-    //     "assert" => {
-    //         assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
-    //         builder.ins().assert(args[0], span);
-    //         vec![]
-    //     }
-    //     "assertz" => {
-    //         assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
-    //         builder.ins().assertz(args[0], span);
-    //         vec![]
-    //     }
-    //     "assert_eq" => {
-    //         assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
-    //         builder.ins().assert_eq(args[0], args[1], span);
-    //         vec![]
-    //     }
-    //     _ => panic!("No felt op intrinsics found for {}", func_id),
-    // }
+) -> WasmResult<Vec<ValueRef>> {
+    match func_id.function.as_symbol().as_str() {
+        // Conversion operations
+        "from_u64_unchecked" => {
+            assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
+            let inst = builder.ins().cast(args[0], Type::Felt, span)?;
+            Ok(vec![inst])
+        }
+        "from_u32" => {
+            assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
+            let inst = builder.ins().bitcast(args[0], Type::Felt, span)?;
+            Ok(vec![inst])
+        }
+        "as_u64" => {
+            assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
+            // we're casting to i64 instead of u64 because Wasm doesn't have u64
+            // and this value will be used in Wasm ops or local vars that expect i64
+            let inst = builder.ins().cast(args[0], Type::I64, span)?;
+            Ok(vec![inst])
+        }
+        // Arithmetic operations
+        "add" => {
+            assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
+            let inst = builder.ins().add_unchecked(args[0], args[1], span)?;
+            Ok(vec![inst])
+        }
+        "sub" => {
+            assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
+            let inst = builder.ins().sub_unchecked(args[0], args[1], span)?;
+            Ok(vec![inst])
+        }
+        "mul" => {
+            assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
+            let inst = builder.ins().mul_unchecked(args[0], args[1], span)?;
+            Ok(vec![inst])
+        }
+        "div" => {
+            assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
+            let inst = builder.ins().div(args[0], args[1], span)?;
+            Ok(vec![inst])
+        }
+        "neg" => {
+            assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
+            let inst = builder.ins().neg(args[0], span)?;
+            Ok(vec![inst])
+        }
+        "inv" => {
+            assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
+            let inst = builder.ins().inv(args[0], span)?;
+            Ok(vec![inst])
+        }
+        "pow2" => {
+            assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
+            let inst = builder.ins().pow2(args[0], span)?;
+            Ok(vec![inst])
+        }
+        "exp" => {
+            assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
+            let inst = builder.ins().exp(args[0], args[1], span)?;
+            Ok(vec![inst])
+        }
+        // Comparison operations
+        "eq" => {
+            assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
+            let inst = builder.ins().eq(args[0], args[1], span)?;
+            let cast = builder.ins().cast(inst, Type::I32, span)?;
+            Ok(vec![cast])
+        }
+        "gt" => {
+            assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
+            let inst = builder.ins().gt(args[0], args[1], span)?;
+            let cast = builder.ins().cast(inst, Type::I32, span)?;
+            Ok(vec![cast])
+        }
+        "ge" => {
+            assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
+            let inst = builder.ins().gte(args[0], args[1], span)?;
+            let cast = builder.ins().cast(inst, Type::I32, span)?;
+            Ok(vec![cast])
+        }
+        "lt" => {
+            assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
+            let inst = builder.ins().lt(args[0], args[1], span)?;
+            let cast = builder.ins().cast(inst, Type::I32, span)?;
+            Ok(vec![cast])
+        }
+        "le" => {
+            assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
+            let inst = builder.ins().lte(args[0], args[1], span)?;
+            let cast = builder.ins().cast(inst, Type::I32, span)?;
+            Ok(vec![cast])
+        }
+        "is_odd" => {
+            assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
+            let inst = builder.ins().is_odd(args[0], span)?;
+            let cast = builder.ins().cast(inst, Type::I32, span)?;
+            Ok(vec![cast])
+        }
+        // Assert operations
+        "assert" => {
+            assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
+            builder.ins().assert(args[0], span);
+            Ok(vec![])
+        }
+        "assertz" => {
+            assert_eq!(args.len(), 1, "{} takes exactly one argument", func_id);
+            builder.ins().assertz(args[0], span);
+            Ok(vec![])
+        }
+        "assert_eq" => {
+            assert_eq!(args.len(), 2, "{} takes exactly two arguments", func_id);
+            builder.ins().assert_eq(args[0], args[1], span);
+            Ok(vec![])
+        }
+        _ => panic!("No felt op intrinsics found for {}", func_id),
+    }
 }

--- a/frontend-wasm2/src/module/module_translation_state.rs
+++ b/frontend-wasm2/src/module/module_translation_state.rs
@@ -8,22 +8,27 @@ use midenc_hir2::{
 use super::{instance::ModuleArgument, ir_func_type, EntityIndex, FuncIndex, Module, ModuleTypes};
 use crate::{
     error::WasmResult,
-    intrinsics::is_miden_intrinsics_module,
+    intrinsics::{
+        intrinsics_conversion_result, is_miden_intrinsics_module, IntrinsicsConversionResult,
+    },
     miden_abi::{is_miden_abi_module, miden_abi_function_type, recover_imported_masm_function_id},
     translation_utils::sig_from_func_type,
 };
 
-#[derive(Clone, Debug)]
-struct DefinedFunction {
-    wasm_id: FunctionIdent,
-    symbol_path: SymbolPath,
-    signature: Signature,
+/// Local or imported core Wasm module function
+#[derive(Clone)]
+pub struct CallableFunction {
+    /// Module and function name parsed from the core Wasm module
+    pub wasm_id: FunctionIdent,
+    /// Defined IR function or None if it's an intrinsic that will be represented with an op
+    pub function_ref: Option<FunctionRef>,
+    /// Function signature parsed from the core Wasm module
+    pub signature: Signature,
 }
 
 pub struct ModuleTranslationState<'a> {
     /// Imported and local functions
-    /// Stores both the function reference and its signature
-    functions: FxHashMap<FuncIndex, DefinedFunction>,
+    functions: FxHashMap<FuncIndex, CallableFunction>,
     pub module_builder: &'a mut ModuleBuilder,
 }
 
@@ -71,14 +76,33 @@ impl<'a> ModuleTranslationState<'a> {
                 let import = &module.imports[index.as_u32() as usize];
                 let func_id =
                     recover_imported_masm_function_id(import.module.as_str(), &import.field);
-                component_builder.define_import(func_id, sig.clone());
-
-                let root_component = component_builder.component.borrow().name().as_symbol();
-                let path = function_ident_to_sympol_path(root_component, &func_id);
-                let defined_function = DefinedFunction {
-                    wasm_id: func_id,
-                    symbol_path: path,
-                    signature: sig,
+                let defined_function = if is_miden_intrinsics_module(func_id.module.as_symbol())
+                    && intrinsics_conversion_result(&func_id).is_operation()
+                {
+                    CallableFunction {
+                        wasm_id: func_id,
+                        function_ref: None,
+                        signature: sig,
+                    }
+                } else {
+                    let import_module_ref = if let Some(found_module_ref) =
+                        component_builder.find_module(func_id.module.as_symbol())
+                    {
+                        found_module_ref
+                    } else {
+                        component_builder
+                            .define_module(func_id.module)
+                            .expect("failed to create a module for imports")
+                    };
+                    let mut import_module_builder = ModuleBuilder::new(import_module_ref);
+                    let import_func_ref = import_module_builder
+                        .define_function(func_id.function, sig.clone())
+                        .expect("failed to create an import function");
+                    CallableFunction {
+                        wasm_id: func_id,
+                        function_ref: Some(import_func_ref),
+                        signature: sig,
+                    }
                 };
                 functions.insert(index, defined_function);
             } else {
@@ -87,17 +111,15 @@ impl<'a> ModuleTranslationState<'a> {
                     module: Ident::from(module.name().as_str()),
                     function: Ident::from(func_name.as_str()),
                 };
-                let root_component = component_builder.component.borrow().name().as_symbol();
-                let path = function_ident_to_sympol_path(root_component, &func_id);
-                let defined_function = DefinedFunction {
+                let func_ref = module_builder
+                    .define_function(func_id.function, sig.clone())
+                    .expect("adding new function failed");
+                let defined_function = CallableFunction {
                     wasm_id: func_id,
-                    symbol_path: path,
+                    function_ref: Some(func_ref),
                     signature: sig.clone(),
                 };
                 functions.insert(index, defined_function);
-                module_builder
-                    .define_function(func_id.function, sig)
-                    .expect("adding new function failed");
             };
         }
         Self {
@@ -108,80 +130,12 @@ impl<'a> ModuleTranslationState<'a> {
 
     /// Get the `FunctionIdent` that should be used to make a direct call to function
     /// `index`.
-    ///
-    /// Import the callee into `func`'s DFG if it is not already present.
     pub(crate) fn get_direct_func(
         &mut self,
         index: FuncIndex,
         diagnostics: &DiagnosticsHandler,
-    ) -> WasmResult<FunctionRef> {
+    ) -> WasmResult<CallableFunction> {
         let defined_func = self.functions[&index].clone();
-        let symbol_ref = self
-            .module_builder
-            .module
-            .borrow()
-            .resolve(&defined_func.symbol_path)
-            .unwrap_or_else(|| {
-                panic!("Failed to resolve function {:?}", defined_func);
-            });
-
-        let op = symbol_ref.borrow();
-        let func = op
-            .as_symbol_operation()
-            .downcast_ref::<Function>()
-            .expect("expected resolved symbol to be a Function");
-        let func_ref = func.as_function_ref();
-        Ok(func_ref)
-
-        // let function = symbol_ref.borrow().downcast_ref::<Function>().unwrap().as_symbol_ref();
-        // let (func_id, wasm_sig) = self.functions[&index].clone();
-        // let (func_id, sig) = if is_miden_abi_module(func_id.module.as_symbol()) {
-        //     let func_id = FunctionIdent {
-        //         module: func_id.module,
-        //         function: Ident::from(func_id.function.as_str().replace("-", "_").as_str()),
-        //     };
-        //     let ft =
-        //         miden_abi_function_type(func_id.module.as_symbol(), func_id.function.as_symbol());
-        //     (
-        //         func_id,
-        //         Signature::new(
-        //             ft.params.into_iter().map(AbiParam::new),
-        //             ft.results.into_iter().map(AbiParam::new),
-        //         ),
-        //     )
-        // } else {
-        //     (func_id, wasm_sig.clone())
-        // };
-        //
-        // if is_miden_intrinsics_module(func_id.module.as_symbol()) {
-        //     // Exit and do not import intrinsics functions into the DFG
-        //     return Ok(func_id);
-        // }
-        //
-        // if dfg.get_import(&func_id).is_none() {
-        //     dfg.import_function(func_id.module, func_id.function, sig.clone())
-        //         .map_err(|_e| {
-        //             let message = format!(
-        //                 "Function with name {} in module {} with signature {sig:?} is already \
-        //                  imported (function call) with a different signature",
-        //                 func_id.function, func_id.module
-        //             );
-        //             diagnostics.diagnostic(Severity::Error).with_message(message).into_report()
-        //         })?;
-        // }
-        // Ok(func_id)
+        Ok(defined_func)
     }
-}
-
-fn function_ident_to_sympol_path(
-    root_component: SymbolName,
-    func_id: &FunctionIdent,
-) -> SymbolPath {
-    SymbolPath::new(vec![
-        SymbolNameComponent::Root,
-        SymbolNameComponent::Component(root_component),
-        SymbolNameComponent::Component(func_id.module.as_symbol()),
-        SymbolNameComponent::Leaf(func_id.function.as_symbol()),
-    ])
-    .unwrap()
 }

--- a/hir2/src/dialects/builtin/builders/component.rs
+++ b/hir2/src/dialects/builtin/builders/component.rs
@@ -1,9 +1,8 @@
-use super::ModuleBuilder;
 use crate::{
     dialects::builtin::{
-        ComponentRef, InterfaceRef, ModuleRef, PrimInterfaceBuilder, PrimModuleBuilder,
+        ComponentRef, InterfaceRef, Module, ModuleRef, PrimInterfaceBuilder, PrimModuleBuilder,
     },
-    Builder, FunctionIdent, Ident, Op, OpBuilder, Report, Signature, Spanned, SymbolTable,
+    Builder, Ident, Op, OpBuilder, Report, Spanned, SymbolName, SymbolTable,
 };
 
 pub struct ComponentBuilder {
@@ -49,11 +48,10 @@ impl ComponentBuilder {
         Ok(module_ref)
     }
 
-    pub fn define_import(&mut self, func_id: FunctionIdent, sig: Signature) {
-        let module_ref = self.define_module(func_id.module).expect("failed to define module");
-        let mut module_builder = ModuleBuilder::new(module_ref);
-        module_builder
-            .define_function(func_id.function, sig)
-            .expect("failed to define function");
+    pub fn find_module(&self, name: SymbolName) -> Option<ModuleRef> {
+        self.component.borrow().get(name).and_then(|symbol_ref| {
+            let op = symbol_ref.borrow();
+            op.as_symbol_operation().downcast_ref::<Module>().map(|m| m.as_module_ref())
+        })
     }
 }

--- a/hir2/src/dialects/builtin/ops/module.rs
+++ b/hir2/src/dialects/builtin/ops/module.rs
@@ -74,6 +74,13 @@ pub struct Module {
     uses: SymbolUseList,
 }
 
+impl Module {
+    #[inline(always)]
+    pub fn as_module_ref(&self) -> ModuleRef {
+        unsafe { ModuleRef::from_raw(self) }
+    }
+}
+
 impl RegionKindInterface for Module {
     #[inline(always)]
     fn kind(&self) -> RegionKind {

--- a/tests/integration/expected/felt_intrinsics.hir
+++ b/tests/integration/expected/felt_intrinsics.hir
@@ -1,0 +1,20 @@
+builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+
+    builtin.module  #[name = #felt_intrinsics] #[visibility = public] {
+
+        builtin.function public @entrypoint(v0: felt, v1: felt) -> felt {
+        ^block3(v0: felt, v1: felt):
+            v3 = hir.mul v0, v1 : felt #[overflow = unchecked];
+            v4 = hir.sub v3, v0 : felt #[overflow = unchecked];
+            v5 = hir.add v4, v1 : felt #[overflow = unchecked];
+            v6 = hir.div v0, v5 : felt;
+            hir.br block4 v6;
+        ^block4(v2: felt):
+            hir.ret v2;
+        };
+        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+            hir.ret_imm  #[value = 1048576];
+        };
+    };
+};

--- a/tests/integration/expected/felt_intrinsics.wat
+++ b/tests/integration/expected/felt_intrinsics.wat
@@ -1,0 +1,23 @@
+(module $felt_intrinsics.wasm
+  (type (;0;) (func (param f32 f32) (result f32)))
+  (import "miden:core-import/intrinsics-felt@1.0.0" "mul" (func $miden_stdlib_sys::intrinsics::felt::extern_mul (;0;) (type 0)))
+  (import "miden:core-import/intrinsics-felt@1.0.0" "sub" (func $miden_stdlib_sys::intrinsics::felt::extern_sub (;1;) (type 0)))
+  (import "miden:core-import/intrinsics-felt@1.0.0" "add" (func $miden_stdlib_sys::intrinsics::felt::extern_add (;2;) (type 0)))
+  (import "miden:core-import/intrinsics-felt@1.0.0" "div" (func $miden_stdlib_sys::intrinsics::felt::extern_div (;3;) (type 0)))
+  (func $entrypoint (;4;) (type 0) (param f32 f32) (result f32)
+    local.get 0
+    local.get 0
+    local.get 1
+    call $miden_stdlib_sys::intrinsics::felt::extern_mul
+    local.get 0
+    call $miden_stdlib_sys::intrinsics::felt::extern_sub
+    local.get 1
+    call $miden_stdlib_sys::intrinsics::felt::extern_add
+    call $miden_stdlib_sys::intrinsics::felt::extern_div
+  )
+  (table (;0;) 1 1 funcref)
+  (memory (;0;) 16)
+  (global $__stack_pointer (;0;) (mut i32) i32.const 1048576)
+  (export "memory" (memory 0))
+  (export "entrypoint" (func $entrypoint))
+)

--- a/tools/cargo-miden/src/commands/new_project.rs
+++ b/tools/cargo-miden/src/commands/new_project.rs
@@ -4,7 +4,11 @@ use anyhow::Context;
 use cargo_generate::{GenerateArgs, TemplatePath};
 use clap::Args;
 
-const TEMPLATES_REPO_TAG: &str = "v0.6.0";
+/// The tag used in checkout of the new project template.
+///
+/// Before changing it make sure the new tag exists in the rust-templates repo and points to the
+/// desired commit.
+const TEMPLATES_REPO_TAG: &str = "v0.7.0";
 
 // This should have been an enum but I could not bend `clap` to expose variants as flags
 /// Project template


### PR DESCRIPTION
#363 

This PR implements felt intrinsics translation and switch `cargo miden new` to v0.7.0 tag with program template using Felts instead of u32 (added in https://github.com/0xPolygonMiden/rust-templates/pull/9)