### PR TITLE
[2/x] feature(frontend): translate Wasm `if-else` op

### DIFF
--- a/frontend-wasm2/src/code_translator/mod.rs
+++ b/frontend-wasm2/src/code_translator/mod.rs
@@ -184,7 +184,7 @@ pub fn translate_operator(
             type_index: _,
             table_index: _,
         } => {
-            // TODO:
+            todo!("CallIndirect is not supported yet");
         }
         /******************************* Memory management *********************************/
         Operator::MemoryGrow { .. } => {

--- a/frontend-wasm2/src/code_translator/mod.rs
+++ b/frontend-wasm2/src/code_translator/mod.rs
@@ -938,71 +938,78 @@ fn translate_else(
     builder: &mut FunctionBuilderExt,
     span: SourceSpan,
 ) -> WasmResult<()> {
-    todo!()
-    // let i = state.control_stack.len() - 1;
-    // match state.control_stack[i] {
-    //     ControlStackFrame::If {
-    //         ref else_data,
-    //         head_is_reachable,
-    //         ref mut consequent_ends_reachable,
-    //         num_return_values,
-    //         ref blocktype,
-    //         destination,
-    //         ..
-    //     } => {
-    //         // We finished the consequent, so record its final
-    //         // reachability state.
-    //         debug_assert!(consequent_ends_reachable.is_none());
-    //         *consequent_ends_reachable = Some(state.reachable);
-    //
-    //         if head_is_reachable {
-    //             // We have a branch from the head of the `if` to the `else`.
-    //             state.reachable = true;
-    //
-    //             // Ensure we have a block for the `else` block (it may have
-    //             // already been pre-allocated, see `ElseData` for details).
-    //             let else_block = match *else_data {
-    //                 ElseData::NoElse {
-    //                     branch_inst,
-    //                     placeholder,
-    //                 } => {
-    //                     debug_assert_eq!(blocktype.params.len(), num_return_values);
-    //                     let else_block =
-    //                         builder.create_block_with_params(blocktype.params.clone(), span);
-    //                     let params_len = blocktype.params.len();
-    //                     builder.ins().br(destination, state.peekn(params_len), span);
-    //                     state.popn(params_len);
-    //
-    //                     builder.change_jump_destination(branch_inst, placeholder, else_block);
-    //                     builder.seal_block(else_block);
-    //                     else_block
-    //                 }
-    //                 ElseData::WithElse { else_block } => {
-    //                     builder.ins().br(destination, state.peekn(num_return_values), span);
-    //                     state.popn(num_return_values);
-    //                     else_block
-    //                 }
-    //             };
-    //
-    //             // You might be expecting that we push the parameters for this
-    //             // `else` block here, something like this:
-    //             //
-    //             //     state.pushn(&control_stack_frame.params);
-    //             //
-    //             // We don't do that because they are already on the top of the stack
-    //             // for us: we pushed the parameters twice when we saw the initial
-    //             // `if` so that we wouldn't have to save the parameters in the
-    //             // `ControlStackFrame` as another `Vec` allocation.
-    //
-    //             builder.switch_to_block(else_block);
-    //
-    //             // We don't bother updating the control frame's `ElseData`
-    //             // to `WithElse` because nothing else will read it.
-    //         }
-    //     }
-    //     _ => unreachable!(),
-    // };
-    // Ok(())
+    let i = state.control_stack.len() - 1;
+    match state.control_stack[i] {
+        ControlStackFrame::If {
+            ref else_data,
+            head_is_reachable,
+            ref mut consequent_ends_reachable,
+            num_return_values,
+            ref blocktype,
+            destination,
+            ..
+        } => {
+            // We finished the consequent, so record its final
+            // reachability state.
+            debug_assert!(consequent_ends_reachable.is_none());
+            *consequent_ends_reachable = Some(state.reachable);
+
+            if head_is_reachable {
+                // We have a branch from the head of the `if` to the `else`.
+                state.reachable = true;
+
+                // Ensure we have a block for the `else` block (it may have
+                // already been pre-allocated, see `ElseData` for details).
+                let else_block = match *else_data {
+                    ElseData::NoElse {
+                        branch_inst,
+                        placeholder,
+                    } => {
+                        debug_assert_eq!(blocktype.params.len(), num_return_values);
+                        let else_block =
+                            builder.create_block_with_params(blocktype.params.clone(), span);
+                        let params_len = blocktype.params.len();
+                        builder.ins().br(
+                            destination,
+                            state.peekn(params_len).iter().copied(),
+                            span,
+                        );
+                        state.popn(params_len);
+
+                        builder.change_jump_destination(branch_inst, placeholder, else_block);
+                        builder.seal_block(else_block);
+                        else_block
+                    }
+                    ElseData::WithElse { else_block } => {
+                        builder.ins().br(
+                            destination,
+                            state.peekn(num_return_values).iter().copied(),
+                            span,
+                        );
+                        state.popn(num_return_values);
+                        else_block
+                    }
+                };
+
+                // You might be expecting that we push the parameters for this
+                // `else` block here, something like this:
+                //
+                //     state.pushn(&control_stack_frame.params);
+                //
+                // We don't do that because they are already on the top of the stack
+                // for us: we pushed the parameters twice when we saw the initial
+                // `if` so that we wouldn't have to save the parameters in the
+                // `ControlStackFrame` as another `Vec` allocation.
+
+                builder.switch_to_block(else_block);
+
+                // We don't bother updating the control frame's `ElseData`
+                // to `WithElse` because nothing else will read it.
+            }
+        }
+        _ => unreachable!(),
+    };
+    Ok(())
 }
 
 fn translate_if(
@@ -1013,55 +1020,60 @@ fn translate_if(
     diagnostics: &DiagnosticsHandler,
     span: SourceSpan,
 ) -> WasmResult<()> {
-    todo!()
-    // let blockty = BlockType::from_wasm(blockty, mod_types, diagnostics)?;
-    // let cond = state.pop1();
-    // // cond is expected to be a i32 value
-    // let cond_i1 = builder.ins().neq_imm(cond, Immediate::I32(0), span);
-    // let next_block = builder.create_block();
-    // let (destination, else_data) = if blockty.params.eq(&blockty.results) {
-    //     // It is possible there is no `else` block, so we will only
-    //     // allocate a block for it if/when we find the `else`. For now,
-    //     // we if the condition isn't true, then we jump directly to the
-    //     // destination block following the whole `if...end`. If we do end
-    //     // up discovering an `else`, then we will allocate a block for it
-    //     // and go back and patch the jump.
-    //     let destination = builder.create_block_with_params(blockty.results.clone(), span);
-    //     let branch_inst = builder.ins().cond_br(
-    //         cond_i1,
-    //         next_block,
-    //         &[],
-    //         destination,
-    //         state.peekn(blockty.params.len()),
-    //         span,
-    //     );
-    //     (
-    //         destination,
-    //         ElseData::NoElse {
-    //             branch_inst,
-    //             placeholder: destination,
-    //         },
-    //     )
-    // } else {
-    //     // The `if` type signature is not valid without an `else` block,
-    //     // so we eagerly allocate the `else` block here.
-    //     let destination = builder.create_block_with_params(blockty.results.clone(), span);
-    //     let else_block = builder.create_block_with_params(blockty.params.clone(), span);
-    //     builder.ins().cond_br(
-    //         cond_i1,
-    //         next_block,
-    //         &[],
-    //         else_block,
-    //         state.peekn(blockty.params.len()),
-    //         span,
-    //     );
-    //     builder.seal_block(else_block);
-    //     (destination, ElseData::WithElse { else_block })
-    // };
-    // builder.seal_block(next_block);
-    // builder.switch_to_block(next_block);
-    // state.push_if(destination, else_data, blockty.params.len(), blockty.results.len(), blockty);
-    // Ok(())
+    let blockty = BlockType::from_wasm(blockty, mod_types, diagnostics)?;
+    let cond = state.pop1();
+    // cond is expected to be a i32 value
+    let imm = builder.ins().imm(Immediate::I32(0), span);
+    let cond_i1 = builder.ins().neq(cond, imm, span)?;
+    let next_block = builder.create_block();
+    let (destination, else_data) = if blockty.params.eq(&blockty.results) {
+        // It is possible there is no `else` block, so we will only
+        // allocate a block for it if/when we find the `else`. For now,
+        // we if the condition isn't true, then we jump directly to the
+        // destination block following the whole `if...end`. If we do end
+        // up discovering an `else`, then we will allocate a block for it
+        // and go back and patch the jump.
+        let destination = builder.create_block_with_params(blockty.results.clone(), span);
+        let branch_inst = builder
+            .ins()
+            .cond_br(
+                cond_i1,
+                next_block,
+                [],
+                destination,
+                state.peekn(blockty.params.len()).iter().copied(),
+                span,
+            )?
+            .borrow()
+            .as_ref()
+            .as_operation_ref();
+        (
+            destination,
+            ElseData::NoElse {
+                branch_inst,
+                placeholder: destination,
+            },
+        )
+    } else {
+        // The `if` type signature is not valid without an `else` block,
+        // so we eagerly allocate the `else` block here.
+        let destination = builder.create_block_with_params(blockty.results.clone(), span);
+        let else_block = builder.create_block_with_params(blockty.params.clone(), span);
+        builder.ins().cond_br(
+            cond_i1,
+            next_block,
+            [],
+            else_block,
+            state.peekn(blockty.params.len()).iter().copied(),
+            span,
+        )?;
+        builder.seal_block(else_block);
+        (destination, ElseData::WithElse { else_block })
+    };
+    builder.seal_block(next_block);
+    builder.switch_to_block(next_block);
+    state.push_if(destination, else_data, blockty.params.len(), blockty.results.len(), blockty);
+    Ok(())
 }
 
 fn translate_loop(

--- a/frontend-wasm2/src/code_translator/tests.rs
+++ b/frontend-wasm2/src/code_translator/tests.rs
@@ -1,6 +1,3 @@
-// TODO: remove when completed
-#![allow(unused)]
-
 use core::fmt::Write;
 use std::{any::Any, rc::Rc};
 
@@ -2071,6 +2068,40 @@ fn select_i32() {
                 hir.br block3 ;
             ^block3:
                 hir.ret ;
+            };
+        "#]],
+    )
+}
+
+#[test]
+fn if_else() {
+    check_op(
+        r#"
+        i32.const 2
+        if (result i32)
+            i32.const 3
+        else
+            i32.const 5
+        end
+        drop
+    "#,
+        expect![[r#"
+            builtin.function public @test_wrapper() {
+            ^block2:
+                v0 = hir.constant 2 : i32;
+                v1 = hir.constant 0 : i32;
+                v2 = hir.neq v0, v1 : i1;
+                hir.cond_br block4, block6 v2;
+            ^block3:
+                hir.ret ;
+            ^block4:
+                v4 = hir.constant 3 : i32;
+                hir.br block5 v4;
+            ^block5(v3: i32):
+                hir.br block3 ;
+            ^block6:
+                v5 = hir.constant 5 : i32;
+                hir.br block5 v5;
             };
         "#]],
     )

--- a/frontend-wasm2/src/module/build_ir.rs
+++ b/frontend-wasm2/src/module/build_ir.rs
@@ -1,6 +1,3 @@
-// TODO: remove when completed
-#![allow(unused)]
-
 use core::mem;
 use std::rc::Rc;
 
@@ -56,7 +53,6 @@ pub fn translate_module_as_component(
     }
     let module_types = module_types_builder.finish();
 
-    // TODO: get proper ns and name (from exported interfaces?)
     let ns = Ident::from("root_ns");
     let name = Ident::from("root");
     let ver = Version::parse("1.0.0").unwrap();
@@ -80,30 +76,6 @@ pub fn translate_module_as_component(
         &context.session.diagnostics,
     );
     build_ir_module(&mut parsed_module, &module_types, &mut module_state, config, context)?;
-
-    // TODO: translate core module imports (create empty Components?)
-    //
-    // let mut cb = midenc_hir::ComponentBuilder::new(&context.session.diagnostics);
-    // let module_imports = module.imports();
-    // for import_module_id in module_imports.iter_module_names() {
-    //     if let Some(imports) = module_imports.imported(import_module_id) {
-    //         for ext_func in imports {
-    //             if is_miden_intrinsics_module(ext_func.module.as_symbol()) {
-    //                 // ignore intrinsics imports
-    //                 continue;
-    //             }
-    //             let function_ty = miden_abi_function_type(
-    //                 ext_func.module.as_symbol(),
-    //                 ext_func.function.as_symbol(),
-    //             );
-    //             let component_import =
-    //                 midenc_hir::ComponentImport::MidenAbiImport(MidenAbiImport::new(function_ty));
-    //             cb.add_import(*ext_func, component_import);
-    //         }
-    //     }
-    // }
-    // cb.add_module(module.into()).expect("module is already added");
-
     Ok(component_ref)
 }
 

--- a/frontend-wasm2/src/module/mod.rs
+++ b/frontend-wasm2/src/module/mod.rs
@@ -1,8 +1,5 @@
 //! Data structures for representing parsed Wasm modules.
 
-// TODO: remove this once Wasm CM support is complete
-#![allow(dead_code)]
-
 use std::{borrow::Cow, collections::BTreeMap, ops::Range};
 
 use indexmap::IndexMap;


### PR DESCRIPTION
#363 

**This PR is stacked on the #398 and should be merged after it.**

This PR adds translation for the Wasm `if-else` op and concludes the implementation of all the missing Wasm ops that were implemented in the old frontend(IR).