### PR TITLE
[2/x] chore: update `cargo miden new` to use `v0.8.0` of the program template

### DIFF
--- a/examples/collatz/src/lib.rs
+++ b/examples/collatz/src/lib.rs
@@ -12,6 +12,7 @@
 // static ALLOC: BumpAlloc = miden::BumpAlloc::new();
 
 // Required for no-std crates
+#[cfg(not(test))]
 #[panic_handler]
 fn my_panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}

--- a/examples/fibonacci/src/lib.rs
+++ b/examples/fibonacci/src/lib.rs
@@ -13,6 +13,7 @@
 
 // Required for no-std crates
 #[panic_handler]
+#[cfg(not(test))]
 fn my_panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}
 }

--- a/tools/cargo-miden/src/commands/new_project.rs
+++ b/tools/cargo-miden/src/commands/new_project.rs
@@ -8,7 +8,7 @@ use clap::Args;
 ///
 /// Before changing it make sure the new tag exists in the rust-templates repo and points to the
 /// desired commit.
-const TEMPLATES_REPO_TAG: &str = "v0.7.0";
+const TEMPLATES_REPO_TAG: &str = "v0.8.0";
 
 // This should have been an enum but I could not bend `clap` to expose variants as flags
 /// Project template


### PR DESCRIPTION

**This PR is stacked on the #407 and should be merged after it**

Corresponding PR - https://github.com/0xPolygonMiden/rust-templates/pull/10