### PR TITLE
[1/x] feature(frontend): generate synthetic functions with Miden ABI transformation (stdlib, tx_kernel);

### DIFF
--- a/tests/integration/expected/abi_transform_stdlib_blake3_hash.hir
+++ b/tests/integration/expected/abi_transform_stdlib_blake3_hash.hir
@@ -1,131 +1,161 @@
-(component 
-    ;; Modules
-    (module #abi_transform_stdlib_blake3_hash
-        ;; Constants
-        (const (id 0) 0x00100000)
+builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        ;; Global Variables
-        (global (export #__stack_pointer) (id 0) (type i32) (const 0))
+    builtin.module  #[name = #abi_transform_stdlib_blake3_hash] #[visibility = public] {
 
-        ;; Functions
-        (func (export #entrypoint) (param i32) (param i32)
-            (block 0 (param v0 i32) (param v1 i32)
-                (let (v2 i32) (const.i32 0))
-                (let (v3 i32) (global.load i32 (global.symbol #__stack_pointer)))
-                (let (v4 i32) (const.i32 32))
-                (let (v5 i32) (sub.wrapping v3 v4))
-                (let (v6 i32) (const.i32 -32))
-                (let (v7 i32) (band v5 v6))
-                (let (v8 (ptr i32)) (global.symbol #__stack_pointer))
-                (store v8 v7)
-                (let (v9 u32) (bitcast v1))
-                (let (v10 (ptr i32)) (inttoptr v9))
-                (let (v11 i32) (load v10))
-                (let (v12 u32) (bitcast v1))
-                (let (v13 u32) (add.checked v12 4))
-                (let (v14 (ptr i32)) (inttoptr v13))
-                (let (v15 i32) (load v14))
-                (let (v16 u32) (bitcast v1))
-                (let (v17 u32) (add.checked v16 8))
-                (let (v18 (ptr i32)) (inttoptr v17))
-                (let (v19 i32) (load v18))
-                (let (v20 u32) (bitcast v1))
-                (let (v21 u32) (add.checked v20 12))
-                (let (v22 (ptr i32)) (inttoptr v21))
-                (let (v23 i32) (load v22))
-                (let (v24 u32) (bitcast v1))
-                (let (v25 u32) (add.checked v24 16))
-                (let (v26 (ptr i32)) (inttoptr v25))
-                (let (v27 i32) (load v26))
-                (let (v28 u32) (bitcast v1))
-                (let (v29 u32) (add.checked v28 20))
-                (let (v30 (ptr i32)) (inttoptr v29))
-                (let (v31 i32) (load v30))
-                (let (v32 u32) (bitcast v1))
-                (let (v33 u32) (add.checked v32 24))
-                (let (v34 (ptr i32)) (inttoptr v33))
-                (let (v35 i32) (load v34))
-                (let (v36 u32) (bitcast v1))
-                (let (v37 u32) (add.checked v36 28))
-                (let (v38 (ptr i32)) (inttoptr v37))
-                (let (v39 i32) (load v38))
-                (let [(v40 i32) (v41 i32) (v42 i32) (v43 i32) (v44 i32) (v45 i32) (v46 i32) (v47 i32)] (call (#std::crypto::hashes::blake3 #hash_1to1) v11 v15 v19 v23 v27 v31 v35 v39))
-                (let (v48 u32) (bitcast v7))
-                (let (v49 (ptr i32)) (inttoptr v48))
-                (store v49 v40)
-                (let (v50 u32) (add.checked v48 4))
-                (let (v51 (ptr i32)) (inttoptr v50))
-                (store v51 v41)
-                (let (v52 u32) (add.checked v48 8))
-                (let (v53 (ptr i32)) (inttoptr v52))
-                (store v53 v42)
-                (let (v54 u32) (add.checked v48 12))
-                (let (v55 (ptr i32)) (inttoptr v54))
-                (store v55 v43)
-                (let (v56 u32) (add.checked v48 16))
-                (let (v57 (ptr i32)) (inttoptr v56))
-                (store v57 v44)
-                (let (v58 u32) (add.checked v48 20))
-                (let (v59 (ptr i32)) (inttoptr v58))
-                (store v59 v45)
-                (let (v60 u32) (add.checked v48 24))
-                (let (v61 (ptr i32)) (inttoptr v60))
-                (store v61 v46)
-                (let (v62 u32) (add.checked v48 28))
-                (let (v63 (ptr i32)) (inttoptr v62))
-                (store v63 v47)
-                (let (v64 i32) (const.i32 24))
-                (let (v65 i32) (add.wrapping v0 v64))
-                (let (v66 u32) (bitcast v7))
-                (let (v67 u32) (add.checked v66 24))
-                (let (v68 u32) (mod.unchecked v67 8))
-                (assertz 250 v68)
-                (let (v69 (ptr i64)) (inttoptr v67))
-                (let (v70 i64) (load v69))
-                (let (v71 u32) (bitcast v65))
-                (let (v72 (ptr i64)) (inttoptr v71))
-                (store v72 v70)
-                (let (v73 i32) (const.i32 16))
-                (let (v74 i32) (add.wrapping v0 v73))
-                (let (v75 u32) (bitcast v7))
-                (let (v76 u32) (add.checked v75 16))
-                (let (v77 u32) (mod.unchecked v76 8))
-                (assertz 250 v77)
-                (let (v78 (ptr i64)) (inttoptr v76))
-                (let (v79 i64) (load v78))
-                (let (v80 u32) (bitcast v74))
-                (let (v81 (ptr i64)) (inttoptr v80))
-                (store v81 v79)
-                (let (v82 i32) (const.i32 8))
-                (let (v83 i32) (add.wrapping v0 v82))
-                (let (v84 u32) (bitcast v7))
-                (let (v85 u32) (add.checked v84 8))
-                (let (v86 u32) (mod.unchecked v85 8))
-                (assertz 250 v86)
-                (let (v87 (ptr i64)) (inttoptr v85))
-                (let (v88 i64) (load v87))
-                (let (v89 u32) (bitcast v83))
-                (let (v90 (ptr i64)) (inttoptr v89))
-                (store v90 v88)
-                (let (v91 u32) (bitcast v7))
-                (let (v92 u32) (mod.unchecked v91 8))
-                (assertz 250 v92)
-                (let (v93 (ptr i64)) (inttoptr v91))
-                (let (v94 i64) (load v93))
-                (let (v95 u32) (bitcast v0))
-                (let (v96 (ptr i64)) (inttoptr v95))
-                (store v96 v94)
-                (let (v97 (ptr i32)) (global.symbol #__stack_pointer))
-                (store v97 v3)
-                (br (block 1)))
+        builtin.function public @miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32, v8: i32) {
+        ^block2(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32, v8: i32):
+            v9, v10, v11, v12, v13, v14, v15, v16 = hir.exec v0, v1, v2, v3, v4, v5, v6, v7 : i32, i32, i32, i32, i32, i32, i32, i32 #[callee = root/std::crypto::hashes::blake3/hash_1to1] #[signature = (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (result i32 i32 i32 i32 i32 i32 i32 i32)];
+            v17 = hir.bitcast v8 : u32 #[ty = u32];
+            v18 = hir.int_to_ptr v17 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v18, v9;
+            v19 = hir.constant 4 : u32;
+            v20 = hir.add v17, v19 : u32 #[overflow = checked];
+            v21 = hir.int_to_ptr v20 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v21, v10;
+            v22 = hir.constant 8 : u32;
+            v23 = hir.add v17, v22 : u32 #[overflow = checked];
+            v24 = hir.int_to_ptr v23 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v24, v11;
+            v25 = hir.constant 12 : u32;
+            v26 = hir.add v17, v25 : u32 #[overflow = checked];
+            v27 = hir.int_to_ptr v26 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v27, v12;
+            v28 = hir.constant 16 : u32;
+            v29 = hir.add v17, v28 : u32 #[overflow = checked];
+            v30 = hir.int_to_ptr v29 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v30, v13;
+            v31 = hir.constant 20 : u32;
+            v32 = hir.add v17, v31 : u32 #[overflow = checked];
+            v33 = hir.int_to_ptr v32 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v33, v14;
+            v34 = hir.constant 24 : u32;
+            v35 = hir.add v17, v34 : u32 #[overflow = checked];
+            v36 = hir.int_to_ptr v35 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v36, v15;
+            v37 = hir.constant 28 : u32;
+            v38 = hir.add v17, v37 : u32 #[overflow = checked];
+            v39 = hir.int_to_ptr v38 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v39, v16;
+            hir.br block4 ;
+        ^block4:
+            hir.ret ;
+        };
+        builtin.function public @entrypoint(v40: i32, v41: i32) {
+        ^block6(v40: i32, v41: i32):
+            v42 = hir.constant 0 : i32;
+            v43 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_stdlib_blake3_hash/__stack_pointer];
+            v44 = hir.bitcast v43 : (ptr i32) #[ty = (ptr i32)];
+            v45 = hir.load v44 : i32;
+            v46 = hir.constant 32 : i32;
+            v47 = hir.sub v45, v46 : i32 #[overflow = wrapping];
+            v48 = hir.constant -32 : i32;
+            v49 = hir.band v47, v48 : i32;
+            v50 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_stdlib_blake3_hash/__stack_pointer];
+            v51 = hir.bitcast v50 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v51, v49;
+            v52 = hir.bitcast v41 : u32 #[ty = u32];
+            v53 = hir.int_to_ptr v52 : (ptr i32) #[ty = (ptr i32)];
+            v54 = hir.load v53 : i32;
+            v55 = hir.bitcast v41 : u32 #[ty = u32];
+            v56 = hir.constant 4 : u32;
+            v57 = hir.add v55, v56 : u32 #[overflow = checked];
+            v58 = hir.int_to_ptr v57 : (ptr i32) #[ty = (ptr i32)];
+            v59 = hir.load v58 : i32;
+            v60 = hir.bitcast v41 : u32 #[ty = u32];
+            v61 = hir.constant 8 : u32;
+            v62 = hir.add v60, v61 : u32 #[overflow = checked];
+            v63 = hir.int_to_ptr v62 : (ptr i32) #[ty = (ptr i32)];
+            v64 = hir.load v63 : i32;
+            v65 = hir.bitcast v41 : u32 #[ty = u32];
+            v66 = hir.constant 12 : u32;
+            v67 = hir.add v65, v66 : u32 #[overflow = checked];
+            v68 = hir.int_to_ptr v67 : (ptr i32) #[ty = (ptr i32)];
+            v69 = hir.load v68 : i32;
+            v70 = hir.bitcast v41 : u32 #[ty = u32];
+            v71 = hir.constant 16 : u32;
+            v72 = hir.add v70, v71 : u32 #[overflow = checked];
+            v73 = hir.int_to_ptr v72 : (ptr i32) #[ty = (ptr i32)];
+            v74 = hir.load v73 : i32;
+            v75 = hir.bitcast v41 : u32 #[ty = u32];
+            v76 = hir.constant 20 : u32;
+            v77 = hir.add v75, v76 : u32 #[overflow = checked];
+            v78 = hir.int_to_ptr v77 : (ptr i32) #[ty = (ptr i32)];
+            v79 = hir.load v78 : i32;
+            v80 = hir.bitcast v41 : u32 #[ty = u32];
+            v81 = hir.constant 24 : u32;
+            v82 = hir.add v80, v81 : u32 #[overflow = checked];
+            v83 = hir.int_to_ptr v82 : (ptr i32) #[ty = (ptr i32)];
+            v84 = hir.load v83 : i32;
+            v85 = hir.bitcast v41 : u32 #[ty = u32];
+            v86 = hir.constant 28 : u32;
+            v87 = hir.add v85, v86 : u32 #[overflow = checked];
+            v88 = hir.int_to_ptr v87 : (ptr i32) #[ty = (ptr i32)];
+            v89 = hir.load v88 : i32;
+            hir.exec v54, v59, v64, v69, v74, v79, v84, v89, v49 #[callee = root/abi_transform_stdlib_blake3_hash/miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1] #[signature = (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32)];
+            v90 = hir.constant 24 : i32;
+            v91 = hir.add v40, v90 : i32 #[overflow = wrapping];
+            v92 = hir.bitcast v49 : u32 #[ty = u32];
+            v93 = hir.constant 24 : u32;
+            v94 = hir.add v92, v93 : u32 #[overflow = checked];
+            v95 = hir.constant 8 : u32;
+            v96 = hir.mod v94, v95 : u32;
+            hir.assertz v96 #[code = 250];
+            v97 = hir.int_to_ptr v94 : (ptr i64) #[ty = (ptr i64)];
+            v98 = hir.load v97 : i64;
+            v99 = hir.bitcast v91 : u32 #[ty = u32];
+            v100 = hir.int_to_ptr v99 : (ptr i64) #[ty = (ptr i64)];
+            hir.store v100, v98;
+            v101 = hir.constant 16 : i32;
+            v102 = hir.add v40, v101 : i32 #[overflow = wrapping];
+            v103 = hir.bitcast v49 : u32 #[ty = u32];
+            v104 = hir.constant 16 : u32;
+            v105 = hir.add v103, v104 : u32 #[overflow = checked];
+            v106 = hir.constant 8 : u32;
+            v107 = hir.mod v105, v106 : u32;
+            hir.assertz v107 #[code = 250];
+            v108 = hir.int_to_ptr v105 : (ptr i64) #[ty = (ptr i64)];
+            v109 = hir.load v108 : i64;
+            v110 = hir.bitcast v102 : u32 #[ty = u32];
+            v111 = hir.int_to_ptr v110 : (ptr i64) #[ty = (ptr i64)];
+            hir.store v111, v109;
+            v112 = hir.constant 8 : i32;
+            v113 = hir.add v40, v112 : i32 #[overflow = wrapping];
+            v114 = hir.bitcast v49 : u32 #[ty = u32];
+            v115 = hir.constant 8 : u32;
+            v116 = hir.add v114, v115 : u32 #[overflow = checked];
+            v117 = hir.constant 8 : u32;
+            v118 = hir.mod v116, v117 : u32;
+            hir.assertz v118 #[code = 250];
+            v119 = hir.int_to_ptr v116 : (ptr i64) #[ty = (ptr i64)];
+            v120 = hir.load v119 : i64;
+            v121 = hir.bitcast v113 : u32 #[ty = u32];
+            v122 = hir.int_to_ptr v121 : (ptr i64) #[ty = (ptr i64)];
+            hir.store v122, v120;
+            v123 = hir.bitcast v49 : u32 #[ty = u32];
+            v124 = hir.constant 8 : u32;
+            v125 = hir.mod v123, v124 : u32;
+            hir.assertz v125 #[code = 250];
+            v126 = hir.int_to_ptr v123 : (ptr i64) #[ty = (ptr i64)];
+            v127 = hir.load v126 : i64;
+            v128 = hir.bitcast v40 : u32 #[ty = u32];
+            v129 = hir.int_to_ptr v128 : (ptr i64) #[ty = (ptr i64)];
+            hir.store v129, v127;
+            v130 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_stdlib_blake3_hash/__stack_pointer];
+            v131 = hir.bitcast v130 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v131, v45;
+            hir.br block7 ;
+        ^block7:
+            hir.ret ;
+        };
+        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            (block 1
-                (ret))
-        )
+            hir.ret_imm  #[value = 1048576];
+        };
+    };
+    builtin.module  #[name = #std::crypto::hashes::blake3] #[visibility = public] {
 
-        ;; Imports
-        (func (import #std::crypto::hashes::blake3 #hash_1to1)
-              (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (result i32 i32 i32 i32 i32 i32 i32 i32))
-    )
+        builtin.function public @hash_1to1(param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (result i32 i32 i32 i32 i32 i32 i32 i32) {
 
-)
+        };
+    };
+};

--- a/tests/integration/expected/abi_transform_tx_kernel_get_id.hir
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_id.hir
@@ -1,0 +1,37 @@
+builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+
+    builtin.module  #[name = #abi_transform_tx_kernel_get_id] #[visibility = public] {
+
+        builtin.function public @miden_base_sys::bindings::account::extern_account_get_id() -> felt {
+        ^block2:
+            v0 = hir.exec  : felt #[callee = root/miden::account/get_id] #[signature = (result felt)];
+            hir.br block4 v0;
+        ^block4(v1: felt):
+            hir.ret ;
+        };
+        builtin.function public @entrypoint() -> felt {
+        ^block6:
+            v3 = hir.exec  : felt #[callee = root/abi_transform_tx_kernel_get_id/miden_base_sys::bindings::account::get_id] #[signature = (result felt)];
+            hir.br block7 v3;
+        ^block7(v2: felt):
+            hir.ret v2;
+        };
+        builtin.function public @miden_base_sys::bindings::account::get_id() -> felt {
+        ^block8:
+            v5 = hir.exec  : felt #[callee = root/abi_transform_tx_kernel_get_id/miden_base_sys::bindings::account::extern_account_get_id] #[signature = (result felt)];
+            hir.br block9 v5;
+        ^block9(v4: felt):
+            hir.ret v4;
+        };
+        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+            hir.ret_imm  #[value = 1048576];
+        };
+    };
+    builtin.module  #[name = #miden::account] #[visibility = public] {
+
+        builtin.function public @get_id(result felt) {
+
+        };
+    };
+};

--- a/tests/integration/expected/abi_transform_tx_kernel_get_id.wat
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_id.wat
@@ -1,0 +1,15 @@
+(module $abi_transform_tx_kernel_get_id.wasm
+  (type (;0;) (func (result f32)))
+  (import "miden:core-import/account@1.0.0" "get-id" (func $miden_base_sys::bindings::account::extern_account_get_id (;0;) (type 0)))
+  (func $entrypoint (;1;) (type 0) (result f32)
+    call $miden_base_sys::bindings::account::get_id
+  )
+  (func $miden_base_sys::bindings::account::get_id (;2;) (type 0) (result f32)
+    call $miden_base_sys::bindings::account::extern_account_get_id
+  )
+  (table (;0;) 1 1 funcref)
+  (memory (;0;) 16)
+  (global $__stack_pointer (;0;) (mut i32) i32.const 1048576)
+  (export "memory" (memory 0))
+  (export "entrypoint" (func $entrypoint))
+)

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.hir
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.hir
@@ -1,527 +1,556 @@
-(component 
-    ;; Modules
-    (module #abi_transform_tx_kernel_get_inputs_4
-        ;; Data Segments
-        (data (mut) (offset 1048576) 0x2e2e2f2e2e2f73646b2f626173652d7379732f7372632f62696e64696e67732f6e6f74652e72730000001000270000001100000021000000)
+builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        ;; Constants
-        (const (id 0) 0x00100000)
+    builtin.module  #[name = #abi_transform_tx_kernel_get_inputs_4] #[visibility = public] {
 
-        ;; Global Variables
-        (global (export #__stack_pointer) (id 0) (type i32) (const 0))
+        builtin.function public @miden_base_sys::bindings::note::extern_note_get_inputs(v0: i32) -> i32 {
+        ^block3(v0: i32):
+            v1, v2 = hir.exec v0 : i32, i32 #[callee = root/miden::note/get_inputs] #[signature = (param i32) (result i32 i32)];
+            hir.br block5 v1;
+        ^block5(v3: i32):
+            hir.ret ;
+        };
+        builtin.function public @entrypoint(v4: i32) {
+        ^block7(v4: i32):
+            hir.exec v4 #[callee = root/abi_transform_tx_kernel_get_inputs_4/miden_base_sys::bindings::note::get_inputs] #[signature = (param i32)];
+            hir.br block8 ;
+        ^block8:
+            hir.ret ;
+        };
+        builtin.function public @__rust_alloc(v5: i32, v6: i32) -> i32 {
+        ^block9(v5: i32, v6: i32):
+            v8 = hir.constant 1048632 : i32;
+            v9 = hir.exec v8, v6, v5 : i32 #[callee = root/abi_transform_tx_kernel_get_inputs_4/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc] #[signature = (param i32) (param i32) (param i32) (result i32)];
+            hir.br block10 v9;
+        ^block10(v7: i32):
+            hir.ret v7;
+        };
+        builtin.function public @__rust_alloc_zeroed(v10: i32, v11: i32) -> i32 {
+        ^block11(v10: i32, v11: i32):
+            v13 = hir.constant 1048632 : i32;
+            v14 = hir.exec v13, v11, v10 : i32 #[callee = root/abi_transform_tx_kernel_get_inputs_4/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc] #[signature = (param i32) (param i32) (param i32) (result i32)];
+            v15 = hir.constant 0 : i32;
+            v16 = hir.eq v14, v15 : i1;
+            v17 = hir.zext v16 : u32 #[ty = u32];
+            v18 = hir.bitcast v17 : i32 #[ty = i32];
+            v19 = hir.constant 0 : i32;
+            v20 = hir.neq v18, v19 : i1;
+            hir.cond_br block13, block14 v20, v14;
+        ^block12(v12: i32):
+            hir.ret v12;
+        ^block13(v26: i32):
+            hir.br block12 v26;
+        ^block14:
+            v21 = hir.constant 0 : i32;
+            v22 = hir.trunc v21 : u8 #[ty = u8];
+            v23 = hir.bitcast v10 : u32 #[ty = u32];
+            v24 = hir.bitcast v14 : u32 #[ty = u32];
+            v25 = hir.int_to_ptr v24 : (ptr u8) #[ty = (ptr u8)];
+            hir.mem_set v25, v23, v22;
+            hir.br block13 v14;
+        };
+        builtin.function public @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v27: i32, v28: i32, v29: i32) -> i32 {
+        ^block15(v27: i32, v28: i32, v29: i32):
+            v31 = hir.constant 0 : i32;
+            v32 = hir.constant 32 : i32;
+            v33 = hir.constant 32 : i32;
+            v34 = hir.bitcast v28 : u32 #[ty = u32];
+            v35 = hir.bitcast v33 : u32 #[ty = u32];
+            v36 = hir.gt v34, v35 : i1;
+            v37 = hir.zext v36 : u32 #[ty = u32];
+            v38 = hir.constant 0 : i32;
+            v39 = hir.neq v37, v38 : i1;
+            v40 = hir.select v39, v28, v32 : i32;
+            v41 = hir.popcnt v40 : u32;
+            v42 = hir.bitcast v41 : i32 #[ty = i32];
+            v43 = hir.constant 1 : i32;
+            v44 = hir.neq v42, v43 : i1;
+            v45 = hir.zext v44 : u32 #[ty = u32];
+            v46 = hir.bitcast v45 : i32 #[ty = i32];
+            v47 = hir.constant 0 : i32;
+            v48 = hir.neq v46, v47 : i1;
+            hir.cond_br block17, block18 v48;
+        ^block16(v30: i32):
 
-        ;; Functions
-        (func (export #entrypoint) (param i32)
-            (block 0 (param v0 i32)
-                (exec #miden_base_sys::bindings::note::get_inputs v0)
-                (br (block 1)))
+        ^block17:
+            hir.unreachable ;
+        ^block18:
+            v49 = hir.constant -2147483648 : i32;
+            v50 = hir.exec v28, v40 : i32 #[callee = root/abi_transform_tx_kernel_get_inputs_4/core::ptr::alignment::Alignment::max] #[signature = (param i32) (param i32) (result i32)];
+            v51 = hir.sub v49, v50 : i32 #[overflow = wrapping];
+            v52 = hir.bitcast v51 : u32 #[ty = u32];
+            v53 = hir.bitcast v29 : u32 #[ty = u32];
+            v54 = hir.lt v52, v53 : i1;
+            v55 = hir.zext v54 : u32 #[ty = u32];
+            v56 = hir.bitcast v55 : i32 #[ty = i32];
+            v57 = hir.constant 0 : i32;
+            v58 = hir.neq v56, v57 : i1;
+            hir.cond_br block17, block19 v58;
+        ^block19:
+            v59 = hir.constant 0 : i32;
+            v60 = hir.add v29, v50 : i32 #[overflow = wrapping];
+            v61 = hir.constant -1 : i32;
+            v62 = hir.add v60, v61 : i32 #[overflow = wrapping];
+            v63 = hir.constant 0 : i32;
+            v64 = hir.sub v63, v50 : i32 #[overflow = wrapping];
+            v65 = hir.band v62, v64 : i32;
+            v66 = hir.bitcast v27 : u32 #[ty = u32];
+            v67 = hir.constant 4 : u32;
+            v68 = hir.mod v66, v67 : u32;
+            hir.assertz v68 #[code = 250];
+            v69 = hir.int_to_ptr v66 : (ptr i32) #[ty = (ptr i32)];
+            v70 = hir.load v69 : i32;
+            v71 = hir.constant 0 : i32;
+            v72 = hir.neq v70, v71 : i1;
+            hir.cond_br block20, block21 v72, v27, v65, v50, v59;
+        ^block20(v85: i32, v92: i32, v105: i32, v108: i32):
+            v84 = hir.constant 268435456 : i32;
+            v86 = hir.bitcast v85 : u32 #[ty = u32];
+            v87 = hir.constant 4 : u32;
+            v88 = hir.mod v86, v87 : u32;
+            hir.assertz v88 #[code = 250];
+            v89 = hir.int_to_ptr v86 : (ptr i32) #[ty = (ptr i32)];
+            v90 = hir.load v89 : i32;
+            v91 = hir.sub v84, v90 : i32 #[overflow = wrapping];
+            v93 = hir.bitcast v91 : u32 #[ty = u32];
+            v94 = hir.bitcast v92 : u32 #[ty = u32];
+            v95 = hir.lt v93, v94 : i1;
+            v96 = hir.zext v95 : u32 #[ty = u32];
+            v97 = hir.bitcast v96 : i32 #[ty = i32];
+            v98 = hir.constant 0 : i32;
+            v99 = hir.neq v97, v98 : i1;
+            hir.cond_br block22, block23 v99, v108;
+        ^block21:
+            v73 = hir.exec  : i32 #[callee = root/intrinsics::mem/heap_base] #[signature = (result i32)];
+            v74 = hir.mem_size  : u32;
+            v75 = hir.constant 16 : i32;
+            v76 = hir.bitcast v75 : u32 #[ty = u32];
+            v77 = hir.shl v74, v76 : u32;
+            v78 = hir.bitcast v77 : i32 #[ty = i32];
+            v79 = hir.add v73, v78 : i32 #[overflow = wrapping];
+            v80 = hir.bitcast v27 : u32 #[ty = u32];
+            v81 = hir.constant 4 : u32;
+            v82 = hir.mod v80, v81 : u32;
+            hir.assertz v82 #[code = 250];
+            v83 = hir.int_to_ptr v80 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v83, v79;
+            hir.br block20 v27, v65, v50, v59;
+        ^block22(v107: i32):
+            hir.ret v107;
+        ^block23:
+            v100 = hir.add v90, v92 : i32 #[overflow = wrapping];
+            v101 = hir.bitcast v85 : u32 #[ty = u32];
+            v102 = hir.constant 4 : u32;
+            v103 = hir.mod v101, v102 : u32;
+            hir.assertz v103 #[code = 250];
+            v104 = hir.int_to_ptr v101 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v104, v100;
+            v106 = hir.add v90, v105 : i32 #[overflow = wrapping];
+            hir.br block22 v106;
+        };
+        builtin.function public @miden_base_sys::bindings::note::get_inputs(v109: i32) {
+        ^block24(v109: i32):
+            v110 = hir.constant 0 : i32;
+            v111 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+            v112 = hir.bitcast v111 : (ptr i32) #[ty = (ptr i32)];
+            v113 = hir.load v112 : i32;
+            v114 = hir.constant 16 : i32;
+            v115 = hir.sub v113, v114 : i32 #[overflow = wrapping];
+            v116 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+            v117 = hir.bitcast v116 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v117, v115;
+            v118 = hir.constant 4 : i32;
+            v119 = hir.add v115, v118 : i32 #[overflow = wrapping];
+            v120 = hir.constant 256 : i32;
+            v121 = hir.constant 0 : i32;
+            v122 = hir.constant 4 : i32;
+            v123 = hir.constant 4 : i32;
+            hir.exec v119, v120, v121, v122, v123 #[callee = root/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::RawVecInner<A>::try_allocate_in] #[signature = (param i32) (param i32) (param i32) (param i32) (param i32)];
+            v124 = hir.bitcast v115 : u32 #[ty = u32];
+            v125 = hir.constant 8 : u32;
+            v126 = hir.add v124, v125 : u32 #[overflow = checked];
+            v127 = hir.constant 4 : u32;
+            v128 = hir.mod v126, v127 : u32;
+            hir.assertz v128 #[code = 250];
+            v129 = hir.int_to_ptr v126 : (ptr i32) #[ty = (ptr i32)];
+            v130 = hir.load v129 : i32;
+            v131 = hir.bitcast v115 : u32 #[ty = u32];
+            v132 = hir.constant 4 : u32;
+            v133 = hir.add v131, v132 : u32 #[overflow = checked];
+            v134 = hir.constant 4 : u32;
+            v135 = hir.mod v133, v134 : u32;
+            hir.assertz v135 #[code = 250];
+            v136 = hir.int_to_ptr v133 : (ptr i32) #[ty = (ptr i32)];
+            v137 = hir.load v136 : i32;
+            v138 = hir.constant 1 : i32;
+            v139 = hir.neq v137, v138 : i1;
+            v140 = hir.zext v139 : u32 #[ty = u32];
+            v141 = hir.bitcast v140 : i32 #[ty = i32];
+            v142 = hir.constant 0 : i32;
+            v143 = hir.neq v141, v142 : i1;
+            hir.cond_br block26, block27 v143;
+        ^block25:
+            hir.ret ;
+        ^block26:
+            v152 = hir.bitcast v115 : u32 #[ty = u32];
+            v153 = hir.constant 12 : u32;
+            v154 = hir.add v152, v153 : u32 #[overflow = checked];
+            v155 = hir.constant 4 : u32;
+            v156 = hir.mod v154, v155 : u32;
+            hir.assertz v156 #[code = 250];
+            v157 = hir.int_to_ptr v154 : (ptr i32) #[ty = (ptr i32)];
+            v158 = hir.load v157 : i32;
+            v159 = hir.constant 4 : i32;
+            v160 = hir.bitcast v158 : u32 #[ty = u32];
+            v161 = hir.bitcast v159 : u32 #[ty = u32];
+            v162 = hir.shr v160, v161 : u32;
+            v163 = hir.bitcast v162 : i32 #[ty = i32];
+            v164 = hir.exec v163 : i32 #[callee = root/abi_transform_tx_kernel_get_inputs_4/miden_base_sys::bindings::note::extern_note_get_inputs] #[signature = (param i32) (result i32)];
+            v165 = hir.bitcast v109 : u32 #[ty = u32];
+            v166 = hir.constant 8 : u32;
+            v167 = hir.add v165, v166 : u32 #[overflow = checked];
+            v168 = hir.constant 4 : u32;
+            v169 = hir.mod v167, v168 : u32;
+            hir.assertz v169 #[code = 250];
+            v170 = hir.int_to_ptr v167 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v170, v164;
+            v171 = hir.bitcast v109 : u32 #[ty = u32];
+            v172 = hir.constant 4 : u32;
+            v173 = hir.add v171, v172 : u32 #[overflow = checked];
+            v174 = hir.constant 4 : u32;
+            v175 = hir.mod v173, v174 : u32;
+            hir.assertz v175 #[code = 250];
+            v176 = hir.int_to_ptr v173 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v176, v158;
+            v177 = hir.bitcast v109 : u32 #[ty = u32];
+            v178 = hir.constant 4 : u32;
+            v179 = hir.mod v177, v178 : u32;
+            hir.assertz v179 #[code = 250];
+            v180 = hir.int_to_ptr v177 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v180, v130;
+            v181 = hir.constant 16 : i32;
+            v182 = hir.add v115, v181 : i32 #[overflow = wrapping];
+            v183 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+            v184 = hir.bitcast v183 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v184, v182;
+            hir.br block25 ;
+        ^block27:
+            v144 = hir.bitcast v115 : u32 #[ty = u32];
+            v145 = hir.constant 12 : u32;
+            v146 = hir.add v144, v145 : u32 #[overflow = checked];
+            v147 = hir.constant 4 : u32;
+            v148 = hir.mod v146, v147 : u32;
+            hir.assertz v148 #[code = 250];
+            v149 = hir.int_to_ptr v146 : (ptr i32) #[ty = (ptr i32)];
+            v150 = hir.load v149 : i32;
+            v151 = hir.constant 1048616 : i32;
+            hir.exec v130, v150, v151 #[callee = root/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::handle_error] #[signature = (param i32) (param i32) (param i32)];
+            hir.unreachable ;
+        };
+        builtin.function public @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v185: i32, v186: i32, v187: i32, v188: i32, v189: i32) {
+        ^block28(v185: i32, v186: i32, v187: i32, v188: i32, v189: i32):
+            v190 = hir.constant 0 : i32;
+            v191 = hir.constant 0 : i64;
+            v192 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+            v193 = hir.bitcast v192 : (ptr i32) #[ty = (ptr i32)];
+            v194 = hir.load v193 : i32;
+            v195 = hir.constant 16 : i32;
+            v196 = hir.sub v194, v195 : i32 #[overflow = wrapping];
+            v197 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+            v198 = hir.bitcast v197 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v198, v196;
+            v199 = hir.add v188, v189 : i32 #[overflow = wrapping];
+            v200 = hir.constant -1 : i32;
+            v201 = hir.add v199, v200 : i32 #[overflow = wrapping];
+            v202 = hir.constant 0 : i32;
+            v203 = hir.sub v202, v188 : i32 #[overflow = wrapping];
+            v204 = hir.band v201, v203 : i32;
+            v205 = hir.bitcast v204 : u32 #[ty = u32];
+            v206 = hir.zext v205 : u64 #[ty = u64];
+            v207 = hir.bitcast v206 : i64 #[ty = i64];
+            v208 = hir.bitcast v186 : u32 #[ty = u32];
+            v209 = hir.zext v208 : u64 #[ty = u64];
+            v210 = hir.bitcast v209 : i64 #[ty = i64];
+            v211 = hir.mul v207, v210 : i64 #[overflow = wrapping];
+            v212 = hir.constant 32 : i64;
+            v213 = hir.bitcast v211 : u64 #[ty = u64];
+            v214 = hir.cast v212 : u32 #[ty = u32];
+            v215 = hir.shr v213, v214 : u64;
+            v216 = hir.bitcast v215 : i64 #[ty = i64];
+            v217 = hir.trunc v216 : i32 #[ty = i32];
+            v218 = hir.constant 0 : i32;
+            v219 = hir.neq v217, v218 : i1;
+            hir.cond_br block32, block33 v219, v185, v196;
+        ^block29:
+            hir.ret ;
+        ^block30(v309: i32, v310: i32, v315: i32):
+            v311 = hir.bitcast v309 : u32 #[ty = u32];
+            v312 = hir.constant 4 : u32;
+            v313 = hir.mod v311, v312 : u32;
+            hir.assertz v313 #[code = 250];
+            v314 = hir.int_to_ptr v311 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v314, v310;
+            v318 = hir.constant 16 : i32;
+            v319 = hir.add v315, v318 : i32 #[overflow = wrapping];
+            v320 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+            v321 = hir.bitcast v320 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v321, v319;
+            hir.br block29 ;
+        ^block31:
+            v295 = hir.bitcast v270 : u32 #[ty = u32];
+            v296 = hir.constant 8 : u32;
+            v297 = hir.add v295, v296 : u32 #[overflow = checked];
+            v298 = hir.constant 4 : u32;
+            v299 = hir.mod v297, v298 : u32;
+            hir.assertz v299 #[code = 250];
+            v300 = hir.int_to_ptr v297 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v300, v294;
+            v302 = hir.bitcast v270 : u32 #[ty = u32];
+            v303 = hir.constant 4 : u32;
+            v304 = hir.add v302, v303 : u32 #[overflow = checked];
+            v305 = hir.constant 4 : u32;
+            v306 = hir.mod v304, v305 : u32;
+            hir.assertz v306 #[code = 250];
+            v307 = hir.int_to_ptr v304 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v307, v301;
+            v308 = hir.constant 1 : i32;
+            hir.br block30 v270, v308, v316;
+        ^block32(v285: i32, v317: i32):
+            v286 = hir.constant 0 : i32;
+            v287 = hir.bitcast v285 : u32 #[ty = u32];
+            v288 = hir.constant 4 : u32;
+            v289 = hir.add v287, v288 : u32 #[overflow = checked];
+            v290 = hir.constant 4 : u32;
+            v291 = hir.mod v289, v290 : u32;
+            hir.assertz v291 #[code = 250];
+            v292 = hir.int_to_ptr v289 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v292, v286;
+            v293 = hir.constant 1 : i32;
+            hir.br block30 v285, v293, v317;
+        ^block33:
+            v220 = hir.constant -2147483648 : i32;
+            v221 = hir.sub v220, v188 : i32 #[overflow = wrapping];
+            v222 = hir.trunc v211 : i32 #[ty = i32];
+            v223 = hir.bitcast v221 : u32 #[ty = u32];
+            v224 = hir.bitcast v222 : u32 #[ty = u32];
+            v225 = hir.lt v223, v224 : i1;
+            v226 = hir.zext v225 : u32 #[ty = u32];
+            v227 = hir.bitcast v226 : i32 #[ty = i32];
+            v228 = hir.constant 0 : i32;
+            v229 = hir.neq v227, v228 : i1;
+            hir.cond_br block32, block34 v229, v185, v196;
+        ^block34:
+            v230 = hir.constant 0 : i32;
+            v231 = hir.neq v222, v230 : i1;
+            hir.cond_br block35, block36 v231;
+        ^block35:
+            v246 = hir.constant 0 : i32;
+            v247 = hir.neq v187, v246 : i1;
+            hir.cond_br block38, block39 v247;
+        ^block36:
+            v232 = hir.bitcast v185 : u32 #[ty = u32];
+            v233 = hir.constant 8 : u32;
+            v234 = hir.add v232, v233 : u32 #[overflow = checked];
+            v235 = hir.constant 4 : u32;
+            v236 = hir.mod v234, v235 : u32;
+            hir.assertz v236 #[code = 250];
+            v237 = hir.int_to_ptr v234 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v237, v188;
+            v238 = hir.constant 0 : i32;
+            v239 = hir.constant 0 : i32;
+            v240 = hir.bitcast v185 : u32 #[ty = u32];
+            v241 = hir.constant 4 : u32;
+            v242 = hir.add v240, v241 : u32 #[overflow = checked];
+            v243 = hir.constant 4 : u32;
+            v244 = hir.mod v242, v243 : u32;
+            hir.assertz v244 #[code = 250];
+            v245 = hir.int_to_ptr v242 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v245, v239;
+            hir.br block30 v185, v238, v196;
+        ^block37(v263: i32, v270: i32, v277: i32, v294: i32, v301: i32, v316: i32):
+            v264 = hir.constant 0 : i32;
+            v265 = hir.eq v263, v264 : i1;
+            v266 = hir.zext v265 : u32 #[ty = u32];
+            v267 = hir.bitcast v266 : i32 #[ty = i32];
+            v268 = hir.constant 0 : i32;
+            v269 = hir.neq v267, v268 : i1;
+            hir.cond_br block31, block40 v269;
+        ^block38:
+            v257 = hir.constant 1 : i32;
+            hir.exec v196, v188, v222, v257 #[callee = root/abi_transform_tx_kernel_get_inputs_4/alloc::alloc::Global::alloc_impl] #[signature = (param i32) (param i32) (param i32) (param i32)];
+            v258 = hir.bitcast v196 : u32 #[ty = u32];
+            v259 = hir.constant 4 : u32;
+            v260 = hir.mod v258, v259 : u32;
+            hir.assertz v260 #[code = 250];
+            v261 = hir.int_to_ptr v258 : (ptr i32) #[ty = (ptr i32)];
+            v262 = hir.load v261 : i32;
+            hir.br block37 v262, v185, v186, v222, v188, v196;
+        ^block39:
+            v248 = hir.constant 8 : i32;
+            v249 = hir.add v196, v248 : i32 #[overflow = wrapping];
+            hir.exec v249, v188, v222 #[callee = root/abi_transform_tx_kernel_get_inputs_4/<alloc::alloc::Global as core::alloc::Allocator>::allocate] #[signature = (param i32) (param i32) (param i32)];
+            v250 = hir.bitcast v196 : u32 #[ty = u32];
+            v251 = hir.constant 8 : u32;
+            v252 = hir.add v250, v251 : u32 #[overflow = checked];
+            v253 = hir.constant 4 : u32;
+            v254 = hir.mod v252, v253 : u32;
+            hir.assertz v254 #[code = 250];
+            v255 = hir.int_to_ptr v252 : (ptr i32) #[ty = (ptr i32)];
+            v256 = hir.load v255 : i32;
+            hir.br block37 v256, v185, v186, v222, v188, v196;
+        ^block40:
+            v271 = hir.bitcast v270 : u32 #[ty = u32];
+            v272 = hir.constant 8 : u32;
+            v273 = hir.add v271, v272 : u32 #[overflow = checked];
+            v274 = hir.constant 4 : u32;
+            v275 = hir.mod v273, v274 : u32;
+            hir.assertz v275 #[code = 250];
+            v276 = hir.int_to_ptr v273 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v276, v263;
+            v278 = hir.bitcast v270 : u32 #[ty = u32];
+            v279 = hir.constant 4 : u32;
+            v280 = hir.add v278, v279 : u32 #[overflow = checked];
+            v281 = hir.constant 4 : u32;
+            v282 = hir.mod v280, v281 : u32;
+            hir.assertz v282 #[code = 250];
+            v283 = hir.int_to_ptr v280 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v283, v277;
+            v284 = hir.constant 0 : i32;
+            hir.br block30 v270, v284, v316;
+        };
+        builtin.function public @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v322: i32, v323: i32, v324: i32) {
+        ^block41(v322: i32, v323: i32, v324: i32):
+            v325 = hir.constant 0 : i32;
+            v326 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+            v327 = hir.bitcast v326 : (ptr i32) #[ty = (ptr i32)];
+            v328 = hir.load v327 : i32;
+            v329 = hir.constant 16 : i32;
+            v330 = hir.sub v328, v329 : i32 #[overflow = wrapping];
+            v331 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+            v332 = hir.bitcast v331 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v332, v330;
+            v333 = hir.constant 8 : i32;
+            v334 = hir.add v330, v333 : i32 #[overflow = wrapping];
+            v335 = hir.constant 0 : i32;
+            hir.exec v334, v323, v324, v335 #[callee = root/abi_transform_tx_kernel_get_inputs_4/alloc::alloc::Global::alloc_impl] #[signature = (param i32) (param i32) (param i32) (param i32)];
+            v336 = hir.bitcast v330 : u32 #[ty = u32];
+            v337 = hir.constant 12 : u32;
+            v338 = hir.add v336, v337 : u32 #[overflow = checked];
+            v339 = hir.constant 4 : u32;
+            v340 = hir.mod v338, v339 : u32;
+            hir.assertz v340 #[code = 250];
+            v341 = hir.int_to_ptr v338 : (ptr i32) #[ty = (ptr i32)];
+            v342 = hir.load v341 : i32;
+            v343 = hir.bitcast v330 : u32 #[ty = u32];
+            v344 = hir.constant 8 : u32;
+            v345 = hir.add v343, v344 : u32 #[overflow = checked];
+            v346 = hir.constant 4 : u32;
+            v347 = hir.mod v345, v346 : u32;
+            hir.assertz v347 #[code = 250];
+            v348 = hir.int_to_ptr v345 : (ptr i32) #[ty = (ptr i32)];
+            v349 = hir.load v348 : i32;
+            v350 = hir.bitcast v322 : u32 #[ty = u32];
+            v351 = hir.constant 4 : u32;
+            v352 = hir.mod v350, v351 : u32;
+            hir.assertz v352 #[code = 250];
+            v353 = hir.int_to_ptr v350 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v353, v349;
+            v354 = hir.bitcast v322 : u32 #[ty = u32];
+            v355 = hir.constant 4 : u32;
+            v356 = hir.add v354, v355 : u32 #[overflow = checked];
+            v357 = hir.constant 4 : u32;
+            v358 = hir.mod v356, v357 : u32;
+            hir.assertz v358 #[code = 250];
+            v359 = hir.int_to_ptr v356 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v359, v342;
+            v360 = hir.constant 16 : i32;
+            v361 = hir.add v330, v360 : i32 #[overflow = wrapping];
+            v362 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+            v363 = hir.bitcast v362 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v363, v361;
+            hir.br block42 ;
+        ^block42:
+            hir.ret ;
+        };
+        builtin.function public @alloc::alloc::Global::alloc_impl(v364: i32, v365: i32, v366: i32, v367: i32) {
+        ^block43(v364: i32, v365: i32, v366: i32, v367: i32):
+            v368 = hir.constant 0 : i32;
+            v369 = hir.eq v366, v368 : i1;
+            v370 = hir.zext v369 : u32 #[ty = u32];
+            v371 = hir.bitcast v370 : i32 #[ty = i32];
+            v372 = hir.constant 0 : i32;
+            v373 = hir.neq v371, v372 : i1;
+            hir.cond_br block45, block46 v373, v364, v366, v365;
+        ^block44:
+            hir.ret ;
+        ^block45(v385: i32, v386: i32, v393: i32):
+            v387 = hir.bitcast v385 : u32 #[ty = u32];
+            v388 = hir.constant 4 : u32;
+            v389 = hir.add v387, v388 : u32 #[overflow = checked];
+            v390 = hir.constant 4 : u32;
+            v391 = hir.mod v389, v390 : u32;
+            hir.assertz v391 #[code = 250];
+            v392 = hir.int_to_ptr v389 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v392, v386;
+            v394 = hir.bitcast v385 : u32 #[ty = u32];
+            v395 = hir.constant 4 : u32;
+            v396 = hir.mod v394, v395 : u32;
+            hir.assertz v396 #[code = 250];
+            v397 = hir.int_to_ptr v394 : (ptr i32) #[ty = (ptr i32)];
+            hir.store v397, v393;
+            hir.br block44 ;
+        ^block46:
+            v374 = hir.constant 0 : i32;
+            v375 = hir.bitcast v374 : u32 #[ty = u32];
+            v376 = hir.constant 1048636 : u32;
+            v377 = hir.add v375, v376 : u32 #[overflow = checked];
+            v378 = hir.int_to_ptr v377 : (ptr u8) #[ty = (ptr u8)];
+            v379 = hir.load v378 : u8;
+            v380 = hir.zext v379 : u32 #[ty = u32];
+            v381 = hir.constant 0 : i32;
+            v382 = hir.neq v367, v381 : i1;
+            hir.cond_br block47, block48 v382;
+        ^block47:
+            v384 = hir.exec v366, v365 : i32 #[callee = root/abi_transform_tx_kernel_get_inputs_4/__rust_alloc_zeroed] #[signature = (param i32) (param i32) (result i32)];
+            hir.br block45 v364, v366, v384;
+        ^block48:
+            v383 = hir.exec v366, v365 : i32 #[callee = root/abi_transform_tx_kernel_get_inputs_4/__rust_alloc] #[signature = (param i32) (param i32) (result i32)];
+            hir.br block45 v364, v366, v383;
+        };
+        builtin.function public @alloc::raw_vec::handle_error(v398: i32, v399: i32, v400: i32) {
+        ^block49(v398: i32, v399: i32, v400: i32):
+            hir.unreachable ;
+        ^block50:
 
-            (block 1
-                (ret))
-        )
+        };
+        builtin.function public @core::ptr::alignment::Alignment::max(v401: i32, v402: i32) -> i32 {
+        ^block51(v401: i32, v402: i32):
+            v404 = hir.bitcast v401 : u32 #[ty = u32];
+            v405 = hir.bitcast v402 : u32 #[ty = u32];
+            v406 = hir.gt v404, v405 : i1;
+            v407 = hir.zext v406 : u32 #[ty = u32];
+            v408 = hir.constant 0 : i32;
+            v409 = hir.neq v407, v408 : i1;
+            v410 = hir.select v409, v401, v402 : i32;
+            hir.br block52 v410;
+        ^block52(v403: i32):
+            hir.ret v403;
+        };
+        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-        (func #__rust_alloc (param i32) (param i32) (result i32)
-            (block 0 (param v0 i32) (param v1 i32)
-                (let (v3 i32) (const.i32 1048632))
-                (let (v4 i32) (exec #<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc v3 v1 v0))
-                (br (block 1 v4)))
+            hir.ret_imm  #[value = 1048576];
+        };
+        builtin.segment  #[data = 000000210000001100000027001000000073722e65746f6e2f73676e69646e69622f6372732f7379732d657361622f6b64732f2e2e2f2e2e] #[offset = 1048576] #[readonly = false];
+    };
+    builtin.module  #[name = #intrinsics::mem] #[visibility = public] {
 
-            (block 1 (param v2 i32)
-                (ret v2))
-        )
+        builtin.function public @heap_base(result i32) {
 
-        (func #__rust_alloc_zeroed (param i32) (param i32) (result i32)
-            (block 0 (param v0 i32) (param v1 i32)
-                (let (v3 i32) (const.i32 1048632))
-                (let (v4 i32) (exec #<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc v3 v1 v0))
-                (let (v5 i1) (eq v4 0))
-                (let (v6 i32) (zext v5))
-                (let (v7 i1) (neq v6 0))
-                (condbr v7 (block 2 v4) (block 3)))
+        };
+    };
+    builtin.module  #[name = #miden::note] #[visibility = public] {
 
-            (block 1 (param v2 i32)
-                (ret v2))
+        builtin.function public @get_inputs(param i32) (result i32 i32) {
 
-            (block 2 (param v13 i32)
-                (br (block 1 v13)))
-
-            (block 3
-                (let (v8 i32) (const.i32 0))
-                (let (v9 u8) (trunc v8))
-                (let (v10 u32) (bitcast v0))
-                (let (v11 u32) (bitcast v4))
-                (let (v12 (ptr u8)) (inttoptr v11))
-                (memset v12 v10 v9)
-                (br (block 2 v4)))
-        )
-
-        (func #<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
-              (param i32) (param i32) (param i32) (result i32)
-            (block 0 (param v0 i32) (param v1 i32) (param v2 i32)
-                (let (v4 i32) (const.i32 0))
-                (let (v5 i32) (const.i32 32))
-                (let (v6 i32) (const.i32 32))
-                (let (v7 u32) (bitcast v1))
-                (let (v8 u32) (bitcast v6))
-                (let (v9 i1) (gt v7 v8))
-                (let (v10 i32) (sext v9))
-                (let (v11 i1) (neq v10 0))
-                (let (v12 i32) (select v11 v1 v5))
-                (let (v13 u32) (popcnt v12))
-                (let (v14 i32) (bitcast v13))
-                (let (v15 i32) (const.i32 1))
-                (let (v16 i1) (neq v14 v15))
-                (let (v17 i32) (zext v16))
-                (let (v18 i1) (neq v17 0))
-                (condbr v18 (block 2) (block 3)))
-
-            (block 1 (param v3 i32))
-
-            (block 2
-                (unreachable))
-
-            (block 3
-                (let (v19 i32) (const.i32 -2147483648))
-                (let (v20 i32) (exec #core::ptr::alignment::Alignment::max v1 v12))
-                (let (v21 i32) (sub.wrapping v19 v20))
-                (let (v22 u32) (bitcast v21))
-                (let (v23 u32) (bitcast v2))
-                (let (v24 i1) (lt v22 v23))
-                (let (v25 i32) (sext v24))
-                (let (v26 i1) (neq v25 0))
-                (condbr v26 (block 2) (block 4)))
-
-            (block 4
-                (let (v27 i32) (const.i32 0))
-                (let (v28 i32) (add.wrapping v2 v20))
-                (let (v29 i32) (const.i32 -1))
-                (let (v30 i32) (add.wrapping v28 v29))
-                (let (v31 i32) (const.i32 0))
-                (let (v32 i32) (sub.wrapping v31 v20))
-                (let (v33 i32) (band v30 v32))
-                (let (v34 u32) (bitcast v0))
-                (let (v35 u32) (mod.unchecked v34 4))
-                (assertz 250 v35)
-                (let (v36 (ptr i32)) (inttoptr v34))
-                (let (v37 i32) (load v36))
-                (let (v38 i1) (neq v37 0))
-                (condbr v38 (block 5 v0 v33 v20 v27) (block 6)))
-
-            (block 5
-                    (param v50 i32)
-                    (param v56 i32)
-                    (param v66 i32)
-                    (param v69 i32)
-                (let (v49 i32) (const.i32 268435456))
-                (let (v51 u32) (bitcast v50))
-                (let (v52 u32) (mod.unchecked v51 4))
-                (assertz 250 v52)
-                (let (v53 (ptr i32)) (inttoptr v51))
-                (let (v54 i32) (load v53))
-                (let (v55 i32) (sub.wrapping v49 v54))
-                (let (v57 u32) (bitcast v55))
-                (let (v58 u32) (bitcast v56))
-                (let (v59 i1) (lt v57 v58))
-                (let (v60 i32) (sext v59))
-                (let (v61 i1) (neq v60 0))
-                (condbr v61 (block 7 v69) (block 8)))
-
-            (block 6
-                (let (v39 u32) (exec (#intrinsics::mem #heap_base)))
-                (let (v40 u32) (memory.size))
-                (let (v41 i32) (const.i32 16))
-                (let (v42 u32) (bitcast v41))
-                (let (v43 u32) (shl.wrapping v40 v42))
-                (let (v44 u32) (add.wrapping v39 v43))
-                (let (v45 i32) (bitcast v44))
-                (let (v46 u32) (bitcast v0))
-                (let (v47 u32) (mod.unchecked v46 4))
-                (assertz 250 v47)
-                (let (v48 (ptr i32)) (inttoptr v46))
-                (store v48 v45)
-                (br (block 5 v0 v33 v20 v27)))
-
-            (block 7 (param v68 i32)
-                (ret v68))
-
-            (block 8
-                (let (v62 i32) (add.wrapping v54 v56))
-                (let (v63 u32) (bitcast v50))
-                (let (v64 u32) (mod.unchecked v63 4))
-                (assertz 250 v64)
-                (let (v65 (ptr i32)) (inttoptr v63))
-                (store v65 v62)
-                (let (v67 i32) (add.wrapping v54 v66))
-                (br (block 7 v67)))
-        )
-
-        (func #miden_base_sys::bindings::note::get_inputs
-              (param i32)
-            (block 0 (param v0 i32)
-                (let (v1 i32) (const.i32 0))
-                (let (v2 i32) (global.load i32 (global.symbol #__stack_pointer)))
-                (let (v3 i32) (const.i32 16))
-                (let (v4 i32) (sub.wrapping v2 v3))
-                (let (v5 (ptr i32)) (global.symbol #__stack_pointer))
-                (store v5 v4)
-                (let (v6 i32) (const.i32 4))
-                (let (v7 i32) (add.wrapping v4 v6))
-                (let (v8 i32) (const.i32 256))
-                (let (v9 i32) (const.i32 0))
-                (let (v10 i32) (const.i32 4))
-                (let (v11 i32) (const.i32 4))
-                (exec #alloc::raw_vec::RawVecInner<A>::try_allocate_in v7 v8 v9 v10 v11)
-                (let (v12 u32) (bitcast v4))
-                (let (v13 u32) (add.checked v12 8))
-                (let (v14 u32) (mod.unchecked v13 4))
-                (assertz 250 v14)
-                (let (v15 (ptr i32)) (inttoptr v13))
-                (let (v16 i32) (load v15))
-                (let (v17 u32) (bitcast v4))
-                (let (v18 u32) (add.checked v17 4))
-                (let (v19 u32) (mod.unchecked v18 4))
-                (assertz 250 v19)
-                (let (v20 (ptr i32)) (inttoptr v18))
-                (let (v21 i32) (load v20))
-                (let (v22 i32) (const.i32 1))
-                (let (v23 i1) (neq v21 v22))
-                (let (v24 i32) (zext v23))
-                (let (v25 i1) (neq v24 0))
-                (condbr v25 (block 2) (block 3)))
-
-            (block 1
-                (ret))
-
-            (block 2
-                (let (v32 u32) (bitcast v4))
-                (let (v33 u32) (add.checked v32 12))
-                (let (v34 u32) (mod.unchecked v33 4))
-                (assertz 250 v34)
-                (let (v35 (ptr i32)) (inttoptr v33))
-                (let (v36 i32) (load v35))
-                (let (v37 i32) (const.i32 4))
-                (let (v38 u32) (bitcast v36))
-                (let (v39 u32) (bitcast v37))
-                (let (v40 u32) (shr.wrapping v38 v39))
-                (let (v41 i32) (bitcast v40))
-                (let [(v42 i32) (v43 i32)] (exec (#miden::note #get_inputs) v41))
-                (let (v44 u32) (bitcast v0))
-                (let (v45 u32) (add.checked v44 8))
-                (let (v46 u32) (mod.unchecked v45 4))
-                (assertz 250 v46)
-                (let (v47 (ptr i32)) (inttoptr v45))
-                (store v47 v42)
-                (let (v48 u32) (bitcast v0))
-                (let (v49 u32) (add.checked v48 4))
-                (let (v50 u32) (mod.unchecked v49 4))
-                (assertz 250 v50)
-                (let (v51 (ptr i32)) (inttoptr v49))
-                (store v51 v36)
-                (let (v52 u32) (bitcast v0))
-                (let (v53 u32) (mod.unchecked v52 4))
-                (assertz 250 v53)
-                (let (v54 (ptr i32)) (inttoptr v52))
-                (store v54 v16)
-                (let (v55 i32) (const.i32 16))
-                (let (v56 i32) (add.wrapping v4 v55))
-                (let (v57 (ptr i32)) (global.symbol #__stack_pointer))
-                (store v57 v56)
-                (br (block 1)))
-
-            (block 3
-                (let (v26 u32) (bitcast v4))
-                (let (v27 u32) (add.checked v26 12))
-                (let (v28 u32) (mod.unchecked v27 4))
-                (assertz 250 v28)
-                (let (v29 (ptr i32)) (inttoptr v27))
-                (let (v30 i32) (load v29))
-                (let (v31 i32) (const.i32 1048616))
-                (exec #alloc::raw_vec::handle_error v16 v30 v31)
-                (unreachable))
-        )
-
-        (func #alloc::raw_vec::RawVecInner<A>::try_allocate_in
-              (param i32) (param i32) (param i32) (param i32) (param i32)
-            (block 0
-                    (param v0 i32)
-                    (param v1 i32)
-                    (param v2 i32)
-                    (param v3 i32)
-                    (param v4 i32)
-                (let (v5 i32) (const.i32 0))
-                (let (v6 i64) (const.i64 0))
-                (let (v7 i32) (global.load i32 (global.symbol #__stack_pointer)))
-                (let (v8 i32) (const.i32 16))
-                (let (v9 i32) (sub.wrapping v7 v8))
-                (let (v10 (ptr i32)) (global.symbol #__stack_pointer))
-                (store v10 v9)
-                (let (v11 i32) (add.wrapping v3 v4))
-                (let (v12 i32) (const.i32 -1))
-                (let (v13 i32) (add.wrapping v11 v12))
-                (let (v14 i32) (const.i32 0))
-                (let (v15 i32) (sub.wrapping v14 v3))
-                (let (v16 i32) (band v13 v15))
-                (let (v17 u32) (bitcast v16))
-                (let (v18 u64) (zext v17))
-                (let (v19 i64) (bitcast v18))
-                (let (v20 u32) (bitcast v1))
-                (let (v21 u64) (zext v20))
-                (let (v22 i64) (bitcast v21))
-                (let (v23 i64) (mul.wrapping v19 v22))
-                (let (v24 i64) (const.i64 32))
-                (let (v25 u64) (bitcast v23))
-                (let (v26 u32) (cast v24))
-                (let (v27 u64) (shr.wrapping v25 v26))
-                (let (v28 i64) (bitcast v27))
-                (let (v29 i32) (trunc v28))
-                (let (v30 i1) (neq v29 0))
-                (condbr v30 (block 4 v0 v9) (block 5)))
-
-            (block 1
-                (ret))
-
-            (block 2 (param v96 i32) (param v97 i32) (param v101 i32)
-                (let (v98 u32) (bitcast v96))
-                (let (v99 u32) (mod.unchecked v98 4))
-                (assertz 250 v99)
-                (let (v100 (ptr i32)) (inttoptr v98))
-                (store v100 v97)
-                (let (v104 i32) (const.i32 16))
-                (let (v105 i32) (add.wrapping v101 v104))
-                (let (v106 (ptr i32)) (global.symbol #__stack_pointer))
-                (store v106 v105)
-                (br (block 1)))
-
-            (block 3
-                (let (v86 u32) (bitcast v67))
-                (let (v87 u32) (add.checked v86 8))
-                (let (v88 u32) (mod.unchecked v87 4))
-                (assertz 250 v88)
-                (let (v89 (ptr i32)) (inttoptr v87))
-                (store v89 v85)
-                (let (v91 u32) (bitcast v67))
-                (let (v92 u32) (add.checked v91 4))
-                (let (v93 u32) (mod.unchecked v92 4))
-                (assertz 250 v93)
-                (let (v94 (ptr i32)) (inttoptr v92))
-                (store v94 v90)
-                (let (v95 i32) (const.i32 1))
-                (br (block 2 v67 v95 v102)))
-
-            (block 4 (param v78 i32) (param v103 i32)
-                (let (v79 i32) (const.i32 0))
-                (let (v80 u32) (bitcast v78))
-                (let (v81 u32) (add.checked v80 4))
-                (let (v82 u32) (mod.unchecked v81 4))
-                (assertz 250 v82)
-                (let (v83 (ptr i32)) (inttoptr v81))
-                (store v83 v79)
-                (let (v84 i32) (const.i32 1))
-                (br (block 2 v78 v84 v103)))
-
-            (block 5
-                (let (v31 i32) (const.i32 -2147483648))
-                (let (v32 i32) (sub.wrapping v31 v3))
-                (let (v33 i32) (trunc v23))
-                (let (v34 u32) (bitcast v32))
-                (let (v35 u32) (bitcast v33))
-                (let (v36 i1) (lt v34 v35))
-                (let (v37 i32) (sext v36))
-                (let (v38 i1) (neq v37 0))
-                (condbr v38 (block 4 v0 v9) (block 6)))
-
-            (block 6
-                (let (v39 i1) (neq v33 0))
-                (condbr v39 (block 7) (block 8)))
-
-            (block 7
-                (let (v50 i1) (neq v2 0))
-                (condbr v50 (block 10) (block 11)))
-
-            (block 8
-                (let (v40 u32) (bitcast v0))
-                (let (v41 u32) (add.checked v40 8))
-                (let (v42 u32) (mod.unchecked v41 4))
-                (assertz 250 v42)
-                (let (v43 (ptr i32)) (inttoptr v41))
-                (store v43 v3)
-                (let (v44 i32) (const.i32 0))
-                (let (v45 i32) (const.i32 0))
-                (let (v46 u32) (bitcast v0))
-                (let (v47 u32) (add.checked v46 4))
-                (let (v48 u32) (mod.unchecked v47 4))
-                (assertz 250 v48)
-                (let (v49 (ptr i32)) (inttoptr v47))
-                (store v49 v45)
-                (br (block 2 v0 v44 v9)))
-
-            (block 9
-                    (param v63 i32)
-                    (param v67 i32)
-                    (param v72 i32)
-                    (param v85 i32)
-                    (param v90 i32)
-                    (param v102 i32)
-                (let (v64 i1) (eq v63 0))
-                (let (v65 i32) (zext v64))
-                (let (v66 i1) (neq v65 0))
-                (condbr v66 (block 3) (block 12)))
-
-            (block 10
-                (let (v58 i32) (const.i32 1))
-                (exec #alloc::alloc::Global::alloc_impl v9 v3 v33 v58)
-                (let (v59 u32) (bitcast v9))
-                (let (v60 u32) (mod.unchecked v59 4))
-                (assertz 250 v60)
-                (let (v61 (ptr i32)) (inttoptr v59))
-                (let (v62 i32) (load v61))
-                (br (block 9 v62 v0 v1 v33 v3 v9)))
-
-            (block 11
-                (let (v51 i32) (const.i32 8))
-                (let (v52 i32) (add.wrapping v9 v51))
-                (exec #<alloc::alloc::Global as core::alloc::Allocator>::allocate v52 v3 v33)
-                (let (v53 u32) (bitcast v9))
-                (let (v54 u32) (add.checked v53 8))
-                (let (v55 u32) (mod.unchecked v54 4))
-                (assertz 250 v55)
-                (let (v56 (ptr i32)) (inttoptr v54))
-                (let (v57 i32) (load v56))
-                (br (block 9 v57 v0 v1 v33 v3 v9)))
-
-            (block 12
-                (let (v68 u32) (bitcast v67))
-                (let (v69 u32) (add.checked v68 8))
-                (let (v70 u32) (mod.unchecked v69 4))
-                (assertz 250 v70)
-                (let (v71 (ptr i32)) (inttoptr v69))
-                (store v71 v63)
-                (let (v73 u32) (bitcast v67))
-                (let (v74 u32) (add.checked v73 4))
-                (let (v75 u32) (mod.unchecked v74 4))
-                (assertz 250 v75)
-                (let (v76 (ptr i32)) (inttoptr v74))
-                (store v76 v72)
-                (let (v77 i32) (const.i32 0))
-                (br (block 2 v67 v77 v102)))
-        )
-
-        (func #<alloc::alloc::Global as core::alloc::Allocator>::allocate
-              (param i32) (param i32) (param i32)
-            (block 0 (param v0 i32) (param v1 i32) (param v2 i32)
-                (let (v3 i32) (const.i32 0))
-                (let (v4 i32) (global.load i32 (global.symbol #__stack_pointer)))
-                (let (v5 i32) (const.i32 16))
-                (let (v6 i32) (sub.wrapping v4 v5))
-                (let (v7 (ptr i32)) (global.symbol #__stack_pointer))
-                (store v7 v6)
-                (let (v8 i32) (const.i32 8))
-                (let (v9 i32) (add.wrapping v6 v8))
-                (let (v10 i32) (const.i32 0))
-                (exec #alloc::alloc::Global::alloc_impl v9 v1 v2 v10)
-                (let (v11 u32) (bitcast v6))
-                (let (v12 u32) (add.checked v11 12))
-                (let (v13 u32) (mod.unchecked v12 4))
-                (assertz 250 v13)
-                (let (v14 (ptr i32)) (inttoptr v12))
-                (let (v15 i32) (load v14))
-                (let (v16 u32) (bitcast v6))
-                (let (v17 u32) (add.checked v16 8))
-                (let (v18 u32) (mod.unchecked v17 4))
-                (assertz 250 v18)
-                (let (v19 (ptr i32)) (inttoptr v17))
-                (let (v20 i32) (load v19))
-                (let (v21 u32) (bitcast v0))
-                (let (v22 u32) (mod.unchecked v21 4))
-                (assertz 250 v22)
-                (let (v23 (ptr i32)) (inttoptr v21))
-                (store v23 v20)
-                (let (v24 u32) (bitcast v0))
-                (let (v25 u32) (add.checked v24 4))
-                (let (v26 u32) (mod.unchecked v25 4))
-                (assertz 250 v26)
-                (let (v27 (ptr i32)) (inttoptr v25))
-                (store v27 v15)
-                (let (v28 i32) (const.i32 16))
-                (let (v29 i32) (add.wrapping v6 v28))
-                (let (v30 (ptr i32)) (global.symbol #__stack_pointer))
-                (store v30 v29)
-                (br (block 1)))
-
-            (block 1
-                (ret))
-        )
-
-        (func #alloc::alloc::Global::alloc_impl
-              (param i32) (param i32) (param i32) (param i32)
-            (block 0 (param v0 i32) (param v1 i32) (param v2 i32) (param v3 i32)
-                (let (v4 i1) (eq v2 0))
-                (let (v5 i32) (zext v4))
-                (let (v6 i1) (neq v5 0))
-                (condbr v6 (block 2 v0 v2 v1) (block 3)))
-
-            (block 1
-                (ret))
-
-            (block 2 (param v16 i32) (param v17 i32) (param v22 i32)
-                (let (v18 u32) (bitcast v16))
-                (let (v19 u32) (add.checked v18 4))
-                (let (v20 u32) (mod.unchecked v19 4))
-                (assertz 250 v20)
-                (let (v21 (ptr i32)) (inttoptr v19))
-                (store v21 v17)
-                (let (v23 u32) (bitcast v16))
-                (let (v24 u32) (mod.unchecked v23 4))
-                (assertz 250 v24)
-                (let (v25 (ptr i32)) (inttoptr v23))
-                (store v25 v22)
-                (br (block 1)))
-
-            (block 3
-                (let (v7 i32) (const.i32 0))
-                (let (v8 u32) (bitcast v7))
-                (let (v9 u32) (add.checked v8 1048636))
-                (let (v10 (ptr u8)) (inttoptr v9))
-                (let (v11 u8) (load v10))
-                (let (v12 i32) (zext v11))
-                (let (v13 i1) (neq v3 0))
-                (condbr v13 (block 4) (block 5)))
-
-            (block 4
-                (let (v15 i32) (exec #__rust_alloc_zeroed v2 v1))
-                (br (block 2 v0 v2 v15)))
-
-            (block 5
-                (let (v14 i32) (exec #__rust_alloc v2 v1))
-                (br (block 2 v0 v2 v14)))
-        )
-
-        (func #alloc::raw_vec::handle_error
-              (param i32) (param i32) (param i32)
-            (block 0 (param v0 i32) (param v1 i32) (param v2 i32)
-                (unreachable))
-
-            (block 1)
-        )
-
-        (func #core::ptr::alignment::Alignment::max
-              (param i32) (param i32) (result i32)
-            (block 0 (param v0 i32) (param v1 i32)
-                (let (v3 u32) (bitcast v0))
-                (let (v4 u32) (bitcast v1))
-                (let (v5 i1) (gt v3 v4))
-                (let (v6 i32) (sext v5))
-                (let (v7 i1) (neq v6 0))
-                (let (v8 i32) (select v7 v0 v1))
-                (br (block 1 v8)))
-
-            (block 1 (param v2 i32)
-                (ret v2))
-        )
-
-        ;; Imports
-        (func (import #intrinsics::mem #heap_base) (result u32))
-        (func (import #miden::note #get_inputs) (param i32) (result i32 i32))
-    )
-
-)
+        };
+    };
+};

--- a/tests/integration/src/rust_masm_tests/abi_transform/stdlib.rs
+++ b/tests/integration/src/rust_masm_tests/abi_transform/stdlib.rs
@@ -16,7 +16,6 @@ use proptest::{
 
 use crate::CompilerTest;
 
-#[ignore = "until https://github.com/0xPolygonMiden/compiler/issues/352 is fixed"]
 #[test]
 fn test_blake3_hash() {
     let main_fn =
@@ -30,57 +29,59 @@ fn test_blake3_hash() {
     );
     // Test expected compilation artifacts
     test.expect_wasm(expect_file![format!("../../../expected/{artifact_name}.wat")]);
-    test.expect_ir(expect_file![format!("../../../expected/{artifact_name}.hir")]);
+    test.expect_ir2(expect_file![format!("../../../expected/{artifact_name}.hir")]);
     test.expect_masm(expect_file![format!("../../../expected/{artifact_name}.masm")]);
 
-    let package = test.compiled_package();
-
-    // Run the Rust and compiled MASM code against a bunch of random inputs and compare the results
-    let res = TestRunner::default().run(&any::<[u8; 32]>(), move |ibytes| {
-        let hash_bytes = blake3::hash(&ibytes);
-        let rs_out = hash_bytes.as_bytes();
-        let in_addr = 21u32 * 65536;
-        let out_addr = 20u32 * 65536;
-        let mut frame = Vec::<Felt>::default();
-        // Convert input bytes to words
-        let words = midenc_debug::bytes_to_words(&ibytes);
-        for word in words.into_iter().rev() {
-            PushToStack::try_push(&word, &mut frame);
-        }
-        PushToStack::try_push(&2u32, &mut frame); // num_words
-        PushToStack::try_push(&(in_addr / 16), &mut frame); // dest_ptr
-        dbg!(&ibytes, &frame, rs_out);
-        // Arguments are: [hash_output_ptr, hash_input_ptr]
-        let mut exec = Executor::for_package(
-            &package,
-            // Place the hash output at 20 * PAGE_SIZE, and the hash input at 21 * PAGE_SIZE
-            vec![Felt::new(in_addr as u64), Felt::new(out_addr as u64)],
-            &test.session,
-        )
-        .map_err(|err| TestCaseError::fail(err.to_string()))?;
-        // Reverse the stack contents, so that the correct order is preserved after
-        // MemAdviceProvider does its own reverse
-        frame.reverse();
-        let advice_inputs = AdviceInputs::default().with_stack(frame);
-        exec.with_advice_inputs(advice_inputs);
-        let trace = exec.execute(&package.unwrap_program(), &test.session);
-        let vm_in: [u8; 32] = trace
-            .read_from_rust_memory(in_addr)
-            .expect("expected memory to have been written");
-        dbg!(&vm_in);
-        let vm_out: [u8; 32] = trace
-            .read_from_rust_memory(out_addr)
-            .expect("expected memory to have been written");
-        dbg!(&vm_out);
-        prop_assert_eq!(rs_out, &vm_out, "VM output mismatch");
-        Ok(())
-    });
-
-    match res {
-        Err(TestError::Fail(_, value)) => {
-            panic!("Found minimal(shrinked) failing case: {:?}", value);
-        }
-        Ok(_) => (),
-        _ => panic!("Unexpected test result: {:?}", res),
-    }
+    // FIX: uncomment when https://github.com/0xPolygonMiden/compiler/issues/352 is fixed
+    //
+    // let package = test.compiled_package();
+    //
+    // // Run the Rust and compiled MASM code against a bunch of random inputs and compare the results
+    // let res = TestRunner::default().run(&any::<[u8; 32]>(), move |ibytes| {
+    //     let hash_bytes = blake3::hash(&ibytes);
+    //     let rs_out = hash_bytes.as_bytes();
+    //     let in_addr = 21u32 * 65536;
+    //     let out_addr = 20u32 * 65536;
+    //     let mut frame = Vec::<Felt>::default();
+    //     // Convert input bytes to words
+    //     let words = midenc_debug::bytes_to_words(&ibytes);
+    //     for word in words.into_iter().rev() {
+    //         PushToStack::try_push(&word, &mut frame);
+    //     }
+    //     PushToStack::try_push(&2u32, &mut frame); // num_words
+    //     PushToStack::try_push(&(in_addr / 16), &mut frame); // dest_ptr
+    //     dbg!(&ibytes, &frame, rs_out);
+    //     // Arguments are: [hash_output_ptr, hash_input_ptr]
+    //     let mut exec = Executor::for_package(
+    //         &package,
+    //         // Place the hash output at 20 * PAGE_SIZE, and the hash input at 21 * PAGE_SIZE
+    //         vec![Felt::new(in_addr as u64), Felt::new(out_addr as u64)],
+    //         &test.session,
+    //     )
+    //     .map_err(|err| TestCaseError::fail(err.to_string()))?;
+    //     // Reverse the stack contents, so that the correct order is preserved after
+    //     // MemAdviceProvider does its own reverse
+    //     frame.reverse();
+    //     let advice_inputs = AdviceInputs::default().with_stack(frame);
+    //     exec.with_advice_inputs(advice_inputs);
+    //     let trace = exec.execute(&package.unwrap_program(), &test.session);
+    //     let vm_in: [u8; 32] = trace
+    //         .read_from_rust_memory(in_addr)
+    //         .expect("expected memory to have been written");
+    //     dbg!(&vm_in);
+    //     let vm_out: [u8; 32] = trace
+    //         .read_from_rust_memory(out_addr)
+    //         .expect("expected memory to have been written");
+    //     dbg!(&vm_out);
+    //     prop_assert_eq!(rs_out, &vm_out, "VM output mismatch");
+    //     Ok(())
+    // });
+    //
+    // match res {
+    //     Err(TestError::Fail(_, value)) => {
+    //         panic!("Found minimal(shrinked) failing case: {:?}", value);
+    //     }
+    //     Ok(_) => (),
+    //     _ => panic!("Unexpected test result: {:?}", res),
+    // }
 }

--- a/tests/integration/src/rust_masm_tests/abi_transform/tx_kernel.rs
+++ b/tests/integration/src/rust_masm_tests/abi_transform/tx_kernel.rs
@@ -20,7 +20,6 @@ fn setup_log() {
 }
 
 #[test]
-#[ignore = "temporarily disabled until we figure out what broke"]
 fn test_get_inputs_4() -> Result<(), Report> {
     test_get_inputs("4", vec![u32::MAX.into(), Felt::ONE, Felt::ZERO, u32::MAX.into()])
 }
@@ -51,41 +50,55 @@ end
 
     // Test expected compilation artifacts
     test.expect_wasm(expect_file![format!("../../../expected/{artifact_name}.wat")]);
-    test.expect_ir(expect_file![format!("../../../expected/{artifact_name}.hir")]);
-    test.expect_masm(expect_file![format!("../../../expected/{artifact_name}.masm")]);
+    test.expect_ir2(expect_file![format!("../../../expected/{artifact_name}.hir")]);
 
-    let package = test.compiled_package();
+    // FIX: temporarily disabled until we figure out what broke
 
-    // Provide a place in memory where the vector returned by `get_inputs` should be stored
-    let out_addr = 18u32 * 65536;
-    let exec = Executor::for_package(&package, vec![Felt::new(out_addr as u64)], &test.session)?;
-    let trace = exec.execute(&package.unwrap_program(), &test.session);
-    // Verify that the vector contains the expected elements:
+    // test.expect_masm(expect_file![format!("../../../expected/{artifact_name}.masm")]);
+    // let package = test.compiled_package();
     //
-    // Rust lays out the vector struct as follows (lowest addressed bytes first):
+    // // Provide a place in memory where the vector returned by `get_inputs` should be stored
+    // let out_addr = 18u32 * 65536;
+    // let exec = Executor::for_package(&package, vec![Felt::new(out_addr as u64)], &test.session)?;
+    // let trace = exec.execute(&package.unwrap_program(), &test.session);
+    // // Verify that the vector contains the expected elements:
+    // //
+    // // Rust lays out the vector struct as follows (lowest addressed bytes first):
+    // //
+    // //     [capacity, buf_ptr, len]
+    // //
+    // // 1. Extract the data pointer and length from the vector written to out_addr
+    // let data_ptr = trace.read_memory_element(out_addr / 16, 1).unwrap().as_int() as u32;
+    // assert_ne!(data_ptr, 0, "expected non-null data pointer");
+    // dbg!(data_ptr);
+    // let len = trace.read_memory_element(out_addr / 16, 2).unwrap().as_int() as usize;
+    // assert_eq!(
+    //     len,
+    //     expected_inputs.len(),
+    //     "expected vector to contain all of the expected inputs"
+    // );
+    // // 2. Read the vector elements via data_ptr and ensure they match the inputs
+    // dbg!(len);
+    // let word = trace.read_memory_word(data_ptr / 16).unwrap();
+    // assert_eq!(
+    //     word.as_slice(),
+    //     expected_inputs.as_slice(),
+    //     "expected vector contents to match inputs"
+    // );
     //
-    //     [capacity, buf_ptr, len]
-    //
-    // 1. Extract the data pointer and length from the vector written to out_addr
-    let data_ptr = trace.read_memory_element(out_addr / 16, 1).unwrap().as_int() as u32;
-    assert_ne!(data_ptr, 0, "expected non-null data pointer");
-    dbg!(data_ptr);
-    let len = trace.read_memory_element(out_addr / 16, 2).unwrap().as_int() as usize;
-    assert_eq!(
-        len,
-        expected_inputs.len(),
-        "expected vector to contain all of the expected inputs"
-    );
-    // 2. Read the vector elements via data_ptr and ensure they match the inputs
-    dbg!(len);
-    let word = trace.read_memory_word(data_ptr / 16).unwrap();
-    assert_eq!(
-        word.as_slice(),
-        expected_inputs.as_slice(),
-        "expected vector contents to match inputs"
-    );
-
-    // let ir_program = test.ir_masm_program();
-    // let emul_out = execute_emulator(ir_program.clone(), &[]);
+    // // let ir_program = test.ir_masm_program();
+    // // let emul_out = execute_emulator(ir_program.clone(), &[]);
     Ok(())
+}
+
+#[test]
+fn test_get_id() {
+    let main_fn = "() -> Felt { miden::account::get_id().into() }";
+    let artifact_name = "abi_transform_tx_kernel_get_id";
+    let test_builder =
+        CompilerTestBuilder::rust_fn_body_with_sdk(artifact_name, main_fn, true, None);
+    let mut test = test_builder.build();
+    // Test expected compilation artifacts
+    test.expect_wasm(expect_file![format!("../../../expected/{artifact_name}.wat")]);
+    test.expect_ir2(expect_file![format!("../../../expected/{artifact_name}.hir")]);
 }

--- a/tests/integration/src/rust_masm_tests/rust_sdk.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk.rs
@@ -221,38 +221,6 @@ fn rust_sdk_cross_ctx_note() {
 }
 
 #[test]
-fn rust_sdk_hir2_sketch_multiple_interface_exports() {
-    // Testing the new frontend's Wasm component translator producing HIR2(sketch)
-    // from a Wasm component exporting two interfaces
-    let _ = env_logger::builder().is_test(true).try_init();
-    let config = WasmTranslationConfig::default();
-    let mut test = CompilerTest::rust_source_cargo_miden(
-        "../rust-apps-wasm/rust-sdk/basic-wallet",
-        config,
-        [],
-    );
-    let artifact_name = "hir2_sketch_multi_interface";
-    test.expect_wasm(expect_file![format!("../../expected/rust_sdk/{artifact_name}.wat")]);
-    test.expect_ir2(expect_file![format!("../../expected/rust_sdk/{artifact_name}.hir")]);
-}
-
-#[test]
-fn rust_sdk_hir2_single_interface_export() {
-    // Testing the new frontend's Wasm component translator producing HIR2(sketch)
-    // from a Wasm component exporting one interface
-    let _ = env_logger::builder().is_test(true).try_init();
-    let config = WasmTranslationConfig::default();
-    let mut test = CompilerTest::rust_source_cargo_miden(
-        "../rust-apps-wasm/rust-sdk/cross-ctx-account",
-        config,
-        [],
-    );
-    let artifact_name = "hir2_sketch_single_interface";
-    test.expect_wasm(expect_file![format!("../../expected/rust_sdk/{artifact_name}.wat")]);
-    test.expect_ir2(expect_file![format!("../../expected/rust_sdk/{artifact_name}.hir")]);
-}
-
-#[test]
 fn pure_rust_hir2() {
     let _ = env_logger::builder().is_test(true).try_init();
     let config = WasmTranslationConfig::default();


### PR DESCRIPTION
#363 

This PR:
- Adds synthetic function generation with Miden ABI transformation for all known transformation strategies for Miden stdlib and tx_kernel;
- Partially restores the `get_inputs` and `blake3` tests (up to HIR2 generation);
- Adds `get_id` test for testing the HIR2 generation to test the `no_transform` strategy;

**NOTE**: I think that imported functions (the ones called from the synthetic ones) should probably be defined in the separate `Component` but since it requires establishing the `World` op it deserves a separate PR. I temporarily put them in the separate module in the same component.

**EDIT**: I'm not entirely happy with the code and overall design, but I decided to leave it as is and to get back to it after the Component Model translation is implemented, since it should affect the synthetic function generation significantly.