### PR TITLE
[2/x] Add `World` op and use it in the frontend for core Wasm module translation code path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ cranelift-bforest = "0.108"
 compact_str = { version = "0.8", default-features = false }
 env_logger = "0.11"
 either = { version = "1.10", default-features = false }
-expect-test = "1.4.1"
+expect-test = "1.5"
 hashbrown = { version = "0.14", features = ["nightly"] }
 Inflector = "0.11"
 intrusive-collections = "0.9"

--- a/frontend-wasm2/src/code_translator/expected/globals.hir
+++ b/frontend-wasm2/src/code_translator/expected/globals.hir
@@ -1,0 +1,14 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = world/root/noname/MyGlobalVal];
+    v1 = hir.bitcast v0 : (ptr i32) #[ty = (ptr i32)];
+    v2 = hir.load v1 : i32;
+    v3 = hir.constant 9 : i32;
+    v4 = hir.add v2, v3 : i32 #[overflow = wrapping];
+    v5 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = world/root/noname/MyGlobalVal];
+    v6 = hir.bitcast v5 : (ptr i32) #[ty = (ptr i32)];
+    hir.store v6, v4;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_add.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_add.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 3 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.add v0, v1 : i32 #[overflow = wrapping];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_and.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_and.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.band v0, v1 : i32;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_clz.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_clz.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1 : i32;
+    v1 = hir.clz v0 : u32;
+    v2 = hir.bitcast v1 : i32 #[ty = i32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_const.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_const.hir
@@ -1,0 +1,7 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1 : i32;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_ctz.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_ctz.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1 : i32;
+    v1 = hir.ctz v0 : u32;
+    v2 = hir.bitcast v1 : i32 #[ty = i32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_div_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_div_s.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.div v0, v1 : i32;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_div_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_div_u.hir
@@ -1,0 +1,12 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bitcast v0 : u32 #[ty = u32];
+    v3 = hir.bitcast v1 : u32 #[ty = u32];
+    v4 = hir.div v2, v3 : u32;
+    v5 = hir.bitcast v4 : i32 #[ty = i32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_eq.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_eq.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.eq v0, v1 : i1;
+    v3 = hir.zext v2 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_eqz.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_eqz.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 0 : i32;
+    v2 = hir.eq v0, v1 : i1;
+    v3 = hir.zext v2 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_ge_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_ge_s.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.gte v0, v1 : i1;
+    v3 = hir.zext v2 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_ge_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_ge_u.hir
@@ -1,0 +1,12 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bitcast v0 : u32 #[ty = u32];
+    v3 = hir.bitcast v1 : u32 #[ty = u32];
+    v4 = hir.gte v2, v3 : i1;
+    v5 = hir.zext v4 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_gt_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_gt_s.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.gt v0, v1 : i1;
+    v3 = hir.zext v2 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_gt_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_gt_u.hir
@@ -1,0 +1,12 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bitcast v0 : u32 #[ty = u32];
+    v3 = hir.bitcast v1 : u32 #[ty = u32];
+    v4 = hir.gt v2, v3 : i1;
+    v5 = hir.zext v4 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_le_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_le_s.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.lte v0, v1 : i1;
+    v3 = hir.zext v2 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_le_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_le_u.hir
@@ -1,0 +1,12 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bitcast v0 : u32 #[ty = u32];
+    v3 = hir.bitcast v1 : u32 #[ty = u32];
+    v4 = hir.lte v2, v3 : i1;
+    v5 = hir.zext v4 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_load.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_load.hir
@@ -1,0 +1,13 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.bitcast v0 : u32 #[ty = u32];
+    v2 = hir.constant 4 : u32;
+    v3 = hir.mod v1, v2 : u32;
+    hir.assertz v3 #[code = 250];
+    v4 = hir.int_to_ptr v1 : (ptr i32) #[ty = (ptr i32)];
+    v5 = hir.load v4 : i32;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_load16_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_load16_s.hir
@@ -1,0 +1,14 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.bitcast v0 : u32 #[ty = u32];
+    v2 = hir.constant 2 : u32;
+    v3 = hir.mod v1, v2 : u32;
+    hir.assertz v3 #[code = 250];
+    v4 = hir.int_to_ptr v1 : (ptr i16) #[ty = (ptr i16)];
+    v5 = hir.load v4 : i16;
+    v6 = hir.sext v5 : i32 #[ty = i32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_load16_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_load16_u.hir
@@ -1,0 +1,14 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.bitcast v0 : u32 #[ty = u32];
+    v2 = hir.constant 2 : u32;
+    v3 = hir.mod v1, v2 : u32;
+    hir.assertz v3 #[code = 250];
+    v4 = hir.int_to_ptr v1 : (ptr u16) #[ty = (ptr u16)];
+    v5 = hir.load v4 : u16;
+    v6 = hir.zext v5 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_load8_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_load8_s.hir
@@ -1,0 +1,11 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.bitcast v0 : u32 #[ty = u32];
+    v2 = hir.int_to_ptr v1 : (ptr i8) #[ty = (ptr i8)];
+    v3 = hir.load v2 : i8;
+    v4 = hir.sext v3 : i32 #[ty = i32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_load8_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_load8_u.hir
@@ -1,0 +1,11 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.bitcast v0 : u32 #[ty = u32];
+    v2 = hir.int_to_ptr v1 : (ptr u8) #[ty = (ptr u8)];
+    v3 = hir.load v2 : u8;
+    v4 = hir.zext v3 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_lt_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_lt_s.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.lt v0, v1 : i1;
+    v3 = hir.zext v2 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_lt_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_lt_u.hir
@@ -1,0 +1,12 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bitcast v0 : u32 #[ty = u32];
+    v3 = hir.bitcast v1 : u32 #[ty = u32];
+    v4 = hir.lt v2, v3 : i1;
+    v5 = hir.zext v4 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_mul.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_mul.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.mul v0, v1 : i32 #[overflow = wrapping];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_ne.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_ne.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.neq v0, v1 : i1;
+    v3 = hir.zext v2 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_or.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_or.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bor v0, v1 : i32;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_popcnt.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_popcnt.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1 : i32;
+    v1 = hir.popcnt v0 : u32;
+    v2 = hir.bitcast v1 : i32 #[ty = i32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_rem_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_rem_s.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.mod v0, v1 : i32;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_rem_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_rem_u.hir
@@ -1,0 +1,12 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bitcast v0 : u32 #[ty = u32];
+    v3 = hir.bitcast v1 : u32 #[ty = u32];
+    v4 = hir.mod v2, v3 : u32;
+    v5 = hir.bitcast v4 : i32 #[ty = i32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_rotl.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_rotl.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bitcast v1 : u32 #[ty = u32];
+    v3 = hir.rotl v0, v2 : i32;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_rotr.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_rotr.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bitcast v1 : u32 #[ty = u32];
+    v3 = hir.rotr v0, v2 : i32;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_shl.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_shl.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bitcast v1 : u32 #[ty = u32];
+    v3 = hir.shl v0, v2 : i32;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_shr_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_shr_s.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bitcast v1 : u32 #[ty = u32];
+    v3 = hir.shr v0, v2 : i32;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_shr_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_shr_u.hir
@@ -1,0 +1,12 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bitcast v0 : u32 #[ty = u32];
+    v3 = hir.bitcast v1 : u32 #[ty = u32];
+    v4 = hir.shr v2, v3 : u32;
+    v5 = hir.bitcast v4 : i32 #[ty = i32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_store.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_store.hir
@@ -1,0 +1,14 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bitcast v0 : u32 #[ty = u32];
+    v3 = hir.constant 4 : u32;
+    v4 = hir.mod v2, v3 : u32;
+    hir.assertz v4 #[code = 250];
+    v5 = hir.int_to_ptr v2 : (ptr i32) #[ty = (ptr i32)];
+    hir.store v5, v1;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_store16.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_store16.hir
@@ -1,0 +1,16 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bitcast v1 : u32 #[ty = u32];
+    v3 = hir.trunc v2 : u16 #[ty = u16];
+    v4 = hir.bitcast v0 : u32 #[ty = u32];
+    v5 = hir.constant 2 : u32;
+    v6 = hir.mod v4, v5 : u32;
+    hir.assertz v6 #[code = 250];
+    v7 = hir.int_to_ptr v4 : (ptr u16) #[ty = (ptr u16)];
+    hir.store v7, v3;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_store8.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_store8.hir
@@ -1,0 +1,13 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bitcast v1 : u32 #[ty = u32];
+    v3 = hir.trunc v2 : u8 #[ty = u8];
+    v4 = hir.bitcast v0 : u32 #[ty = u32];
+    v5 = hir.int_to_ptr v4 : (ptr u8) #[ty = (ptr u8)];
+    hir.store v5, v3;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_sub.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_sub.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 3 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.sub v0, v1 : i32 #[overflow = wrapping];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_wrap_i64.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_wrap_i64.hir
@@ -1,0 +1,8 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1 : i64;
+    v1 = hir.trunc v0 : i32 #[ty = i32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i32_xor.hir
+++ b/frontend-wasm2/src/code_translator/expected/i32_xor.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 1 : i32;
+    v2 = hir.bxor v0, v1 : i32;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_add.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_add.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 3 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.add v0, v1 : i64 #[overflow = wrapping];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_and.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_and.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.band v0, v1 : i64;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_clz.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_clz.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1 : i64;
+    v1 = hir.clz v0 : u32;
+    v2 = hir.bitcast v1 : i32 #[ty = i32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_const.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_const.hir
@@ -1,0 +1,7 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1 : i64;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_ctz.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_ctz.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1 : i64;
+    v1 = hir.ctz v0 : u32;
+    v2 = hir.bitcast v1 : i32 #[ty = i32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_div_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_div_s.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.div v0, v1 : i64;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_div_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_div_u.hir
@@ -1,0 +1,12 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.bitcast v0 : u64 #[ty = u64];
+    v3 = hir.bitcast v1 : u64 #[ty = u64];
+    v4 = hir.div v2, v3 : u64;
+    v5 = hir.bitcast v4 : i64 #[ty = i64];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_eq.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_eq.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.eq v0, v1 : i1;
+    v3 = hir.zext v2 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_eqz.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_eqz.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 0 : i64;
+    v2 = hir.eq v0, v1 : i1;
+    v3 = hir.zext v2 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_extend_i32_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_extend_i32_s.hir
@@ -1,0 +1,8 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1 : i32;
+    v1 = hir.sext v0 : i64 #[ty = i64];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_extend_i32_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_extend_i32_u.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1 : i32;
+    v1 = hir.bitcast v0 : u32 #[ty = u32];
+    v2 = hir.zext v1 : u64 #[ty = u64];
+    v3 = hir.bitcast v2 : i64 #[ty = i64];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_ge_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_ge_s.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.gte v0, v1 : i1;
+    v3 = hir.zext v2 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_ge_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_ge_u.hir
@@ -1,0 +1,12 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.bitcast v0 : u64 #[ty = u64];
+    v3 = hir.bitcast v1 : u64 #[ty = u64];
+    v4 = hir.gte v2, v3 : i1;
+    v5 = hir.zext v4 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_gt_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_gt_s.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.gt v0, v1 : i1;
+    v3 = hir.zext v2 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_gt_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_gt_u.hir
@@ -1,0 +1,12 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.bitcast v0 : u64 #[ty = u64];
+    v3 = hir.bitcast v1 : u64 #[ty = u64];
+    v4 = hir.gt v2, v3 : i1;
+    v5 = hir.zext v4 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_le_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_le_s.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.lte v0, v1 : i1;
+    v3 = hir.zext v2 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_le_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_le_u.hir
@@ -1,0 +1,12 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.bitcast v0 : u64 #[ty = u64];
+    v3 = hir.bitcast v1 : u64 #[ty = u64];
+    v4 = hir.lte v2, v3 : i1;
+    v5 = hir.zext v4 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_load.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_load.hir
@@ -1,0 +1,13 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.bitcast v0 : u32 #[ty = u32];
+    v2 = hir.constant 8 : u32;
+    v3 = hir.mod v1, v2 : u32;
+    hir.assertz v3 #[code = 250];
+    v4 = hir.int_to_ptr v1 : (ptr i64) #[ty = (ptr i64)];
+    v5 = hir.load v4 : i64;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_load16_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_load16_s.hir
@@ -1,0 +1,14 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.bitcast v0 : u32 #[ty = u32];
+    v2 = hir.constant 2 : u32;
+    v3 = hir.mod v1, v2 : u32;
+    hir.assertz v3 #[code = 250];
+    v4 = hir.int_to_ptr v1 : (ptr i16) #[ty = (ptr i16)];
+    v5 = hir.load v4 : i16;
+    v6 = hir.sext v5 : i64 #[ty = i64];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_load16_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_load16_u.hir
@@ -1,0 +1,14 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.bitcast v0 : u32 #[ty = u32];
+    v2 = hir.constant 2 : u32;
+    v3 = hir.mod v1, v2 : u32;
+    hir.assertz v3 #[code = 250];
+    v4 = hir.int_to_ptr v1 : (ptr u16) #[ty = (ptr u16)];
+    v5 = hir.load v4 : u16;
+    v6 = hir.zext v5 : u64 #[ty = u64];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_load32_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_load32_s.hir
@@ -1,0 +1,14 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.bitcast v0 : u32 #[ty = u32];
+    v2 = hir.constant 4 : u32;
+    v3 = hir.mod v1, v2 : u32;
+    hir.assertz v3 #[code = 250];
+    v4 = hir.int_to_ptr v1 : (ptr i32) #[ty = (ptr i32)];
+    v5 = hir.load v4 : i32;
+    v6 = hir.sext v5 : i64 #[ty = i64];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_load32_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_load32_u.hir
@@ -1,0 +1,14 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.bitcast v0 : u32 #[ty = u32];
+    v2 = hir.constant 4 : u32;
+    v3 = hir.mod v1, v2 : u32;
+    hir.assertz v3 #[code = 250];
+    v4 = hir.int_to_ptr v1 : (ptr u32) #[ty = (ptr u32)];
+    v5 = hir.load v4 : u32;
+    v6 = hir.zext v5 : u64 #[ty = u64];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_load8_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_load8_s.hir
@@ -1,0 +1,11 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.bitcast v0 : u32 #[ty = u32];
+    v2 = hir.int_to_ptr v1 : (ptr i8) #[ty = (ptr i8)];
+    v3 = hir.load v2 : i8;
+    v4 = hir.sext v3 : i64 #[ty = i64];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_load8_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_load8_u.hir
@@ -1,0 +1,11 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.bitcast v0 : u32 #[ty = u32];
+    v2 = hir.int_to_ptr v1 : (ptr u8) #[ty = (ptr u8)];
+    v3 = hir.load v2 : u8;
+    v4 = hir.zext v3 : u64 #[ty = u64];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_lt_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_lt_s.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.lt v0, v1 : i1;
+    v3 = hir.zext v2 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_lt_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_lt_u.hir
@@ -1,0 +1,12 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.bitcast v0 : u64 #[ty = u64];
+    v3 = hir.bitcast v1 : u64 #[ty = u64];
+    v4 = hir.lt v2, v3 : i1;
+    v5 = hir.zext v4 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_mul.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_mul.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.mul v0, v1 : i64 #[overflow = wrapping];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_ne.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_ne.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.neq v0, v1 : i1;
+    v3 = hir.zext v2 : u32 #[ty = u32];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_or.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_or.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.bor v0, v1 : i64;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_rem_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_rem_s.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.mod v0, v1 : i64;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_rem_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_rem_u.hir
@@ -1,0 +1,12 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.bitcast v0 : u64 #[ty = u64];
+    v3 = hir.bitcast v1 : u64 #[ty = u64];
+    v4 = hir.mod v2, v3 : u64;
+    v5 = hir.bitcast v4 : i64 #[ty = i64];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_rotl.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_rotl.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.cast v1 : u32 #[ty = u32];
+    v3 = hir.rotl v0, v2 : i64;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_rotr.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_rotr.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.cast v1 : u32 #[ty = u32];
+    v3 = hir.rotr v0, v2 : i64;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_shl.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_shl.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.cast v1 : u32 #[ty = u32];
+    v3 = hir.shl v0, v2 : i64;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_shr_s.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_shr_s.hir
@@ -1,0 +1,10 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.cast v1 : u32 #[ty = u32];
+    v3 = hir.shr v0, v2 : i64;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_shr_u.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_shr_u.hir
@@ -1,0 +1,12 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.bitcast v0 : u64 #[ty = u64];
+    v3 = hir.cast v1 : u32 #[ty = u32];
+    v4 = hir.shr v2, v3 : u64;
+    v5 = hir.bitcast v4 : i64 #[ty = i64];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_store.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_store.hir
@@ -1,0 +1,14 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.bitcast v0 : u32 #[ty = u32];
+    v3 = hir.constant 8 : u32;
+    v4 = hir.mod v2, v3 : u32;
+    hir.assertz v4 #[code = 250];
+    v5 = hir.int_to_ptr v2 : (ptr i64) #[ty = (ptr i64)];
+    hir.store v5, v1;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_store32.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_store32.hir
@@ -1,0 +1,16 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1024 : i32;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.bitcast v1 : u64 #[ty = u64];
+    v3 = hir.trunc v2 : u32 #[ty = u32];
+    v4 = hir.bitcast v0 : u32 #[ty = u32];
+    v5 = hir.constant 4 : u32;
+    v6 = hir.mod v4, v5 : u32;
+    hir.assertz v6 #[code = 250];
+    v7 = hir.int_to_ptr v4 : (ptr u32) #[ty = (ptr u32)];
+    hir.store v7, v3;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_sub.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_sub.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 3 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.sub v0, v1 : i64 #[overflow = wrapping];
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/i64_xor.hir
+++ b/frontend-wasm2/src/code_translator/expected/i64_xor.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i64;
+    v1 = hir.constant 1 : i64;
+    v2 = hir.bxor v0, v1 : i64;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/if_else.hir
+++ b/frontend-wasm2/src/code_translator/expected/if_else.hir
@@ -1,0 +1,17 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 2 : i32;
+    v1 = hir.constant 0 : i32;
+    v2 = hir.neq v0, v1 : i1;
+    hir.cond_br v2 block6, block8;
+^block5:
+    hir.ret ;
+^block6:
+    v4 = hir.constant 3 : i32;
+    hir.br block7(v4);
+^block7(v3: i32):
+    hir.br block5;
+^block8:
+    v5 = hir.constant 5 : i32;
+    hir.br block7(v5);
+};

--- a/frontend-wasm2/src/code_translator/expected/memory_copy.hir
+++ b/frontend-wasm2/src/code_translator/expected/memory_copy.hir
@@ -1,0 +1,15 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 20 : i32;
+    v1 = hir.constant 10 : i32;
+    v2 = hir.constant 1 : i32;
+    v3 = hir.bitcast v2 : u32 #[ty = u32];
+    v4 = hir.bitcast v0 : u32 #[ty = u32];
+    v5 = hir.int_to_ptr v4 : (ptr u8) #[ty = (ptr u8)];
+    v6 = hir.bitcast v1 : u32 #[ty = u32];
+    v7 = hir.int_to_ptr v6 : (ptr u8) #[ty = (ptr u8)];
+    hir.mem_cpy v7, v5, v3;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/memory_grow.hir
+++ b/frontend-wasm2/src/code_translator/expected/memory_grow.hir
@@ -1,0 +1,9 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 1 : i32;
+    v1 = hir.bitcast v0 : u32 #[ty = u32];
+    v2 = hir.mem_grow v1 : u32;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/memory_size.hir
+++ b/frontend-wasm2/src/code_translator/expected/memory_size.hir
@@ -1,0 +1,7 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.mem_size  : u32;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/code_translator/expected/select_i32.hir
+++ b/frontend-wasm2/src/code_translator/expected/select_i32.hir
@@ -1,0 +1,12 @@
+builtin.function public @test_wrapper() {
+^block4:
+    v0 = hir.constant 3 : i64;
+    v1 = hir.constant 7 : i64;
+    v2 = hir.constant 1 : i32;
+    v3 = hir.constant 0 : i32;
+    v4 = hir.neq v2, v3 : i1;
+    v5 = hir.select v4, v0, v1 : i64;
+    hir.br block5;
+^block5:
+    hir.ret ;
+};

--- a/frontend-wasm2/src/lib.rs
+++ b/frontend-wasm2/src/lib.rs
@@ -38,13 +38,14 @@ pub fn translate(
     wasm: &[u8],
     config: &WasmTranslationConfig,
     context: Rc<Context>,
-) -> WasmResult<midenc_hir2::dialects::builtin::ComponentRef> {
+) -> WasmResult<midenc_hir2::dialects::builtin::WorldRef> {
     if wasm[4..8] == [0x01, 0x00, 0x00, 0x00] {
         // Wasm core module
         // see https://github.com/WebAssembly/component-model/blob/main/design/mvp/Binary.md#component-definitions
         translate_module_as_component(wasm, config, context)
     } else {
-        translate_component(wasm, config, context)
+        todo!()
+        // translate_component(wasm, config, context)
     }
 }
 

--- a/hir2/src/dialects/builtin.rs
+++ b/hir2/src/dialects/builtin.rs
@@ -31,6 +31,7 @@ impl DialectRegistration for BuiltinDialect {
     }
 
     fn register_operations(info: &mut DialectInfo) {
+        info.register_operation::<ops::World>();
         info.register_operation::<ops::Component>();
         info.register_operation::<ops::Module>();
         info.register_operation::<ops::Function>();

--- a/hir2/src/dialects/builtin.rs
+++ b/hir2/src/dialects/builtin.rs
@@ -2,7 +2,7 @@ mod builders;
 mod ops;
 
 pub use self::{
-    builders::{ComponentBuilder, ModuleBuilder},
+    builders::{ComponentBuilder, ModuleBuilder, WorldBuilder},
     ops::*,
 };
 use crate::{

--- a/hir2/src/dialects/builtin/builders.rs
+++ b/hir2/src/dialects/builtin/builders.rs
@@ -1,4 +1,5 @@
 mod component;
 mod module;
+mod world;
 
 pub use self::{component::*, module::*};

--- a/hir2/src/dialects/builtin/builders.rs
+++ b/hir2/src/dialects/builtin/builders.rs
@@ -2,4 +2,4 @@ mod component;
 mod module;
 mod world;
 
-pub use self::{component::*, module::*};
+pub use self::{component::*, module::*, world::*};

--- a/hir2/src/dialects/builtin/builders/world.rs
+++ b/hir2/src/dialects/builtin/builders/world.rs
@@ -1,0 +1,41 @@
+use crate::{
+    dialects::builtin::{ComponentRef, PrimComponentBuilder, WorldRef},
+    version::Version,
+    Builder, Ident, Op, OpBuilder, Report, Spanned,
+};
+
+pub struct WorldBuilder {
+    pub world: WorldRef,
+    builder: OpBuilder,
+}
+impl WorldBuilder {
+    pub fn new(world_ref: WorldRef) -> Self {
+        let world = world_ref.borrow();
+        let context = world.as_operation().context_rc();
+        let mut builder = OpBuilder::new(context);
+
+        let body = world.body();
+        if let Some(current_block) = body.entry_block_ref() {
+            builder.set_insertion_point_to_end(current_block);
+        } else {
+            let body_ref = body.as_region_ref();
+            drop(body);
+            builder.create_block(body_ref, None, &[]);
+        }
+
+        Self {
+            world: world_ref,
+            builder,
+        }
+    }
+
+    pub fn define_component(
+        &mut self,
+        ns: Ident,
+        name: Ident,
+        ver: Version,
+    ) -> Result<ComponentRef, Report> {
+        let builder = PrimComponentBuilder::new(&mut self.builder, name.span());
+        builder(ns, name, ver)
+    }
+}

--- a/hir2/src/dialects/builtin/ops.rs
+++ b/hir2/src/dialects/builtin/ops.rs
@@ -4,6 +4,7 @@ mod global_variable;
 mod interface;
 mod module;
 mod segment;
+mod world;
 
 pub use self::{
     component::{
@@ -15,4 +16,5 @@ pub use self::{
     interface::{Interface, InterfaceBuilder as PrimInterfaceBuilder, InterfaceRef},
     module::{Module, ModuleBuilder as PrimModuleBuilder, ModuleRef},
     segment::*,
+    world::{World, WorldRef},
 };

--- a/hir2/src/dialects/builtin/ops/world.rs
+++ b/hir2/src/dialects/builtin/ops/world.rs
@@ -1,0 +1,120 @@
+use crate::{
+    derive::operation,
+    dialects::builtin::BuiltinDialect,
+    traits::{
+        GraphRegionNoTerminator, HasOnlyGraphRegion, IsolatedFromAbove, NoRegionArguments,
+        NoTerminator, SingleBlock, SingleRegion,
+    },
+    Ident, Operation, RegionKind, RegionKindInterface, Symbol, SymbolManager, SymbolManagerMut,
+    SymbolMap, SymbolName, SymbolRef, SymbolTable, SymbolUseList, UnsafeIntrusiveEntityRef, Usable,
+    Visibility,
+};
+
+pub type WorldRef = UnsafeIntrusiveEntityRef<World>;
+
+/// A [World] is a component abstraction operation, i.e. it is designed to tie particular
+/// [Component]s together.
+///
+/// Worlds can contain only [Component]s.
+///
+/// NOTE: Worlds always have `Public` visibility.
+///
+/// Worlds are linked into Miden Assembly according to the following rules:
+#[operation(
+    dialect = BuiltinDialect,
+    traits(
+        SingleRegion,
+        SingleBlock,
+        NoRegionArguments,
+        NoTerminator,
+        HasOnlyGraphRegion,
+        GraphRegionNoTerminator,
+        IsolatedFromAbove,
+    ),
+    implements(RegionKindInterface, SymbolTable, Symbol)
+)]
+pub struct World {
+    #[attr]
+    name: Ident,
+    #[region]
+    body: RegionRef,
+    #[default]
+    symbols: SymbolMap,
+    #[default]
+    uses: SymbolUseList,
+}
+
+impl RegionKindInterface for World {
+    #[inline(always)]
+    fn kind(&self) -> RegionKind {
+        RegionKind::Graph
+    }
+}
+
+impl Usable for World {
+    type Use = crate::SymbolUse;
+
+    #[inline(always)]
+    fn uses(&self) -> &SymbolUseList {
+        &self.uses
+    }
+
+    #[inline(always)]
+    fn uses_mut(&mut self) -> &mut SymbolUseList {
+        &mut self.uses
+    }
+}
+
+impl Symbol for World {
+    #[inline(always)]
+    fn as_symbol_operation(&self) -> &Operation {
+        &self.op
+    }
+
+    #[inline(always)]
+    fn as_symbol_operation_mut(&mut self) -> &mut Operation {
+        &mut self.op
+    }
+
+    fn name(&self) -> SymbolName {
+        World::name(self).as_symbol()
+    }
+
+    fn set_name(&mut self, name: SymbolName) {
+        let id = self.name_mut();
+        id.name = name;
+    }
+
+    fn visibility(&self) -> Visibility {
+        Visibility::Public
+    }
+
+    fn set_visibility(&mut self, _visibility: Visibility) {
+        panic!("Cannot set World's visibility. It's always Public");
+    }
+}
+
+impl SymbolTable for World {
+    #[inline(always)]
+    fn as_symbol_table_operation(&self) -> &Operation {
+        &self.op
+    }
+
+    #[inline(always)]
+    fn as_symbol_table_operation_mut(&mut self) -> &mut Operation {
+        &mut self.op
+    }
+
+    fn symbol_manager(&self) -> SymbolManager<'_> {
+        SymbolManager::new(&self.op, crate::Symbols::Borrowed(&self.symbols))
+    }
+
+    fn symbol_manager_mut(&mut self) -> SymbolManagerMut<'_> {
+        SymbolManagerMut::new(&mut self.op, crate::SymbolsMut::Borrowed(&mut self.symbols))
+    }
+
+    #[inline]
+    fn get(&self, name: SymbolName) -> Option<SymbolRef> {
+        self.symbols.get(name)
+    }
+}

--- a/tests/integration/expected/abi_transform_stdlib_blake3_hash.hir
+++ b/tests/integration/expected/abi_transform_stdlib_blake3_hash.hir
@@ -1,161 +1,164 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #abi_transform_stdlib_blake3_hash] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32, v8: i32) {
-        ^block2(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32, v8: i32):
-            v9, v10, v11, v12, v13, v14, v15, v16 = hir.exec v0, v1, v2, v3, v4, v5, v6, v7 : i32, i32, i32, i32, i32, i32, i32, i32 #[callee = root/std::crypto::hashes::blake3/hash_1to1] #[signature = (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (result i32 i32 i32 i32 i32 i32 i32 i32)];
-            v17 = hir.bitcast v8 : u32 #[ty = u32];
-            v18 = hir.int_to_ptr v17 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v18, v9;
-            v19 = hir.constant 4 : u32;
-            v20 = hir.add v17, v19 : u32 #[overflow = checked];
-            v21 = hir.int_to_ptr v20 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v21, v10;
-            v22 = hir.constant 8 : u32;
-            v23 = hir.add v17, v22 : u32 #[overflow = checked];
-            v24 = hir.int_to_ptr v23 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v24, v11;
-            v25 = hir.constant 12 : u32;
-            v26 = hir.add v17, v25 : u32 #[overflow = checked];
-            v27 = hir.int_to_ptr v26 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v27, v12;
-            v28 = hir.constant 16 : u32;
-            v29 = hir.add v17, v28 : u32 #[overflow = checked];
-            v30 = hir.int_to_ptr v29 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v30, v13;
-            v31 = hir.constant 20 : u32;
-            v32 = hir.add v17, v31 : u32 #[overflow = checked];
-            v33 = hir.int_to_ptr v32 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v33, v14;
-            v34 = hir.constant 24 : u32;
-            v35 = hir.add v17, v34 : u32 #[overflow = checked];
-            v36 = hir.int_to_ptr v35 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v36, v15;
-            v37 = hir.constant 28 : u32;
-            v38 = hir.add v17, v37 : u32 #[overflow = checked];
-            v39 = hir.int_to_ptr v38 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v39, v16;
-            hir.br block4;
-        ^block4:
-            hir.ret ;
+        builtin.module  #[name = #abi_transform_stdlib_blake3_hash] #[visibility = public] {
+
+            builtin.function public @miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32, v8: i32) {
+            ^block3(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32, v8: i32):
+                v9, v10, v11, v12, v13, v14, v15, v16 = hir.exec v0, v1, v2, v3, v4, v5, v6, v7 : i32, i32, i32, i32, i32, i32, i32, i32 #[callee = world/root/std::crypto::hashes::blake3/hash_1to1] #[signature = (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (result i32 i32 i32 i32 i32 i32 i32 i32)];
+                v17 = hir.bitcast v8 : u32 #[ty = u32];
+                v18 = hir.int_to_ptr v17 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v18, v9;
+                v19 = hir.constant 4 : u32;
+                v20 = hir.add v17, v19 : u32 #[overflow = checked];
+                v21 = hir.int_to_ptr v20 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v21, v10;
+                v22 = hir.constant 8 : u32;
+                v23 = hir.add v17, v22 : u32 #[overflow = checked];
+                v24 = hir.int_to_ptr v23 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v24, v11;
+                v25 = hir.constant 12 : u32;
+                v26 = hir.add v17, v25 : u32 #[overflow = checked];
+                v27 = hir.int_to_ptr v26 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v27, v12;
+                v28 = hir.constant 16 : u32;
+                v29 = hir.add v17, v28 : u32 #[overflow = checked];
+                v30 = hir.int_to_ptr v29 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v30, v13;
+                v31 = hir.constant 20 : u32;
+                v32 = hir.add v17, v31 : u32 #[overflow = checked];
+                v33 = hir.int_to_ptr v32 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v33, v14;
+                v34 = hir.constant 24 : u32;
+                v35 = hir.add v17, v34 : u32 #[overflow = checked];
+                v36 = hir.int_to_ptr v35 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v36, v15;
+                v37 = hir.constant 28 : u32;
+                v38 = hir.add v17, v37 : u32 #[overflow = checked];
+                v39 = hir.int_to_ptr v38 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v39, v16;
+                hir.br block5;
+            ^block5:
+                hir.ret ;
+            };
+            builtin.function public @entrypoint(v40: i32, v41: i32) {
+            ^block7(v40: i32, v41: i32):
+                v42 = hir.constant 0 : i32;
+                v43 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = world/root/abi_transform_stdlib_blake3_hash/__stack_pointer];
+                v44 = hir.bitcast v43 : (ptr i32) #[ty = (ptr i32)];
+                v45 = hir.load v44 : i32;
+                v46 = hir.constant 32 : i32;
+                v47 = hir.sub v45, v46 : i32 #[overflow = wrapping];
+                v48 = hir.constant -32 : i32;
+                v49 = hir.band v47, v48 : i32;
+                v50 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = world/root/abi_transform_stdlib_blake3_hash/__stack_pointer];
+                v51 = hir.bitcast v50 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v51, v49;
+                v52 = hir.bitcast v41 : u32 #[ty = u32];
+                v53 = hir.int_to_ptr v52 : (ptr i32) #[ty = (ptr i32)];
+                v54 = hir.load v53 : i32;
+                v55 = hir.bitcast v41 : u32 #[ty = u32];
+                v56 = hir.constant 4 : u32;
+                v57 = hir.add v55, v56 : u32 #[overflow = checked];
+                v58 = hir.int_to_ptr v57 : (ptr i32) #[ty = (ptr i32)];
+                v59 = hir.load v58 : i32;
+                v60 = hir.bitcast v41 : u32 #[ty = u32];
+                v61 = hir.constant 8 : u32;
+                v62 = hir.add v60, v61 : u32 #[overflow = checked];
+                v63 = hir.int_to_ptr v62 : (ptr i32) #[ty = (ptr i32)];
+                v64 = hir.load v63 : i32;
+                v65 = hir.bitcast v41 : u32 #[ty = u32];
+                v66 = hir.constant 12 : u32;
+                v67 = hir.add v65, v66 : u32 #[overflow = checked];
+                v68 = hir.int_to_ptr v67 : (ptr i32) #[ty = (ptr i32)];
+                v69 = hir.load v68 : i32;
+                v70 = hir.bitcast v41 : u32 #[ty = u32];
+                v71 = hir.constant 16 : u32;
+                v72 = hir.add v70, v71 : u32 #[overflow = checked];
+                v73 = hir.int_to_ptr v72 : (ptr i32) #[ty = (ptr i32)];
+                v74 = hir.load v73 : i32;
+                v75 = hir.bitcast v41 : u32 #[ty = u32];
+                v76 = hir.constant 20 : u32;
+                v77 = hir.add v75, v76 : u32 #[overflow = checked];
+                v78 = hir.int_to_ptr v77 : (ptr i32) #[ty = (ptr i32)];
+                v79 = hir.load v78 : i32;
+                v80 = hir.bitcast v41 : u32 #[ty = u32];
+                v81 = hir.constant 24 : u32;
+                v82 = hir.add v80, v81 : u32 #[overflow = checked];
+                v83 = hir.int_to_ptr v82 : (ptr i32) #[ty = (ptr i32)];
+                v84 = hir.load v83 : i32;
+                v85 = hir.bitcast v41 : u32 #[ty = u32];
+                v86 = hir.constant 28 : u32;
+                v87 = hir.add v85, v86 : u32 #[overflow = checked];
+                v88 = hir.int_to_ptr v87 : (ptr i32) #[ty = (ptr i32)];
+                v89 = hir.load v88 : i32;
+                hir.exec v54, v59, v64, v69, v74, v79, v84, v89, v49 #[callee = world/root/abi_transform_stdlib_blake3_hash/miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1] #[signature = (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32)];
+                v90 = hir.constant 24 : i32;
+                v91 = hir.add v40, v90 : i32 #[overflow = wrapping];
+                v92 = hir.bitcast v49 : u32 #[ty = u32];
+                v93 = hir.constant 24 : u32;
+                v94 = hir.add v92, v93 : u32 #[overflow = checked];
+                v95 = hir.constant 8 : u32;
+                v96 = hir.mod v94, v95 : u32;
+                hir.assertz v96 #[code = 250];
+                v97 = hir.int_to_ptr v94 : (ptr i64) #[ty = (ptr i64)];
+                v98 = hir.load v97 : i64;
+                v99 = hir.bitcast v91 : u32 #[ty = u32];
+                v100 = hir.int_to_ptr v99 : (ptr i64) #[ty = (ptr i64)];
+                hir.store v100, v98;
+                v101 = hir.constant 16 : i32;
+                v102 = hir.add v40, v101 : i32 #[overflow = wrapping];
+                v103 = hir.bitcast v49 : u32 #[ty = u32];
+                v104 = hir.constant 16 : u32;
+                v105 = hir.add v103, v104 : u32 #[overflow = checked];
+                v106 = hir.constant 8 : u32;
+                v107 = hir.mod v105, v106 : u32;
+                hir.assertz v107 #[code = 250];
+                v108 = hir.int_to_ptr v105 : (ptr i64) #[ty = (ptr i64)];
+                v109 = hir.load v108 : i64;
+                v110 = hir.bitcast v102 : u32 #[ty = u32];
+                v111 = hir.int_to_ptr v110 : (ptr i64) #[ty = (ptr i64)];
+                hir.store v111, v109;
+                v112 = hir.constant 8 : i32;
+                v113 = hir.add v40, v112 : i32 #[overflow = wrapping];
+                v114 = hir.bitcast v49 : u32 #[ty = u32];
+                v115 = hir.constant 8 : u32;
+                v116 = hir.add v114, v115 : u32 #[overflow = checked];
+                v117 = hir.constant 8 : u32;
+                v118 = hir.mod v116, v117 : u32;
+                hir.assertz v118 #[code = 250];
+                v119 = hir.int_to_ptr v116 : (ptr i64) #[ty = (ptr i64)];
+                v120 = hir.load v119 : i64;
+                v121 = hir.bitcast v113 : u32 #[ty = u32];
+                v122 = hir.int_to_ptr v121 : (ptr i64) #[ty = (ptr i64)];
+                hir.store v122, v120;
+                v123 = hir.bitcast v49 : u32 #[ty = u32];
+                v124 = hir.constant 8 : u32;
+                v125 = hir.mod v123, v124 : u32;
+                hir.assertz v125 #[code = 250];
+                v126 = hir.int_to_ptr v123 : (ptr i64) #[ty = (ptr i64)];
+                v127 = hir.load v126 : i64;
+                v128 = hir.bitcast v40 : u32 #[ty = u32];
+                v129 = hir.int_to_ptr v128 : (ptr i64) #[ty = (ptr i64)];
+                hir.store v129, v127;
+                v130 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = world/root/abi_transform_stdlib_blake3_hash/__stack_pointer];
+                v131 = hir.bitcast v130 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v131, v45;
+                hir.br block8;
+            ^block8:
+                hir.ret ;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
-        builtin.function public @entrypoint(v40: i32, v41: i32) {
-        ^block6(v40: i32, v41: i32):
-            v42 = hir.constant 0 : i32;
-            v43 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_stdlib_blake3_hash/__stack_pointer];
-            v44 = hir.bitcast v43 : (ptr i32) #[ty = (ptr i32)];
-            v45 = hir.load v44 : i32;
-            v46 = hir.constant 32 : i32;
-            v47 = hir.sub v45, v46 : i32 #[overflow = wrapping];
-            v48 = hir.constant -32 : i32;
-            v49 = hir.band v47, v48 : i32;
-            v50 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_stdlib_blake3_hash/__stack_pointer];
-            v51 = hir.bitcast v50 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v51, v49;
-            v52 = hir.bitcast v41 : u32 #[ty = u32];
-            v53 = hir.int_to_ptr v52 : (ptr i32) #[ty = (ptr i32)];
-            v54 = hir.load v53 : i32;
-            v55 = hir.bitcast v41 : u32 #[ty = u32];
-            v56 = hir.constant 4 : u32;
-            v57 = hir.add v55, v56 : u32 #[overflow = checked];
-            v58 = hir.int_to_ptr v57 : (ptr i32) #[ty = (ptr i32)];
-            v59 = hir.load v58 : i32;
-            v60 = hir.bitcast v41 : u32 #[ty = u32];
-            v61 = hir.constant 8 : u32;
-            v62 = hir.add v60, v61 : u32 #[overflow = checked];
-            v63 = hir.int_to_ptr v62 : (ptr i32) #[ty = (ptr i32)];
-            v64 = hir.load v63 : i32;
-            v65 = hir.bitcast v41 : u32 #[ty = u32];
-            v66 = hir.constant 12 : u32;
-            v67 = hir.add v65, v66 : u32 #[overflow = checked];
-            v68 = hir.int_to_ptr v67 : (ptr i32) #[ty = (ptr i32)];
-            v69 = hir.load v68 : i32;
-            v70 = hir.bitcast v41 : u32 #[ty = u32];
-            v71 = hir.constant 16 : u32;
-            v72 = hir.add v70, v71 : u32 #[overflow = checked];
-            v73 = hir.int_to_ptr v72 : (ptr i32) #[ty = (ptr i32)];
-            v74 = hir.load v73 : i32;
-            v75 = hir.bitcast v41 : u32 #[ty = u32];
-            v76 = hir.constant 20 : u32;
-            v77 = hir.add v75, v76 : u32 #[overflow = checked];
-            v78 = hir.int_to_ptr v77 : (ptr i32) #[ty = (ptr i32)];
-            v79 = hir.load v78 : i32;
-            v80 = hir.bitcast v41 : u32 #[ty = u32];
-            v81 = hir.constant 24 : u32;
-            v82 = hir.add v80, v81 : u32 #[overflow = checked];
-            v83 = hir.int_to_ptr v82 : (ptr i32) #[ty = (ptr i32)];
-            v84 = hir.load v83 : i32;
-            v85 = hir.bitcast v41 : u32 #[ty = u32];
-            v86 = hir.constant 28 : u32;
-            v87 = hir.add v85, v86 : u32 #[overflow = checked];
-            v88 = hir.int_to_ptr v87 : (ptr i32) #[ty = (ptr i32)];
-            v89 = hir.load v88 : i32;
-            hir.exec v54, v59, v64, v69, v74, v79, v84, v89, v49 #[callee = root/abi_transform_stdlib_blake3_hash/miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1] #[signature = (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32)];
-            v90 = hir.constant 24 : i32;
-            v91 = hir.add v40, v90 : i32 #[overflow = wrapping];
-            v92 = hir.bitcast v49 : u32 #[ty = u32];
-            v93 = hir.constant 24 : u32;
-            v94 = hir.add v92, v93 : u32 #[overflow = checked];
-            v95 = hir.constant 8 : u32;
-            v96 = hir.mod v94, v95 : u32;
-            hir.assertz v96 #[code = 250];
-            v97 = hir.int_to_ptr v94 : (ptr i64) #[ty = (ptr i64)];
-            v98 = hir.load v97 : i64;
-            v99 = hir.bitcast v91 : u32 #[ty = u32];
-            v100 = hir.int_to_ptr v99 : (ptr i64) #[ty = (ptr i64)];
-            hir.store v100, v98;
-            v101 = hir.constant 16 : i32;
-            v102 = hir.add v40, v101 : i32 #[overflow = wrapping];
-            v103 = hir.bitcast v49 : u32 #[ty = u32];
-            v104 = hir.constant 16 : u32;
-            v105 = hir.add v103, v104 : u32 #[overflow = checked];
-            v106 = hir.constant 8 : u32;
-            v107 = hir.mod v105, v106 : u32;
-            hir.assertz v107 #[code = 250];
-            v108 = hir.int_to_ptr v105 : (ptr i64) #[ty = (ptr i64)];
-            v109 = hir.load v108 : i64;
-            v110 = hir.bitcast v102 : u32 #[ty = u32];
-            v111 = hir.int_to_ptr v110 : (ptr i64) #[ty = (ptr i64)];
-            hir.store v111, v109;
-            v112 = hir.constant 8 : i32;
-            v113 = hir.add v40, v112 : i32 #[overflow = wrapping];
-            v114 = hir.bitcast v49 : u32 #[ty = u32];
-            v115 = hir.constant 8 : u32;
-            v116 = hir.add v114, v115 : u32 #[overflow = checked];
-            v117 = hir.constant 8 : u32;
-            v118 = hir.mod v116, v117 : u32;
-            hir.assertz v118 #[code = 250];
-            v119 = hir.int_to_ptr v116 : (ptr i64) #[ty = (ptr i64)];
-            v120 = hir.load v119 : i64;
-            v121 = hir.bitcast v113 : u32 #[ty = u32];
-            v122 = hir.int_to_ptr v121 : (ptr i64) #[ty = (ptr i64)];
-            hir.store v122, v120;
-            v123 = hir.bitcast v49 : u32 #[ty = u32];
-            v124 = hir.constant 8 : u32;
-            v125 = hir.mod v123, v124 : u32;
-            hir.assertz v125 #[code = 250];
-            v126 = hir.int_to_ptr v123 : (ptr i64) #[ty = (ptr i64)];
-            v127 = hir.load v126 : i64;
-            v128 = hir.bitcast v40 : u32 #[ty = u32];
-            v129 = hir.int_to_ptr v128 : (ptr i64) #[ty = (ptr i64)];
-            hir.store v129, v127;
-            v130 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_stdlib_blake3_hash/__stack_pointer];
-            v131 = hir.bitcast v130 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v131, v45;
-            hir.br block7;
-        ^block7:
-            hir.ret ;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #std::crypto::hashes::blake3] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-    };
-    builtin.module  #[name = #std::crypto::hashes::blake3] #[visibility = public] {
+            builtin.function public @hash_1to1(param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (result i32 i32 i32 i32 i32 i32 i32 i32) {
 
-        builtin.function public @hash_1to1(param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (result i32 i32 i32 i32 i32 i32 i32 i32) {
-
+            };
         };
     };
 };

--- a/tests/integration/expected/abi_transform_tx_kernel_get_id.hir
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_id.hir
@@ -1,37 +1,40 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #abi_transform_tx_kernel_get_id] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @miden_base_sys::bindings::account::extern_account_get_id() -> felt {
-        ^block2:
-            v0 = hir.exec  : felt #[callee = root/miden::account/get_id] #[signature = (result felt)];
-            hir.br block4(v0);
-        ^block4(v1: felt):
-            hir.ret ;
+        builtin.module  #[name = #abi_transform_tx_kernel_get_id] #[visibility = public] {
+
+            builtin.function public @miden_base_sys::bindings::account::extern_account_get_id() -> felt {
+            ^block3:
+                v0 = hir.exec  : felt #[callee = world/root/miden::account/get_id] #[signature = (result felt)];
+                hir.br block5(v0);
+            ^block5(v1: felt):
+                hir.ret ;
+            };
+            builtin.function public @entrypoint() -> felt {
+            ^block7:
+                v3 = hir.exec  : felt #[callee = world/root/abi_transform_tx_kernel_get_id/miden_base_sys::bindings::account::get_id] #[signature = (result felt)];
+                hir.br block8(v3);
+            ^block8(v2: felt):
+                hir.ret v2;
+            };
+            builtin.function public @miden_base_sys::bindings::account::get_id() -> felt {
+            ^block9:
+                v5 = hir.exec  : felt #[callee = world/root/abi_transform_tx_kernel_get_id/miden_base_sys::bindings::account::extern_account_get_id] #[signature = (result felt)];
+                hir.br block10(v5);
+            ^block10(v4: felt):
+                hir.ret v4;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
-        builtin.function public @entrypoint() -> felt {
-        ^block6:
-            v3 = hir.exec  : felt #[callee = root/abi_transform_tx_kernel_get_id/miden_base_sys::bindings::account::get_id] #[signature = (result felt)];
-            hir.br block7(v3);
-        ^block7(v2: felt):
-            hir.ret v2;
-        };
-        builtin.function public @miden_base_sys::bindings::account::get_id() -> felt {
-        ^block8:
-            v5 = hir.exec  : felt #[callee = root/abi_transform_tx_kernel_get_id/miden_base_sys::bindings::account::extern_account_get_id] #[signature = (result felt)];
-            hir.br block9(v5);
-        ^block9(v4: felt):
-            hir.ret v4;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #miden::account] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-    };
-    builtin.module  #[name = #miden::account] #[visibility = public] {
+            builtin.function public @get_id(result felt) {
 
-        builtin.function public @get_id(result felt) {
-
+            };
         };
     };
 };

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.hir
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.hir
@@ -1,556 +1,559 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #abi_transform_tx_kernel_get_inputs_4] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @miden_base_sys::bindings::note::extern_note_get_inputs(v0: i32) -> i32 {
-        ^block3(v0: i32):
-            v1, v2 = hir.exec v0 : i32, i32 #[callee = root/miden::note/get_inputs] #[signature = (param i32) (result i32 i32)];
-            hir.br block5(v1);
-        ^block5(v3: i32):
-            hir.ret ;
-        };
-        builtin.function public @entrypoint(v4: i32) {
-        ^block7(v4: i32):
-            hir.exec v4 #[callee = root/abi_transform_tx_kernel_get_inputs_4/miden_base_sys::bindings::note::get_inputs] #[signature = (param i32)];
-            hir.br block8;
-        ^block8:
-            hir.ret ;
-        };
-        builtin.function public @__rust_alloc(v5: i32, v6: i32) -> i32 {
-        ^block9(v5: i32, v6: i32):
-            v8 = hir.constant 1048632 : i32;
-            v9 = hir.exec v8, v6, v5 : i32 #[callee = root/abi_transform_tx_kernel_get_inputs_4/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc] #[signature = (param i32) (param i32) (param i32) (result i32)];
-            hir.br block10(v9);
-        ^block10(v7: i32):
-            hir.ret v7;
-        };
-        builtin.function public @__rust_alloc_zeroed(v10: i32, v11: i32) -> i32 {
-        ^block11(v10: i32, v11: i32):
-            v13 = hir.constant 1048632 : i32;
-            v14 = hir.exec v13, v11, v10 : i32 #[callee = root/abi_transform_tx_kernel_get_inputs_4/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc] #[signature = (param i32) (param i32) (param i32) (result i32)];
-            v15 = hir.constant 0 : i32;
-            v16 = hir.eq v14, v15 : i1;
-            v17 = hir.zext v16 : u32 #[ty = u32];
-            v18 = hir.bitcast v17 : i32 #[ty = i32];
-            v19 = hir.constant 0 : i32;
-            v20 = hir.neq v18, v19 : i1;
-            hir.cond_br v20 block13(v14), block14;
-        ^block12(v12: i32):
-            hir.ret v12;
-        ^block13(v26: i32):
-            hir.br block12(v26);
-        ^block14:
-            v21 = hir.constant 0 : i32;
-            v22 = hir.trunc v21 : u8 #[ty = u8];
-            v23 = hir.bitcast v10 : u32 #[ty = u32];
-            v24 = hir.bitcast v14 : u32 #[ty = u32];
-            v25 = hir.int_to_ptr v24 : (ptr u8) #[ty = (ptr u8)];
-            hir.mem_set v25, v23, v22;
-            hir.br block13(v14);
-        };
-        builtin.function public @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v27: i32, v28: i32, v29: i32) -> i32 {
-        ^block15(v27: i32, v28: i32, v29: i32):
-            v31 = hir.constant 0 : i32;
-            v32 = hir.constant 32 : i32;
-            v33 = hir.constant 32 : i32;
-            v34 = hir.bitcast v28 : u32 #[ty = u32];
-            v35 = hir.bitcast v33 : u32 #[ty = u32];
-            v36 = hir.gt v34, v35 : i1;
-            v37 = hir.zext v36 : u32 #[ty = u32];
-            v38 = hir.constant 0 : i32;
-            v39 = hir.neq v37, v38 : i1;
-            v40 = hir.select v39, v28, v32 : i32;
-            v41 = hir.popcnt v40 : u32;
-            v42 = hir.bitcast v41 : i32 #[ty = i32];
-            v43 = hir.constant 1 : i32;
-            v44 = hir.neq v42, v43 : i1;
-            v45 = hir.zext v44 : u32 #[ty = u32];
-            v46 = hir.bitcast v45 : i32 #[ty = i32];
-            v47 = hir.constant 0 : i32;
-            v48 = hir.neq v46, v47 : i1;
-            hir.cond_br v48 block17, block18;
-        ^block16(v30: i32):
+        builtin.module  #[name = #abi_transform_tx_kernel_get_inputs_4] #[visibility = public] {
 
-        ^block17:
-            hir.unreachable ;
-        ^block18:
-            v49 = hir.constant -2147483648 : i32;
-            v50 = hir.exec v28, v40 : i32 #[callee = root/abi_transform_tx_kernel_get_inputs_4/core::ptr::alignment::Alignment::max] #[signature = (param i32) (param i32) (result i32)];
-            v51 = hir.sub v49, v50 : i32 #[overflow = wrapping];
-            v52 = hir.bitcast v51 : u32 #[ty = u32];
-            v53 = hir.bitcast v29 : u32 #[ty = u32];
-            v54 = hir.lt v52, v53 : i1;
-            v55 = hir.zext v54 : u32 #[ty = u32];
-            v56 = hir.bitcast v55 : i32 #[ty = i32];
-            v57 = hir.constant 0 : i32;
-            v58 = hir.neq v56, v57 : i1;
-            hir.cond_br v58 block17, block19;
-        ^block19:
-            v59 = hir.constant 0 : i32;
-            v60 = hir.add v29, v50 : i32 #[overflow = wrapping];
-            v61 = hir.constant -1 : i32;
-            v62 = hir.add v60, v61 : i32 #[overflow = wrapping];
-            v63 = hir.constant 0 : i32;
-            v64 = hir.sub v63, v50 : i32 #[overflow = wrapping];
-            v65 = hir.band v62, v64 : i32;
-            v66 = hir.bitcast v27 : u32 #[ty = u32];
-            v67 = hir.constant 4 : u32;
-            v68 = hir.mod v66, v67 : u32;
-            hir.assertz v68 #[code = 250];
-            v69 = hir.int_to_ptr v66 : (ptr i32) #[ty = (ptr i32)];
-            v70 = hir.load v69 : i32;
-            v71 = hir.constant 0 : i32;
-            v72 = hir.neq v70, v71 : i1;
-            hir.cond_br v72 block20(v27, v65, v50, v59), block21;
-        ^block20(v85: i32, v92: i32, v105: i32, v108: i32):
-            v84 = hir.constant 268435456 : i32;
-            v86 = hir.bitcast v85 : u32 #[ty = u32];
-            v87 = hir.constant 4 : u32;
-            v88 = hir.mod v86, v87 : u32;
-            hir.assertz v88 #[code = 250];
-            v89 = hir.int_to_ptr v86 : (ptr i32) #[ty = (ptr i32)];
-            v90 = hir.load v89 : i32;
-            v91 = hir.sub v84, v90 : i32 #[overflow = wrapping];
-            v93 = hir.bitcast v91 : u32 #[ty = u32];
-            v94 = hir.bitcast v92 : u32 #[ty = u32];
-            v95 = hir.lt v93, v94 : i1;
-            v96 = hir.zext v95 : u32 #[ty = u32];
-            v97 = hir.bitcast v96 : i32 #[ty = i32];
-            v98 = hir.constant 0 : i32;
-            v99 = hir.neq v97, v98 : i1;
-            hir.cond_br v99 block22(v108), block23;
-        ^block21:
-            v73 = hir.exec  : i32 #[callee = root/intrinsics::mem/heap_base] #[signature = (result i32)];
-            v74 = hir.mem_size  : u32;
-            v75 = hir.constant 16 : i32;
-            v76 = hir.bitcast v75 : u32 #[ty = u32];
-            v77 = hir.shl v74, v76 : u32;
-            v78 = hir.bitcast v77 : i32 #[ty = i32];
-            v79 = hir.add v73, v78 : i32 #[overflow = wrapping];
-            v80 = hir.bitcast v27 : u32 #[ty = u32];
-            v81 = hir.constant 4 : u32;
-            v82 = hir.mod v80, v81 : u32;
-            hir.assertz v82 #[code = 250];
-            v83 = hir.int_to_ptr v80 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v83, v79;
-            hir.br block20(v27, v65, v50, v59);
-        ^block22(v107: i32):
-            hir.ret v107;
-        ^block23:
-            v100 = hir.add v90, v92 : i32 #[overflow = wrapping];
-            v101 = hir.bitcast v85 : u32 #[ty = u32];
-            v102 = hir.constant 4 : u32;
-            v103 = hir.mod v101, v102 : u32;
-            hir.assertz v103 #[code = 250];
-            v104 = hir.int_to_ptr v101 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v104, v100;
-            v106 = hir.add v90, v105 : i32 #[overflow = wrapping];
-            hir.br block22(v106);
-        };
-        builtin.function public @miden_base_sys::bindings::note::get_inputs(v109: i32) {
-        ^block24(v109: i32):
-            v110 = hir.constant 0 : i32;
-            v111 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
-            v112 = hir.bitcast v111 : (ptr i32) #[ty = (ptr i32)];
-            v113 = hir.load v112 : i32;
-            v114 = hir.constant 16 : i32;
-            v115 = hir.sub v113, v114 : i32 #[overflow = wrapping];
-            v116 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
-            v117 = hir.bitcast v116 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v117, v115;
-            v118 = hir.constant 4 : i32;
-            v119 = hir.add v115, v118 : i32 #[overflow = wrapping];
-            v120 = hir.constant 256 : i32;
-            v121 = hir.constant 0 : i32;
-            v122 = hir.constant 4 : i32;
-            v123 = hir.constant 4 : i32;
-            hir.exec v119, v120, v121, v122, v123 #[callee = root/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::RawVecInner<A>::try_allocate_in] #[signature = (param i32) (param i32) (param i32) (param i32) (param i32)];
-            v124 = hir.bitcast v115 : u32 #[ty = u32];
-            v125 = hir.constant 8 : u32;
-            v126 = hir.add v124, v125 : u32 #[overflow = checked];
-            v127 = hir.constant 4 : u32;
-            v128 = hir.mod v126, v127 : u32;
-            hir.assertz v128 #[code = 250];
-            v129 = hir.int_to_ptr v126 : (ptr i32) #[ty = (ptr i32)];
-            v130 = hir.load v129 : i32;
-            v131 = hir.bitcast v115 : u32 #[ty = u32];
-            v132 = hir.constant 4 : u32;
-            v133 = hir.add v131, v132 : u32 #[overflow = checked];
-            v134 = hir.constant 4 : u32;
-            v135 = hir.mod v133, v134 : u32;
-            hir.assertz v135 #[code = 250];
-            v136 = hir.int_to_ptr v133 : (ptr i32) #[ty = (ptr i32)];
-            v137 = hir.load v136 : i32;
-            v138 = hir.constant 1 : i32;
-            v139 = hir.neq v137, v138 : i1;
-            v140 = hir.zext v139 : u32 #[ty = u32];
-            v141 = hir.bitcast v140 : i32 #[ty = i32];
-            v142 = hir.constant 0 : i32;
-            v143 = hir.neq v141, v142 : i1;
-            hir.cond_br v143 block26, block27;
-        ^block25:
-            hir.ret ;
-        ^block26:
-            v152 = hir.bitcast v115 : u32 #[ty = u32];
-            v153 = hir.constant 12 : u32;
-            v154 = hir.add v152, v153 : u32 #[overflow = checked];
-            v155 = hir.constant 4 : u32;
-            v156 = hir.mod v154, v155 : u32;
-            hir.assertz v156 #[code = 250];
-            v157 = hir.int_to_ptr v154 : (ptr i32) #[ty = (ptr i32)];
-            v158 = hir.load v157 : i32;
-            v159 = hir.constant 4 : i32;
-            v160 = hir.bitcast v158 : u32 #[ty = u32];
-            v161 = hir.bitcast v159 : u32 #[ty = u32];
-            v162 = hir.shr v160, v161 : u32;
-            v163 = hir.bitcast v162 : i32 #[ty = i32];
-            v164 = hir.exec v163 : i32 #[callee = root/abi_transform_tx_kernel_get_inputs_4/miden_base_sys::bindings::note::extern_note_get_inputs] #[signature = (param i32) (result i32)];
-            v165 = hir.bitcast v109 : u32 #[ty = u32];
-            v166 = hir.constant 8 : u32;
-            v167 = hir.add v165, v166 : u32 #[overflow = checked];
-            v168 = hir.constant 4 : u32;
-            v169 = hir.mod v167, v168 : u32;
-            hir.assertz v169 #[code = 250];
-            v170 = hir.int_to_ptr v167 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v170, v164;
-            v171 = hir.bitcast v109 : u32 #[ty = u32];
-            v172 = hir.constant 4 : u32;
-            v173 = hir.add v171, v172 : u32 #[overflow = checked];
-            v174 = hir.constant 4 : u32;
-            v175 = hir.mod v173, v174 : u32;
-            hir.assertz v175 #[code = 250];
-            v176 = hir.int_to_ptr v173 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v176, v158;
-            v177 = hir.bitcast v109 : u32 #[ty = u32];
-            v178 = hir.constant 4 : u32;
-            v179 = hir.mod v177, v178 : u32;
-            hir.assertz v179 #[code = 250];
-            v180 = hir.int_to_ptr v177 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v180, v130;
-            v181 = hir.constant 16 : i32;
-            v182 = hir.add v115, v181 : i32 #[overflow = wrapping];
-            v183 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
-            v184 = hir.bitcast v183 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v184, v182;
-            hir.br block25;
-        ^block27:
-            v144 = hir.bitcast v115 : u32 #[ty = u32];
-            v145 = hir.constant 12 : u32;
-            v146 = hir.add v144, v145 : u32 #[overflow = checked];
-            v147 = hir.constant 4 : u32;
-            v148 = hir.mod v146, v147 : u32;
-            hir.assertz v148 #[code = 250];
-            v149 = hir.int_to_ptr v146 : (ptr i32) #[ty = (ptr i32)];
-            v150 = hir.load v149 : i32;
-            v151 = hir.constant 1048616 : i32;
-            hir.exec v130, v150, v151 #[callee = root/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::handle_error] #[signature = (param i32) (param i32) (param i32)];
-            hir.unreachable ;
-        };
-        builtin.function public @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v185: i32, v186: i32, v187: i32, v188: i32, v189: i32) {
-        ^block28(v185: i32, v186: i32, v187: i32, v188: i32, v189: i32):
-            v190 = hir.constant 0 : i32;
-            v191 = hir.constant 0 : i64;
-            v192 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
-            v193 = hir.bitcast v192 : (ptr i32) #[ty = (ptr i32)];
-            v194 = hir.load v193 : i32;
-            v195 = hir.constant 16 : i32;
-            v196 = hir.sub v194, v195 : i32 #[overflow = wrapping];
-            v197 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
-            v198 = hir.bitcast v197 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v198, v196;
-            v199 = hir.add v188, v189 : i32 #[overflow = wrapping];
-            v200 = hir.constant -1 : i32;
-            v201 = hir.add v199, v200 : i32 #[overflow = wrapping];
-            v202 = hir.constant 0 : i32;
-            v203 = hir.sub v202, v188 : i32 #[overflow = wrapping];
-            v204 = hir.band v201, v203 : i32;
-            v205 = hir.bitcast v204 : u32 #[ty = u32];
-            v206 = hir.zext v205 : u64 #[ty = u64];
-            v207 = hir.bitcast v206 : i64 #[ty = i64];
-            v208 = hir.bitcast v186 : u32 #[ty = u32];
-            v209 = hir.zext v208 : u64 #[ty = u64];
-            v210 = hir.bitcast v209 : i64 #[ty = i64];
-            v211 = hir.mul v207, v210 : i64 #[overflow = wrapping];
-            v212 = hir.constant 32 : i64;
-            v213 = hir.bitcast v211 : u64 #[ty = u64];
-            v214 = hir.cast v212 : u32 #[ty = u32];
-            v215 = hir.shr v213, v214 : u64;
-            v216 = hir.bitcast v215 : i64 #[ty = i64];
-            v217 = hir.trunc v216 : i32 #[ty = i32];
-            v218 = hir.constant 0 : i32;
-            v219 = hir.neq v217, v218 : i1;
-            hir.cond_br v219 block32(v185, v196), block33;
-        ^block29:
-            hir.ret ;
-        ^block30(v309: i32, v310: i32, v315: i32):
-            v311 = hir.bitcast v309 : u32 #[ty = u32];
-            v312 = hir.constant 4 : u32;
-            v313 = hir.mod v311, v312 : u32;
-            hir.assertz v313 #[code = 250];
-            v314 = hir.int_to_ptr v311 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v314, v310;
-            v318 = hir.constant 16 : i32;
-            v319 = hir.add v315, v318 : i32 #[overflow = wrapping];
-            v320 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
-            v321 = hir.bitcast v320 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v321, v319;
-            hir.br block29;
-        ^block31:
-            v295 = hir.bitcast v270 : u32 #[ty = u32];
-            v296 = hir.constant 8 : u32;
-            v297 = hir.add v295, v296 : u32 #[overflow = checked];
-            v298 = hir.constant 4 : u32;
-            v299 = hir.mod v297, v298 : u32;
-            hir.assertz v299 #[code = 250];
-            v300 = hir.int_to_ptr v297 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v300, v294;
-            v302 = hir.bitcast v270 : u32 #[ty = u32];
-            v303 = hir.constant 4 : u32;
-            v304 = hir.add v302, v303 : u32 #[overflow = checked];
-            v305 = hir.constant 4 : u32;
-            v306 = hir.mod v304, v305 : u32;
-            hir.assertz v306 #[code = 250];
-            v307 = hir.int_to_ptr v304 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v307, v301;
-            v308 = hir.constant 1 : i32;
-            hir.br block30(v270, v308, v316);
-        ^block32(v285: i32, v317: i32):
-            v286 = hir.constant 0 : i32;
-            v287 = hir.bitcast v285 : u32 #[ty = u32];
-            v288 = hir.constant 4 : u32;
-            v289 = hir.add v287, v288 : u32 #[overflow = checked];
-            v290 = hir.constant 4 : u32;
-            v291 = hir.mod v289, v290 : u32;
-            hir.assertz v291 #[code = 250];
-            v292 = hir.int_to_ptr v289 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v292, v286;
-            v293 = hir.constant 1 : i32;
-            hir.br block30(v285, v293, v317);
-        ^block33:
-            v220 = hir.constant -2147483648 : i32;
-            v221 = hir.sub v220, v188 : i32 #[overflow = wrapping];
-            v222 = hir.trunc v211 : i32 #[ty = i32];
-            v223 = hir.bitcast v221 : u32 #[ty = u32];
-            v224 = hir.bitcast v222 : u32 #[ty = u32];
-            v225 = hir.lt v223, v224 : i1;
-            v226 = hir.zext v225 : u32 #[ty = u32];
-            v227 = hir.bitcast v226 : i32 #[ty = i32];
-            v228 = hir.constant 0 : i32;
-            v229 = hir.neq v227, v228 : i1;
-            hir.cond_br v229 block32(v185, v196), block34;
-        ^block34:
-            v230 = hir.constant 0 : i32;
-            v231 = hir.neq v222, v230 : i1;
-            hir.cond_br v231 block35, block36;
-        ^block35:
-            v246 = hir.constant 0 : i32;
-            v247 = hir.neq v187, v246 : i1;
-            hir.cond_br v247 block38, block39;
-        ^block36:
-            v232 = hir.bitcast v185 : u32 #[ty = u32];
-            v233 = hir.constant 8 : u32;
-            v234 = hir.add v232, v233 : u32 #[overflow = checked];
-            v235 = hir.constant 4 : u32;
-            v236 = hir.mod v234, v235 : u32;
-            hir.assertz v236 #[code = 250];
-            v237 = hir.int_to_ptr v234 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v237, v188;
-            v238 = hir.constant 0 : i32;
-            v239 = hir.constant 0 : i32;
-            v240 = hir.bitcast v185 : u32 #[ty = u32];
-            v241 = hir.constant 4 : u32;
-            v242 = hir.add v240, v241 : u32 #[overflow = checked];
-            v243 = hir.constant 4 : u32;
-            v244 = hir.mod v242, v243 : u32;
-            hir.assertz v244 #[code = 250];
-            v245 = hir.int_to_ptr v242 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v245, v239;
-            hir.br block30(v185, v238, v196);
-        ^block37(v263: i32, v270: i32, v277: i32, v294: i32, v301: i32, v316: i32):
-            v264 = hir.constant 0 : i32;
-            v265 = hir.eq v263, v264 : i1;
-            v266 = hir.zext v265 : u32 #[ty = u32];
-            v267 = hir.bitcast v266 : i32 #[ty = i32];
-            v268 = hir.constant 0 : i32;
-            v269 = hir.neq v267, v268 : i1;
-            hir.cond_br v269 block31, block40;
-        ^block38:
-            v257 = hir.constant 1 : i32;
-            hir.exec v196, v188, v222, v257 #[callee = root/abi_transform_tx_kernel_get_inputs_4/alloc::alloc::Global::alloc_impl] #[signature = (param i32) (param i32) (param i32) (param i32)];
-            v258 = hir.bitcast v196 : u32 #[ty = u32];
-            v259 = hir.constant 4 : u32;
-            v260 = hir.mod v258, v259 : u32;
-            hir.assertz v260 #[code = 250];
-            v261 = hir.int_to_ptr v258 : (ptr i32) #[ty = (ptr i32)];
-            v262 = hir.load v261 : i32;
-            hir.br block37(v262, v185, v186, v222, v188, v196);
-        ^block39:
-            v248 = hir.constant 8 : i32;
-            v249 = hir.add v196, v248 : i32 #[overflow = wrapping];
-            hir.exec v249, v188, v222 #[callee = root/abi_transform_tx_kernel_get_inputs_4/<alloc::alloc::Global as core::alloc::Allocator>::allocate] #[signature = (param i32) (param i32) (param i32)];
-            v250 = hir.bitcast v196 : u32 #[ty = u32];
-            v251 = hir.constant 8 : u32;
-            v252 = hir.add v250, v251 : u32 #[overflow = checked];
-            v253 = hir.constant 4 : u32;
-            v254 = hir.mod v252, v253 : u32;
-            hir.assertz v254 #[code = 250];
-            v255 = hir.int_to_ptr v252 : (ptr i32) #[ty = (ptr i32)];
-            v256 = hir.load v255 : i32;
-            hir.br block37(v256, v185, v186, v222, v188, v196);
-        ^block40:
-            v271 = hir.bitcast v270 : u32 #[ty = u32];
-            v272 = hir.constant 8 : u32;
-            v273 = hir.add v271, v272 : u32 #[overflow = checked];
-            v274 = hir.constant 4 : u32;
-            v275 = hir.mod v273, v274 : u32;
-            hir.assertz v275 #[code = 250];
-            v276 = hir.int_to_ptr v273 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v276, v263;
-            v278 = hir.bitcast v270 : u32 #[ty = u32];
-            v279 = hir.constant 4 : u32;
-            v280 = hir.add v278, v279 : u32 #[overflow = checked];
-            v281 = hir.constant 4 : u32;
-            v282 = hir.mod v280, v281 : u32;
-            hir.assertz v282 #[code = 250];
-            v283 = hir.int_to_ptr v280 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v283, v277;
-            v284 = hir.constant 0 : i32;
-            hir.br block30(v270, v284, v316);
-        };
-        builtin.function public @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v322: i32, v323: i32, v324: i32) {
-        ^block41(v322: i32, v323: i32, v324: i32):
-            v325 = hir.constant 0 : i32;
-            v326 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
-            v327 = hir.bitcast v326 : (ptr i32) #[ty = (ptr i32)];
-            v328 = hir.load v327 : i32;
-            v329 = hir.constant 16 : i32;
-            v330 = hir.sub v328, v329 : i32 #[overflow = wrapping];
-            v331 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
-            v332 = hir.bitcast v331 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v332, v330;
-            v333 = hir.constant 8 : i32;
-            v334 = hir.add v330, v333 : i32 #[overflow = wrapping];
-            v335 = hir.constant 0 : i32;
-            hir.exec v334, v323, v324, v335 #[callee = root/abi_transform_tx_kernel_get_inputs_4/alloc::alloc::Global::alloc_impl] #[signature = (param i32) (param i32) (param i32) (param i32)];
-            v336 = hir.bitcast v330 : u32 #[ty = u32];
-            v337 = hir.constant 12 : u32;
-            v338 = hir.add v336, v337 : u32 #[overflow = checked];
-            v339 = hir.constant 4 : u32;
-            v340 = hir.mod v338, v339 : u32;
-            hir.assertz v340 #[code = 250];
-            v341 = hir.int_to_ptr v338 : (ptr i32) #[ty = (ptr i32)];
-            v342 = hir.load v341 : i32;
-            v343 = hir.bitcast v330 : u32 #[ty = u32];
-            v344 = hir.constant 8 : u32;
-            v345 = hir.add v343, v344 : u32 #[overflow = checked];
-            v346 = hir.constant 4 : u32;
-            v347 = hir.mod v345, v346 : u32;
-            hir.assertz v347 #[code = 250];
-            v348 = hir.int_to_ptr v345 : (ptr i32) #[ty = (ptr i32)];
-            v349 = hir.load v348 : i32;
-            v350 = hir.bitcast v322 : u32 #[ty = u32];
-            v351 = hir.constant 4 : u32;
-            v352 = hir.mod v350, v351 : u32;
-            hir.assertz v352 #[code = 250];
-            v353 = hir.int_to_ptr v350 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v353, v349;
-            v354 = hir.bitcast v322 : u32 #[ty = u32];
-            v355 = hir.constant 4 : u32;
-            v356 = hir.add v354, v355 : u32 #[overflow = checked];
-            v357 = hir.constant 4 : u32;
-            v358 = hir.mod v356, v357 : u32;
-            hir.assertz v358 #[code = 250];
-            v359 = hir.int_to_ptr v356 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v359, v342;
-            v360 = hir.constant 16 : i32;
-            v361 = hir.add v330, v360 : i32 #[overflow = wrapping];
-            v362 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
-            v363 = hir.bitcast v362 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v363, v361;
-            hir.br block42;
-        ^block42:
-            hir.ret ;
-        };
-        builtin.function public @alloc::alloc::Global::alloc_impl(v364: i32, v365: i32, v366: i32, v367: i32) {
-        ^block43(v364: i32, v365: i32, v366: i32, v367: i32):
-            v368 = hir.constant 0 : i32;
-            v369 = hir.eq v366, v368 : i1;
-            v370 = hir.zext v369 : u32 #[ty = u32];
-            v371 = hir.bitcast v370 : i32 #[ty = i32];
-            v372 = hir.constant 0 : i32;
-            v373 = hir.neq v371, v372 : i1;
-            hir.cond_br v373 block45(v364, v366, v365), block46;
-        ^block44:
-            hir.ret ;
-        ^block45(v385: i32, v386: i32, v393: i32):
-            v387 = hir.bitcast v385 : u32 #[ty = u32];
-            v388 = hir.constant 4 : u32;
-            v389 = hir.add v387, v388 : u32 #[overflow = checked];
-            v390 = hir.constant 4 : u32;
-            v391 = hir.mod v389, v390 : u32;
-            hir.assertz v391 #[code = 250];
-            v392 = hir.int_to_ptr v389 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v392, v386;
-            v394 = hir.bitcast v385 : u32 #[ty = u32];
-            v395 = hir.constant 4 : u32;
-            v396 = hir.mod v394, v395 : u32;
-            hir.assertz v396 #[code = 250];
-            v397 = hir.int_to_ptr v394 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v397, v393;
-            hir.br block44;
-        ^block46:
-            v374 = hir.constant 0 : i32;
-            v375 = hir.bitcast v374 : u32 #[ty = u32];
-            v376 = hir.constant 1048636 : u32;
-            v377 = hir.add v375, v376 : u32 #[overflow = checked];
-            v378 = hir.int_to_ptr v377 : (ptr u8) #[ty = (ptr u8)];
-            v379 = hir.load v378 : u8;
-            v380 = hir.zext v379 : u32 #[ty = u32];
-            v381 = hir.constant 0 : i32;
-            v382 = hir.neq v367, v381 : i1;
-            hir.cond_br v382 block47, block48;
-        ^block47:
-            v384 = hir.exec v366, v365 : i32 #[callee = root/abi_transform_tx_kernel_get_inputs_4/__rust_alloc_zeroed] #[signature = (param i32) (param i32) (result i32)];
-            hir.br block45(v364, v366, v384);
-        ^block48:
-            v383 = hir.exec v366, v365 : i32 #[callee = root/abi_transform_tx_kernel_get_inputs_4/__rust_alloc] #[signature = (param i32) (param i32) (result i32)];
-            hir.br block45(v364, v366, v383);
-        };
-        builtin.function public @alloc::raw_vec::handle_error(v398: i32, v399: i32, v400: i32) {
-        ^block49(v398: i32, v399: i32, v400: i32):
-            hir.unreachable ;
-        ^block50:
+            builtin.function public @miden_base_sys::bindings::note::extern_note_get_inputs(v0: i32) -> i32 {
+            ^block4(v0: i32):
+                v1, v2 = hir.exec v0 : i32, i32 #[callee = world/root/miden::note/get_inputs] #[signature = (param i32) (result i32 i32)];
+                hir.br block6(v1);
+            ^block6(v3: i32):
+                hir.ret ;
+            };
+            builtin.function public @entrypoint(v4: i32) {
+            ^block8(v4: i32):
+                hir.exec v4 #[callee = world/root/abi_transform_tx_kernel_get_inputs_4/miden_base_sys::bindings::note::get_inputs] #[signature = (param i32)];
+                hir.br block9;
+            ^block9:
+                hir.ret ;
+            };
+            builtin.function public @__rust_alloc(v5: i32, v6: i32) -> i32 {
+            ^block10(v5: i32, v6: i32):
+                v8 = hir.constant 1048632 : i32;
+                v9 = hir.exec v8, v6, v5 : i32 #[callee = world/root/abi_transform_tx_kernel_get_inputs_4/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc] #[signature = (param i32) (param i32) (param i32) (result i32)];
+                hir.br block11(v9);
+            ^block11(v7: i32):
+                hir.ret v7;
+            };
+            builtin.function public @__rust_alloc_zeroed(v10: i32, v11: i32) -> i32 {
+            ^block12(v10: i32, v11: i32):
+                v13 = hir.constant 1048632 : i32;
+                v14 = hir.exec v13, v11, v10 : i32 #[callee = world/root/abi_transform_tx_kernel_get_inputs_4/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc] #[signature = (param i32) (param i32) (param i32) (result i32)];
+                v15 = hir.constant 0 : i32;
+                v16 = hir.eq v14, v15 : i1;
+                v17 = hir.zext v16 : u32 #[ty = u32];
+                v18 = hir.bitcast v17 : i32 #[ty = i32];
+                v19 = hir.constant 0 : i32;
+                v20 = hir.neq v18, v19 : i1;
+                hir.cond_br v20 block14(v14), block15;
+            ^block13(v12: i32):
+                hir.ret v12;
+            ^block14(v26: i32):
+                hir.br block13(v26);
+            ^block15:
+                v21 = hir.constant 0 : i32;
+                v22 = hir.trunc v21 : u8 #[ty = u8];
+                v23 = hir.bitcast v10 : u32 #[ty = u32];
+                v24 = hir.bitcast v14 : u32 #[ty = u32];
+                v25 = hir.int_to_ptr v24 : (ptr u8) #[ty = (ptr u8)];
+                hir.mem_set v25, v23, v22;
+                hir.br block14(v14);
+            };
+            builtin.function public @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v27: i32, v28: i32, v29: i32) -> i32 {
+            ^block16(v27: i32, v28: i32, v29: i32):
+                v31 = hir.constant 0 : i32;
+                v32 = hir.constant 32 : i32;
+                v33 = hir.constant 32 : i32;
+                v34 = hir.bitcast v28 : u32 #[ty = u32];
+                v35 = hir.bitcast v33 : u32 #[ty = u32];
+                v36 = hir.gt v34, v35 : i1;
+                v37 = hir.zext v36 : u32 #[ty = u32];
+                v38 = hir.constant 0 : i32;
+                v39 = hir.neq v37, v38 : i1;
+                v40 = hir.select v39, v28, v32 : i32;
+                v41 = hir.popcnt v40 : u32;
+                v42 = hir.bitcast v41 : i32 #[ty = i32];
+                v43 = hir.constant 1 : i32;
+                v44 = hir.neq v42, v43 : i1;
+                v45 = hir.zext v44 : u32 #[ty = u32];
+                v46 = hir.bitcast v45 : i32 #[ty = i32];
+                v47 = hir.constant 0 : i32;
+                v48 = hir.neq v46, v47 : i1;
+                hir.cond_br v48 block18, block19;
+            ^block17(v30: i32):
 
+            ^block18:
+                hir.unreachable ;
+            ^block19:
+                v49 = hir.constant -2147483648 : i32;
+                v50 = hir.exec v28, v40 : i32 #[callee = world/root/abi_transform_tx_kernel_get_inputs_4/core::ptr::alignment::Alignment::max] #[signature = (param i32) (param i32) (result i32)];
+                v51 = hir.sub v49, v50 : i32 #[overflow = wrapping];
+                v52 = hir.bitcast v51 : u32 #[ty = u32];
+                v53 = hir.bitcast v29 : u32 #[ty = u32];
+                v54 = hir.lt v52, v53 : i1;
+                v55 = hir.zext v54 : u32 #[ty = u32];
+                v56 = hir.bitcast v55 : i32 #[ty = i32];
+                v57 = hir.constant 0 : i32;
+                v58 = hir.neq v56, v57 : i1;
+                hir.cond_br v58 block18, block20;
+            ^block20:
+                v59 = hir.constant 0 : i32;
+                v60 = hir.add v29, v50 : i32 #[overflow = wrapping];
+                v61 = hir.constant -1 : i32;
+                v62 = hir.add v60, v61 : i32 #[overflow = wrapping];
+                v63 = hir.constant 0 : i32;
+                v64 = hir.sub v63, v50 : i32 #[overflow = wrapping];
+                v65 = hir.band v62, v64 : i32;
+                v66 = hir.bitcast v27 : u32 #[ty = u32];
+                v67 = hir.constant 4 : u32;
+                v68 = hir.mod v66, v67 : u32;
+                hir.assertz v68 #[code = 250];
+                v69 = hir.int_to_ptr v66 : (ptr i32) #[ty = (ptr i32)];
+                v70 = hir.load v69 : i32;
+                v71 = hir.constant 0 : i32;
+                v72 = hir.neq v70, v71 : i1;
+                hir.cond_br v72 block21(v27, v65, v50, v59), block22;
+            ^block21(v85: i32, v92: i32, v105: i32, v108: i32):
+                v84 = hir.constant 268435456 : i32;
+                v86 = hir.bitcast v85 : u32 #[ty = u32];
+                v87 = hir.constant 4 : u32;
+                v88 = hir.mod v86, v87 : u32;
+                hir.assertz v88 #[code = 250];
+                v89 = hir.int_to_ptr v86 : (ptr i32) #[ty = (ptr i32)];
+                v90 = hir.load v89 : i32;
+                v91 = hir.sub v84, v90 : i32 #[overflow = wrapping];
+                v93 = hir.bitcast v91 : u32 #[ty = u32];
+                v94 = hir.bitcast v92 : u32 #[ty = u32];
+                v95 = hir.lt v93, v94 : i1;
+                v96 = hir.zext v95 : u32 #[ty = u32];
+                v97 = hir.bitcast v96 : i32 #[ty = i32];
+                v98 = hir.constant 0 : i32;
+                v99 = hir.neq v97, v98 : i1;
+                hir.cond_br v99 block23(v108), block24;
+            ^block22:
+                v73 = hir.exec  : i32 #[callee = world/root/intrinsics::mem/heap_base] #[signature = (result i32)];
+                v74 = hir.mem_size  : u32;
+                v75 = hir.constant 16 : i32;
+                v76 = hir.bitcast v75 : u32 #[ty = u32];
+                v77 = hir.shl v74, v76 : u32;
+                v78 = hir.bitcast v77 : i32 #[ty = i32];
+                v79 = hir.add v73, v78 : i32 #[overflow = wrapping];
+                v80 = hir.bitcast v27 : u32 #[ty = u32];
+                v81 = hir.constant 4 : u32;
+                v82 = hir.mod v80, v81 : u32;
+                hir.assertz v82 #[code = 250];
+                v83 = hir.int_to_ptr v80 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v83, v79;
+                hir.br block21(v27, v65, v50, v59);
+            ^block23(v107: i32):
+                hir.ret v107;
+            ^block24:
+                v100 = hir.add v90, v92 : i32 #[overflow = wrapping];
+                v101 = hir.bitcast v85 : u32 #[ty = u32];
+                v102 = hir.constant 4 : u32;
+                v103 = hir.mod v101, v102 : u32;
+                hir.assertz v103 #[code = 250];
+                v104 = hir.int_to_ptr v101 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v104, v100;
+                v106 = hir.add v90, v105 : i32 #[overflow = wrapping];
+                hir.br block23(v106);
+            };
+            builtin.function public @miden_base_sys::bindings::note::get_inputs(v109: i32) {
+            ^block25(v109: i32):
+                v110 = hir.constant 0 : i32;
+                v111 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = world/root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+                v112 = hir.bitcast v111 : (ptr i32) #[ty = (ptr i32)];
+                v113 = hir.load v112 : i32;
+                v114 = hir.constant 16 : i32;
+                v115 = hir.sub v113, v114 : i32 #[overflow = wrapping];
+                v116 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = world/root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+                v117 = hir.bitcast v116 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v117, v115;
+                v118 = hir.constant 4 : i32;
+                v119 = hir.add v115, v118 : i32 #[overflow = wrapping];
+                v120 = hir.constant 256 : i32;
+                v121 = hir.constant 0 : i32;
+                v122 = hir.constant 4 : i32;
+                v123 = hir.constant 4 : i32;
+                hir.exec v119, v120, v121, v122, v123 #[callee = world/root/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::RawVecInner<A>::try_allocate_in] #[signature = (param i32) (param i32) (param i32) (param i32) (param i32)];
+                v124 = hir.bitcast v115 : u32 #[ty = u32];
+                v125 = hir.constant 8 : u32;
+                v126 = hir.add v124, v125 : u32 #[overflow = checked];
+                v127 = hir.constant 4 : u32;
+                v128 = hir.mod v126, v127 : u32;
+                hir.assertz v128 #[code = 250];
+                v129 = hir.int_to_ptr v126 : (ptr i32) #[ty = (ptr i32)];
+                v130 = hir.load v129 : i32;
+                v131 = hir.bitcast v115 : u32 #[ty = u32];
+                v132 = hir.constant 4 : u32;
+                v133 = hir.add v131, v132 : u32 #[overflow = checked];
+                v134 = hir.constant 4 : u32;
+                v135 = hir.mod v133, v134 : u32;
+                hir.assertz v135 #[code = 250];
+                v136 = hir.int_to_ptr v133 : (ptr i32) #[ty = (ptr i32)];
+                v137 = hir.load v136 : i32;
+                v138 = hir.constant 1 : i32;
+                v139 = hir.neq v137, v138 : i1;
+                v140 = hir.zext v139 : u32 #[ty = u32];
+                v141 = hir.bitcast v140 : i32 #[ty = i32];
+                v142 = hir.constant 0 : i32;
+                v143 = hir.neq v141, v142 : i1;
+                hir.cond_br v143 block27, block28;
+            ^block26:
+                hir.ret ;
+            ^block27:
+                v152 = hir.bitcast v115 : u32 #[ty = u32];
+                v153 = hir.constant 12 : u32;
+                v154 = hir.add v152, v153 : u32 #[overflow = checked];
+                v155 = hir.constant 4 : u32;
+                v156 = hir.mod v154, v155 : u32;
+                hir.assertz v156 #[code = 250];
+                v157 = hir.int_to_ptr v154 : (ptr i32) #[ty = (ptr i32)];
+                v158 = hir.load v157 : i32;
+                v159 = hir.constant 4 : i32;
+                v160 = hir.bitcast v158 : u32 #[ty = u32];
+                v161 = hir.bitcast v159 : u32 #[ty = u32];
+                v162 = hir.shr v160, v161 : u32;
+                v163 = hir.bitcast v162 : i32 #[ty = i32];
+                v164 = hir.exec v163 : i32 #[callee = world/root/abi_transform_tx_kernel_get_inputs_4/miden_base_sys::bindings::note::extern_note_get_inputs] #[signature = (param i32) (result i32)];
+                v165 = hir.bitcast v109 : u32 #[ty = u32];
+                v166 = hir.constant 8 : u32;
+                v167 = hir.add v165, v166 : u32 #[overflow = checked];
+                v168 = hir.constant 4 : u32;
+                v169 = hir.mod v167, v168 : u32;
+                hir.assertz v169 #[code = 250];
+                v170 = hir.int_to_ptr v167 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v170, v164;
+                v171 = hir.bitcast v109 : u32 #[ty = u32];
+                v172 = hir.constant 4 : u32;
+                v173 = hir.add v171, v172 : u32 #[overflow = checked];
+                v174 = hir.constant 4 : u32;
+                v175 = hir.mod v173, v174 : u32;
+                hir.assertz v175 #[code = 250];
+                v176 = hir.int_to_ptr v173 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v176, v158;
+                v177 = hir.bitcast v109 : u32 #[ty = u32];
+                v178 = hir.constant 4 : u32;
+                v179 = hir.mod v177, v178 : u32;
+                hir.assertz v179 #[code = 250];
+                v180 = hir.int_to_ptr v177 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v180, v130;
+                v181 = hir.constant 16 : i32;
+                v182 = hir.add v115, v181 : i32 #[overflow = wrapping];
+                v183 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = world/root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+                v184 = hir.bitcast v183 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v184, v182;
+                hir.br block26;
+            ^block28:
+                v144 = hir.bitcast v115 : u32 #[ty = u32];
+                v145 = hir.constant 12 : u32;
+                v146 = hir.add v144, v145 : u32 #[overflow = checked];
+                v147 = hir.constant 4 : u32;
+                v148 = hir.mod v146, v147 : u32;
+                hir.assertz v148 #[code = 250];
+                v149 = hir.int_to_ptr v146 : (ptr i32) #[ty = (ptr i32)];
+                v150 = hir.load v149 : i32;
+                v151 = hir.constant 1048616 : i32;
+                hir.exec v130, v150, v151 #[callee = world/root/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::handle_error] #[signature = (param i32) (param i32) (param i32)];
+                hir.unreachable ;
+            };
+            builtin.function public @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v185: i32, v186: i32, v187: i32, v188: i32, v189: i32) {
+            ^block29(v185: i32, v186: i32, v187: i32, v188: i32, v189: i32):
+                v190 = hir.constant 0 : i32;
+                v191 = hir.constant 0 : i64;
+                v192 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = world/root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+                v193 = hir.bitcast v192 : (ptr i32) #[ty = (ptr i32)];
+                v194 = hir.load v193 : i32;
+                v195 = hir.constant 16 : i32;
+                v196 = hir.sub v194, v195 : i32 #[overflow = wrapping];
+                v197 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = world/root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+                v198 = hir.bitcast v197 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v198, v196;
+                v199 = hir.add v188, v189 : i32 #[overflow = wrapping];
+                v200 = hir.constant -1 : i32;
+                v201 = hir.add v199, v200 : i32 #[overflow = wrapping];
+                v202 = hir.constant 0 : i32;
+                v203 = hir.sub v202, v188 : i32 #[overflow = wrapping];
+                v204 = hir.band v201, v203 : i32;
+                v205 = hir.bitcast v204 : u32 #[ty = u32];
+                v206 = hir.zext v205 : u64 #[ty = u64];
+                v207 = hir.bitcast v206 : i64 #[ty = i64];
+                v208 = hir.bitcast v186 : u32 #[ty = u32];
+                v209 = hir.zext v208 : u64 #[ty = u64];
+                v210 = hir.bitcast v209 : i64 #[ty = i64];
+                v211 = hir.mul v207, v210 : i64 #[overflow = wrapping];
+                v212 = hir.constant 32 : i64;
+                v213 = hir.bitcast v211 : u64 #[ty = u64];
+                v214 = hir.cast v212 : u32 #[ty = u32];
+                v215 = hir.shr v213, v214 : u64;
+                v216 = hir.bitcast v215 : i64 #[ty = i64];
+                v217 = hir.trunc v216 : i32 #[ty = i32];
+                v218 = hir.constant 0 : i32;
+                v219 = hir.neq v217, v218 : i1;
+                hir.cond_br v219 block33(v185, v196), block34;
+            ^block30:
+                hir.ret ;
+            ^block31(v309: i32, v310: i32, v315: i32):
+                v311 = hir.bitcast v309 : u32 #[ty = u32];
+                v312 = hir.constant 4 : u32;
+                v313 = hir.mod v311, v312 : u32;
+                hir.assertz v313 #[code = 250];
+                v314 = hir.int_to_ptr v311 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v314, v310;
+                v318 = hir.constant 16 : i32;
+                v319 = hir.add v315, v318 : i32 #[overflow = wrapping];
+                v320 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = world/root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+                v321 = hir.bitcast v320 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v321, v319;
+                hir.br block30;
+            ^block32:
+                v295 = hir.bitcast v270 : u32 #[ty = u32];
+                v296 = hir.constant 8 : u32;
+                v297 = hir.add v295, v296 : u32 #[overflow = checked];
+                v298 = hir.constant 4 : u32;
+                v299 = hir.mod v297, v298 : u32;
+                hir.assertz v299 #[code = 250];
+                v300 = hir.int_to_ptr v297 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v300, v294;
+                v302 = hir.bitcast v270 : u32 #[ty = u32];
+                v303 = hir.constant 4 : u32;
+                v304 = hir.add v302, v303 : u32 #[overflow = checked];
+                v305 = hir.constant 4 : u32;
+                v306 = hir.mod v304, v305 : u32;
+                hir.assertz v306 #[code = 250];
+                v307 = hir.int_to_ptr v304 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v307, v301;
+                v308 = hir.constant 1 : i32;
+                hir.br block31(v270, v308, v316);
+            ^block33(v285: i32, v317: i32):
+                v286 = hir.constant 0 : i32;
+                v287 = hir.bitcast v285 : u32 #[ty = u32];
+                v288 = hir.constant 4 : u32;
+                v289 = hir.add v287, v288 : u32 #[overflow = checked];
+                v290 = hir.constant 4 : u32;
+                v291 = hir.mod v289, v290 : u32;
+                hir.assertz v291 #[code = 250];
+                v292 = hir.int_to_ptr v289 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v292, v286;
+                v293 = hir.constant 1 : i32;
+                hir.br block31(v285, v293, v317);
+            ^block34:
+                v220 = hir.constant -2147483648 : i32;
+                v221 = hir.sub v220, v188 : i32 #[overflow = wrapping];
+                v222 = hir.trunc v211 : i32 #[ty = i32];
+                v223 = hir.bitcast v221 : u32 #[ty = u32];
+                v224 = hir.bitcast v222 : u32 #[ty = u32];
+                v225 = hir.lt v223, v224 : i1;
+                v226 = hir.zext v225 : u32 #[ty = u32];
+                v227 = hir.bitcast v226 : i32 #[ty = i32];
+                v228 = hir.constant 0 : i32;
+                v229 = hir.neq v227, v228 : i1;
+                hir.cond_br v229 block33(v185, v196), block35;
+            ^block35:
+                v230 = hir.constant 0 : i32;
+                v231 = hir.neq v222, v230 : i1;
+                hir.cond_br v231 block36, block37;
+            ^block36:
+                v246 = hir.constant 0 : i32;
+                v247 = hir.neq v187, v246 : i1;
+                hir.cond_br v247 block39, block40;
+            ^block37:
+                v232 = hir.bitcast v185 : u32 #[ty = u32];
+                v233 = hir.constant 8 : u32;
+                v234 = hir.add v232, v233 : u32 #[overflow = checked];
+                v235 = hir.constant 4 : u32;
+                v236 = hir.mod v234, v235 : u32;
+                hir.assertz v236 #[code = 250];
+                v237 = hir.int_to_ptr v234 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v237, v188;
+                v238 = hir.constant 0 : i32;
+                v239 = hir.constant 0 : i32;
+                v240 = hir.bitcast v185 : u32 #[ty = u32];
+                v241 = hir.constant 4 : u32;
+                v242 = hir.add v240, v241 : u32 #[overflow = checked];
+                v243 = hir.constant 4 : u32;
+                v244 = hir.mod v242, v243 : u32;
+                hir.assertz v244 #[code = 250];
+                v245 = hir.int_to_ptr v242 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v245, v239;
+                hir.br block31(v185, v238, v196);
+            ^block38(v263: i32, v270: i32, v277: i32, v294: i32, v301: i32, v316: i32):
+                v264 = hir.constant 0 : i32;
+                v265 = hir.eq v263, v264 : i1;
+                v266 = hir.zext v265 : u32 #[ty = u32];
+                v267 = hir.bitcast v266 : i32 #[ty = i32];
+                v268 = hir.constant 0 : i32;
+                v269 = hir.neq v267, v268 : i1;
+                hir.cond_br v269 block32, block41;
+            ^block39:
+                v257 = hir.constant 1 : i32;
+                hir.exec v196, v188, v222, v257 #[callee = world/root/abi_transform_tx_kernel_get_inputs_4/alloc::alloc::Global::alloc_impl] #[signature = (param i32) (param i32) (param i32) (param i32)];
+                v258 = hir.bitcast v196 : u32 #[ty = u32];
+                v259 = hir.constant 4 : u32;
+                v260 = hir.mod v258, v259 : u32;
+                hir.assertz v260 #[code = 250];
+                v261 = hir.int_to_ptr v258 : (ptr i32) #[ty = (ptr i32)];
+                v262 = hir.load v261 : i32;
+                hir.br block38(v262, v185, v186, v222, v188, v196);
+            ^block40:
+                v248 = hir.constant 8 : i32;
+                v249 = hir.add v196, v248 : i32 #[overflow = wrapping];
+                hir.exec v249, v188, v222 #[callee = world/root/abi_transform_tx_kernel_get_inputs_4/<alloc::alloc::Global as core::alloc::Allocator>::allocate] #[signature = (param i32) (param i32) (param i32)];
+                v250 = hir.bitcast v196 : u32 #[ty = u32];
+                v251 = hir.constant 8 : u32;
+                v252 = hir.add v250, v251 : u32 #[overflow = checked];
+                v253 = hir.constant 4 : u32;
+                v254 = hir.mod v252, v253 : u32;
+                hir.assertz v254 #[code = 250];
+                v255 = hir.int_to_ptr v252 : (ptr i32) #[ty = (ptr i32)];
+                v256 = hir.load v255 : i32;
+                hir.br block38(v256, v185, v186, v222, v188, v196);
+            ^block41:
+                v271 = hir.bitcast v270 : u32 #[ty = u32];
+                v272 = hir.constant 8 : u32;
+                v273 = hir.add v271, v272 : u32 #[overflow = checked];
+                v274 = hir.constant 4 : u32;
+                v275 = hir.mod v273, v274 : u32;
+                hir.assertz v275 #[code = 250];
+                v276 = hir.int_to_ptr v273 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v276, v263;
+                v278 = hir.bitcast v270 : u32 #[ty = u32];
+                v279 = hir.constant 4 : u32;
+                v280 = hir.add v278, v279 : u32 #[overflow = checked];
+                v281 = hir.constant 4 : u32;
+                v282 = hir.mod v280, v281 : u32;
+                hir.assertz v282 #[code = 250];
+                v283 = hir.int_to_ptr v280 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v283, v277;
+                v284 = hir.constant 0 : i32;
+                hir.br block31(v270, v284, v316);
+            };
+            builtin.function public @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v322: i32, v323: i32, v324: i32) {
+            ^block42(v322: i32, v323: i32, v324: i32):
+                v325 = hir.constant 0 : i32;
+                v326 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = world/root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+                v327 = hir.bitcast v326 : (ptr i32) #[ty = (ptr i32)];
+                v328 = hir.load v327 : i32;
+                v329 = hir.constant 16 : i32;
+                v330 = hir.sub v328, v329 : i32 #[overflow = wrapping];
+                v331 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = world/root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+                v332 = hir.bitcast v331 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v332, v330;
+                v333 = hir.constant 8 : i32;
+                v334 = hir.add v330, v333 : i32 #[overflow = wrapping];
+                v335 = hir.constant 0 : i32;
+                hir.exec v334, v323, v324, v335 #[callee = world/root/abi_transform_tx_kernel_get_inputs_4/alloc::alloc::Global::alloc_impl] #[signature = (param i32) (param i32) (param i32) (param i32)];
+                v336 = hir.bitcast v330 : u32 #[ty = u32];
+                v337 = hir.constant 12 : u32;
+                v338 = hir.add v336, v337 : u32 #[overflow = checked];
+                v339 = hir.constant 4 : u32;
+                v340 = hir.mod v338, v339 : u32;
+                hir.assertz v340 #[code = 250];
+                v341 = hir.int_to_ptr v338 : (ptr i32) #[ty = (ptr i32)];
+                v342 = hir.load v341 : i32;
+                v343 = hir.bitcast v330 : u32 #[ty = u32];
+                v344 = hir.constant 8 : u32;
+                v345 = hir.add v343, v344 : u32 #[overflow = checked];
+                v346 = hir.constant 4 : u32;
+                v347 = hir.mod v345, v346 : u32;
+                hir.assertz v347 #[code = 250];
+                v348 = hir.int_to_ptr v345 : (ptr i32) #[ty = (ptr i32)];
+                v349 = hir.load v348 : i32;
+                v350 = hir.bitcast v322 : u32 #[ty = u32];
+                v351 = hir.constant 4 : u32;
+                v352 = hir.mod v350, v351 : u32;
+                hir.assertz v352 #[code = 250];
+                v353 = hir.int_to_ptr v350 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v353, v349;
+                v354 = hir.bitcast v322 : u32 #[ty = u32];
+                v355 = hir.constant 4 : u32;
+                v356 = hir.add v354, v355 : u32 #[overflow = checked];
+                v357 = hir.constant 4 : u32;
+                v358 = hir.mod v356, v357 : u32;
+                hir.assertz v358 #[code = 250];
+                v359 = hir.int_to_ptr v356 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v359, v342;
+                v360 = hir.constant 16 : i32;
+                v361 = hir.add v330, v360 : i32 #[overflow = wrapping];
+                v362 = builtin.global_symbol  : (ptr u8) #[offset = 0] #[symbol = world/root/abi_transform_tx_kernel_get_inputs_4/__stack_pointer];
+                v363 = hir.bitcast v362 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v363, v361;
+                hir.br block43;
+            ^block43:
+                hir.ret ;
+            };
+            builtin.function public @alloc::alloc::Global::alloc_impl(v364: i32, v365: i32, v366: i32, v367: i32) {
+            ^block44(v364: i32, v365: i32, v366: i32, v367: i32):
+                v368 = hir.constant 0 : i32;
+                v369 = hir.eq v366, v368 : i1;
+                v370 = hir.zext v369 : u32 #[ty = u32];
+                v371 = hir.bitcast v370 : i32 #[ty = i32];
+                v372 = hir.constant 0 : i32;
+                v373 = hir.neq v371, v372 : i1;
+                hir.cond_br v373 block46(v364, v366, v365), block47;
+            ^block45:
+                hir.ret ;
+            ^block46(v385: i32, v386: i32, v393: i32):
+                v387 = hir.bitcast v385 : u32 #[ty = u32];
+                v388 = hir.constant 4 : u32;
+                v389 = hir.add v387, v388 : u32 #[overflow = checked];
+                v390 = hir.constant 4 : u32;
+                v391 = hir.mod v389, v390 : u32;
+                hir.assertz v391 #[code = 250];
+                v392 = hir.int_to_ptr v389 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v392, v386;
+                v394 = hir.bitcast v385 : u32 #[ty = u32];
+                v395 = hir.constant 4 : u32;
+                v396 = hir.mod v394, v395 : u32;
+                hir.assertz v396 #[code = 250];
+                v397 = hir.int_to_ptr v394 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v397, v393;
+                hir.br block45;
+            ^block47:
+                v374 = hir.constant 0 : i32;
+                v375 = hir.bitcast v374 : u32 #[ty = u32];
+                v376 = hir.constant 1048636 : u32;
+                v377 = hir.add v375, v376 : u32 #[overflow = checked];
+                v378 = hir.int_to_ptr v377 : (ptr u8) #[ty = (ptr u8)];
+                v379 = hir.load v378 : u8;
+                v380 = hir.zext v379 : u32 #[ty = u32];
+                v381 = hir.constant 0 : i32;
+                v382 = hir.neq v367, v381 : i1;
+                hir.cond_br v382 block48, block49;
+            ^block48:
+                v384 = hir.exec v366, v365 : i32 #[callee = world/root/abi_transform_tx_kernel_get_inputs_4/__rust_alloc_zeroed] #[signature = (param i32) (param i32) (result i32)];
+                hir.br block46(v364, v366, v384);
+            ^block49:
+                v383 = hir.exec v366, v365 : i32 #[callee = world/root/abi_transform_tx_kernel_get_inputs_4/__rust_alloc] #[signature = (param i32) (param i32) (result i32)];
+                hir.br block46(v364, v366, v383);
+            };
+            builtin.function public @alloc::raw_vec::handle_error(v398: i32, v399: i32, v400: i32) {
+            ^block50(v398: i32, v399: i32, v400: i32):
+                hir.unreachable ;
+            ^block51:
+
+            };
+            builtin.function public @core::ptr::alignment::Alignment::max(v401: i32, v402: i32) -> i32 {
+            ^block52(v401: i32, v402: i32):
+                v404 = hir.bitcast v401 : u32 #[ty = u32];
+                v405 = hir.bitcast v402 : u32 #[ty = u32];
+                v406 = hir.gt v404, v405 : i1;
+                v407 = hir.zext v406 : u32 #[ty = u32];
+                v408 = hir.constant 0 : i32;
+                v409 = hir.neq v407, v408 : i1;
+                v410 = hir.select v409, v401, v402 : i32;
+                hir.br block53(v410);
+            ^block53(v403: i32):
+                hir.ret v403;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.segment  #[data = 000000210000001100000027001000000073722e65746f6e2f73676e69646e69622f6372732f7379732d657361622f6b64732f2e2e2f2e2e] #[offset = 1048576] #[readonly = false];
         };
-        builtin.function public @core::ptr::alignment::Alignment::max(v401: i32, v402: i32) -> i32 {
-        ^block51(v401: i32, v402: i32):
-            v404 = hir.bitcast v401 : u32 #[ty = u32];
-            v405 = hir.bitcast v402 : u32 #[ty = u32];
-            v406 = hir.gt v404, v405 : i1;
-            v407 = hir.zext v406 : u32 #[ty = u32];
-            v408 = hir.constant 0 : i32;
-            v409 = hir.neq v407, v408 : i1;
-            v410 = hir.select v409, v401, v402 : i32;
-            hir.br block52(v410);
-        ^block52(v403: i32):
-            hir.ret v403;
+        builtin.module  #[name = #intrinsics::mem] #[visibility = public] {
+
+            builtin.function public @heap_base(result i32) {
+
+            };
         };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #miden::note] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.segment  #[data = 000000210000001100000027001000000073722e65746f6e2f73676e69646e69622f6372732f7379732d657361622f6b64732f2e2e2f2e2e] #[offset = 1048576] #[readonly = false];
-    };
-    builtin.module  #[name = #intrinsics::mem] #[visibility = public] {
+            builtin.function public @get_inputs(param i32) (result i32 i32) {
 
-        builtin.function public @heap_base(result i32) {
-
-        };
-    };
-    builtin.module  #[name = #miden::note] #[visibility = public] {
-
-        builtin.function public @get_inputs(param i32) (result i32 i32) {
-
+            };
         };
     };
 };

--- a/tests/integration/expected/add_felt.hir
+++ b/tests/integration/expected/add_felt.hir
@@ -1,17 +1,20 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #add_felt] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: felt, v1: felt) -> felt {
-        ^block3(v0: felt, v1: felt):
-            v3 = hir.add v0, v1 : felt #[overflow = unchecked];
-            hir.br block4(v3);
-        ^block4(v2: felt):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #add_felt] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+            builtin.function public @entrypoint(v0: felt, v1: felt) -> felt {
+            ^block4(v0: felt, v1: felt):
+                v3 = hir.add v0, v1 : felt #[overflow = unchecked];
+                hir.br block5(v3);
+            ^block5(v2: felt):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/add_i16.hir
+++ b/tests/integration/expected/add_i16.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_4a80dace0dddc4f08e0a7761b4e1d269aa474b6beb14702baa097a4626d593c1] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
-            v4 = hir.sext v3 : i32 #[ty = i32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_4a80dace0dddc4f08e0a7761b4e1d269aa474b6beb14702baa097a4626d593c1] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
+                v4 = hir.sext v3 : i32 #[ty = i32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/add_i32.hir
+++ b/tests/integration/expected/add_i32.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_cc3b19fe60136e21eb08ffee1b6d6f2a6534ca0afa46f10f5296cdb8f0adfc30] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_cc3b19fe60136e21eb08ffee1b6d6f2a6534ca0afa46f10f5296cdb8f0adfc30] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/add_i64.hir
+++ b/tests/integration/expected/add_i64.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_069cf45252371f826e737bc3d7f808e1df77c97acac642efbaf976f4ab507131] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.add v1, v0 : i64 #[overflow = wrapping];
-            hir.br block6(v3);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_069cf45252371f826e737bc3d7f808e1df77c97acac642efbaf976f4ab507131] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.add v1, v0 : i64 #[overflow = wrapping];
+                hir.br block7(v3);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/add_i8.hir
+++ b/tests/integration/expected/add_i8.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_3dc5f4de1f29681a88ff9608b56c29738ebfd35b5bf875f151de489b1c7e50f7] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
-            v4 = hir.sext v3 : i32 #[ty = i32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_3dc5f4de1f29681a88ff9608b56c29738ebfd35b5bf875f151de489b1c7e50f7] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
+                v4 = hir.sext v3 : i32 #[ty = i32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/add_u16.hir
+++ b/tests/integration/expected/add_u16.hir
@@ -1,27 +1,30 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_711c7705576a28225a7e87d297c54811b91eb1b69f3f407376a0af96dcad37b2] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
-            v4 = hir.constant 65535 : i32;
-            v5 = hir.band v3, v4 : i32;
-            hir.br block6(v5);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_711c7705576a28225a7e87d297c54811b91eb1b69f3f407376a0af96dcad37b2] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
+                v4 = hir.constant 65535 : i32;
+                v5 = hir.band v3, v4 : i32;
+                hir.br block7(v5);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/add_u32.hir
+++ b/tests/integration/expected/add_u32.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_ca3478b0c28e59b401b0d632fb0a1c51d0c45a319d503d2a2a705107e8aab84f] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_ca3478b0c28e59b401b0d632fb0a1c51d0c45a319d503d2a2a705107e8aab84f] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/add_u64.hir
+++ b/tests/integration/expected/add_u64.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_11c5a2e5412edeeffd507e0b820658a62ad960143f3b5167b2fe215d1ecfecfa] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.add v1, v0 : i64 #[overflow = wrapping];
-            hir.br block6(v3);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_11c5a2e5412edeeffd507e0b820658a62ad960143f3b5167b2fe215d1ecfecfa] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.add v1, v0 : i64 #[overflow = wrapping];
+                hir.br block7(v3);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/add_u8.hir
+++ b/tests/integration/expected/add_u8.hir
@@ -1,27 +1,30 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_195424540a8740c46e8ef057ffe65c7d2c73576a03c615db26b6ef1ef00d0357] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
-            v4 = hir.constant 255 : i32;
-            v5 = hir.band v3, v4 : i32;
-            hir.br block6(v5);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_195424540a8740c46e8ef057ffe65c7d2c73576a03c615db26b6ef1ef00d0357] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
+                v4 = hir.constant 255 : i32;
+                v5 = hir.band v3, v4 : i32;
+                hir.br block7(v5);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/and_bool.hir
+++ b/tests/integration/expected/and_bool.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_7ce7e9f0710d8cd1e27fed4812e6abf7f7325fdb538e7781120494f2bd2a9cab] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.band v0, v1 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_7ce7e9f0710d8cd1e27fed4812e6abf7f7325fdb538e7781120494f2bd2a9cab] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.band v0, v1 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/band_i16.hir
+++ b/tests/integration/expected/band_i16.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_2d07899decfc53ff76743115618445ad5a97172f61c9e54ea539ff55362f4dc5] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.band v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_2d07899decfc53ff76743115618445ad5a97172f61c9e54ea539ff55362f4dc5] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.band v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/band_i32.hir
+++ b/tests/integration/expected/band_i32.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_3c1243f6bf89d22ea186e66208b1ad921f7332ce215ea72d1d9f2c00cea6323b] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.band v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_3c1243f6bf89d22ea186e66208b1ad921f7332ce215ea72d1d9f2c00cea6323b] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.band v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/band_i64.hir
+++ b/tests/integration/expected/band_i64.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_fda5d5f9a96ae19c191d7fceb423c1b36b7cf8dd7d7c4ca8e768b8305e8195fc] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.band v1, v0 : i64;
-            hir.br block6(v3);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_fda5d5f9a96ae19c191d7fceb423c1b36b7cf8dd7d7c4ca8e768b8305e8195fc] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.band v1, v0 : i64;
+                hir.br block7(v3);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/band_i8.hir
+++ b/tests/integration/expected/band_i8.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_82b97b60f6c2bdfdaa5412831eebdefbd9fcecdcda5ab71592efdf9c8f0a3fb8] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.band v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_82b97b60f6c2bdfdaa5412831eebdefbd9fcecdcda5ab71592efdf9c8f0a3fb8] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.band v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/band_u16.hir
+++ b/tests/integration/expected/band_u16.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_62f08a4fd4cafb7db864c24731da8dab986b2b5c2d54b53e960972953f553406] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.band v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_62f08a4fd4cafb7db864c24731da8dab986b2b5c2d54b53e960972953f553406] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.band v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/band_u32.hir
+++ b/tests/integration/expected/band_u32.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_c4f32e60d0da9da73a9d4beef2081fc955bd8750a29571f11f6916287436cbe3] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.band v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_c4f32e60d0da9da73a9d4beef2081fc955bd8750a29571f11f6916287436cbe3] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.band v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/band_u64.hir
+++ b/tests/integration/expected/band_u64.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_4c7e8f3e1741ccb4a5bbbee6f13443e5deb9c528380592d13a046312348bd927] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.band v1, v0 : i64;
-            hir.br block6(v3);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_4c7e8f3e1741ccb4a5bbbee6f13443e5deb9c528380592d13a046312348bd927] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.band v1, v0 : i64;
+                hir.br block7(v3);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/band_u8.hir
+++ b/tests/integration/expected/band_u8.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_bcd6febe71cae37427fa9ff25c42a5ecaea8f1ac799aa86f8a46e3d07ab1bc01] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.band v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_bcd6febe71cae37427fa9ff25c42a5ecaea8f1ac799aa86f8a46e3d07ab1bc01] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.band v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bnot_bool.hir
+++ b/tests/integration/expected/bnot_bool.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_145320f8e700bf6bdf185aeb1dafe222a5808453dd3ade85b6f787389bf30c0f] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32) -> i32 {
-        ^block5(v0: i32):
-            v2 = hir.constant 1 : i32;
-            v3 = hir.bxor v0, v2 : i32;
-            hir.br block6(v3);
-        ^block6(v1: i32):
-            hir.ret v1;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_145320f8e700bf6bdf185aeb1dafe222a5808453dd3ade85b6f787389bf30c0f] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32) -> i32 {
+            ^block6(v0: i32):
+                v2 = hir.constant 1 : i32;
+                v3 = hir.bxor v0, v2 : i32;
+                hir.br block7(v3);
+            ^block7(v1: i32):
+                hir.ret v1;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bnot_i16.hir
+++ b/tests/integration/expected/bnot_i16.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_00cddfae3f036b7f10355e9d273eb1131e732db63a7ac33f728895e93a394b99] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32) -> i32 {
-        ^block5(v0: i32):
-            v2 = hir.constant -1 : i32;
-            v3 = hir.bxor v0, v2 : i32;
-            hir.br block6(v3);
-        ^block6(v1: i32):
-            hir.ret v1;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_00cddfae3f036b7f10355e9d273eb1131e732db63a7ac33f728895e93a394b99] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32) -> i32 {
+            ^block6(v0: i32):
+                v2 = hir.constant -1 : i32;
+                v3 = hir.bxor v0, v2 : i32;
+                hir.br block7(v3);
+            ^block7(v1: i32):
+                hir.ret v1;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bnot_i32.hir
+++ b/tests/integration/expected/bnot_i32.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_597108c1534cd7c973774710a354c519e8a9ce32a5a499ffe5839f4fea0cd83b] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32) -> i32 {
-        ^block5(v0: i32):
-            v2 = hir.constant -1 : i32;
-            v3 = hir.bxor v0, v2 : i32;
-            hir.br block6(v3);
-        ^block6(v1: i32):
-            hir.ret v1;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_597108c1534cd7c973774710a354c519e8a9ce32a5a499ffe5839f4fea0cd83b] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32) -> i32 {
+            ^block6(v0: i32):
+                v2 = hir.constant -1 : i32;
+                v3 = hir.bxor v0, v2 : i32;
+                hir.br block7(v3);
+            ^block7(v1: i32):
+                hir.ret v1;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bnot_i64.hir
+++ b/tests/integration/expected/bnot_i64.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_318a80316e6bca93f0a48d41942655ffb321d8d6c62d387f9037272e5ec565e3] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64) -> i64 {
-        ^block5(v0: i64):
-            v2 = hir.constant -1 : i64;
-            v3 = hir.bxor v0, v2 : i64;
-            hir.br block6(v3);
-        ^block6(v1: i64):
-            hir.ret v1;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_318a80316e6bca93f0a48d41942655ffb321d8d6c62d387f9037272e5ec565e3] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64) -> i64 {
+            ^block6(v0: i64):
+                v2 = hir.constant -1 : i64;
+                v3 = hir.bxor v0, v2 : i64;
+                hir.br block7(v3);
+            ^block7(v1: i64):
+                hir.ret v1;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bnot_i8.hir
+++ b/tests/integration/expected/bnot_i8.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_694a3a0d438c5be6815982d68ba790c15be6f3f7ce15158c74a6f5adbb86596f] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32) -> i32 {
-        ^block5(v0: i32):
-            v2 = hir.constant -1 : i32;
-            v3 = hir.bxor v0, v2 : i32;
-            hir.br block6(v3);
-        ^block6(v1: i32):
-            hir.ret v1;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_694a3a0d438c5be6815982d68ba790c15be6f3f7ce15158c74a6f5adbb86596f] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32) -> i32 {
+            ^block6(v0: i32):
+                v2 = hir.constant -1 : i32;
+                v3 = hir.bxor v0, v2 : i32;
+                hir.br block7(v3);
+            ^block7(v1: i32):
+                hir.ret v1;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bnot_u16.hir
+++ b/tests/integration/expected/bnot_u16.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_df76c987a66b14b20c7ce818414abfb720a4e3e74eb3dc8015560af9bdb3fee4] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32) -> i32 {
-        ^block5(v0: i32):
-            v2 = hir.constant 65535 : i32;
-            v3 = hir.bxor v0, v2 : i32;
-            hir.br block6(v3);
-        ^block6(v1: i32):
-            hir.ret v1;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_df76c987a66b14b20c7ce818414abfb720a4e3e74eb3dc8015560af9bdb3fee4] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32) -> i32 {
+            ^block6(v0: i32):
+                v2 = hir.constant 65535 : i32;
+                v3 = hir.bxor v0, v2 : i32;
+                hir.br block7(v3);
+            ^block7(v1: i32):
+                hir.ret v1;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bnot_u32.hir
+++ b/tests/integration/expected/bnot_u32.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_a762cb529f6595cbdce20fb1385e8ed3f8f4c23824a512b32f3818d297badb1c] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32) -> i32 {
-        ^block5(v0: i32):
-            v2 = hir.constant -1 : i32;
-            v3 = hir.bxor v0, v2 : i32;
-            hir.br block6(v3);
-        ^block6(v1: i32):
-            hir.ret v1;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_a762cb529f6595cbdce20fb1385e8ed3f8f4c23824a512b32f3818d297badb1c] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32) -> i32 {
+            ^block6(v0: i32):
+                v2 = hir.constant -1 : i32;
+                v3 = hir.bxor v0, v2 : i32;
+                hir.br block7(v3);
+            ^block7(v1: i32):
+                hir.ret v1;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bnot_u64.hir
+++ b/tests/integration/expected/bnot_u64.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_18ecee456448c6244ca46633baac3f3f6281f50c0c17dc427e781fb02b614132] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64) -> i64 {
-        ^block5(v0: i64):
-            v2 = hir.constant -1 : i64;
-            v3 = hir.bxor v0, v2 : i64;
-            hir.br block6(v3);
-        ^block6(v1: i64):
-            hir.ret v1;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_18ecee456448c6244ca46633baac3f3f6281f50c0c17dc427e781fb02b614132] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64) -> i64 {
+            ^block6(v0: i64):
+                v2 = hir.constant -1 : i64;
+                v3 = hir.bxor v0, v2 : i64;
+                hir.br block7(v3);
+            ^block7(v1: i64):
+                hir.ret v1;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bnot_u8.hir
+++ b/tests/integration/expected/bnot_u8.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_eaff6a2806ce4f4f18d6c1d65cab18383e6ac9921c310c1866b5b554b743d7e8] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32) -> i32 {
-        ^block5(v0: i32):
-            v2 = hir.constant 255 : i32;
-            v3 = hir.bxor v0, v2 : i32;
-            hir.br block6(v3);
-        ^block6(v1: i32):
-            hir.ret v1;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_eaff6a2806ce4f4f18d6c1d65cab18383e6ac9921c310c1866b5b554b743d7e8] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32) -> i32 {
+            ^block6(v0: i32):
+                v2 = hir.constant 255 : i32;
+                v3 = hir.bxor v0, v2 : i32;
+                hir.br block7(v3);
+            ^block7(v1: i32):
+                hir.ret v1;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bor_i16.hir
+++ b/tests/integration/expected/bor_i16.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_8dcae0a39212d4ad89597641a65bcf61179a7ecf222225943d30d5d6d1cceed9] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bor v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_8dcae0a39212d4ad89597641a65bcf61179a7ecf222225943d30d5d6d1cceed9] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bor v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bor_i32.hir
+++ b/tests/integration/expected/bor_i32.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_8de4f7a3511ae02636986e75ade7e321e0708f1826bcbc6aad48f37af323b92d] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bor v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_8de4f7a3511ae02636986e75ade7e321e0708f1826bcbc6aad48f37af323b92d] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bor v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bor_i64.hir
+++ b/tests/integration/expected/bor_i64.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_f251de15b0f1cb5576431f7d54bb74bf9a7d3ecd44df0dab5c9d48f9fbc8fc10] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.bor v1, v0 : i64;
-            hir.br block6(v3);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_f251de15b0f1cb5576431f7d54bb74bf9a7d3ecd44df0dab5c9d48f9fbc8fc10] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.bor v1, v0 : i64;
+                hir.br block7(v3);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bor_i8.hir
+++ b/tests/integration/expected/bor_i8.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_e78a5011ab26b989caa809c67e9a8c1aa75b6ed66a6d08724f2ade857dd972e7] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bor v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_e78a5011ab26b989caa809c67e9a8c1aa75b6ed66a6d08724f2ade857dd972e7] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bor v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bor_u16.hir
+++ b/tests/integration/expected/bor_u16.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_dc995daa9cb678e867fa3a5c4e0179784bd1e7d08c037d55bd2297656517604d] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bor v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_dc995daa9cb678e867fa3a5c4e0179784bd1e7d08c037d55bd2297656517604d] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bor v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bor_u32.hir
+++ b/tests/integration/expected/bor_u32.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_77d8f367326a058c1e380ac8136670434cfbc1e8dc697dc19201190d8465e015] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bor v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_77d8f367326a058c1e380ac8136670434cfbc1e8dc697dc19201190d8465e015] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bor v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bor_u64.hir
+++ b/tests/integration/expected/bor_u64.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_ba6ec59331d835edc07f1b6d30f780b5afe487a33c70884f73400189c17cefa6] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.bor v1, v0 : i64;
-            hir.br block6(v3);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_ba6ec59331d835edc07f1b6d30f780b5afe487a33c70884f73400189c17cefa6] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.bor v1, v0 : i64;
+                hir.br block7(v3);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bor_u8.hir
+++ b/tests/integration/expected/bor_u8.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_627a21fd177d4525d8fc796d148d944ac1c73323757235a4c20ab90db532b285] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bor v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_627a21fd177d4525d8fc796d148d944ac1c73323757235a4c20ab90db532b285] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bor v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bxor_i16.hir
+++ b/tests/integration/expected/bxor_i16.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_06b51ddbcc44da2e5b8841fa052397384b0f5d4eefe1a6761fd89258dd630db1] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bxor v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_06b51ddbcc44da2e5b8841fa052397384b0f5d4eefe1a6761fd89258dd630db1] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bxor v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bxor_i32.hir
+++ b/tests/integration/expected/bxor_i32.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_be5e210e7912f50da791746e584735851a9fd43e799bd41c0fbdf5eeef96d97f] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bxor v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_be5e210e7912f50da791746e584735851a9fd43e799bd41c0fbdf5eeef96d97f] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bxor v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bxor_i64.hir
+++ b/tests/integration/expected/bxor_i64.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_885212eb58b38aa5817a1cd1ea309cf5ebf56542a26e25486674166aaa47f2cb] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.bxor v1, v0 : i64;
-            hir.br block6(v3);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_885212eb58b38aa5817a1cd1ea309cf5ebf56542a26e25486674166aaa47f2cb] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.bxor v1, v0 : i64;
+                hir.br block7(v3);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bxor_i8.hir
+++ b/tests/integration/expected/bxor_i8.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_356739565a7fab5b3bf9f65a371ce7f192583c0220bd25c5fee3d50220aadf20] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bxor v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_356739565a7fab5b3bf9f65a371ce7f192583c0220bd25c5fee3d50220aadf20] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bxor v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bxor_u16.hir
+++ b/tests/integration/expected/bxor_u16.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_1b43125ada2df0a7389224838e3cc4580de7ac09a86583219a3c08992ca30695] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bxor v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_1b43125ada2df0a7389224838e3cc4580de7ac09a86583219a3c08992ca30695] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bxor v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bxor_u32.hir
+++ b/tests/integration/expected/bxor_u32.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_8adee8c8a1d96eeb275124845b60cbff14dd0510589dd0280f2e41e39371d112] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bxor v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_8adee8c8a1d96eeb275124845b60cbff14dd0510589dd0280f2e41e39371d112] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bxor v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bxor_u64.hir
+++ b/tests/integration/expected/bxor_u64.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_0ac0889968c0147e0b9ffdf298215e3c144b2f0574e12a5a7110797b6cd692a5] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.bxor v1, v0 : i64;
-            hir.br block6(v3);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_0ac0889968c0147e0b9ffdf298215e3c144b2f0574e12a5a7110797b6cd692a5] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.bxor v1, v0 : i64;
+                hir.br block7(v3);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/bxor_u8.hir
+++ b/tests/integration/expected/bxor_u8.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_4d8ea78f0f6f413d2e269f1030408eff2561031d16e66341c04b75f1a2e08afe] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bxor v1, v0 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_4d8ea78f0f6f413d2e269f1030408eff2561031d16e66341c04b75f1a2e08afe] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bxor v1, v0 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/collatz.hir
+++ b/tests/integration/expected/collatz.hir
@@ -1,48 +1,51 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #collatz] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32) -> i32 {
-        ^block3(v0: i32):
-            v2 = hir.constant 0 : i32;
-            v3 = hir.constant 0 : i32;
-            hir.br block5(v0, v3);
-        ^block4(v1: i32):
+        builtin.module  #[name = #collatz] #[visibility = public] {
 
-        ^block5(v5: i32, v12: i32):
-            v6 = hir.constant 1 : i32;
-            v7 = hir.neq v5, v6 : i1;
-            v8 = hir.zext v7 : u32 #[ty = u32];
-            v9 = hir.bitcast v8 : i32 #[ty = i32];
-            v10 = hir.constant 0 : i32;
-            v11 = hir.neq v9, v10 : i1;
-            hir.cond_br v11 block7, block8;
-        ^block6(v4: i32):
+            builtin.function public @entrypoint(v0: i32) -> i32 {
+            ^block4(v0: i32):
+                v2 = hir.constant 0 : i32;
+                v3 = hir.constant 0 : i32;
+                hir.br block6(v0, v3);
+            ^block5(v1: i32):
 
-        ^block7:
-            v13 = hir.constant 3 : i32;
-            v14 = hir.mul v5, v13 : i32 #[overflow = wrapping];
-            v15 = hir.constant 1 : i32;
-            v16 = hir.add v14, v15 : i32 #[overflow = wrapping];
-            v17 = hir.constant 1 : i32;
-            v18 = hir.bitcast v5 : u32 #[ty = u32];
-            v19 = hir.bitcast v17 : u32 #[ty = u32];
-            v20 = hir.shr v18, v19 : u32;
-            v21 = hir.bitcast v20 : i32 #[ty = i32];
-            v22 = hir.constant 1 : i32;
-            v23 = hir.band v5, v22 : i32;
-            v24 = hir.constant 0 : i32;
-            v25 = hir.neq v23, v24 : i1;
-            v26 = hir.select v25, v16, v21 : i32;
-            v27 = hir.constant 1 : i32;
-            v28 = hir.add v12, v27 : i32 #[overflow = wrapping];
-            hir.br block5(v26, v28);
-        ^block8:
-            hir.ret v12;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+            ^block6(v5: i32, v12: i32):
+                v6 = hir.constant 1 : i32;
+                v7 = hir.neq v5, v6 : i1;
+                v8 = hir.zext v7 : u32 #[ty = u32];
+                v9 = hir.bitcast v8 : i32 #[ty = i32];
+                v10 = hir.constant 0 : i32;
+                v11 = hir.neq v9, v10 : i1;
+                hir.cond_br v11 block8, block9;
+            ^block7(v4: i32):
 
-            hir.ret_imm  #[value = 1048576];
+            ^block8:
+                v13 = hir.constant 3 : i32;
+                v14 = hir.mul v5, v13 : i32 #[overflow = wrapping];
+                v15 = hir.constant 1 : i32;
+                v16 = hir.add v14, v15 : i32 #[overflow = wrapping];
+                v17 = hir.constant 1 : i32;
+                v18 = hir.bitcast v5 : u32 #[ty = u32];
+                v19 = hir.bitcast v17 : u32 #[ty = u32];
+                v20 = hir.shr v18, v19 : u32;
+                v21 = hir.bitcast v20 : i32 #[ty = i32];
+                v22 = hir.constant 1 : i32;
+                v23 = hir.band v5, v22 : i32;
+                v24 = hir.constant 0 : i32;
+                v25 = hir.neq v23, v24 : i1;
+                v26 = hir.select v25, v16, v21 : i32;
+                v27 = hir.constant 1 : i32;
+                v28 = hir.add v12, v27 : i32 #[overflow = wrapping];
+                hir.br block6(v26, v28);
+            ^block9:
+                hir.ret v12;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/core::cmp::max_u8_u8.hir
+++ b/tests/integration/expected/core::cmp::max_u8_u8.hir
@@ -1,31 +1,34 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_935eefccf7923abc0816d374d2bb37d5149355aa52de63cf39d63cd92d8ee41d] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.gt v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            v7 = hir.constant 0 : i32;
-            v8 = hir.neq v6, v7 : i1;
-            v9 = hir.select v8, v0, v1 : i32;
-            hir.br block6(v9);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_935eefccf7923abc0816d374d2bb37d5149355aa52de63cf39d63cd92d8ee41d] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.gt v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                v7 = hir.constant 0 : i32;
+                v8 = hir.neq v6, v7 : i1;
+                v9 = hir.select v8, v0, v1 : i32;
+                hir.br block7(v9);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/core::cmp::min_i32_i32.hir
+++ b/tests/integration/expected/core::cmp::min_i32_i32.hir
@@ -1,29 +1,32 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_7ebd625ebc756910f700d1547e5bf4cc2c32a85181b0c8e5a3b9113c39335db7] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.lt v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            v5 = hir.constant 0 : i32;
-            v6 = hir.neq v4, v5 : i1;
-            v7 = hir.select v6, v0, v1 : i32;
-            hir.br block6(v7);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_7ebd625ebc756910f700d1547e5bf4cc2c32a85181b0c8e5a3b9113c39335db7] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.lt v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                v5 = hir.constant 0 : i32;
+                v6 = hir.neq v4, v5 : i1;
+                v7 = hir.select v6, v0, v1 : i32;
+                hir.br block7(v7);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/core::cmp::min_u32_u32.hir
+++ b/tests/integration/expected/core::cmp::min_u32_u32.hir
@@ -1,31 +1,34 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_2130eab9306152f86439d4a8076319464ef487ebdd8d670f656fd73a23036fa5] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.lt v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            v7 = hir.constant 0 : i32;
-            v8 = hir.neq v6, v7 : i1;
-            v9 = hir.select v8, v0, v1 : i32;
-            hir.br block6(v9);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_2130eab9306152f86439d4a8076319464ef487ebdd8d670f656fd73a23036fa5] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.lt v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                v7 = hir.constant 0 : i32;
+                v8 = hir.neq v6, v7 : i1;
+                v9 = hir.select v8, v0, v1 : i32;
+                hir.br block7(v9);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/core::cmp::min_u8_u8.hir
+++ b/tests/integration/expected/core::cmp::min_u8_u8.hir
@@ -1,31 +1,34 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_3114079be600d0d34a20fede92f64baec1c63ae3845306ba2de322513ab73343] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.lt v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            v7 = hir.constant 0 : i32;
-            v8 = hir.neq v6, v7 : i1;
-            v9 = hir.select v8, v0, v1 : i32;
-            hir.br block6(v9);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_3114079be600d0d34a20fede92f64baec1c63ae3845306ba2de322513ab73343] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.lt v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                v7 = hir.constant 0 : i32;
+                v8 = hir.neq v6, v7 : i1;
+                v9 = hir.select v8, v0, v1 : i32;
+                hir.br block7(v9);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/div_felt.hir
+++ b/tests/integration/expected/div_felt.hir
@@ -1,17 +1,20 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #div_felt] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: felt, v1: felt) -> felt {
-        ^block3(v0: felt, v1: felt):
-            v3 = hir.div v0, v1 : felt;
-            hir.br block4(v3);
-        ^block4(v2: felt):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #div_felt] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+            builtin.function public @entrypoint(v0: felt, v1: felt) -> felt {
+            ^block4(v0: felt, v1: felt):
+                v3 = hir.div v0, v1 : felt;
+                hir.br block5(v3);
+            ^block5(v2: felt):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/eq_felt.hir
+++ b/tests/integration/expected/eq_felt.hir
@@ -1,21 +1,24 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #eq_felt] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: felt, v1: felt) -> i32 {
-        ^block3(v0: felt, v1: felt):
-            v3 = hir.eq v0, v1 : i1;
-            v4 = hir.cast v3 : i32 #[ty = i32];
-            v5 = hir.constant 1 : i32;
-            v6 = hir.eq v4, v5 : i1;
-            v7 = hir.zext v6 : u32 #[ty = u32];
-            hir.br block4(v7);
-        ^block4(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #eq_felt] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+            builtin.function public @entrypoint(v0: felt, v1: felt) -> i32 {
+            ^block4(v0: felt, v1: felt):
+                v3 = hir.eq v0, v1 : i1;
+                v4 = hir.cast v3 : i32 #[ty = i32];
+                v5 = hir.constant 1 : i32;
+                v6 = hir.eq v4, v5 : i1;
+                v7 = hir.zext v6 : u32 #[ty = u32];
+                hir.br block5(v7);
+            ^block5(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/eq_i16.hir
+++ b/tests/integration/expected/eq_i16.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_2f29f68fe27c60920a7ea2ddd41d7b6f088aaca71b06fe98e8543c00277965f4] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.eq v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_2f29f68fe27c60920a7ea2ddd41d7b6f088aaca71b06fe98e8543c00277965f4] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.eq v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/eq_i32.hir
+++ b/tests/integration/expected/eq_i32.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_c28e7308ea5f55f6d78b6647cb9c8148700b1b42240fe9786556265f83fcda8f] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.eq v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_c28e7308ea5f55f6d78b6647cb9c8148700b1b42240fe9786556265f83fcda8f] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.eq v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/eq_i64.hir
+++ b/tests/integration/expected/eq_i64.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_335e8b9940dcc6e8b83a7c4b5c50143e223e0f4e2cb269440866b6f3f4a0d5a6] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.eq v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_335e8b9940dcc6e8b83a7c4b5c50143e223e0f4e2cb269440866b6f3f4a0d5a6] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.eq v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/eq_i8.hir
+++ b/tests/integration/expected/eq_i8.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_d32112fcece9e923c53ef0e7e530a320a042569dc27aa4e4b1682a14933a630b] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.eq v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_d32112fcece9e923c53ef0e7e530a320a042569dc27aa4e4b1682a14933a630b] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.eq v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/eq_u16.hir
+++ b/tests/integration/expected/eq_u16.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_8fbd508d452e6be7333d34171256184bccb35bce63b4c4b324a68dfa222b449a] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.eq v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_8fbd508d452e6be7333d34171256184bccb35bce63b4c4b324a68dfa222b449a] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.eq v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/eq_u32.hir
+++ b/tests/integration/expected/eq_u32.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_1ec18cd34684e347de59c6bcc66cf36588b84dc96b83ce847862c54131b73875] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.eq v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_1ec18cd34684e347de59c6bcc66cf36588b84dc96b83ce847862c54131b73875] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.eq v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/eq_u64.hir
+++ b/tests/integration/expected/eq_u64.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_d3f2b162735bb643456cb68c71d6be70cdb8e4267c7ef3c9cdef6fcfdb77c2cc] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.eq v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_d3f2b162735bb643456cb68c71d6be70cdb8e4267c7ef3c9cdef6fcfdb77c2cc] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.eq v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/eq_u8.hir
+++ b/tests/integration/expected/eq_u8.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_6b299c822e52963f8b3c87b898b867e2147f25b53bb5c38ab829254425824be5] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.eq v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_6b299c822e52963f8b3c87b898b867e2147f25b53bb5c38ab829254425824be5] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.eq v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/examples/fib.hir
+++ b/tests/integration/expected/examples/fib.hir
@@ -1,32 +1,35 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #fibonacci] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32) -> i32 {
-        ^block3(v0: i32):
-            v2 = hir.constant 0 : i32;
-            v3 = hir.constant 0 : i32;
-            v4 = hir.constant 1 : i32;
-            hir.br block5(v4, v0, v3);
-        ^block4(v1: i32):
+        builtin.module  #[name = #fibonacci] #[visibility = public] {
 
-        ^block5(v6: i32, v7: i32, v10: i32):
-            v8 = hir.constant 0 : i32;
-            v9 = hir.neq v7, v8 : i1;
-            hir.cond_br v9 block7, block8;
-        ^block6(v5: i32):
+            builtin.function public @entrypoint(v0: i32) -> i32 {
+            ^block4(v0: i32):
+                v2 = hir.constant 0 : i32;
+                v3 = hir.constant 0 : i32;
+                v4 = hir.constant 1 : i32;
+                hir.br block6(v4, v0, v3);
+            ^block5(v1: i32):
 
-        ^block7:
-            v11 = hir.constant -1 : i32;
-            v12 = hir.add v7, v11 : i32 #[overflow = wrapping];
-            v13 = hir.add v10, v6 : i32 #[overflow = wrapping];
-            hir.br block5(v13, v12, v6);
-        ^block8:
-            hir.ret v10;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+            ^block6(v6: i32, v7: i32, v10: i32):
+                v8 = hir.constant 0 : i32;
+                v9 = hir.neq v7, v8 : i1;
+                hir.cond_br v9 block8, block9;
+            ^block7(v5: i32):
 
-            hir.ret_imm  #[value = 1048576];
+            ^block8:
+                v11 = hir.constant -1 : i32;
+                v12 = hir.add v7, v11 : i32 #[overflow = wrapping];
+                v13 = hir.add v10, v6 : i32 #[overflow = wrapping];
+                hir.br block6(v13, v12, v6);
+            ^block9:
+                hir.ret v10;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/felt_intrinsics.hir
+++ b/tests/integration/expected/felt_intrinsics.hir
@@ -1,20 +1,23 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #felt_intrinsics] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: felt, v1: felt) -> felt {
-        ^block3(v0: felt, v1: felt):
-            v3 = hir.mul v0, v1 : felt #[overflow = unchecked];
-            v4 = hir.sub v3, v0 : felt #[overflow = unchecked];
-            v5 = hir.add v4, v1 : felt #[overflow = unchecked];
-            v6 = hir.div v0, v5 : felt;
-            hir.br block4(v6);
-        ^block4(v2: felt):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #felt_intrinsics] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+            builtin.function public @entrypoint(v0: felt, v1: felt) -> felt {
+            ^block4(v0: felt, v1: felt):
+                v3 = hir.mul v0, v1 : felt #[overflow = unchecked];
+                v4 = hir.sub v3, v0 : felt #[overflow = unchecked];
+                v5 = hir.add v4, v1 : felt #[overflow = unchecked];
+                v6 = hir.div v0, v5 : felt;
+                hir.br block5(v6);
+            ^block5(v2: felt):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/function_call_hir2.hir
+++ b/tests/integration/expected/function_call_hir2.hir
@@ -1,24 +1,27 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #function_call_hir2] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @add(v0: i32, v1: i32) -> i32 {
-        ^block3(v0: i32, v1: i32):
-            v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
-            hir.br block4(v3);
-        ^block4(v2: i32):
-            hir.ret v2;
-        };
-        builtin.function public @entrypoint(v4: i32, v5: i32) -> i32 {
-        ^block5(v4: i32, v5: i32):
-            v7 = hir.exec v4, v5 : i32 #[callee = root/function_call_hir2/add] #[signature = (param i32) (param i32) (result i32)];
-            hir.br block6(v7);
-        ^block6(v6: i32):
-            hir.ret v6;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #function_call_hir2] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+            builtin.function public @add(v0: i32, v1: i32) -> i32 {
+            ^block4(v0: i32, v1: i32):
+                v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
+                hir.br block5(v3);
+            ^block5(v2: i32):
+                hir.ret v2;
+            };
+            builtin.function public @entrypoint(v4: i32, v5: i32) -> i32 {
+            ^block6(v4: i32, v5: i32):
+                v7 = hir.exec v4, v5 : i32 #[callee = world/root/function_call_hir2/add] #[signature = (param i32) (param i32) (result i32)];
+                hir.br block7(v7);
+            ^block7(v6: i32):
+                hir.ret v6;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/ge_felt.hir
+++ b/tests/integration/expected/ge_felt.hir
@@ -1,21 +1,24 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #ge_felt] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: felt, v1: felt) -> i32 {
-        ^block3(v0: felt, v1: felt):
-            v3 = hir.gte v0, v1 : i1;
-            v4 = hir.cast v3 : i32 #[ty = i32];
-            v5 = hir.constant 0 : i32;
-            v6 = hir.neq v4, v5 : i1;
-            v7 = hir.zext v6 : u32 #[ty = u32];
-            hir.br block4(v7);
-        ^block4(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #ge_felt] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+            builtin.function public @entrypoint(v0: felt, v1: felt) -> i32 {
+            ^block4(v0: felt, v1: felt):
+                v3 = hir.gte v0, v1 : i1;
+                v4 = hir.cast v3 : i32 #[ty = i32];
+                v5 = hir.constant 0 : i32;
+                v6 = hir.neq v4, v5 : i1;
+                v7 = hir.zext v6 : u32 #[ty = u32];
+                hir.br block5(v7);
+            ^block5(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/ge_i32.hir
+++ b/tests/integration/expected/ge_i32.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_c0f27bd914ea4f9a33c6502694b5eeace55ed7a40a907b0c5fd68e0aa656a56b] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.gte v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_c0f27bd914ea4f9a33c6502694b5eeace55ed7a40a907b0c5fd68e0aa656a56b] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.gte v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/ge_i64.hir
+++ b/tests/integration/expected/ge_i64.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_1dc910df9e5ef302ee236233065a2a50427fb4ff2db8591dcc6713f05a95d77a] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.gte v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_1dc910df9e5ef302ee236233065a2a50427fb4ff2db8591dcc6713f05a95d77a] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.gte v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/ge_u16.hir
+++ b/tests/integration/expected/ge_u16.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_0eeac93afe2a6fee749f5e48efe12f98e2e005f6a92fa7f020166662c68c1750] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.gte v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_0eeac93afe2a6fee749f5e48efe12f98e2e005f6a92fa7f020166662c68c1750] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.gte v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/ge_u32.hir
+++ b/tests/integration/expected/ge_u32.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_4fa5dff76055193b0eab22d64f4284da486889ba07bebda7bae15ce0af5473af] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.gte v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_4fa5dff76055193b0eab22d64f4284da486889ba07bebda7bae15ce0af5473af] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.gte v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/ge_u64.hir
+++ b/tests/integration/expected/ge_u64.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_77837611a2574dae16586d25d91d315da506c432500ce2d6c4234173b9ea07b2] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.bitcast v0 : u64 #[ty = u64];
-            v4 = hir.bitcast v1 : u64 #[ty = u64];
-            v5 = hir.gte v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_77837611a2574dae16586d25d91d315da506c432500ce2d6c4234173b9ea07b2] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.bitcast v0 : u64 #[ty = u64];
+                v4 = hir.bitcast v1 : u64 #[ty = u64];
+                v5 = hir.gte v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/ge_u8.hir
+++ b/tests/integration/expected/ge_u8.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_e66ace9d45878034c39e91c35eb5f67915dc01fb5a1ed5c34627e3bb99107855] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.gte v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_e66ace9d45878034c39e91c35eb5f67915dc01fb5a1ed5c34627e3bb99107855] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.gte v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/gt_felt.hir
+++ b/tests/integration/expected/gt_felt.hir
@@ -1,21 +1,24 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #gt_felt] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: felt, v1: felt) -> i32 {
-        ^block3(v0: felt, v1: felt):
-            v3 = hir.gt v0, v1 : i1;
-            v4 = hir.cast v3 : i32 #[ty = i32];
-            v5 = hir.constant 0 : i32;
-            v6 = hir.neq v4, v5 : i1;
-            v7 = hir.zext v6 : u32 #[ty = u32];
-            hir.br block4(v7);
-        ^block4(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #gt_felt] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+            builtin.function public @entrypoint(v0: felt, v1: felt) -> i32 {
+            ^block4(v0: felt, v1: felt):
+                v3 = hir.gt v0, v1 : i1;
+                v4 = hir.cast v3 : i32 #[ty = i32];
+                v5 = hir.constant 0 : i32;
+                v6 = hir.neq v4, v5 : i1;
+                v7 = hir.zext v6 : u32 #[ty = u32];
+                hir.br block5(v7);
+            ^block5(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/gt_i32.hir
+++ b/tests/integration/expected/gt_i32.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_dcf68bbd3d38962baca8bcc39895a74e9f927a15ae1af780f83843028d53154e] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.gt v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_dcf68bbd3d38962baca8bcc39895a74e9f927a15ae1af780f83843028d53154e] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.gt v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/gt_i64.hir
+++ b/tests/integration/expected/gt_i64.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_ceadd0c619424ea8897ac24b5176dad699485353543e7607a12bdee342a50966] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.gt v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_ceadd0c619424ea8897ac24b5176dad699485353543e7607a12bdee342a50966] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.gt v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/gt_u16.hir
+++ b/tests/integration/expected/gt_u16.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_f264d3777d3a68a4fab468d26338823b06e58dd59c87e8d6f2fc2d0d672bb1cd] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.gt v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_f264d3777d3a68a4fab468d26338823b06e58dd59c87e8d6f2fc2d0d672bb1cd] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.gt v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/gt_u32.hir
+++ b/tests/integration/expected/gt_u32.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_1e85457275952da03652b53164a185a9463cbfd5807e6d9eeae9b23a1844e96e] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.gt v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_1e85457275952da03652b53164a185a9463cbfd5807e6d9eeae9b23a1844e96e] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.gt v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/gt_u64.hir
+++ b/tests/integration/expected/gt_u64.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_70753af3178921ed6f0c2f66b095a4c78bd32e752ad580a8203438bf231ba0db] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.bitcast v0 : u64 #[ty = u64];
-            v4 = hir.bitcast v1 : u64 #[ty = u64];
-            v5 = hir.gt v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_70753af3178921ed6f0c2f66b095a4c78bd32e752ad580a8203438bf231ba0db] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.bitcast v0 : u64 #[ty = u64];
+                v4 = hir.bitcast v1 : u64 #[ty = u64];
+                v5 = hir.gt v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/gt_u8.hir
+++ b/tests/integration/expected/gt_u8.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_c2720ddf3b4d450003b652cb7974691bccf82cfb40715e2a2f4ac9445d02156e] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.gt v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_c2720ddf3b4d450003b652cb7974691bccf82cfb40715e2a2f4ac9445d02156e] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.gt v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/le_felt.hir
+++ b/tests/integration/expected/le_felt.hir
@@ -1,21 +1,24 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #le_felt] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: felt, v1: felt) -> i32 {
-        ^block3(v0: felt, v1: felt):
-            v3 = hir.lte v1, v0 : i1;
-            v4 = hir.cast v3 : i32 #[ty = i32];
-            v5 = hir.constant 0 : i32;
-            v6 = hir.neq v4, v5 : i1;
-            v7 = hir.zext v6 : u32 #[ty = u32];
-            hir.br block4(v7);
-        ^block4(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #le_felt] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+            builtin.function public @entrypoint(v0: felt, v1: felt) -> i32 {
+            ^block4(v0: felt, v1: felt):
+                v3 = hir.lte v1, v0 : i1;
+                v4 = hir.cast v3 : i32 #[ty = i32];
+                v5 = hir.constant 0 : i32;
+                v6 = hir.neq v4, v5 : i1;
+                v7 = hir.zext v6 : u32 #[ty = u32];
+                hir.br block5(v7);
+            ^block5(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/le_i32.hir
+++ b/tests/integration/expected/le_i32.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_26428c714af584632b95b2863903e39a0f8601727e3054ad7ebaedf128da35c7] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.lte v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_26428c714af584632b95b2863903e39a0f8601727e3054ad7ebaedf128da35c7] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.lte v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/le_i64.hir
+++ b/tests/integration/expected/le_i64.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_c4a9c74221b4f52c7cc028d994d8735ad8985dec62b6a6980159d497d7c3fa93] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.lte v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_c4a9c74221b4f52c7cc028d994d8735ad8985dec62b6a6980159d497d7c3fa93] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.lte v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/le_u16.hir
+++ b/tests/integration/expected/le_u16.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_aaaa272f39ec3f234fd119869db2d6791ce4b1e8d3f284fe6c212db33f480554] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.lte v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_aaaa272f39ec3f234fd119869db2d6791ce4b1e8d3f284fe6c212db33f480554] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.lte v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/le_u32.hir
+++ b/tests/integration/expected/le_u32.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_cdcf596bb19cb80fff51986e5bc56794a88886a743030b2648f5742396b13095] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.lte v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_cdcf596bb19cb80fff51986e5bc56794a88886a743030b2648f5742396b13095] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.lte v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/le_u64.hir
+++ b/tests/integration/expected/le_u64.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_907925d5e81fd1c82255ae3aa7232016c43e62c6867115675920cfe0d85013b1] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.bitcast v0 : u64 #[ty = u64];
-            v4 = hir.bitcast v1 : u64 #[ty = u64];
-            v5 = hir.lte v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_907925d5e81fd1c82255ae3aa7232016c43e62c6867115675920cfe0d85013b1] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.bitcast v0 : u64 #[ty = u64];
+                v4 = hir.bitcast v1 : u64 #[ty = u64];
+                v5 = hir.lte v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/le_u8.hir
+++ b/tests/integration/expected/le_u8.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_aace3f1ae4da30ba44b3c078c978343b282544139b496703f5f6a78953f42b7e] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.lte v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_aace3f1ae4da30ba44b3c078c978343b282544139b496703f5f6a78953f42b7e] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.lte v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/lt_felt.hir
+++ b/tests/integration/expected/lt_felt.hir
@@ -1,21 +1,24 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #lt_felt] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: felt, v1: felt) -> i32 {
-        ^block3(v0: felt, v1: felt):
-            v3 = hir.lt v1, v0 : i1;
-            v4 = hir.cast v3 : i32 #[ty = i32];
-            v5 = hir.constant 0 : i32;
-            v6 = hir.neq v4, v5 : i1;
-            v7 = hir.zext v6 : u32 #[ty = u32];
-            hir.br block4(v7);
-        ^block4(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #lt_felt] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+            builtin.function public @entrypoint(v0: felt, v1: felt) -> i32 {
+            ^block4(v0: felt, v1: felt):
+                v3 = hir.lt v1, v0 : i1;
+                v4 = hir.cast v3 : i32 #[ty = i32];
+                v5 = hir.constant 0 : i32;
+                v6 = hir.neq v4, v5 : i1;
+                v7 = hir.zext v6 : u32 #[ty = u32];
+                hir.br block5(v7);
+            ^block5(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/lt_i32.hir
+++ b/tests/integration/expected/lt_i32.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_57859c51c85389425b294750a9837d618293dd384d0b8582ca4c8bd6789e363e] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.lt v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_57859c51c85389425b294750a9837d618293dd384d0b8582ca4c8bd6789e363e] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.lt v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/lt_i64.hir
+++ b/tests/integration/expected/lt_i64.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_228292094cebd3f423ea05660793b4754a31411dd7db56529b976b81e4d7066b] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.lt v0, v1 : i1;
-            v4 = hir.zext v3 : u32 #[ty = u32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_228292094cebd3f423ea05660793b4754a31411dd7db56529b976b81e4d7066b] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.lt v0, v1 : i1;
+                v4 = hir.zext v3 : u32 #[ty = u32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/lt_u16.hir
+++ b/tests/integration/expected/lt_u16.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_0899dac7a0388d3cd5c5447bcaf230146812c2c0ca4ede178224db721afe9aba] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.lt v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_0899dac7a0388d3cd5c5447bcaf230146812c2c0ca4ede178224db721afe9aba] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.lt v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/lt_u32.hir
+++ b/tests/integration/expected/lt_u32.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_b1f1b13a84c328e970f28e0b366623db73f213249bdf37e4787af5f64f69adf1] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.lt v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_b1f1b13a84c328e970f28e0b366623db73f213249bdf37e4787af5f64f69adf1] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.lt v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/lt_u64.hir
+++ b/tests/integration/expected/lt_u64.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_32f5b5ff2aa96482da580eb924797236536a4ae0cbbb6d7daa491e9293c00bda] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.bitcast v0 : u64 #[ty = u64];
-            v4 = hir.bitcast v1 : u64 #[ty = u64];
-            v5 = hir.lt v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_32f5b5ff2aa96482da580eb924797236536a4ae0cbbb6d7daa491e9293c00bda] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i32 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.bitcast v0 : u64 #[ty = u64];
+                v4 = hir.bitcast v1 : u64 #[ty = u64];
+                v5 = hir.lt v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/lt_u8.hir
+++ b/tests/integration/expected/lt_u8.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_ddc15fe9df7100cbbcc5a51f3d4d29284c4cf43fb071224bc37b218c1758db30] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.lt v3, v4 : i1;
-            v6 = hir.zext v5 : u32 #[ty = u32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_ddc15fe9df7100cbbcc5a51f3d4d29284c4cf43fb071224bc37b218c1758db30] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.lt v3, v4 : i1;
+                v6 = hir.zext v5 : u32 #[ty = u32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/mem_intrinsics_heap_base.hir
+++ b/tests/integration/expected/mem_intrinsics_heap_base.hir
@@ -1,201 +1,204 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #mem_intrinsics_heap_base] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) {
-        ^block4(v0: i32, v1: i32):
-            v2 = hir.constant 0 : i32;
-            v3 = hir.constant 0 : i32;
-            v4 = hir.bitcast v3 : u32 #[ty = u32];
-            v5 = hir.constant 1048580 : u32;
-            v6 = hir.add v4, v5 : u32 #[overflow = checked];
-            v7 = hir.int_to_ptr v6 : (ptr u8) #[ty = (ptr u8)];
-            v8 = hir.load v7 : u8;
-            v9 = hir.zext v8 : u32 #[ty = u32];
-            v10 = hir.constant 4 : i32;
-            v11 = hir.constant 4 : i32;
-            v12 = hir.exec v10, v11 : i32 #[callee = root/mem_intrinsics_heap_base/__rust_alloc] #[signature = (param i32) (param i32) (result i32)];
-            v13 = hir.constant 0 : i32;
-            v14 = hir.neq v12, v13 : i1;
-            hir.cond_br v14 block6, block7;
-        ^block5:
-            hir.ret ;
-        ^block6:
-            v17 = hir.constant 1 : i32;
-            v18 = hir.bitcast v0 : u32 #[ty = u32];
-            v19 = hir.constant 8 : u32;
-            v20 = hir.add v18, v19 : u32 #[overflow = checked];
-            v21 = hir.constant 4 : u32;
-            v22 = hir.mod v20, v21 : u32;
-            hir.assertz v22 #[code = 250];
-            v23 = hir.int_to_ptr v20 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v23, v17;
-            v24 = hir.bitcast v0 : u32 #[ty = u32];
-            v25 = hir.constant 4 : u32;
-            v26 = hir.add v24, v25 : u32 #[overflow = checked];
-            v27 = hir.constant 4 : u32;
-            v28 = hir.mod v26, v27 : u32;
-            hir.assertz v28 #[code = 250];
-            v29 = hir.int_to_ptr v26 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v29, v12;
-            v30 = hir.constant 1 : i32;
-            v31 = hir.bitcast v0 : u32 #[ty = u32];
-            v32 = hir.constant 4 : u32;
-            v33 = hir.mod v31, v32 : u32;
-            hir.assertz v33 #[code = 250];
-            v34 = hir.int_to_ptr v31 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v34, v30;
-            v35 = hir.constant 1 : i32;
-            v36 = hir.bitcast v35 : u32 #[ty = u32];
-            v37 = hir.shl v1, v36 : i32;
-            v38 = hir.bitcast v12 : u32 #[ty = u32];
-            v39 = hir.constant 4 : u32;
-            v40 = hir.mod v38, v39 : u32;
-            hir.assertz v40 #[code = 250];
-            v41 = hir.int_to_ptr v38 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v41, v37;
-            hir.br block5;
-        ^block7:
-            v15 = hir.constant 4 : i32;
-            v16 = hir.constant 4 : i32;
-            hir.exec v15, v16 #[callee = root/mem_intrinsics_heap_base/alloc::alloc::handle_alloc_error] #[signature = (param i32) (param i32)];
-            hir.unreachable ;
+        builtin.module  #[name = #mem_intrinsics_heap_base] #[visibility = public] {
+
+            builtin.function public @entrypoint(v0: i32, v1: i32) {
+            ^block5(v0: i32, v1: i32):
+                v2 = hir.constant 0 : i32;
+                v3 = hir.constant 0 : i32;
+                v4 = hir.bitcast v3 : u32 #[ty = u32];
+                v5 = hir.constant 1048580 : u32;
+                v6 = hir.add v4, v5 : u32 #[overflow = checked];
+                v7 = hir.int_to_ptr v6 : (ptr u8) #[ty = (ptr u8)];
+                v8 = hir.load v7 : u8;
+                v9 = hir.zext v8 : u32 #[ty = u32];
+                v10 = hir.constant 4 : i32;
+                v11 = hir.constant 4 : i32;
+                v12 = hir.exec v10, v11 : i32 #[callee = world/root/mem_intrinsics_heap_base/__rust_alloc] #[signature = (param i32) (param i32) (result i32)];
+                v13 = hir.constant 0 : i32;
+                v14 = hir.neq v12, v13 : i1;
+                hir.cond_br v14 block7, block8;
+            ^block6:
+                hir.ret ;
+            ^block7:
+                v17 = hir.constant 1 : i32;
+                v18 = hir.bitcast v0 : u32 #[ty = u32];
+                v19 = hir.constant 8 : u32;
+                v20 = hir.add v18, v19 : u32 #[overflow = checked];
+                v21 = hir.constant 4 : u32;
+                v22 = hir.mod v20, v21 : u32;
+                hir.assertz v22 #[code = 250];
+                v23 = hir.int_to_ptr v20 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v23, v17;
+                v24 = hir.bitcast v0 : u32 #[ty = u32];
+                v25 = hir.constant 4 : u32;
+                v26 = hir.add v24, v25 : u32 #[overflow = checked];
+                v27 = hir.constant 4 : u32;
+                v28 = hir.mod v26, v27 : u32;
+                hir.assertz v28 #[code = 250];
+                v29 = hir.int_to_ptr v26 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v29, v12;
+                v30 = hir.constant 1 : i32;
+                v31 = hir.bitcast v0 : u32 #[ty = u32];
+                v32 = hir.constant 4 : u32;
+                v33 = hir.mod v31, v32 : u32;
+                hir.assertz v33 #[code = 250];
+                v34 = hir.int_to_ptr v31 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v34, v30;
+                v35 = hir.constant 1 : i32;
+                v36 = hir.bitcast v35 : u32 #[ty = u32];
+                v37 = hir.shl v1, v36 : i32;
+                v38 = hir.bitcast v12 : u32 #[ty = u32];
+                v39 = hir.constant 4 : u32;
+                v40 = hir.mod v38, v39 : u32;
+                hir.assertz v40 #[code = 250];
+                v41 = hir.int_to_ptr v38 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v41, v37;
+                hir.br block6;
+            ^block8:
+                v15 = hir.constant 4 : i32;
+                v16 = hir.constant 4 : i32;
+                hir.exec v15, v16 #[callee = world/root/mem_intrinsics_heap_base/alloc::alloc::handle_alloc_error] #[signature = (param i32) (param i32)];
+                hir.unreachable ;
+            };
+            builtin.function public @__rust_alloc(v42: i32, v43: i32) -> i32 {
+            ^block9(v42: i32, v43: i32):
+                v45 = hir.constant 1048576 : i32;
+                v46 = hir.exec v45, v43, v42 : i32 #[callee = world/root/mem_intrinsics_heap_base/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc] #[signature = (param i32) (param i32) (param i32) (result i32)];
+                hir.br block10(v46);
+            ^block10(v44: i32):
+                hir.ret v44;
+            };
+            builtin.function public @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v47: i32, v48: i32, v49: i32) -> i32 {
+            ^block11(v47: i32, v48: i32, v49: i32):
+                v51 = hir.constant 0 : i32;
+                v52 = hir.constant 32 : i32;
+                v53 = hir.constant 32 : i32;
+                v54 = hir.bitcast v48 : u32 #[ty = u32];
+                v55 = hir.bitcast v53 : u32 #[ty = u32];
+                v56 = hir.gt v54, v55 : i1;
+                v57 = hir.zext v56 : u32 #[ty = u32];
+                v58 = hir.constant 0 : i32;
+                v59 = hir.neq v57, v58 : i1;
+                v60 = hir.select v59, v48, v52 : i32;
+                v61 = hir.popcnt v60 : u32;
+                v62 = hir.bitcast v61 : i32 #[ty = i32];
+                v63 = hir.constant 1 : i32;
+                v64 = hir.neq v62, v63 : i1;
+                v65 = hir.zext v64 : u32 #[ty = u32];
+                v66 = hir.bitcast v65 : i32 #[ty = i32];
+                v67 = hir.constant 0 : i32;
+                v68 = hir.neq v66, v67 : i1;
+                hir.cond_br v68 block13, block14;
+            ^block12(v50: i32):
+
+            ^block13:
+                hir.unreachable ;
+            ^block14:
+                v69 = hir.constant -2147483648 : i32;
+                v70 = hir.exec v48, v60 : i32 #[callee = world/root/mem_intrinsics_heap_base/core::ptr::alignment::Alignment::max] #[signature = (param i32) (param i32) (result i32)];
+                v71 = hir.sub v69, v70 : i32 #[overflow = wrapping];
+                v72 = hir.bitcast v71 : u32 #[ty = u32];
+                v73 = hir.bitcast v49 : u32 #[ty = u32];
+                v74 = hir.lt v72, v73 : i1;
+                v75 = hir.zext v74 : u32 #[ty = u32];
+                v76 = hir.bitcast v75 : i32 #[ty = i32];
+                v77 = hir.constant 0 : i32;
+                v78 = hir.neq v76, v77 : i1;
+                hir.cond_br v78 block13, block15;
+            ^block15:
+                v79 = hir.constant 0 : i32;
+                v80 = hir.add v49, v70 : i32 #[overflow = wrapping];
+                v81 = hir.constant -1 : i32;
+                v82 = hir.add v80, v81 : i32 #[overflow = wrapping];
+                v83 = hir.constant 0 : i32;
+                v84 = hir.sub v83, v70 : i32 #[overflow = wrapping];
+                v85 = hir.band v82, v84 : i32;
+                v86 = hir.bitcast v47 : u32 #[ty = u32];
+                v87 = hir.constant 4 : u32;
+                v88 = hir.mod v86, v87 : u32;
+                hir.assertz v88 #[code = 250];
+                v89 = hir.int_to_ptr v86 : (ptr i32) #[ty = (ptr i32)];
+                v90 = hir.load v89 : i32;
+                v91 = hir.constant 0 : i32;
+                v92 = hir.neq v90, v91 : i1;
+                hir.cond_br v92 block16(v47, v85, v70, v79), block17;
+            ^block16(v105: i32, v112: i32, v125: i32, v128: i32):
+                v104 = hir.constant 268435456 : i32;
+                v106 = hir.bitcast v105 : u32 #[ty = u32];
+                v107 = hir.constant 4 : u32;
+                v108 = hir.mod v106, v107 : u32;
+                hir.assertz v108 #[code = 250];
+                v109 = hir.int_to_ptr v106 : (ptr i32) #[ty = (ptr i32)];
+                v110 = hir.load v109 : i32;
+                v111 = hir.sub v104, v110 : i32 #[overflow = wrapping];
+                v113 = hir.bitcast v111 : u32 #[ty = u32];
+                v114 = hir.bitcast v112 : u32 #[ty = u32];
+                v115 = hir.lt v113, v114 : i1;
+                v116 = hir.zext v115 : u32 #[ty = u32];
+                v117 = hir.bitcast v116 : i32 #[ty = i32];
+                v118 = hir.constant 0 : i32;
+                v119 = hir.neq v117, v118 : i1;
+                hir.cond_br v119 block18(v128), block19;
+            ^block17:
+                v93 = hir.exec  : i32 #[callee = world/root/intrinsics::mem/heap_base] #[signature = (result i32)];
+                v94 = hir.mem_size  : u32;
+                v95 = hir.constant 16 : i32;
+                v96 = hir.bitcast v95 : u32 #[ty = u32];
+                v97 = hir.shl v94, v96 : u32;
+                v98 = hir.bitcast v97 : i32 #[ty = i32];
+                v99 = hir.add v93, v98 : i32 #[overflow = wrapping];
+                v100 = hir.bitcast v47 : u32 #[ty = u32];
+                v101 = hir.constant 4 : u32;
+                v102 = hir.mod v100, v101 : u32;
+                hir.assertz v102 #[code = 250];
+                v103 = hir.int_to_ptr v100 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v103, v99;
+                hir.br block16(v47, v85, v70, v79);
+            ^block18(v127: i32):
+                hir.ret v127;
+            ^block19:
+                v120 = hir.add v110, v112 : i32 #[overflow = wrapping];
+                v121 = hir.bitcast v105 : u32 #[ty = u32];
+                v122 = hir.constant 4 : u32;
+                v123 = hir.mod v121, v122 : u32;
+                hir.assertz v123 #[code = 250];
+                v124 = hir.int_to_ptr v121 : (ptr i32) #[ty = (ptr i32)];
+                hir.store v124, v120;
+                v126 = hir.add v110, v125 : i32 #[overflow = wrapping];
+                hir.br block18(v126);
+            };
+            builtin.function public @alloc::alloc::handle_alloc_error(v129: i32, v130: i32) {
+            ^block20(v129: i32, v130: i32):
+                hir.unreachable ;
+            ^block21:
+
+            };
+            builtin.function public @core::ptr::alignment::Alignment::max(v131: i32, v132: i32) -> i32 {
+            ^block22(v131: i32, v132: i32):
+                v134 = hir.bitcast v131 : u32 #[ty = u32];
+                v135 = hir.bitcast v132 : u32 #[ty = u32];
+                v136 = hir.gt v134, v135 : i1;
+                v137 = hir.zext v136 : u32 #[ty = u32];
+                v138 = hir.constant 0 : i32;
+                v139 = hir.neq v137, v138 : i1;
+                v140 = hir.select v139, v131, v132 : i32;
+                hir.br block23(v140);
+            ^block23(v133: i32):
+                hir.ret v133;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
-        builtin.function public @__rust_alloc(v42: i32, v43: i32) -> i32 {
-        ^block8(v42: i32, v43: i32):
-            v45 = hir.constant 1048576 : i32;
-            v46 = hir.exec v45, v43, v42 : i32 #[callee = root/mem_intrinsics_heap_base/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc] #[signature = (param i32) (param i32) (param i32) (result i32)];
-            hir.br block9(v46);
-        ^block9(v44: i32):
-            hir.ret v44;
-        };
-        builtin.function public @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v47: i32, v48: i32, v49: i32) -> i32 {
-        ^block10(v47: i32, v48: i32, v49: i32):
-            v51 = hir.constant 0 : i32;
-            v52 = hir.constant 32 : i32;
-            v53 = hir.constant 32 : i32;
-            v54 = hir.bitcast v48 : u32 #[ty = u32];
-            v55 = hir.bitcast v53 : u32 #[ty = u32];
-            v56 = hir.gt v54, v55 : i1;
-            v57 = hir.zext v56 : u32 #[ty = u32];
-            v58 = hir.constant 0 : i32;
-            v59 = hir.neq v57, v58 : i1;
-            v60 = hir.select v59, v48, v52 : i32;
-            v61 = hir.popcnt v60 : u32;
-            v62 = hir.bitcast v61 : i32 #[ty = i32];
-            v63 = hir.constant 1 : i32;
-            v64 = hir.neq v62, v63 : i1;
-            v65 = hir.zext v64 : u32 #[ty = u32];
-            v66 = hir.bitcast v65 : i32 #[ty = i32];
-            v67 = hir.constant 0 : i32;
-            v68 = hir.neq v66, v67 : i1;
-            hir.cond_br v68 block12, block13;
-        ^block11(v50: i32):
+        builtin.module  #[name = #intrinsics::mem] #[visibility = public] {
 
-        ^block12:
-            hir.unreachable ;
-        ^block13:
-            v69 = hir.constant -2147483648 : i32;
-            v70 = hir.exec v48, v60 : i32 #[callee = root/mem_intrinsics_heap_base/core::ptr::alignment::Alignment::max] #[signature = (param i32) (param i32) (result i32)];
-            v71 = hir.sub v69, v70 : i32 #[overflow = wrapping];
-            v72 = hir.bitcast v71 : u32 #[ty = u32];
-            v73 = hir.bitcast v49 : u32 #[ty = u32];
-            v74 = hir.lt v72, v73 : i1;
-            v75 = hir.zext v74 : u32 #[ty = u32];
-            v76 = hir.bitcast v75 : i32 #[ty = i32];
-            v77 = hir.constant 0 : i32;
-            v78 = hir.neq v76, v77 : i1;
-            hir.cond_br v78 block12, block14;
-        ^block14:
-            v79 = hir.constant 0 : i32;
-            v80 = hir.add v49, v70 : i32 #[overflow = wrapping];
-            v81 = hir.constant -1 : i32;
-            v82 = hir.add v80, v81 : i32 #[overflow = wrapping];
-            v83 = hir.constant 0 : i32;
-            v84 = hir.sub v83, v70 : i32 #[overflow = wrapping];
-            v85 = hir.band v82, v84 : i32;
-            v86 = hir.bitcast v47 : u32 #[ty = u32];
-            v87 = hir.constant 4 : u32;
-            v88 = hir.mod v86, v87 : u32;
-            hir.assertz v88 #[code = 250];
-            v89 = hir.int_to_ptr v86 : (ptr i32) #[ty = (ptr i32)];
-            v90 = hir.load v89 : i32;
-            v91 = hir.constant 0 : i32;
-            v92 = hir.neq v90, v91 : i1;
-            hir.cond_br v92 block15(v47, v85, v70, v79), block16;
-        ^block15(v105: i32, v112: i32, v125: i32, v128: i32):
-            v104 = hir.constant 268435456 : i32;
-            v106 = hir.bitcast v105 : u32 #[ty = u32];
-            v107 = hir.constant 4 : u32;
-            v108 = hir.mod v106, v107 : u32;
-            hir.assertz v108 #[code = 250];
-            v109 = hir.int_to_ptr v106 : (ptr i32) #[ty = (ptr i32)];
-            v110 = hir.load v109 : i32;
-            v111 = hir.sub v104, v110 : i32 #[overflow = wrapping];
-            v113 = hir.bitcast v111 : u32 #[ty = u32];
-            v114 = hir.bitcast v112 : u32 #[ty = u32];
-            v115 = hir.lt v113, v114 : i1;
-            v116 = hir.zext v115 : u32 #[ty = u32];
-            v117 = hir.bitcast v116 : i32 #[ty = i32];
-            v118 = hir.constant 0 : i32;
-            v119 = hir.neq v117, v118 : i1;
-            hir.cond_br v119 block17(v128), block18;
-        ^block16:
-            v93 = hir.exec  : i32 #[callee = root/intrinsics::mem/heap_base] #[signature = (result i32)];
-            v94 = hir.mem_size  : u32;
-            v95 = hir.constant 16 : i32;
-            v96 = hir.bitcast v95 : u32 #[ty = u32];
-            v97 = hir.shl v94, v96 : u32;
-            v98 = hir.bitcast v97 : i32 #[ty = i32];
-            v99 = hir.add v93, v98 : i32 #[overflow = wrapping];
-            v100 = hir.bitcast v47 : u32 #[ty = u32];
-            v101 = hir.constant 4 : u32;
-            v102 = hir.mod v100, v101 : u32;
-            hir.assertz v102 #[code = 250];
-            v103 = hir.int_to_ptr v100 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v103, v99;
-            hir.br block15(v47, v85, v70, v79);
-        ^block17(v127: i32):
-            hir.ret v127;
-        ^block18:
-            v120 = hir.add v110, v112 : i32 #[overflow = wrapping];
-            v121 = hir.bitcast v105 : u32 #[ty = u32];
-            v122 = hir.constant 4 : u32;
-            v123 = hir.mod v121, v122 : u32;
-            hir.assertz v123 #[code = 250];
-            v124 = hir.int_to_ptr v121 : (ptr i32) #[ty = (ptr i32)];
-            hir.store v124, v120;
-            v126 = hir.add v110, v125 : i32 #[overflow = wrapping];
-            hir.br block17(v126);
-        };
-        builtin.function public @alloc::alloc::handle_alloc_error(v129: i32, v130: i32) {
-        ^block19(v129: i32, v130: i32):
-            hir.unreachable ;
-        ^block20:
+            builtin.function public @heap_base(result i32) {
 
-        };
-        builtin.function public @core::ptr::alignment::Alignment::max(v131: i32, v132: i32) -> i32 {
-        ^block21(v131: i32, v132: i32):
-            v134 = hir.bitcast v131 : u32 #[ty = u32];
-            v135 = hir.bitcast v132 : u32 #[ty = u32];
-            v136 = hir.gt v134, v135 : i1;
-            v137 = hir.zext v136 : u32 #[ty = u32];
-            v138 = hir.constant 0 : i32;
-            v139 = hir.neq v137, v138 : i1;
-            v140 = hir.select v139, v131, v132 : i32;
-            hir.br block22(v140);
-        ^block22(v133: i32):
-            hir.ret v133;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
-
-            hir.ret_imm  #[value = 1048576];
-        };
-    };
-    builtin.module  #[name = #intrinsics::mem] #[visibility = public] {
-
-        builtin.function public @heap_base(result i32) {
-
+            };
         };
     };
 };

--- a/tests/integration/expected/mul_felt.hir
+++ b/tests/integration/expected/mul_felt.hir
@@ -1,17 +1,20 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #mul_felt] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: felt, v1: felt) -> felt {
-        ^block3(v0: felt, v1: felt):
-            v3 = hir.mul v0, v1 : felt #[overflow = unchecked];
-            hir.br block4(v3);
-        ^block4(v2: felt):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #mul_felt] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+            builtin.function public @entrypoint(v0: felt, v1: felt) -> felt {
+            ^block4(v0: felt, v1: felt):
+                v3 = hir.mul v0, v1 : felt #[overflow = unchecked];
+                hir.br block5(v3);
+            ^block5(v2: felt):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/mul_i32.hir
+++ b/tests/integration/expected/mul_i32.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_262e71c5bff4a385e1ce68a8feb20203bbf0c528647e9c602609c0808d505876] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.mul v1, v0 : i32 #[overflow = wrapping];
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_262e71c5bff4a385e1ce68a8feb20203bbf0c528647e9c602609c0808d505876] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.mul v1, v0 : i32 #[overflow = wrapping];
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/mul_i64.hir
+++ b/tests/integration/expected/mul_i64.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_4fa4a84dc2c1fe1a2bc729c72d5e78982ba8edf5490a729e66438056dcb06101] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.mul v1, v0 : i64 #[overflow = wrapping];
-            hir.br block6(v3);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_4fa4a84dc2c1fe1a2bc729c72d5e78982ba8edf5490a729e66438056dcb06101] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.mul v1, v0 : i64 #[overflow = wrapping];
+                hir.br block7(v3);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/mul_u16.hir
+++ b/tests/integration/expected/mul_u16.hir
@@ -1,27 +1,30 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_742f0d1b5e8390cf229b8c736825d5c524abf07a2bec3f4109afcc68d1547946] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.mul v1, v0 : i32 #[overflow = wrapping];
-            v4 = hir.constant 65535 : i32;
-            v5 = hir.band v3, v4 : i32;
-            hir.br block6(v5);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_742f0d1b5e8390cf229b8c736825d5c524abf07a2bec3f4109afcc68d1547946] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.mul v1, v0 : i32 #[overflow = wrapping];
+                v4 = hir.constant 65535 : i32;
+                v5 = hir.band v3, v4 : i32;
+                hir.br block7(v5);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/mul_u32.hir
+++ b/tests/integration/expected/mul_u32.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_b88e2ce441d27c44cb7d5b1e9a0fdde312f6e4c8ba7ce98f46069c983aef0f27] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.mul v1, v0 : i32 #[overflow = wrapping];
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_b88e2ce441d27c44cb7d5b1e9a0fdde312f6e4c8ba7ce98f46069c983aef0f27] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.mul v1, v0 : i32 #[overflow = wrapping];
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/mul_u64.hir
+++ b/tests/integration/expected/mul_u64.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_ac7483d8e665bc8618c926c4a827af8cc8b060db1a400373319417a1045674f6] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.mul v1, v0 : i64 #[overflow = wrapping];
-            hir.br block6(v3);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_ac7483d8e665bc8618c926c4a827af8cc8b060db1a400373319417a1045674f6] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.mul v1, v0 : i64 #[overflow = wrapping];
+                hir.br block7(v3);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/mul_u8.hir
+++ b/tests/integration/expected/mul_u8.hir
@@ -1,27 +1,30 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_ca665f22f7b5ce9ba2e09ff8053ec1ab7a69e93524c27a02273f65f21b7b3e9a] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.mul v1, v0 : i32 #[overflow = wrapping];
-            v4 = hir.constant 255 : i32;
-            v5 = hir.band v3, v4 : i32;
-            hir.br block6(v5);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_ca665f22f7b5ce9ba2e09ff8053ec1ab7a69e93524c27a02273f65f21b7b3e9a] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.mul v1, v0 : i32 #[overflow = wrapping];
+                v4 = hir.constant 255 : i32;
+                v5 = hir.band v3, v4 : i32;
+                hir.br block7(v5);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/neg_felt.hir
+++ b/tests/integration/expected/neg_felt.hir
@@ -1,17 +1,20 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #neg_felt] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: felt, v1: felt) -> felt {
-        ^block3(v0: felt, v1: felt):
-            v3 = hir.sub v0, v1 : felt #[overflow = unchecked];
-            hir.br block4(v3);
-        ^block4(v2: felt):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #neg_felt] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+            builtin.function public @entrypoint(v0: felt, v1: felt) -> felt {
+            ^block4(v0: felt, v1: felt):
+                v3 = hir.sub v0, v1 : felt #[overflow = unchecked];
+                hir.br block5(v3);
+            ^block5(v2: felt):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/neg_i16.hir
+++ b/tests/integration/expected/neg_i16.hir
@@ -1,27 +1,30 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_ba1c5a590d707919e2a80d5ac961624d71143891517702d79d0d07e5430ec666] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32) -> i32 {
-        ^block5(v0: i32):
-            v2 = hir.constant 0 : i32;
-            v3 = hir.sub v2, v0 : i32 #[overflow = wrapping];
-            v4 = hir.sext v3 : i32 #[ty = i32];
-            hir.br block6(v4);
-        ^block6(v1: i32):
-            hir.ret v1;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_ba1c5a590d707919e2a80d5ac961624d71143891517702d79d0d07e5430ec666] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32) -> i32 {
+            ^block6(v0: i32):
+                v2 = hir.constant 0 : i32;
+                v3 = hir.sub v2, v0 : i32 #[overflow = wrapping];
+                v4 = hir.sext v3 : i32 #[ty = i32];
+                hir.br block7(v4);
+            ^block7(v1: i32):
+                hir.ret v1;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/neg_i32.hir
+++ b/tests/integration/expected/neg_i32.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_c8278a646eb10b96eaa494478de597b1874226f5f5037ee4923d9049413f8317] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32) -> i32 {
-        ^block5(v0: i32):
-            v2 = hir.constant 0 : i32;
-            v3 = hir.sub v2, v0 : i32 #[overflow = wrapping];
-            hir.br block6(v3);
-        ^block6(v1: i32):
-            hir.ret v1;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_c8278a646eb10b96eaa494478de597b1874226f5f5037ee4923d9049413f8317] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32) -> i32 {
+            ^block6(v0: i32):
+                v2 = hir.constant 0 : i32;
+                v3 = hir.sub v2, v0 : i32 #[overflow = wrapping];
+                hir.br block7(v3);
+            ^block7(v1: i32):
+                hir.ret v1;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/neg_i64.hir
+++ b/tests/integration/expected/neg_i64.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_01dcb6fbaad510deb917ef5e283ccfaa280559139455d99f8b7c76af466af9dd] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64) -> i64 {
-        ^block5(v0: i64):
-            v2 = hir.constant 0 : i64;
-            v3 = hir.sub v2, v0 : i64 #[overflow = wrapping];
-            hir.br block6(v3);
-        ^block6(v1: i64):
-            hir.ret v1;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_01dcb6fbaad510deb917ef5e283ccfaa280559139455d99f8b7c76af466af9dd] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64) -> i64 {
+            ^block6(v0: i64):
+                v2 = hir.constant 0 : i64;
+                v3 = hir.sub v2, v0 : i64 #[overflow = wrapping];
+                hir.br block7(v3);
+            ^block7(v1: i64):
+                hir.ret v1;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/neg_i8.hir
+++ b/tests/integration/expected/neg_i8.hir
@@ -1,27 +1,30 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_c284c5e58a865bc45e93bf2024b2c204ef39187b90a2cf9cc04c023ea2f4fe6d] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32) -> i32 {
-        ^block5(v0: i32):
-            v2 = hir.constant 0 : i32;
-            v3 = hir.sub v2, v0 : i32 #[overflow = wrapping];
-            v4 = hir.sext v3 : i32 #[ty = i32];
-            hir.br block6(v4);
-        ^block6(v1: i32):
-            hir.ret v1;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_c284c5e58a865bc45e93bf2024b2c204ef39187b90a2cf9cc04c023ea2f4fe6d] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32) -> i32 {
+            ^block6(v0: i32):
+                v2 = hir.constant 0 : i32;
+                v3 = hir.sub v2, v0 : i32 #[overflow = wrapping];
+                v4 = hir.sext v3 : i32 #[ty = i32];
+                hir.br block7(v4);
+            ^block7(v1: i32):
+                hir.ret v1;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/or_bool.hir
+++ b/tests/integration/expected/or_bool.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_fcd39ca2fcbe5490a38db6dfe57f9ead120d9b7ced8d4170a040c64bd03b0413] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bor v0, v1 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_fcd39ca2fcbe5490a38db6dfe57f9ead120d9b7ced8d4170a040c64bd03b0413] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bor v0, v1 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/rust_sdk/pure_rust_add.hir
+++ b/tests/integration/expected/rust_sdk/pure_rust_add.hir
@@ -1,17 +1,20 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #pure_rust_add] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block3(v0: i32, v1: i32):
-            v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
-            hir.br block4(v3);
-        ^block4(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #pure_rust_add] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block4(v0: i32, v1: i32):
+                v3 = hir.add v1, v0 : i32 #[overflow = wrapping];
+                hir.br block5(v3);
+            ^block5(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/shl_i16.hir
+++ b/tests/integration/expected/shl_i16.hir
@@ -1,29 +1,32 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_947b1fd0c78559d180609e8a959684c5090a8ac458193ed6a1103a863d3c8bd0] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.constant 15 : i32;
-            v4 = hir.band v1, v3 : i32;
-            v5 = hir.bitcast v4 : u32 #[ty = u32];
-            v6 = hir.shl v0, v5 : i32;
-            v7 = hir.sext v6 : i32 #[ty = i32];
-            hir.br block6(v7);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_947b1fd0c78559d180609e8a959684c5090a8ac458193ed6a1103a863d3c8bd0] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.constant 15 : i32;
+                v4 = hir.band v1, v3 : i32;
+                v5 = hir.bitcast v4 : u32 #[ty = u32];
+                v6 = hir.shl v0, v5 : i32;
+                v7 = hir.sext v6 : i32 #[ty = i32];
+                hir.br block7(v7);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/shl_i32.hir
+++ b/tests/integration/expected/shl_i32.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_b1a7a85321f9f6b080f6e9a0676c7398d86d5c2a5214aa2a59f442c8152d33f8] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v1 : u32 #[ty = u32];
-            v4 = hir.shl v0, v3 : i32;
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_b1a7a85321f9f6b080f6e9a0676c7398d86d5c2a5214aa2a59f442c8152d33f8] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v1 : u32 #[ty = u32];
+                v4 = hir.shl v0, v3 : i32;
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/shl_i64.hir
+++ b/tests/integration/expected/shl_i64.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_25e2507052972928b154ff844858eb75529a3497622ee9ca52b471d8a099e59f] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.cast v1 : u32 #[ty = u32];
-            v4 = hir.shl v0, v3 : i64;
-            hir.br block6(v4);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_25e2507052972928b154ff844858eb75529a3497622ee9ca52b471d8a099e59f] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.cast v1 : u32 #[ty = u32];
+                v4 = hir.shl v0, v3 : i64;
+                hir.br block7(v4);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/shl_i8.hir
+++ b/tests/integration/expected/shl_i8.hir
@@ -1,29 +1,32 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_5f1b43480ab6707fd5d599fff30d72a40baf9972173edc344c239f0c3b48da64] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.constant 7 : i32;
-            v4 = hir.band v1, v3 : i32;
-            v5 = hir.bitcast v4 : u32 #[ty = u32];
-            v6 = hir.shl v0, v5 : i32;
-            v7 = hir.sext v6 : i32 #[ty = i32];
-            hir.br block6(v7);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_5f1b43480ab6707fd5d599fff30d72a40baf9972173edc344c239f0c3b48da64] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.constant 7 : i32;
+                v4 = hir.band v1, v3 : i32;
+                v5 = hir.bitcast v4 : u32 #[ty = u32];
+                v6 = hir.shl v0, v5 : i32;
+                v7 = hir.sext v6 : i32 #[ty = i32];
+                hir.br block7(v7);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/shl_u16.hir
+++ b/tests/integration/expected/shl_u16.hir
@@ -1,30 +1,33 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_0ab094171adf5f867d5a41b825b648320b4a7b9662828d177cacb8db3f7de5ef] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.constant 15 : i32;
-            v4 = hir.band v1, v3 : i32;
-            v5 = hir.bitcast v4 : u32 #[ty = u32];
-            v6 = hir.shl v0, v5 : i32;
-            v7 = hir.constant 65535 : i32;
-            v8 = hir.band v6, v7 : i32;
-            hir.br block6(v8);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_0ab094171adf5f867d5a41b825b648320b4a7b9662828d177cacb8db3f7de5ef] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.constant 15 : i32;
+                v4 = hir.band v1, v3 : i32;
+                v5 = hir.bitcast v4 : u32 #[ty = u32];
+                v6 = hir.shl v0, v5 : i32;
+                v7 = hir.constant 65535 : i32;
+                v8 = hir.band v6, v7 : i32;
+                hir.br block7(v8);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/shl_u32.hir
+++ b/tests/integration/expected/shl_u32.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_7e6c842b77a3cb1324eb4149ea3db75e8175bb301dd8d842a28fa5eb165bc64c] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v1 : u32 #[ty = u32];
-            v4 = hir.shl v0, v3 : i32;
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_7e6c842b77a3cb1324eb4149ea3db75e8175bb301dd8d842a28fa5eb165bc64c] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v1 : u32 #[ty = u32];
+                v4 = hir.shl v0, v3 : i32;
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/shl_u64.hir
+++ b/tests/integration/expected/shl_u64.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_2a329af439c3fda4a420516309900eb5dee52a3d62676c5dfee856e4056b3fa5] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.cast v1 : u32 #[ty = u32];
-            v4 = hir.shl v0, v3 : i64;
-            hir.br block6(v4);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_2a329af439c3fda4a420516309900eb5dee52a3d62676c5dfee856e4056b3fa5] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.cast v1 : u32 #[ty = u32];
+                v4 = hir.shl v0, v3 : i64;
+                hir.br block7(v4);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/shl_u8.hir
+++ b/tests/integration/expected/shl_u8.hir
@@ -1,30 +1,33 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_c41b1b7ac309f4bb3497653978e4c903a0185e0b268c2fca135833d9389bacc9] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.constant 7 : i32;
-            v4 = hir.band v1, v3 : i32;
-            v5 = hir.bitcast v4 : u32 #[ty = u32];
-            v6 = hir.shl v0, v5 : i32;
-            v7 = hir.constant 255 : i32;
-            v8 = hir.band v6, v7 : i32;
-            hir.br block6(v8);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_c41b1b7ac309f4bb3497653978e4c903a0185e0b268c2fca135833d9389bacc9] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.constant 7 : i32;
+                v4 = hir.band v1, v3 : i32;
+                v5 = hir.bitcast v4 : u32 #[ty = u32];
+                v6 = hir.shl v0, v5 : i32;
+                v7 = hir.constant 255 : i32;
+                v8 = hir.band v6, v7 : i32;
+                hir.br block7(v8);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/shr_i64.hir
+++ b/tests/integration/expected/shr_i64.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_9e782fbd0f39c9f1f4f8c1623ec32ad4d1666e9dfad0fc58c43a8ade8dfcb60c] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.cast v1 : u32 #[ty = u32];
-            v4 = hir.shr v0, v3 : i64;
-            hir.br block6(v4);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_9e782fbd0f39c9f1f4f8c1623ec32ad4d1666e9dfad0fc58c43a8ade8dfcb60c] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.cast v1 : u32 #[ty = u32];
+                v4 = hir.shr v0, v3 : i64;
+                hir.br block7(v4);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/shr_u16.hir
+++ b/tests/integration/expected/shr_u16.hir
@@ -1,30 +1,33 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_044d9f6f5bf1c98609cfe5f9496ee9e517cb2900d43714636541400c34d5fb03] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.constant 15 : i32;
-            v4 = hir.band v1, v3 : i32;
-            v5 = hir.bitcast v0 : u32 #[ty = u32];
-            v6 = hir.bitcast v4 : u32 #[ty = u32];
-            v7 = hir.shr v5, v6 : u32;
-            v8 = hir.bitcast v7 : i32 #[ty = i32];
-            hir.br block6(v8);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_044d9f6f5bf1c98609cfe5f9496ee9e517cb2900d43714636541400c34d5fb03] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.constant 15 : i32;
+                v4 = hir.band v1, v3 : i32;
+                v5 = hir.bitcast v0 : u32 #[ty = u32];
+                v6 = hir.bitcast v4 : u32 #[ty = u32];
+                v7 = hir.shr v5, v6 : u32;
+                v8 = hir.bitcast v7 : i32 #[ty = i32];
+                hir.br block7(v8);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/shr_u32.hir
+++ b/tests/integration/expected/shr_u32.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_8ce82de7c4fb77fe54a97d76d270876e6dc8484997171b1a52821c97bc67dbba] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bitcast v0 : u32 #[ty = u32];
-            v4 = hir.bitcast v1 : u32 #[ty = u32];
-            v5 = hir.shr v3, v4 : u32;
-            v6 = hir.bitcast v5 : i32 #[ty = i32];
-            hir.br block6(v6);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_8ce82de7c4fb77fe54a97d76d270876e6dc8484997171b1a52821c97bc67dbba] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bitcast v0 : u32 #[ty = u32];
+                v4 = hir.bitcast v1 : u32 #[ty = u32];
+                v5 = hir.shr v3, v4 : u32;
+                v6 = hir.bitcast v5 : i32 #[ty = i32];
+                hir.br block7(v6);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/shr_u64.hir
+++ b/tests/integration/expected/shr_u64.hir
@@ -1,28 +1,31 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_06af793a34a89f72818a0d65a5b5ac2526e0731e32c76ae951f9d05d12b6d4e4] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.bitcast v0 : u64 #[ty = u64];
-            v4 = hir.cast v1 : u32 #[ty = u32];
-            v5 = hir.shr v3, v4 : u64;
-            v6 = hir.bitcast v5 : i64 #[ty = i64];
-            hir.br block6(v6);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_06af793a34a89f72818a0d65a5b5ac2526e0731e32c76ae951f9d05d12b6d4e4] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.bitcast v0 : u64 #[ty = u64];
+                v4 = hir.cast v1 : u32 #[ty = u32];
+                v5 = hir.shr v3, v4 : u64;
+                v6 = hir.bitcast v5 : i64 #[ty = i64];
+                hir.br block7(v6);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/shr_u8.hir
+++ b/tests/integration/expected/shr_u8.hir
@@ -1,30 +1,33 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_5e6fba59478d938d56559a1d9ca7b9fe13244e2b0714fdfc42042b83af78612f] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.constant 7 : i32;
-            v4 = hir.band v1, v3 : i32;
-            v5 = hir.bitcast v0 : u32 #[ty = u32];
-            v6 = hir.bitcast v4 : u32 #[ty = u32];
-            v7 = hir.shr v5, v6 : u32;
-            v8 = hir.bitcast v7 : i32 #[ty = i32];
-            hir.br block6(v8);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_5e6fba59478d938d56559a1d9ca7b9fe13244e2b0714fdfc42042b83af78612f] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.constant 7 : i32;
+                v4 = hir.band v1, v3 : i32;
+                v5 = hir.bitcast v0 : u32 #[ty = u32];
+                v6 = hir.bitcast v4 : u32 #[ty = u32];
+                v7 = hir.shr v5, v6 : u32;
+                v8 = hir.bitcast v7 : i32 #[ty = i32];
+                hir.br block7(v8);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/sub_felt.hir
+++ b/tests/integration/expected/sub_felt.hir
@@ -1,17 +1,20 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #sub_felt] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: felt, v1: felt) -> felt {
-        ^block3(v0: felt, v1: felt):
-            v3 = hir.sub v0, v1 : felt #[overflow = unchecked];
-            hir.br block4(v3);
-        ^block4(v2: felt):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #sub_felt] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+            builtin.function public @entrypoint(v0: felt, v1: felt) -> felt {
+            ^block4(v0: felt, v1: felt):
+                v3 = hir.sub v0, v1 : felt #[overflow = unchecked];
+                hir.br block5(v3);
+            ^block5(v2: felt):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/sub_i16.hir
+++ b/tests/integration/expected/sub_i16.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_6fb192cd8f45d09bfbce4dc3824f4ab50385e70882ac508535654ca25af2ff66] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.sub v0, v1 : i32 #[overflow = wrapping];
-            v4 = hir.sext v3 : i32 #[ty = i32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_6fb192cd8f45d09bfbce4dc3824f4ab50385e70882ac508535654ca25af2ff66] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.sub v0, v1 : i32 #[overflow = wrapping];
+                v4 = hir.sext v3 : i32 #[ty = i32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/sub_i32.hir
+++ b/tests/integration/expected/sub_i32.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_698d995f2c0b88d2812071d204a744bc080ce741c0da79a5c54d851946837d51] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.sub v0, v1 : i32 #[overflow = wrapping];
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_698d995f2c0b88d2812071d204a744bc080ce741c0da79a5c54d851946837d51] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.sub v0, v1 : i32 #[overflow = wrapping];
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/sub_i64.hir
+++ b/tests/integration/expected/sub_i64.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_52c69166bf1f3ac3df7337dc12e7ba379d9ff44d7d8a8eb36c6c73182238ea88] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.sub v0, v1 : i64 #[overflow = wrapping];
-            hir.br block6(v3);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_52c69166bf1f3ac3df7337dc12e7ba379d9ff44d7d8a8eb36c6c73182238ea88] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.sub v0, v1 : i64 #[overflow = wrapping];
+                hir.br block7(v3);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/sub_i8.hir
+++ b/tests/integration/expected/sub_i8.hir
@@ -1,26 +1,29 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_ad1749dbdf86cbb2d7af210b3181b5a21a0a457d8a76cf3261cf21a9902c3de0] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.sub v0, v1 : i32 #[overflow = wrapping];
-            v4 = hir.sext v3 : i32 #[ty = i32];
-            hir.br block6(v4);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_ad1749dbdf86cbb2d7af210b3181b5a21a0a457d8a76cf3261cf21a9902c3de0] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.sub v0, v1 : i32 #[overflow = wrapping];
+                v4 = hir.sext v3 : i32 #[ty = i32];
+                hir.br block7(v4);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/sub_u16.hir
+++ b/tests/integration/expected/sub_u16.hir
@@ -1,27 +1,30 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_f938d50f6700b001e6e4fa342fa235de0b28c5e79d3c4837b142860d9d8b8e6f] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.sub v0, v1 : i32 #[overflow = wrapping];
-            v4 = hir.constant 65535 : i32;
-            v5 = hir.band v3, v4 : i32;
-            hir.br block6(v5);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_f938d50f6700b001e6e4fa342fa235de0b28c5e79d3c4837b142860d9d8b8e6f] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.sub v0, v1 : i32 #[overflow = wrapping];
+                v4 = hir.constant 65535 : i32;
+                v5 = hir.band v3, v4 : i32;
+                hir.br block7(v5);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/sub_u32.hir
+++ b/tests/integration/expected/sub_u32.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_a27a86095ba52da4bcd985229e6b3275c1a4a8354c4b119cef358f6ec3ac98c4] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.sub v0, v1 : i32 #[overflow = wrapping];
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_a27a86095ba52da4bcd985229e6b3275c1a4a8354c4b119cef358f6ec3ac98c4] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.sub v0, v1 : i32 #[overflow = wrapping];
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/sub_u64.hir
+++ b/tests/integration/expected/sub_u64.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_5574a62019b06e2b235711c006fa92058c6184438940dab99ef3bc7024353803] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
-        ^block5(v0: i64, v1: i64):
-            v3 = hir.sub v0, v1 : i64 #[overflow = wrapping];
-            hir.br block6(v3);
-        ^block6(v2: i64):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_5574a62019b06e2b235711c006fa92058c6184438940dab99ef3bc7024353803] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i64, v1: i64) -> i64 {
+            ^block6(v0: i64, v1: i64):
+                v3 = hir.sub v0, v1 : i64 #[overflow = wrapping];
+                hir.br block7(v3);
+            ^block7(v2: i64):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/sub_u8.hir
+++ b/tests/integration/expected/sub_u8.hir
@@ -1,27 +1,30 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_35c4da632353887f7b18847780ef2124ea854f0ed6df12437e5a3eaa8f8aacc6] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.sub v0, v1 : i32 #[overflow = wrapping];
-            v4 = hir.constant 255 : i32;
-            v5 = hir.band v3, v4 : i32;
-            hir.br block6(v5);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_35c4da632353887f7b18847780ef2124ea854f0ed6df12437e5a3eaa8f8aacc6] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.sub v0, v1 : i32 #[overflow = wrapping];
+                v4 = hir.constant 255 : i32;
+                v5 = hir.band v3, v4 : i32;
+                hir.br block7(v5);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/types/array.hir
+++ b/tests/integration/expected/types/array.hir
@@ -1,69 +1,72 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_d63291a98b435c53f58385d5782fb46f0b0b78bee8e860843e7223106d66f7d6] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @sum_arr(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.constant 0 : i32;
-            v4 = hir.constant 0 : i32;
-            v5 = hir.constant 0 : i32;
-            v6 = hir.eq v1, v5 : i1;
-            v7 = hir.zext v6 : u32 #[ty = u32];
-            v8 = hir.bitcast v7 : i32 #[ty = i32];
-            v9 = hir.constant 0 : i32;
-            v10 = hir.neq v8, v9 : i1;
-            hir.cond_br v10 block7(v4), block8;
-        ^block6(v2: i32):
-            hir.ret v2;
-        ^block7(v26: i32):
-            hir.br block6(v26);
-        ^block8:
-            hir.br block9(v0, v4, v1);
-        ^block9(v11: i32, v17: i32, v21: i32):
-            v12 = hir.bitcast v11 : u32 #[ty = u32];
-            v13 = hir.constant 4 : u32;
-            v14 = hir.mod v12, v13 : u32;
-            hir.assertz v14 #[code = 250];
-            v15 = hir.int_to_ptr v12 : (ptr i32) #[ty = (ptr i32)];
-            v16 = hir.load v15 : i32;
-            v18 = hir.add v16, v17 : i32 #[overflow = wrapping];
-            v19 = hir.constant 4 : i32;
-            v20 = hir.add v11, v19 : i32 #[overflow = wrapping];
-            v22 = hir.constant -1 : i32;
-            v23 = hir.add v21, v22 : i32 #[overflow = wrapping];
-            v24 = hir.constant 0 : i32;
-            v25 = hir.neq v23, v24 : i1;
-            hir.cond_br v25 block9(v20, v18, v23), block11;
-        ^block10:
-            hir.br block7(v18);
-        ^block11:
-            hir.br block10;
-        };
-        builtin.function public @__main() -> i32 {
-        ^block12:
-            v28 = hir.constant 1048576 : i32;
-            v29 = hir.constant 5 : i32;
-            v30 = hir.exec v28, v29 : i32 #[callee = root/test_rust_d63291a98b435c53f58385d5782fb46f0b0b78bee8e860843e7223106d66f7d6/sum_arr] #[signature = (param i32) (param i32) (result i32)];
-            v31 = hir.constant 1048596 : i32;
-            v32 = hir.constant 5 : i32;
-            v33 = hir.exec v31, v32 : i32 #[callee = root/test_rust_d63291a98b435c53f58385d5782fb46f0b0b78bee8e860843e7223106d66f7d6/sum_arr] #[signature = (param i32) (param i32) (result i32)];
-            v34 = hir.add v30, v33 : i32 #[overflow = wrapping];
-            hir.br block13(v34);
-        ^block13(v27: i32):
-            hir.ret v27;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_d63291a98b435c53f58385d5782fb46f0b0b78bee8e860843e7223106d66f7d6] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @sum_arr(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.constant 0 : i32;
+                v4 = hir.constant 0 : i32;
+                v5 = hir.constant 0 : i32;
+                v6 = hir.eq v1, v5 : i1;
+                v7 = hir.zext v6 : u32 #[ty = u32];
+                v8 = hir.bitcast v7 : i32 #[ty = i32];
+                v9 = hir.constant 0 : i32;
+                v10 = hir.neq v8, v9 : i1;
+                hir.cond_br v10 block8(v4), block9;
+            ^block7(v2: i32):
+                hir.ret v2;
+            ^block8(v26: i32):
+                hir.br block7(v26);
+            ^block9:
+                hir.br block10(v0, v4, v1);
+            ^block10(v11: i32, v17: i32, v21: i32):
+                v12 = hir.bitcast v11 : u32 #[ty = u32];
+                v13 = hir.constant 4 : u32;
+                v14 = hir.mod v12, v13 : u32;
+                hir.assertz v14 #[code = 250];
+                v15 = hir.int_to_ptr v12 : (ptr i32) #[ty = (ptr i32)];
+                v16 = hir.load v15 : i32;
+                v18 = hir.add v16, v17 : i32 #[overflow = wrapping];
+                v19 = hir.constant 4 : i32;
+                v20 = hir.add v11, v19 : i32 #[overflow = wrapping];
+                v22 = hir.constant -1 : i32;
+                v23 = hir.add v21, v22 : i32 #[overflow = wrapping];
+                v24 = hir.constant 0 : i32;
+                v25 = hir.neq v23, v24 : i1;
+                hir.cond_br v25 block10(v20, v18, v23), block12;
+            ^block11:
+                hir.br block8(v18);
+            ^block12:
+                hir.br block11;
+            };
+            builtin.function public @__main() -> i32 {
+            ^block13:
+                v28 = hir.constant 1048576 : i32;
+                v29 = hir.constant 5 : i32;
+                v30 = hir.exec v28, v29 : i32 #[callee = world/root/test_rust_d63291a98b435c53f58385d5782fb46f0b0b78bee8e860843e7223106d66f7d6/sum_arr] #[signature = (param i32) (param i32) (result i32)];
+                v31 = hir.constant 1048596 : i32;
+                v32 = hir.constant 5 : i32;
+                v33 = hir.exec v31, v32 : i32 #[callee = world/root/test_rust_d63291a98b435c53f58385d5782fb46f0b0b78bee8e860843e7223106d66f7d6/sum_arr] #[signature = (param i32) (param i32) (result i32)];
+                v34 = hir.add v30, v33 : i32 #[overflow = wrapping];
+                hir.br block14(v34);
+            ^block14(v27: i32):
+                hir.ret v27;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048616];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048624];
+                hir.ret_imm  #[value = 1048616];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048624];
+            };
+            builtin.segment  #[data = 0000000a000000090000000800000007000000060000000500000004000000030000000200000001] #[offset = 1048576] #[readonly = false];
         };
-        builtin.segment  #[data = 0000000a000000090000000800000007000000060000000500000004000000030000000200000001] #[offset = 1048576] #[readonly = false];
     };
 };

--- a/tests/integration/expected/types/enum.hir
+++ b/tests/integration/expected/types/enum.hir
@@ -1,56 +1,59 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_f0bb65319ffababec660ada9dd2dd5f137503f60cf9c37332d6f7e171f275824] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @match_enum(v0: i32, v1: i32, v2: i32) -> i32 {
-        ^block5(v0: i32, v1: i32, v2: i32):
-            v4 = hir.constant 255 : i32;
-            v5 = hir.band v2, v4 : i32;
-            v6 = hir.cast v5 : u32 #[ty = u32];
-            hir.switch v6 block9, block8, block7, block9;
-        ^block6(v3: i32):
-            hir.ret v3;
-        ^block7:
-            v9 = hir.mul v1, v0 : i32 #[overflow = wrapping];
-            hir.br block6(v9);
-        ^block8:
-            v8 = hir.sub v0, v1 : i32 #[overflow = wrapping];
-            hir.ret v8;
-        ^block9:
-            v7 = hir.add v1, v0 : i32 #[overflow = wrapping];
-            hir.ret v7;
-        };
-        builtin.function public @__main() -> i32 {
-        ^block10:
-            v11 = hir.constant 3 : i32;
-            v12 = hir.constant 5 : i32;
-            v13 = hir.constant 0 : i32;
-            v14 = hir.exec v11, v12, v13 : i32 #[callee = root/test_rust_f0bb65319ffababec660ada9dd2dd5f137503f60cf9c37332d6f7e171f275824/match_enum] #[signature = (param i32) (param i32) (param i32) (result i32)];
-            v15 = hir.constant 3 : i32;
-            v16 = hir.constant 5 : i32;
-            v17 = hir.constant 1 : i32;
-            v18 = hir.exec v15, v16, v17 : i32 #[callee = root/test_rust_f0bb65319ffababec660ada9dd2dd5f137503f60cf9c37332d6f7e171f275824/match_enum] #[signature = (param i32) (param i32) (param i32) (result i32)];
-            v19 = hir.add v14, v18 : i32 #[overflow = wrapping];
-            v20 = hir.constant 3 : i32;
-            v21 = hir.constant 5 : i32;
-            v22 = hir.constant 2 : i32;
-            v23 = hir.exec v20, v21, v22 : i32 #[callee = root/test_rust_f0bb65319ffababec660ada9dd2dd5f137503f60cf9c37332d6f7e171f275824/match_enum] #[signature = (param i32) (param i32) (param i32) (result i32)];
-            v24 = hir.add v19, v23 : i32 #[overflow = wrapping];
-            hir.br block11(v24);
-        ^block11(v10: i32):
-            hir.ret v10;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_f0bb65319ffababec660ada9dd2dd5f137503f60cf9c37332d6f7e171f275824] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @match_enum(v0: i32, v1: i32, v2: i32) -> i32 {
+            ^block6(v0: i32, v1: i32, v2: i32):
+                v4 = hir.constant 255 : i32;
+                v5 = hir.band v2, v4 : i32;
+                v6 = hir.cast v5 : u32 #[ty = u32];
+                hir.switch v6 block10, block9, block8, block10;
+            ^block7(v3: i32):
+                hir.ret v3;
+            ^block8:
+                v9 = hir.mul v1, v0 : i32 #[overflow = wrapping];
+                hir.br block7(v9);
+            ^block9:
+                v8 = hir.sub v0, v1 : i32 #[overflow = wrapping];
+                hir.ret v8;
+            ^block10:
+                v7 = hir.add v1, v0 : i32 #[overflow = wrapping];
+                hir.ret v7;
+            };
+            builtin.function public @__main() -> i32 {
+            ^block11:
+                v11 = hir.constant 3 : i32;
+                v12 = hir.constant 5 : i32;
+                v13 = hir.constant 0 : i32;
+                v14 = hir.exec v11, v12, v13 : i32 #[callee = world/root/test_rust_f0bb65319ffababec660ada9dd2dd5f137503f60cf9c37332d6f7e171f275824/match_enum] #[signature = (param i32) (param i32) (param i32) (result i32)];
+                v15 = hir.constant 3 : i32;
+                v16 = hir.constant 5 : i32;
+                v17 = hir.constant 1 : i32;
+                v18 = hir.exec v15, v16, v17 : i32 #[callee = world/root/test_rust_f0bb65319ffababec660ada9dd2dd5f137503f60cf9c37332d6f7e171f275824/match_enum] #[signature = (param i32) (param i32) (param i32) (result i32)];
+                v19 = hir.add v14, v18 : i32 #[overflow = wrapping];
+                v20 = hir.constant 3 : i32;
+                v21 = hir.constant 5 : i32;
+                v22 = hir.constant 2 : i32;
+                v23 = hir.exec v20, v21, v22 : i32 #[callee = world/root/test_rust_f0bb65319ffababec660ada9dd2dd5f137503f60cf9c37332d6f7e171f275824/match_enum] #[signature = (param i32) (param i32) (param i32) (result i32)];
+                v24 = hir.add v19, v23 : i32 #[overflow = wrapping];
+                hir.br block12(v24);
+            ^block12(v10: i32):
+                hir.ret v10;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };

--- a/tests/integration/expected/types/static_mut.hir
+++ b/tests/integration/expected/types/static_mut.hir
@@ -1,73 +1,76 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_e6d553fb1c80aef6e5d6f2891701197bedac471cf510bd2495f99889d9543cd4] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @global_var_update() {
-        ^block5:
-            v0 = hir.constant 0 : i32;
-            v1 = hir.constant 0 : i32;
-            v2 = hir.bitcast v1 : u32 #[ty = u32];
-            v3 = hir.constant 1048577 : u32;
-            v4 = hir.add v2, v3 : u32 #[overflow = checked];
-            v5 = hir.int_to_ptr v4 : (ptr u8) #[ty = (ptr u8)];
-            v6 = hir.load v5 : u8;
-            v7 = hir.zext v6 : u32 #[ty = u32];
-            v8 = hir.constant 1 : i32;
-            v9 = hir.bitcast v8 : u32 #[ty = u32];
-            v10 = hir.add v7, v9 : u32 #[overflow = wrapping];
-            v11 = hir.trunc v10 : u8 #[ty = u8];
-            v12 = hir.bitcast v0 : u32 #[ty = u32];
-            v13 = hir.constant 1048576 : u32;
-            v14 = hir.add v12, v13 : u32 #[overflow = checked];
-            v15 = hir.int_to_ptr v14 : (ptr u8) #[ty = (ptr u8)];
-            hir.store v15, v11;
-            hir.br block6;
-        ^block6:
-            hir.ret ;
-        };
-        builtin.function public @__main() -> i32 {
-        ^block7:
-            v17 = hir.constant 0 : i32;
-            hir.exec  #[callee = root/test_rust_e6d553fb1c80aef6e5d6f2891701197bedac471cf510bd2495f99889d9543cd4/global_var_update] #[signature = ];
-            v18 = hir.constant 0 : i32;
-            v19 = hir.constant -9 : i32;
-            hir.br block9(v19, v18);
-        ^block8(v16: i32):
-            hir.ret v16;
-        ^block9(v20: i32, v27: i32):
-            v21 = hir.constant 1048585 : i32;
-            v22 = hir.add v20, v21 : i32 #[overflow = wrapping];
-            v23 = hir.bitcast v22 : u32 #[ty = u32];
-            v24 = hir.int_to_ptr v23 : (ptr u8) #[ty = (ptr u8)];
-            v25 = hir.load v24 : u8;
-            v26 = hir.zext v25 : u32 #[ty = u32];
-            v28 = hir.bitcast v27 : u32 #[ty = u32];
-            v29 = hir.add v26, v28 : u32 #[overflow = wrapping];
-            v30 = hir.bitcast v29 : i32 #[ty = i32];
-            v31 = hir.constant 1 : i32;
-            v32 = hir.add v20, v31 : i32 #[overflow = wrapping];
-            v33 = hir.constant 0 : i32;
-            v34 = hir.neq v32, v33 : i1;
-            hir.cond_br v34 block9(v32, v30), block11;
-        ^block10:
-            v35 = hir.constant 255 : i32;
-            v36 = hir.band v30, v35 : i32;
-            hir.br block8(v36);
-        ^block11:
-            hir.br block10;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_e6d553fb1c80aef6e5d6f2891701197bedac471cf510bd2495f99889d9543cd4] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @global_var_update() {
+            ^block6:
+                v0 = hir.constant 0 : i32;
+                v1 = hir.constant 0 : i32;
+                v2 = hir.bitcast v1 : u32 #[ty = u32];
+                v3 = hir.constant 1048577 : u32;
+                v4 = hir.add v2, v3 : u32 #[overflow = checked];
+                v5 = hir.int_to_ptr v4 : (ptr u8) #[ty = (ptr u8)];
+                v6 = hir.load v5 : u8;
+                v7 = hir.zext v6 : u32 #[ty = u32];
+                v8 = hir.constant 1 : i32;
+                v9 = hir.bitcast v8 : u32 #[ty = u32];
+                v10 = hir.add v7, v9 : u32 #[overflow = wrapping];
+                v11 = hir.trunc v10 : u8 #[ty = u8];
+                v12 = hir.bitcast v0 : u32 #[ty = u32];
+                v13 = hir.constant 1048576 : u32;
+                v14 = hir.add v12, v13 : u32 #[overflow = checked];
+                v15 = hir.int_to_ptr v14 : (ptr u8) #[ty = (ptr u8)];
+                hir.store v15, v11;
+                hir.br block7;
+            ^block7:
+                hir.ret ;
+            };
+            builtin.function public @__main() -> i32 {
+            ^block8:
+                v17 = hir.constant 0 : i32;
+                hir.exec  #[callee = world/root/test_rust_e6d553fb1c80aef6e5d6f2891701197bedac471cf510bd2495f99889d9543cd4/global_var_update] #[signature = ];
+                v18 = hir.constant 0 : i32;
+                v19 = hir.constant -9 : i32;
+                hir.br block10(v19, v18);
+            ^block9(v16: i32):
+                hir.ret v16;
+            ^block10(v20: i32, v27: i32):
+                v21 = hir.constant 1048585 : i32;
+                v22 = hir.add v20, v21 : i32 #[overflow = wrapping];
+                v23 = hir.bitcast v22 : u32 #[ty = u32];
+                v24 = hir.int_to_ptr v23 : (ptr u8) #[ty = (ptr u8)];
+                v25 = hir.load v24 : u8;
+                v26 = hir.zext v25 : u32 #[ty = u32];
+                v28 = hir.bitcast v27 : u32 #[ty = u32];
+                v29 = hir.add v26, v28 : u32 #[overflow = wrapping];
+                v30 = hir.bitcast v29 : i32 #[ty = i32];
+                v31 = hir.constant 1 : i32;
+                v32 = hir.add v20, v31 : i32 #[overflow = wrapping];
+                v33 = hir.constant 0 : i32;
+                v34 = hir.neq v32, v33 : i1;
+                hir.cond_br v34 block10(v32, v30), block12;
+            ^block11:
+                v35 = hir.constant 255 : i32;
+                v36 = hir.band v30, v35 : i32;
+                hir.br block9(v36);
+            ^block12:
+                hir.br block11;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048585];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048592];
+                hir.ret_imm  #[value = 1048585];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048592];
+            };
+            builtin.segment  #[data = 090807060504030201] #[offset = 1048576] #[readonly = false];
         };
-        builtin.segment  #[data = 090807060504030201] #[offset = 1048576] #[readonly = false];
     };
 };

--- a/tests/integration/expected/xor_bool.hir
+++ b/tests/integration/expected/xor_bool.hir
@@ -1,25 +1,28 @@
-builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
+builtin.world  #[name = #world] {
 
-    builtin.module  #[name = #test_rust_bf1daa4716c09a8fc6f8362a72042139765ebe6efcfdd17e817a70b2a495f6b1] #[visibility = public] {
+    builtin.component  #[name = #root] #[namespace = #root_ns] #[version = 1.0.0] #[visibility = public] {
 
-        builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
-        ^block5(v0: i32, v1: i32):
-            v3 = hir.bxor v0, v1 : i32;
-            hir.br block6(v3);
-        ^block6(v2: i32):
-            hir.ret v2;
-        };
-        builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
+        builtin.module  #[name = #test_rust_bf1daa4716c09a8fc6f8362a72042139765ebe6efcfdd17e817a70b2a495f6b1] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
+            builtin.function public @entrypoint(v0: i32, v1: i32) -> i32 {
+            ^block6(v0: i32, v1: i32):
+                v3 = hir.bxor v0, v1 : i32;
+                hir.br block7(v3);
+            ^block7(v2: i32):
+                hir.ret v2;
+            };
+            builtin.global_variable  #[name = #__stack_pointer] #[ty = i32] #[visibility = private] {
 
-            hir.ret_imm  #[value = 1048576];
-        };
-        builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv1] #[ty = i32] #[visibility = public] {
 
-            hir.ret_imm  #[value = 1048576];
+                hir.ret_imm  #[value = 1048576];
+            };
+            builtin.global_variable  #[name = #gv2] #[ty = i32] #[visibility = public] {
+
+                hir.ret_imm  #[value = 1048576];
+            };
         };
     };
 };


### PR DESCRIPTION
#363 

**This PR is stacked on the #412 and should be merged after it**

This PR introduces `World` op and uses it in the frontend for core Wasm module translation code path. 

**Note**. I suggest reviewing this PR by commits, since I tried to pack all the expected test updates in separate commits.

TODO: 
- [ ] move `intrinsics` and Miden ABI transformation imports `Module` into a separate `Component`;