### PR TITLE
fix: collatz example readme

### DIFF
--- a/examples/collatz/README.md
+++ b/examples/collatz/README.md
@@ -1,8 +1,8 @@
-# fibonacci
+# collatz
 
 ## Useful commands
 
-`fibonacci` is built using the [Miden compiler](https://github.com/0xPolygonMiden/compiler).
+`collatz` is built using the [Miden compiler](https://github.com/0xPolygonMiden/compiler).
 
 `cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xpolygonmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
 for more details on how to build and run the compiled programs.
@@ -16,6 +16,6 @@ cargo miden build --release
 ## Run
 
 ```bash
-midenc run target/miden/release/fibonacci.masp --inputs inputs.toml
+midenc run target/miden/release/collatz.masp --inputs inputs.toml
 ```
 


### PR DESCRIPTION
Fixing the reference to "fibonacci" in the collatz example readme