### PR TITLE
chore: switch to the published version `v0.21` of the `cargo-component` with type remapping in `wit-bindgen`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auditable-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7bf8143dfc3c0258df908843e169b5cc5fcf76c7718bd66135ef4a9cd558c5"
+dependencies = [
+ "semver 1.0.23",
+ "serde",
+ "serde_json",
+ "topological-sort",
+]
+
+[[package]]
 name = "auth-git2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,8 +586,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-component"
-version = "0.20.0-dev"
-source = "git+https://github.com/greenhat/cargo-component?rev=093ee4ce75e67814e9ec912faed87160e9a762ca#093ee4ce75e67814e9ec912faed87160e9a762ca"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5909c9e8cfc35bb77ad11e2cde9edf033e9414680e42c1ad0b06462b6cb78a7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -603,20 +616,21 @@ dependencies = [
  "toml_edit",
  "url",
  "wasi-preview1-component-adapter-provider",
- "wasm-metadata 0.225.0",
+ "wasm-metadata 0.227.1",
  "wasm-pkg-client",
- "wasmparser 0.225.0",
+ "wasmparser 0.227.1",
  "which",
  "wit-bindgen-core",
  "wit-bindgen-rust",
- "wit-component 0.225.0",
- "wit-parser 0.225.0",
+ "wit-component 0.227.1",
+ "wit-parser 0.227.1",
 ]
 
 [[package]]
 name = "cargo-component-core"
-version = "0.20.0-dev"
-source = "git+https://github.com/greenhat/cargo-component?rev=093ee4ce75e67814e9ec912faed87160e9a762ca#093ee4ce75e67814e9ec912faed87160e9a762ca"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa80e12d67aaa39caead178bab83ece59da502dcd51f4190378a04ad6320b2a"
 dependencies = [
  "anyhow",
  "clap",
@@ -635,8 +649,8 @@ dependencies = [
  "url",
  "wasm-pkg-client",
  "windows-sys 0.52.0",
- "wit-component 0.225.0",
- "wit-parser 0.225.0",
+ "wit-component 0.227.1",
+ "wit-parser 0.227.1",
 ]
 
 [[package]]
@@ -702,7 +716,7 @@ dependencies = [
  "cargo-component-core",
  "cargo-config2",
  "cargo-generate",
- "cargo_metadata 0.18.1",
+ "cargo_metadata 0.19.1",
  "clap",
  "env_logger 0.11.5",
  "log",
@@ -1629,9 +1643,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -3572,9 +3586,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -5823,6 +5837,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "topological-sort"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6448,12 +6468,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.225.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f7eac0445cac73bcf09e6a97f83248d64356dccf9f2b100199769b6b42464e5"
+checksum = "80bb72f02e7fbf07183443b27b0f3d4144abf8c114189f2e088ed95b696a7822"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.225.0",
+ "wasmparser 0.227.1",
 ]
 
 [[package]]
@@ -6491,19 +6511,21 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.225.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d20d0bf2c73c32a5114cf35a5c10ccf9f9aa37a3a2c0114b3e11cbf6faac12"
+checksum = "ce1ef0faabbbba6674e97a56bee857ccddf942785a336c8b47b42373c922a91d"
 dependencies = [
  "anyhow",
+ "auditable-serde",
+ "flate2",
  "indexmap 2.7.1",
  "serde",
  "serde_derive",
  "serde_json",
  "spdx",
  "url",
- "wasm-encoder 0.225.0",
- "wasmparser 0.225.0",
+ "wasm-encoder 0.227.1",
+ "wasmparser 0.227.1",
 ]
 
 [[package]]
@@ -6627,9 +6649,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.225.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e5456165f81e64cb9908a0fe9b9d852c2c74582aa3fe2be3c2da57f937d3ae"
+checksum = "0f51cad774fb3c9461ab9bccc9c62dfb7388397b5deda31bf40e8108ccd678b2"
 dependencies = [
  "bitflags 2.6.0",
  "hashbrown 0.15.2",
@@ -7057,27 +7079,29 @@ checksum = "1507ef312ea5569d54c2c7446a18b82143eb2a2e21f5c3ec7cfbe8200c03bd7c"
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.39.0"
-source = "git+https://github.com/greenhat/wit-bindgen.git?rev=613d2fd95f360e554613d435e74c1c52b85617bf#613d2fd95f360e554613d435e74c1c52b85617bf"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92fa781d4f2ff6d3f27f3cc9b74a73327b31ca0dc4a3ef25a0ce2983e0e5af9b"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.225.0",
+ "wit-parser 0.227.1",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.39.0"
-source = "git+https://github.com/greenhat/wit-bindgen.git?rev=613d2fd95f360e554613d435e74c1c52b85617bf#613d2fd95f360e554613d435e74c1c52b85617bf"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d0809dc5ba19e2e98661bf32fc0addc5a3ca5bf3a6a7083aa6ba484085ff3ce"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.7.1",
  "prettyplease",
  "syn",
- "wasm-metadata 0.225.0",
+ "wasm-metadata 0.227.1",
  "wit-bindgen-core",
- "wit-component 0.225.0",
+ "wit-component 0.227.1",
 ]
 
 [[package]]
@@ -7120,9 +7144,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.225.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2505c917564c1d74774563bbcd3e4f8c216a6508050862fd5f449ee56e3c5125"
+checksum = "635c3adc595422cbf2341a17fb73a319669cc8d33deed3a48368a841df86b676"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -7131,10 +7155,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.225.0",
- "wasm-metadata 0.225.0",
- "wasmparser 0.225.0",
- "wit-parser 0.225.0",
+ "wasm-encoder 0.227.1",
+ "wasm-metadata 0.227.1",
+ "wasmparser 0.227.1",
+ "wit-parser 0.227.1",
 ]
 
 [[package]]
@@ -7175,9 +7199,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.225.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebefaa234e47224f10ce60480c5bfdece7497d0f3b87a12b41ff39e5c8377a78"
+checksum = "ddf445ed5157046e4baf56f9138c124a0824d4d1657e7204d71886ad8ce2fc11"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -7188,7 +7212,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.225.0",
+ "wasmparser 0.227.1",
 ]
 
 [[package]]

--- a/tests/integration/expected/rust_sdk/cross_ctx_account.wat
+++ b/tests/integration/expected/rust_sdk/cross_ctx_account.wat
@@ -1,4 +1,4 @@
-(component
+(component $cross-ctx-account
   (type (;0;)
     (instance
       (type (;0;) (func (result s32)))

--- a/tools/cargo-miden/Cargo.toml
+++ b/tools/cargo-miden/Cargo.toml
@@ -28,9 +28,9 @@ env_logger.workspace = true
 log.workspace = true
 clap.workspace = true
 anyhow.workspace = true
-cargo-component = { version = "0.20.0-dev", git = "https://github.com/greenhat/cargo-component", rev = "093ee4ce75e67814e9ec912faed87160e9a762ca" }
-cargo-component-core = { version = "0.20.0-dev", git = "https://github.com/greenhat/cargo-component", rev = "093ee4ce75e67814e9ec912faed87160e9a762ca" }
-cargo_metadata = "0.18"
+cargo-component = { version = "0.21" }
+cargo-component-core = { version = "0.21" }
+cargo_metadata = "0.19"
 cargo-generate = "0.22"
 semver = "1.0.20"
 parse_arg = "0.1.4"


### PR DESCRIPTION
Close #116 

**This PR is stacked on the #417 and should be merged after it**