### PR TITLE
fix: missing wasmparser feature causing cargo build failure

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -165,7 +165,7 @@ args = [
     "build",
     "-p",
     "midenc",
-    "--out-dir",
+    "--artifact-dir",
     "${MIDENC_BIN_DIR}",
 ]
 

--- a/frontend-wasm2/Cargo.toml
+++ b/frontend-wasm2/Cargo.toml
@@ -35,6 +35,7 @@ wasmparser = { version = "0.227", default-features = false, features = [
     "features",
     "component-model",
     "validate",
+    "simd",
 ] }
 
 [dev-dependencies]

--- a/midenc-compile/Cargo.toml
+++ b/midenc-compile/Cargo.toml
@@ -15,7 +15,15 @@ edition.workspace = true
 
 [features]
 default = ["std"]
-std = ["miden-assembly/std", "midenc-hir/std", "dep:clap"]
+std = [
+    "miden-assembly/std",
+    "midenc-codegen-masm/std",
+    "midenc-frontend-wasm2/std",
+    "midenc-hir/std",
+    "midenc-session/std",
+    "dep:clap",
+    "dep:wat",
+]
 
 [dependencies]
 clap = { workspace = true, optional = true }
@@ -31,4 +39,4 @@ midenc-hir.workspace = true
 midenc-hir-transform.workspace = true
 midenc-session.workspace = true
 thiserror.workspace = true
-wat.workspace = true
+wat = { workspace = true, optional = true }

--- a/midenc-compile/src/stages/parse.rs
+++ b/midenc-compile/src/stages/parse.rs
@@ -50,6 +50,9 @@ impl Stage for ParseStage {
                     Err(Report::msg("invalid input: hir parsing is temporarily unsupported"))
                 }
                 FileType::Wasm => Ok(ParseOutput::Wasm(InputType::Real(path))),
+                #[cfg(not(feature = "std"))]
+                FileType::Wat => unimplemented!(),
+                #[cfg(feature = "std")]
                 FileType::Wat => self.parse_wasm_from_wat_file(path.as_ref()),
                 FileType::Masm => self.parse_masm_from_file(path.as_ref(), context.clone()),
                 FileType::Mast => miden_assembly::Library::deserialize_from_file(&path)
@@ -81,6 +84,9 @@ impl Stage for ParseStage {
                     Err(Report::msg("invalid input: hir parsing is temporarily unsupported"))
                 }
                 FileType::Wasm => Ok(ParseOutput::Wasm(InputType::Stdin { name, input })),
+                #[cfg(not(feature = "std"))]
+                FileType::Wat => unimplemented!(),
+                #[cfg(feature = "std")]
                 FileType::Wat => {
                     let wasm = wat::parse_bytes(&input)
                         .into_diagnostic()


### PR DESCRIPTION
This fixes the issue `cargo make build` failing, and a couple related fixes found in the process.