### PR TITLE
feat: implement support for element-addressable memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -604,7 +604,7 @@ dependencies = [
  "p256",
  "parse_arg",
  "pretty_env_logger",
- "rand_core",
+ "rand_core 0.6.4",
  "rpassword",
  "semver 1.0.26",
  "serde",
@@ -1143,7 +1143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1227,7 +1227,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "sha2",
 ]
 
@@ -1455,7 +1455,7 @@ dependencies = [
  "group",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1643,7 +1643,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2173,7 +2173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2614,7 +2614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
 dependencies = [
  "bitmaps",
- "rand_core",
+ "rand_core 0.6.4",
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
@@ -3208,8 +3208,9 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.11.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb#4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72269e041e915d6c34325a8906f08a8ff6ec9b92c79ae07f3a0de8c3588694b5"
 dependencies = [
  "miden-core",
  "thiserror 2.0.11",
@@ -3219,8 +3220,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.11.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb#4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce5680a0e75470389b65cc00900422ad7e1aa7972477c75ff88f63c3a01671e9"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -3244,8 +3246,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.11.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb#4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ba125a31e9ec0e732f47e639525c753973e553126cfc46cc63674049ea4134"
 dependencies = [
  "lock_api",
  "loom",
@@ -3263,17 +3266,17 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06bf3ad2a85f3f8f0da73b6357c77e482b1ceb36cacda8a2d85caae3bd1f702"
+checksum = "d521a9d5fa949d60e4029e55ff1da892561b298ed636afb5f71d0dde0925bf57"
 dependencies = [
  "blake3",
  "cc",
  "glob",
  "num",
  "num-complex",
- "rand",
- "rand_core",
+ "rand 0.9.0",
+ "rand_core 0.9.3",
  "sha3",
  "thiserror 2.0.11",
  "winter-crypto",
@@ -3324,8 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.12.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb#4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418ddee9db301f4348751f8bc5e0776caba0aff12df709c080014b3719b33cbf"
 dependencies = [
  "derive_more",
  "miden-assembly",
@@ -3376,8 +3380,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.11.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb#4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5f362138a7bfe6c20246de651e848566843a0d5062cc4a7a8ebff6bd14668d"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -3392,10 +3397,12 @@ version = "0.0.7"
 
 [[package]]
 name = "miden-stdlib"
-version = "0.11.0"
-source = "git+https://github.com/0xPolygonMiden/miden-vm?rev=4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb#4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "116d30a8db5167f88944509007b8bb7aad4fa0d9d03f2610b4e80be3a198ad37"
 dependencies = [
  "miden-assembly",
+ "miden-core",
 ]
 
 [[package]]
@@ -3790,7 +3797,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4411,7 +4418,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -4520,8 +4527,8 @@ dependencies = [
  "bitflags 2.6.0",
  "lazy_static 1.5.0",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -4668,7 +4675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
- "rand",
+ "rand 0.8.5",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4719,8 +4726,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4730,7 +4748,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4743,12 +4771,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4757,7 +4794,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5200,7 +5237,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2",
  "zbus",
@@ -5509,7 +5546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6497,7 +6534,7 @@ dependencies = [
  "leb128",
  "once_cell",
  "p256",
- "rand_core",
+ "rand_core 0.6.4",
  "secrecy",
  "serde",
  "sha2",
@@ -7243,9 +7280,9 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "winter-air"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8fdb702503625f54dcaf9222aa2c7a0b2e868b3eb84b90d1837d68034bf999"
+checksum = "8d7fbdcaa53d220b84811199790c1dda77c025533cdd27715cf1625af2b4027a"
 dependencies = [
  "libm",
  "winter-crypto",
@@ -7256,9 +7293,9 @@ dependencies = [
 
 [[package]]
 name = "winter-crypto"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c57748fd2da77742be601f03eda639ff6046879738fd1faae86e80018263cb"
+checksum = "32247cde9f43e5bbd05362caa7274608790ea69b14f7c81cd509aae7127c5ff2"
 dependencies = [
  "blake3",
  "sha3",
@@ -7268,9 +7305,9 @@ dependencies = [
 
 [[package]]
 name = "winter-fri"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9f999bc248c6254138b627035cb6d2c319580eb37dadcab6672298dbf00e41"
+checksum = "32b346b0eea2292986a1193bfc70dd2dbcdbb6adb3e5110b71d18c6f1077df10"
 dependencies = [
  "winter-crypto",
  "winter-math",
@@ -7279,18 +7316,18 @@ dependencies = [
 
 [[package]]
 name = "winter-math"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6020c17839fa107ce4a7cc178e407ebbc24adfac1980f4fa2111198e052700ab"
+checksum = "326dfe4bfa4072b7c909133a88f8807820d3e49e5dfd246f67981771f74a0ed3"
 dependencies = [
  "winter-utils",
 ]
 
 [[package]]
 name = "winter-maybe-async"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ce144fde121b98523bb8a6c15a311773e1d534d33c1cb47f5580bba9cff8e7"
+checksum = "eaa132be74e602b707f1dab5a69c38496445e54ee940e7c281c02b15007241bd"
 dependencies = [
  "quote",
  "syn",
@@ -7298,9 +7335,9 @@ dependencies = [
 
 [[package]]
 name = "winter-prover"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c2f3cf80955f084fd614c86883195331116b6c96dc88532d43d6836bd7adee"
+checksum = "426be0767a25150af20a241a6ae46bad1bf2f7da86393d897e5ec9967124f760"
 dependencies = [
  "tracing",
  "winter-air",
@@ -7313,9 +7350,9 @@ dependencies = [
 
 [[package]]
 name = "winter-utils"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1507ef312ea5569d54c2c7446a18b82143eb2a2e21f5c3ec7cfbe8200c03bd7c"
+checksum = "2d47518e6931955dcac73a584cacb04550b82ab2f45c72880cbbbdbe13adb63c"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -7569,7 +7606,7 @@ dependencies = [
  "hex",
  "nix",
  "ordered-stream",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "sha1",
@@ -7614,7 +7651,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -7622,6 +7668,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,18 +89,17 @@ smallvec = { version = "1.14", default-features = false, features = [
 thiserror = { package = "miden-thiserror", version = "1.0" }
 toml = { version = "0.8", features = ["preserve_order"] }
 miden-formatting = { version = "0.1", default-features = false }
-# miden-assembly = { version = "0.11.0", path = "../vm-aux/assembly" }
-# miden-core = { version = "0.11.0", path = "../vm-aux/core" }
-# miden-processor = { version = "0.11.0", path = "../vm-aux/processor" }
-# miden-stdlib = { version = "0.11.0", path = "../vm-aux/stdlib" }
-# miden-package = { version = "0.11.0", path = "../vm-aux/package" }
-miden-assembly = { version = "0.11.0", git = "https://github.com/0xPolygonMiden/miden-vm", rev = "4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb" }
-miden-core = { version = "0.11.0", git = "https://github.com/0xPolygonMiden/miden-vm", rev = "4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb" }
-miden-processor = { version = "0.11.0", git = "https://github.com/0xPolygonMiden/miden-vm", rev = "4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb" }
-miden-stdlib = { version = "0.11.0", git = "https://github.com/0xPolygonMiden/miden-vm", rev = "4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb", features = [
+miden-assembly = { version = "0.13.0", default-features = false }
+miden-core = { version = "0.13.0", default-features = false, features = [
+    "diagnostics",
+] }
+miden-processor = { version = "0.13.0", default-features = false }
+miden-stdlib = { version = "0.13.0", default-features = false, features = [
     "with-debug-info",
 ] }
-miden-mast-package = { version = "0.12.0", git = "https://github.com/0xPolygonMiden/miden-vm", rev = "4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb" }
+miden-mast-package = { version = "0.13.0", default-features = false }
+# This is here for convenience if we need to quickly use a git ref of the VM crates
+#miden-assembly = { version = "0.11.0", git = "https://github.com/0xPolygonMiden/miden-vm", rev = "4d23f948bbf0c8fb7cd7ecba80bb02d37c1724bb" }
 midenc-codegen-masm = { version = "0.0.7", path = "codegen/masm" }
 midenc-dialect-arith = { version = "0.0.7", path = "dialects/arith" }
 midenc-dialect-hir = { version = "0.0.7", path = "dialects/hir" }

--- a/codegen/masm/intrinsics/mem.masm
+++ b/codegen/masm/intrinsics/mem.masm
@@ -1,27 +1,45 @@
 # The location where we store information about the dynamic heap
-const.HEAP_INFO_ADDR=0x80000000 # (address in words)
+const.HEAP_INFO_ADDR=0x80000000 # 2^31 (address in elements)
+
+# The location of the heap_top value
+const.HEAP_INFO_TOP=HEAP_INFO_ADDR
+
+# The location of the heap_size value
+const.HEAP_INFO_SIZE=HEAP_INFO_ADDR + 1
+
+# The location of the heap_base value
+const.HEAP_INFO_BASE=HEAP_INFO_ADDR + 2
+
+# The location of the MAGIC value
+const.HEAP_INFO_MAGIC=HEAP_INFO_ADDR + 3
+
 # The address beyond which the dynamic heap cannot be allowed to grow
-const.HEAP_END=0x10000000 # 2^30 / 4 (i.e. byte address, not word)
+const.HEAP_END=0x10000000 # 2^30 * 4 (i.e. byte address, not element address)
+
 # The assertion error code used when intrinsics are used without calling heap_init
 const.HEAP_ERR=0x68656170 # b"heap"
-const.NEG1=4294967295 # u32::MAX
+
+# u32::MAX | -1i32
+const.NEG1=4294967295
+
 # The magic bytes used to verify that the heap was properly initialized
 const.MAGIC=0xDEADBEEF
+
+# The size in bytes of each page of memory
 const.PAGE_SIZE=65536
 
 # Checks the HEAP_INFO magic to ensure heap initialization has taken place
 #
 # This consumes the input element.
-proc.verify_heap_magic # [input]
-    u32assert.err=HEAP_ERR
+proc.verify_heap_magic
+    mem_load.HEAP_INFO_MAGIC
     push.MAGIC
     assert_eq.err=HEAP_ERR
 end
 
 # Intrinsic used to initialize the heap globals manipulated by memory intrinsics
 #
-# This must be called before any other heap intrinsics are called. This is checked
-# by each intrinsic
+# This must be called before any other heap intrinsics are called. This is checked by each intrinsic
 export.heap_init # [heap_base]
     dup.0 push.0 swap.1 push.MAGIC # [MAGIC, heap_base, heap_size, heap_top]
     mem_storew.HEAP_INFO_ADDR
@@ -30,65 +48,60 @@ end
 
 # Get the (byte) address where the base of the heap starts
 export.heap_base
-    padw mem_loadw.HEAP_INFO_ADDR
-    exec.verify_heap_magic movdn.2 drop drop
+    exec.verify_heap_magic
+    mem_load.HEAP_INFO_BASE
 end
 
 # Get the (byte) address of the top of the heap
 export.heap_top_unchecked
-    mem_load.HEAP_INFO_ADDR
+    mem_load.HEAP_INFO_TOP
 end
 
 # Get the (byte) address of the top of the heap
 export.heap_top
-    padw mem_loadw.HEAP_INFO_ADDR
-    exec.verify_heap_magic drop drop
+    exec.verify_heap_magic
+    mem_load.HEAP_INFO_TOP
 end
 
 # Intrinsic corresponding to the `memory_size` instruction
 export.memory_size
-    padw mem_loadw.HEAP_INFO_ADDR
-    exec.verify_heap_magic drop swap.1 drop
+    exec.verify_heap_magic
+    mem_load.HEAP_INFO_SIZE
 end
 
 # Intrinsic corresponding to the `memory_grow` instruction
 export.memory_grow # [num_pages]
-    padw mem_loadw.HEAP_INFO_ADDR # [MAGIC, heap_base, heap_size, heap_top, num_pages]
-    dup.0 exec.verify_heap_magic  # [MAGIC, heap_base, heap_size, heap_top, num_pages]
-    swap.3 drop   # [heap_base, heap_size, MAGIC, num_pages]
-    dup.1 movdn.4 # [heap_base, heap_size, MAGIC, num_pages, heap_size]
-    swap.1        # [heap_size, heap_base, MAGIC, num_pages, heap_size]
-    movup.3       # [num_pages, heap_size, heap_base, MAGIC, heap_size]
-    u32overflowing_add # [overflowed, heap_size + num_pages, heap_base, MAGIC, heap_size]
-    if.true # [new_heap_size, heap_base, MAGIC, heap_size]
+    exec.verify_heap_magic
+    mem_load.HEAP_INFO_SIZE # [heap_size, num_pages]
+    dup.0                   # [heap_size, heap_size, num_pages]
+    swap.2                  # [num_pages, heap_size, heap_size]
+    u32overflowing_add      # [overflowed, heap_size + num_pages, heap_size]
+    if.true # [new_heap_size, heap_size]
         # Cannot grow the memory, return -1
-        dropw # []
+        drop drop
         push.NEG1
     else
         # Success, recompute the heap_top, and make sure it doesn't exceed HEAP_END
-        dup.0          # [new_heap_size, new_heap_size, heap_base, MAGIC, heap_size]
-        push.PAGE_SIZE # [PAGE_SIZE, new_heap_size, new_heap_size, heap_base, MAGIC, heap_size]
-        dup.3          # [heap_base, PAGE_SIZE, new_heap_size, new_heap_size, heap_base, MAGIC, heap_size]
-        movdn.2        # [PAGE_SIZE, new_heap_size, heap_base, ..]
-        u32overflowing_madd # [overflow, PAGE_SIZE * new_heap_size + heap_base, ..]
-        if.true        # [new_heap_top, new_heap_size, heap_base, MAGIC, heap_size]
-          # Overflow, drop the changes and return -1
-          dropw drop
-          push.NEG1
-        else
-          # Ensure the new heap_top is <= HEAP_END
-          dup.0 u32lte.HEAP_END
-          if.true
-            # Write updated heap information, and return the old heap size (in pages)
-            swap.2  # [heap_base, new_heap_size, new_heap_top, MAGIC, heap_size]
-            movup.3 # [MAGIC, heap_base, new_heap_size, new_heap_top, heap_size]
-            mem_storew.HEAP_INFO_ADDR
-            dropw
-          else
+        mem_load.HEAP_INFO_BASE   # [heap_base, new_heap_size, heap_size]
+        dup.1                     # [new_heap_size, heap_base, new_heap_size, heap_size]
+        push.PAGE_SIZE            # [PAGE_SIZE, new_heap_size, heap_base, new_heap_size, heap_size]
+        u32overflowing_madd       # [overflowed, PAGE_SIZE * new_heap_size + heap_base, ..]
+        if.true  # [new_heap_top, new_heap_size, heap_size]
             # Overflow, drop the changes and return -1
-            dropw drop
+            drop drop drop
             push.NEG1
-          end
+        else     # [new_heap_top, new_heap_size, heap_size]
+            # Ensure the new heap_top is <= HEAP_END
+            dup.0 u32lte.HEAP_END
+            if.true
+                # Write updated heap information, and return the old heap size (in pages)
+                mem_store.HEAP_INFO_TOP   # [new_heap_size, heap_size]
+                mem_store.HEAP_INFO_SIZE  # [heap_size]
+            else
+                # Overflow, drop the changes and return -1
+                drop drop drop
+                push.NEG1
+            end
         end
     end
 end
@@ -119,170 +132,100 @@ export.extract_element # [element_index, w3, w2, w1, w0]
     movup.2 cdrop
 end
 
-# See `load_felt` for safe usage
-proc.load_felt_unchecked # [waddr, index]
-    # prepare the stack to receive the loaded word
-    # [waddr, 0, 0, 0, 0, index]
-    padw movup.4
-    # load the word which contains the desired element
-    mem_loadw  # [w3, w2, w1, w0, index]
-
-    # select the desired element
-    movup.4
-    exec.extract_element
-end
-
 # Load a field element from the given native pointer triplet.
 #
-# A native pointer triplet consists of a word address which contains the
-# start of the data; an element index, which indicates which element of
-# the word the data starts in; and a byte offset, which indicates which
-# byte is the start of the data.
+# A native pointer tuple consists of an element address where the data begins, and a byte offset,
+# which is the offset of the first byte, in the 32-bit representation of that element.
 #
 # A field element must be naturally aligned, i.e. it's byte offset must be zero.
-export.load_felt # [waddr, index, offset]
+export.load_felt # [addr, offset]
     # assert the pointer is felt-aligned, then load
-    movup.2 assertz exec.load_felt_unchecked
+    swap.1 assertz mem_load
 end
 
-# Load a single 32-bit machine word from the given native pointer triplet.
+# Load a single 32-bit machine word from the given native pointer tuple.
 #
-# A native pointer triplet consists of a word address which contains the
-# start of the data; an element index, which indicates which element of
-# the word the data starts in; and a byte offset, which indicates which
-# byte is the start of the data.
-export.load_sw # [waddr, index, offset]
+# A native pointer tuple consists of an element address where the data begins, and a byte offset,
+# which is the offset of the first byte, in the 32-bit representation of that element.
+export.load_sw # [addr, offset]
     # check for alignment and offset validity
-    dup.2 eq.0
-    dup.3 push.8 u32lt assert # offset must be < 8
+    dup.1 eq.0                # [offset == 0, addr, offset]
+    # offset must be < 4
+    dup.2 push.4 u32lt assert # [offset == 0, addr, offset]
     # if the pointer is naturally aligned..
-    if.true
+    if.true  # [addr, offset]
         # drop the byte offset
-        movup.2 drop
+        swap.1 drop
         # load the element containing the data we want
-        exec.load_felt_unchecked
-    else
-        # check if the load starts in the first element
-        dup.1 eq.0
-        if.true
-            # the load is across both the first and second elements
-            # drop the element index
-            swap.1 drop
-            # load
-            padw movup.4 mem_loadw # [w3, w2, w1, w0, offset]
-            # drop the unused elements
-            drop drop
-            # shift low bits
-            push.32 dup.3 # [offset, 32, w1, w0, offset]
-            u32overflowing_sub assertz # [32 - offset, w1, w0, offset]
-            u32shr        # [lo, w0, offset]
-            # shift high bits left by the offset
-            swap.2        # [offset, w0, lo]
-            u32shl        # [hi, lo]
-            # combine the two halves
-            u32or         # [result]
-        else
-            # check if the load starts in the second element
-            dup.1 eq.1
-            if.true
-                # the load is across both the second and third elements
-                # drop the element idnex
-                swap.1 drop
-                # load
-                padw movup.4 mem_loadw # [w3, w2, w1, w0, offset]
-                # drop the unused elements
-                drop movup.2 drop      # [w2, w1, offset]
-                # shift the low bits
-                push.32 dup.3          # [offset, 32, w2, w1, offset]
-                u32overflowing_sub assertz # [32 - offset, w2, w1, offset]
-                u32shr                 # [lo, w1, offset]
-                # shift high bits left by the offset
-                swap.2                 # [offset, w1, lo]
-                u32shl                 # [hi, lo]
-                # combine the two halves
-                u32or                  # [result]
-            else
-                # check if the load starts in the third element
-                swap.1 eq.2
-                if.true
-                    # the load is across both the third and fourth elements
-                    padw movup.4 mem_loadw    # [w3, w2, w1, w0, offset]
-                    # drop the unused elements
-                    movup.3 movup.3 drop drop # [w3, w2, offset]
-                    # shift the low bits
-                    push.32 dup.3             # [offset, 32, w3, w2, offset]
-                    u32overflowing_sub assertz # [32 - offset, w3, w2, offset]
-                    u32shr                    # [lo, w2, offset]
-                    # shift the high bits left by the offset
-                    swap.2                    # [offset, w2, lo]
-                    u32shl                    # [hi, lo]
-                    # combine the two halves
-                    u32or  # [result]
-                else
-                    # the load crosses a word boundary
-                    # start with the word containing the low bits
-                    dup.0                        # [waddr, waddr, offset]
-                    u32overflowing_add.1 assertz # [waddr + 1, waddr, offset]
-                    # load the low bits
-                    mem_load                   # [w0, waddr, offset]
-                    # shift the low bits
-                    push.32 dup.3              # [offset, 32, w0, waddr, offset]
-                    u32overflowing_sub assertz # [32 - offset, w0, waddr, offset]
-                    u32shr                     # [lo, waddr, offset]
-                    # load the word with the high bits, drop unused elements
-                    swap.1 padw movup.4 mem_loadw movdn.3 drop drop drop # [w3, lo, offset]
-                    # shift high bits
-                    movup.2 u32shl             # [hi, lo]
-                    # combine the two halves
-                    u32or                      # [result]
-                end
-            end
-        end
+        mem_load
+    else     # [addr, offset]
+        # the load crosses an element boundary
+        #
+        # 1. load the first element
+        dup.0 mem_load   # [e0, addr, offset]
+        # 2. load the second element
+        swap.1           # [addr, e0, offset]
+        push.1 u32overflowing_add  # [overflowed, addr + 1, e0, offset]
+        assertz mem_load # [e1, e0, offset]
+        # shift low bits
+        push.32 dup.3 # [offset, 32, e1, e0, offset]
+        u32overflowing_sub assertz # [32 - offset, e1, e0, offset]
+        u32shr        # [lo, e0, offset]
+        # shift high bits left by the offset
+        swap.2        # [offset, e0, lo]
+        u32shl        # [hi, lo]
+        # combine the two halves
+        u32or         # [result]
     end
 end
 
-# This handles emitting code that handles aligning an unaligned double
-# machine-word value which is split across three machine words (field elements).
+# This handles emitting code that handles aligning an unaligned 64-bit value which is split across
+# three elements.
 #
-# To recap:
+# To recap our terminology and memory mapping spec:
 #
-# * A machine word is a 32-bit chunk stored in a single field element
-# * A double word is a pair of 32-bit chunks
-# * A quad word is a quartet of 32-bit chunks (i.e. a Miden "word")
-# * An unaligned double-word requires three 32-bit chunks to represent,
-# since the first chunk does not contain a full 32-bits, so an extra is
-# needed to hold those bits.
+# * A Miden "word" is a quartet of field elements, capable of representing 16 bytes
+# * A machine word is a 32-bit chunk stored in a single field element. The term "machine" here
+#   refers to the fact that the abstract machine presented by the compiler IR is a 32-bit machine,
+#   where the "native" integral type is a 32-bit integer. In typical compiler parlance, a "machine
+#   word" refers to the default integer type of a machine's general purpose registers.
+# * A double word is a pair of 32-bit chunks, i.e. a single 64-bit value.
+# * A quad word is a quartet of 32-bit chunks (and naturally corresponds to a Miden "word")
+# * An unaligned double-word requires three 32-bit chunks to represent, since the first chunk does
+#   not contain a full 32-bits, so an extra is needed to hold those bits.
 #
-# As an example, assume the pointer we are dereferencing is a u64 value,
-# which has 8-byte alignment, and the value is stored 40 bytes from the
-# nearest quad-word-aligned boundary. To load the value, we must fetch
-# the full quad-word from the aligned address, drop the first word, as
-# it is unused, and then recombine the 64 bits we need spread across
-# the remaining three words to obtain the double-word value we actually want.
+# As an example, assume the pointer we are dereferencing is a u64 value, which has 8-byte
+# alignment, and the value is stored 40 bytes from the nearest element address divisible by 4
+# (i.e. Miden word-aligned). To load the value, we must fetch the full Miden word from that
+# address, drop the first element, as it is unused, and then recombine the 64 bits we need spread
+# across the remaining three elements to obtain the double-word value we actually want.
 #
 # The data, on the stack, is shown below:
 #
-# If we visualize which bytes are contained in each 32-bit chunk on the stack,
-# when loaded by `mem_loadw`, we get:
+# If we visualize which bytes are contained in each 32-bit chunk on the stack, when loaded by
+# `mem_loadw`, we get:
 #
 #     [<unused>, 9..=12, 5..=8, 0..=4]
 #
-# These byte indices are relative to the nearest word-aligned address, in the
-# same order as they would occur in a byte-addressable address space. The
-# significance of each byte depends on the value being dereferenced, but Miden
-# is a little-endian machine, so typically the most significant bytes come first
-# (i.e. also commonly referred to as "high" vs "low" bits).
+# These byte indices are relative to the nearest Miden word-aligned address, in the same order as
+# they would occur in a byte-addressable address space. The significance of each byte depends on
+# the value being dereferenced, but Miden is a little-endian machine, so typically the most
+# significant bytes come first (i.e. also commonly referred to as "high" vs "low" bits).
 #
-# If we visualize the layout of the bits of our u64 value spread across the
-# three chunks, we get:
+# If we visualize the layout of the bits of our u64 value spread across the three chunks, we get:
 #
-#     [<unused>, 00000000111111111111111111111111, 111111111111111111111111111111, 11111111111111111111111100000000]
+#     [
+#         <unused>,
+#         00000000111111111111111111111111,
+#         111111111111111111111111111111,
+#         11111111111111111111111100000000
+#     ]
 #
-# As illustrated above, what should be a double-word value is occupying three words.
-# To "realign" the value, i.e. ensure that it is naturally aligned and fits in two
-# words, we have to perform a sequence of shifts and masks to get the bits where
-# they belong. This function performs those steps, with the assumption that the caller
-# has three values on the operand stack representing any unaligned double-word value
+# As illustrated above, what should be a double-word value is occupying three elements. To
+# "realign" the value, i.e. ensure that it is naturally aligned and fits in two elements, we have
+# to perform a sequence of shifts and masks to get the bits where they belong. This function
+# performs those steps, with the assumption that the caller has three values on the operand stack
+# representing any unaligned double-word value
 export.realign_dw # [chunk_hi, chunk_mid, chunk_lo, offset]
     # We will refer to the parts of our desired double-word value
     # as two parts, `x_hi` and `x_lo`.
@@ -342,7 +285,8 @@ export.realign_dw # [chunk_hi, chunk_mid, chunk_lo, offset]
     swap.1 # [x_hi, x_lo]
 end
 
-# Shift a double-word (64-bit, in two 32-bit chunks) value by the given offset
+# Shift a double-word (64-bit, in two 32-bit chunks) value by the given offset.
+#
 # Returns three 32-bit chunks [chunk_lo, chunk_mid, chunk_hi]
 export.offset_dw # [value_hi, value_lo, offset]
     dup.0
@@ -359,114 +303,39 @@ export.offset_dw # [value_hi, value_lo, offset]
     u32shl       # [ chunk_lo, chunk_mid, chunk_hi]
 end
 
-# Load a pair of machine words (32-bit elements) to the operand stack
-export.load_dw # [waddr, index, offset]
+# Load a machine double-word (64-bit value, in two 32-bit chunks) to the operand stack
+export.load_dw # [addr, offset]
     # check for alignment and offset validity
-    dup.2 eq.0
-    dup.3 push.8 u32lt assert # offset must be < 8
-    # convert offset from bytes to bits
-    movup.3 push.8 u32wrapping_mul movdn.3 # [waddr, index, offset, value_hi, value_lo]
+    dup.1 eq.0                # [offset == 0, addr, offset]
+    # offset must be < 4
+    dup.2 push.4 u32lt assert # [offset == 0, addr, offset]
     # if the pointer is naturally aligned..
     if.true
-        # drop byte offset
-        movup.2 drop # [waddr, index]
-        # check which element to start at
-        dup.1 eq.0
-        if.true
-            # drop index
-            swap.1 drop # [waddr]
-            # load first two elements
-            padw movup.4 mem_loadw # [w3, w2, w1, w0]
-            # drop last two elements, and we're done
-            drop drop swap.1       # [w0, w1]
-        else
-          dup.1 eq.1
-          if.true
-              # drop index
-              swap.1 drop # [waddr]
-              # load second and third elements
-              padw movup.4 mem_loadw   # [w3, w2, w1, w0]
-              # drop unused elements, and we're done
-              movup.3 drop drop swap.1 # [w1, w2]
-          else
-              swap.1 eq.2
-              if.true
-                # load third and fourth elements, drop unused, and we're done
-                padw movup.4 mem_loadw           # [w3, w2, w1, w0]
-                movup.3 movup.3 drop drop swap.1 # [w2, w3]
-              else
-                # load first element of next word
-                dup.0 u32overflowing_add.1 assertz # [waddr + 1, waddr]
-                mem_load                           # [w0, waddr]
-                # load fourth element, and we're done
-                swap.1 padw movup.4 mem_loadw      # [w3, w2, w1, w0, lo]
-                movdn.3 drop drop drop             # [hi, lo]
-              end
-          end
-        end
-    else # unaligned; an unaligned double-word spans three elements
-        # check if we start in the first element
-        dup.1 eq.0
-        if.true
-            # memory layout: [<unused>, lo, mid, hi]
-            # drop the index
-            swap.1 drop  # [waddr, offset]
-            # load three elements containing the double-word on the stack
-            padw movup.4 mem_loadw # [w3, w2, w1, w0, offset]
-            drop                   # [w2, w1, w0, offset]
-            # move into stack order (hi bytes first)
-            swap.2                 # [w0, w1, w2, offset]
-            # re-align it, and we're done; realign_dw gets [w0, w1, w2, offset]
-            exec.realign_dw
-        else
-            # check if we start in the second element
-            dup.1 eq.1
-            if.true
-                # memory layout: [lo, mid, hi, <unused>]
-                # drop the index
-                swap.1 drop
-                # load three elements containing the double-word on the stack
-                padw movup.4 mem_loadw # [w3, w2, w1, w0, offset]
-                movup.3 drop           # [w3, w2, w1, offset]
-                # move into stack order
-                swap.2                 # [w1, w2, w3, offset]
-                # re-align it, and we're done; realign_dw gets [w1, w2, w3, offset]
-                exec.realign_dw
-            else
-                # check if we start in the third element
-                swap.1 eq.2 # [waddr, offset]
-                if.true
-                    # memory layout: [mid, hi, ..] [<unused>, <unused>, <unused>, lo]
-                    # load one element from the next word
-                    dup.0 u32overflowing_add.1 assertz # [waddr + 1, waddr, offset]
-                    mem_load            # [chunk_lo, waddr, offset]
-                    # load two elements from the first word
-                    padw movup.5        # [waddr, 0, 0, 0, 0, chunk_lo, offset]
-                    mem_loadw           # [chunk_mid, chunk_hi, ?, ?, chunk_lo, offset]
-                    swap.3 drop         # [chunk_hi, ?, chunk_mid, chunk_lo, offset]
-                    swap.1 drop         # [chunk_hi, chunk_mid, chunk_lo, offset]
-                    # re-align it, and we're done
-                    exec.realign_dw
-                else
-                    # memory layout: [hi, ..], [<unused>, <unused>, lo, mid]
-                    # load the two least-significant elements from the next word first
-                    dup.0 u32overflowing_add.1 assertz # [waddr + 1, waddr, offset]
-                    padw movup.4         # [waddr + 1, 0, 0, 0, 0, waddr, offset]
-                    mem_loadw drop drop  # [lo, mid, waddr, offset]
-                    swap.1 # [mid, lo, waddr, offset]
-                    # load the most significant element from the first word
-                    padw movup.6 # [waddr, 0, 0, 0, 0, mid, lo, offset]
-                    mem_loadw movdn.3 drop drop drop # [hi, mid, lo, offset]
-                    # re-align it, and we're done
-                    exec.realign_dw
-                end
-            end
-        end
+        # drop offset
+        swap.1 drop            # [addr]
+        # load second element
+        dup.0 push.1 u32overflowing_add assertz # [addr + 1, addr]
+        mem_load               # [e1, addr]
+        # load first element
+        swap.1 mem_load        # [e0, e1]
+    else
+        # unaligned; an unaligned double-word spans three elements
+        #
+        # convert offset from bytes to bits
+        swap.1 push.8 u32wrapping_mul swap.1              # [addr, bit_offset]
+
+        # load the three elements containing the double-word on the stack
+        dup.0 push.2 u32overflowing_add assertz mem_load  # [e2, addr, bit_offset]
+        dup.1 push.1 add mem_load                         # [e1, e2, addr, bit_offset]
+        movup.2 mem_load                                  # [e0, e1, e2, bit_offset]
+
+        # re-align it, and we're done
+        exec.realign_dw
     end
 end
 
-# Given an element index, a new element, and a word, in that order, replace the element
-# at the specified index, leaving the modified word on top of the stack
+# Given an element index, a new element, and a word, in that order, replace the element at the
+# specified index, leaving the modified word on top of the stack
 #
 # The element index must be in the range 0..=3.
 export.replace_element # [element_index, value, w3, w2, w1, w0]
@@ -488,325 +357,210 @@ export.replace_element # [element_index, value, w3, w2, w1, w0]
     movdn.3               # [w3', w2', w1', w0']
 end
 
-# See `store_felt` for safe usage
-proc.store_felt_unchecked # [waddr, index, value]
-    # prepare the stack to receive the loaded word
-    # [waddr, 0, 0, 0, 0, waddr, index, value]
-    padw dup.4
-    # load the original word
-    mem_loadw  # [w3, w2, w1, w0, waddr, index, value]
-
-    # rewrite the desired element
-    movup.6 # [value, w3, w2, w1, w0, waddr, index]
-    movup.6 # [index, value, w3, w2, w1, w0, waddr]
-    exec.replace_element # [w3', w2', w1', w0', waddr]
-
-    # store the updated word
-    movup.4 mem_storew
-    dropw
-end
-
-# Store a field element to the given native pointer triplet.
+# Store a field element to the given native pointer tuple.
 #
-# A native pointer triplet consists of a word address which contains the
-# start of the data; an element index, which indicates which element of
-# the word the data starts in; and a byte offset, which indicates which
-# byte is the start of the data.
+# A native pointer tuple consists of an element address where the data begins, and a byte offset,
+# which is the offset of the first byte, in the 32-bit representation of that element.
 #
 # A field element must be naturally aligned, i.e. it's byte offset must be zero.
-export.store_felt # [waddr, index, offset, value]
+export.store_felt # [addr, offset, value]
     # assert the pointer is felt-aligned, then load
-    movup.2 assertz exec.store_felt_unchecked
+    swap.1 assertz mem_store
 end
 
-# Store a single 32-bit machine word from the given native pointer triplet.
+# Store a single 32-bit machine word from the given native pointer tuple.
 #
-# A native pointer triplet consists of a word address which contains the
-# start of the data; an element index, which indicates which element of
-# the word the data starts in; and a byte offset, which indicates which
-# byte is the start of the data.
-export.store_sw # [waddr, index, offset, value]
+# A native pointer tuple consists of an element address where the data begins, and a byte offset,
+# which is the offset of the first byte, in the 32-bit representation of that element.
+export.store_sw # [addr, offset, value]
     # check for alignment and offset validity
-    dup.2 eq.0
-    dup.3 push.8 u32lt assert # offset must be < 8
+    dup.1 eq.0                # [offset == 0, addr, offset, value]
+    # offset must be < 4
+    dup.2 push.4 u32lt assert
     # if the pointer is naturally aligned..
-    if.true
+    if.true           # [addr, offset, value]
         # drop the byte offset
-        movup.2 drop
-        # load the element containing the data we want
-        exec.store_felt_unchecked
+        swap.1 drop   # [addr, value]
+        # store the element
+        mem_store     # []
     else
-        # check if the store starts in the first element
-        dup.1 eq.0
-        if.true
-            # the store is across both the first and second elements
-            # drop the element index
-            swap.1 drop
-            # load current value
-            padw dup.4 mem_loadw # [w3, w2, w1, w0, waddr, offset, value]
+        # convert offset to bits
+        swap.1 push.8 u32wrapping_mul swap.1   # [addr, bit_offset]
 
-            # compute the bit shift
-            push.32 dup.6 sub    # [rshift, w3..w0, waddr, offset, value]
+        # the store is across an element boundary
+        #
+        # load the current value of the two elements involved
+        dup.0 push.1 u32overflowing_add assertz mem_load # [e1, addr, bit_offset, value]
+        dup.1 mem_load    # [e0, e1, addr, bit_offset, value]
 
-            # compute the masks
-            push.4294967295 dup.1 u32shl  # [mask_hi, rshift, w3..w0, waddr, offset, value]
-            dup.0 u32not                  # [mask_lo, mask_hi, rshift, w3, w2, w1, w0, waddr, offset, value]
+        # compute the bit shift
+        push.32 dup.4 sub # [32 - bit_offset, e0, e1, addr, bit_offset, value]
 
-            # manipulate the bits of the two target elements, such that the 32-bit word
-            # we're storing is placed at the correct offset from the start of the memory
-            # cell when viewing the cell as a set of 4 32-bit chunks
-            movup.5 u32and         # [w1_masked, mask_hi, rshift, w3, w2, w0, waddr, offset, value]
-            movup.5 movup.2 u32and # [w0_masked, w1_masked, rshift, w3, w2, waddr, offset, value]
+        # compute the masks
+        push.4294967295 dup.1 u32shl  # [mask_hi, rshift, e0, e1, addr, bit_offset, value]
+        dup.0 u32not                  # [mask_lo, mask_hi, rshift, e0, e1, addr, bit_offset, value]
 
-            # now, we need to shift/mask/split the 32-bit value into two elements, then
-            # combine them with the preserved bits of the original contents of the cell
-            #
-            # first, the contents of w0
-            dup.7 movup.7 u32shr u32or   # [w0', w1_masked, rshift, w3..w2, waddr, value]
-            # then the contents of w1
-            swap.1
-            movup.6 movup.3 u32shl u32or # [w1', w0', w3, w2, waddr]
+        # manipulate the bits of the two target elements, such that the 32-bit word we're storing
+        # is placed at the correct offset from the start of the memory cell when viewing the cell
+        # as a set of 4 32-bit chunks
+        movup.4 u32and         # [e1_masked, mask_hi, rshift, e0, addr, bit_offset, value]
+        movup.3 movup.2 u32and # [e0_masked, e1_masked, rshift, addr, bit_offset, value]
 
-            # ensure word is in order
-            movup.3 movup.3              # [w3, w2, w1', w0', waddr]
+        # now, we need to shift/mask/split the 32-bit value into two elements, then
+        # combine them with the preserved bits of the original contents of the cell
+        #
+        # first, the contents of e0
+        dup.7 movup.7    # [bit_offset, value, e0_masked, e1_masked, rshift, addr, value]
+        u32shr           # [value >> bit_offset, e0_masked, e1_masked, rshift, addr, value]
+        u32or            # [e0', e1_masked, rshift, addr, value]
+        # then the contents of w1
+        swap.1           # [e1_masked, e0', rshift, addr, value]
+        movup.4          # [value, e1_masked, e0', rshift, addr]
+        movup.3          # [rshift, value, e1_masked, e0', addr]
+        u32shl           # [value << rshift, e1_masked, e0', addr]
+        u32or            # [e1', e0', addr]
 
-            # finally, write back the updated word, and clean up the operand stack
-            movup.4 mem_storew dropw
-        else
-            # check if the load starts in the second element
-            dup.1 eq.1
-            if.true
-                # the load is across both the second and third elements
-                # drop the element index
-                swap.1 drop
-
-                # load current value
-                padw dup.4 mem_loadw # [w3, w2, w1, w0, waddr, offset, value]
-
-                # compute the bit shift
-                push.32 dup.6 sub    # [rshift, w3..w0, waddr, offset, value]
-
-                # compute the masks
-                push.4294967295 dup.1 u32shl  # [mask_hi, rshift, w3..w0, waddr, offset, value]
-                dup.0 u32not                  # [mask_lo, mask_hi, rshift, w3, w2, w1, w0, waddr, offset, value]
-
-                # manipulate the bits of the two target elements, such that the 32-bit word
-                # we're storing is placed at the correct offset from the start of the memory
-                # cell when viewing the cell as a set of 4 32-bit chunks
-                movup.4 u32and         # [w2_masked, mask_hi, rshift, w3, w1, w0, waddr, offset, value]
-                movup.4 movup.2 u32and # [w1_masked, w2_masked, rshift, w3, w0, waddr, offset, value]
-
-                # now, we need to shift/mask/split the 32-bit value into two elements, then
-                # combine them with the preserved bits of the original contents of the cell
-                #
-                # first, the contents of w1
-                dup.7 movup.7 u32shr u32or   # [w1', w2_masked, rshift, w3, w0, waddr, value]
-                # then the contents of w2
-                swap.1
-                movup.6 movup.3 u32shl u32or # [w2', w1', w3, w0, waddr]
-
-                # ensure the elements are in order
-                movup.3 swap.3  # [w3, w2', w1', w0, waddr]
-
-                # finally, write back the updated word, and clean up the operand stack
-                movup.4 mem_storew dropw
-            else
-                # check if the load starts in the third element
-                swap.1 eq.2
-                if.true
-                    # the load is across both the third and fourth elements
-                    # load current value
-                    padw dup.4 mem_loadw # [w3, w2, w1, w0, waddr, offset, value]
-
-                    # compute the bit shift
-                    push.32 dup.6 sub    # [rshift, w3..w0, waddr, offset, value]
-
-                    # compute the masks
-                    push.4294967295 dup.1 u32shl  # [mask_hi, rshift, w3..w0, waddr, offset, value]
-                    dup.0 u32not                  # [mask_lo, mask_hi, rshift, w3, w2, w1, w0, waddr, offset, value]
-
-                    # manipulate the bits of the two target elements, such that the 32-bit word
-                    # we're storing is placed at the correct offset from the start of the memory
-                    # cell when viewing the cell as a set of 4 32-bit chunks
-                    movup.3 u32and         # [w3_masked, mask_hi, rshift, w2, w1, w0, waddr, offset, value]
-                    movup.3 movup.2 u32and # [w2_masked, w3_masked, rshift, w1, w0, waddr, offset, value]
-
-                    # now, we need to shift/mask/split the 32-bit value into two elements, then
-                    # combine them with the preserved bits of the original contents of the cell
-                    #
-                    # first, the contents of w2
-                    dup.7 movup.7 u32shr u32or   # [w2', w3_masked, rshift, w1, w0, waddr, value]
-                    # then the contents of w3
-                    swap.1
-                    movup.6 movup.3 u32shl u32or # [w3', w2', w1, w0, waddr]
-
-                    # finally, write back the updated word, and clean up the operand stack
-                    movup.4 mem_storew dropw
-                else
-                    # the load crosses a word boundary, start with the word containing the highest-addressed bits
-
-                    # compute the address for the second word
-                    dup.0  # [waddr, waddr, offset, value]
-                    u32overflowing_add.1 assertz # [waddr + 1, waddr, offset, value]
-
-                    # load the element we need to mix bits with
-                    mem_load  # [w0, waddr, offset, value]
-
-                    # compute the bit shift
-                    push.32 dup.3 sub    # [rshift, w0, waddr, offset, value]
-
-                    # compute the masks
-                    push.4294967295 dup.1 u32shl  # [mask_hi, rshift, w0, waddr, offset, value]
-                    dup.0 u32not                  # [mask_lo, mask_hi, rshift, w0, waddr, offset, value]
-
-                    # mask out the bits of the value that are being overwritten
-                    movup.3 u32and # [w0', mask_hi, rshift, waddr, offset, value]
-
-                    # extract the bits to be stored in this word
-                    dup.5 movup.3 u32shl u32or # [w0'', mask_hi, waddr, offset, value]
-
-                    # store the updated element
-                    dup.2 add.1 # [waddr + 1, w0'', mask_hi, waddr, offset, value]
-                    mem_store # [mask_hi, waddr, offset, value]
-
-                    # next, update the last element of the lowest addressed word
-                    padw dup.5 mem_loadw # [w3, w2, w1, w0, mask_hi, waddr, offset, value]
-
-                    # mask out the bits of the value that are being overwritten
-                    movup.4 u32and # [w3_masked, w2, w1, w0, waddr, offset, value]
-
-                    # extract the bits to be stored in this word and combine them
-                    movup.6 movup.6 u32shr u32or # [w3', w2, w1, w0, waddr]
-
-                    # write updated word
-                    movup.4 mem_storew
-
-                    # clean up operand stack
-                    dropw
-                end
-            end
-        end
+        # finally, write back the updated elements
+        dup.2 add.1 mem_store  # [e0', addr]
+        swap.1 mem_store       # []
     end
 end
 
-# Store a double 32-bit machine word from the given native pointer triplet.
+# Store a 64-bit value, i.e. two 32-bit machine words from the given native pointer tuple.
 #
-# A native pointer triplet consists of a word address which contains the
-# start of the data; an element index, which indicates which element of
-# the word the data starts in; and a byte offset, which indicates which
-# byte is the start of the data.
-export.store_dw # [waddr, index, offset, value_hi, value_lo]
+# A native pointer tuple consists of an element address where the data begins, and a byte offset,
+# which is the offset of the first byte, in the 32-bit representation of that element.
+export.store_dw # [addr, offset, value_hi, value_lo]
     # check for alignment and offset validity
-    dup.2 eq.0
-    dup.3 push.8 u32lt assert # offset must be < 8
-    # convert offset from bytes to bits
-    movup.3 push.8 u32wrapping_mul movdn.3 # [offset == 0, waddr, index, offset, value_hi, value_lo]
+    dup.1 eq.0   # [offset == 0, addr, offset]
+    # offset must be < 4
+    dup.2 push.4 u32lt assert
     # if the pointer is naturally aligned..
-    if.true
+    if.true  # [addr, offset, value_hi, value_lo]
         # drop byte offset
-        movup.2 drop # [waddr, index, value_hi, value_lo]
-        # check which element to start at
-        dup.1 eq.0
-        if.true
-            # drop index
-            swap.1 drop    # [waddr, value_hi, value_lo]
-            swap.2         # [value_lo, value_hi, waddr]
-            padw dup.6 mem_loadw # [w3, w2, w1, w0, value_lo, value_hi, waddr]
-            swap.2 drop    # [w2, w3, w0, value_lo, value_hi, waddr]
-            swap.2 drop    # [w3, w2, value_lo, value_hi, waddr]
-            movup.4        # [waddr, w3, w2, value_lo, value_hi]
-            mem_storew
-            # cleanup the operand stack
-            dropw
-        else
-            dup.1 eq.1
-            if.true
-                # drop index
-                swap.1 drop      # [waddr, value_hi, value_lo]
-                # store as the second and third elements of the word
-                swap.2           # [value_lo, value_hi, waddr]
-                padw dup.6 mem_loadw # [w3, w2, w1, w0, value_lo, value_hi, waddr]
-                movup.4 swap.2 drop  # [w3, value_lo, w1, w0, value_hi, waddr]
-                movup.4 swap.3 drop  # [w3, value_lo, value_hi, w0, waddr]
-                movup.4 mem_storew
-                # cleanup the operand stack
-                dropw
-            else
-                swap.1 eq.2
-                if.true
-                    # store as the third and fourth elements of the word
-                    swap.2                   # [value_lo, value_hi, waddr]
-                    padw dup.6 mem_loadw     # [w3, w2, w1, w0, value_lo, value_hi, waddr]
-                    movup.5 swap.2 drop      # [w3, value_hi, w1, w0, value_lo, waddr]
-                    drop movup.3             # [value_lo, value_hi, w1, w0, waddr]
-                    movup.4 mem_storew
-                    # cleanup the operand stack
-                    dropw
-                else
-                    # store the first element of the next word
-                    swap.2                             # [value_lo, value_hi, waddr]
-                    dup.2 u32overflowing_add.1 assertz # [waddr + 1, value_lo, value_hi, waddr]
-                    mem_store  # [value_hi, waddr]
-                    # store the fourth element
-                    padw dup.5 mem_loadw  # [w3, w2, w1, w0, value_hi, waddr]
-                    drop movup.3 movup.4  # [waddr, value_hi, w2, w1, w0]
-                    mem_storew dropw
-                end
-            end
-        end
-    else # unaligned; an unaligned double-word spans three elements
-        # [waddr, index, offset, value_hi, value_lo]
-        movup.2 # [offset, waddr, index, value_hi, value_lo]
-        movup.4 # [value_lo, offset, waddr, index, value_hi]
-        movup.4 # [value_hi, value_lo, offset, waddr, index]
-        exec.offset_dw # [chunk_lo, chunk_mid, chunk_hi, waddr, index]
-        movup.4 # [index, chunk_lo, chunk_mid, chunk_hi, waddr]
-        # check if we start in the first element
-        dup.0 eq.0
-        if.true
-            # target memory layout: [0, lo, mid, hi]
-            # drop the index
-            drop                 # [lo, mid, hi, waddr]
-            padw dup.7 mem_loadw # [w3, w2, w1, w0, lo, mid, hi, waddr]
-            movdn.3        # [w2, w1, w0, w3, lo, mid, hi, waddr]
-            drop drop drop # [w3, lo, mid, hi, waddr]
-            movup.4 mem_storew
-            dropw
-        else
-            # check if we start in the second element
-            dup.0 eq.1
-            if.true
-                # target memory layout: [lo, mid, hi, 0]
-                # drop the index
-                drop           # [lo, mid, hi, waddr]
-                padw dup.7 mem_loadw # [w3, w2, w1, w0, lo, mid, hi, waddr]
-                drop drop drop # [w0, lo, mid, hi, waddr]
-                movdn.3        # [lo, mid, hi, w0, waddr]
-                movup.4 mem_storew
-                dropw
-            else
-                # check if we start in the third element
-                eq.2 # [lo, mid, hi, waddr]
-                if.true
-                    # target memory layout: [mid, hi, ..], [..lo]
-                    padw dup.7 mem_loadw # [w3, w2, w1, w0, lo, mid, hi, waddr]
-                    drop drop movup.4 movup.4 # [mid, hi, w1, w0, lo, waddr]
-                    dup.5 mem_storew dropw # [lo, waddr]
-                    swap.1 u32overflowing_add.1 assertz # [waddr + 1, lo]
-                    mem_store
-                else
-                    # target memory layout: [hi, ..], [..lo, mid]
-                    padw dup.7 mem_loadw # [w3, w2, w1, w0, lo, mid, hi, waddr]
-                    drop movup.5 # [hi, w2, w1, w0, lo, mid, waddr]
-                    dup.6 mem_storew dropw # [lo, mid, waddr]
-                    movup.2 u32overflowing_add.1 assertz # [waddr + 1, lo, mid]
-                    dup.0 movdn.3 # [waddr + 1, lo, mid, waddr + 1]
-                    padw movup.4 mem_loadw # [w3, w2, w1, w0, lo, mid, waddr + 1]
-                    movup.5 swap.4 drop # [w3, w2, w1, mid, lo, waddr + 1]
-                    movup.4 swap.3 drop # [w3, w2, lo, mid, waddr + 1]
-                    movup.4 mem_storew dropw
-                end
-            end
-        end
+        swap.1 drop   # [addr, value_hi, value_lo]
+        swap.1 dup.1  # [addr, value_hi, addr, value_lo]
+        mem_store     # [addr, value_lo]
+        push.1 u32overflowing_add assertz # [addr + 1, value_lo]
+        mem_store
+    else     # [addr, offset, value_hi, value_lo]
+        # unaligned; an unaligned double-word spans three elements
+        #
+        # convert offset from bytes to bits
+        swap.1 push.8 u32wrapping_mul swap.1   # [addr, bit_offset, value_hi, value_lo]
+        movdn.3        # [bit_offset, value_hi, value_lo, addr]
+        dup.0 movdn.4  # [bit_offset, value_hi, value_lo, addr, bit_offset]
+        movdn.2        # [value_hi, value_lo, bit_offset, addr, bit_offset]
+        exec.offset_dw # [chunk_lo, chunk_mid, chunk_hi, addr, bit_offset]
+
+        # compute the bit shift
+        push.32 movup.5 sub           # [32 - bit_offset, lo, mid, hi, addr]
+
+        # compute the masks
+        push.4294967295 swap.1 u32shl # [mask_hi, lo, mid, hi, addr]
+        dup.0 u32not                  # [mask_lo, mask_hi, lo, mid, hi, addr]
+
+        # combine the bits of the lo and hi chunks with their corresponding elements, so that we
+        # do not overwrite memory that is out of bounds of the actual value being stored.
+        #
+        # 1. load e2 (lo)
+        dup.5 push.2 u32overflowing_add assertz mem_load
+        # 2. mask e2 (lo)
+        u32and                       # [e2_masked, mask_hi, lo, mid, hi, addr]
+        # 3. load e0 (hi)
+        dup.5 mem_load               # [e0, e2_masked, mask_hi, lo, mid, hi, addr]
+        # 4. mask e0 (hi)
+        movup.2 u32and               # [e0_masked, e2_masked, lo, mid, hi, addr]
+        # 5. combine e2 & lo
+        movdn.2 u32or                # [e2', e0_masked, mid, hi, addr]
+        # 6. store e2
+        dup.4 add.2 mem_store        # [e0_masked, mid, hi, addr]
+        # 7. store e1 (mid)
+        swap.1 dup.3 add.1 mem_store # [e0_masked, hi, addr]
+        # 8. combine e0 & hi
+        u32or                        # [e0', addr]
+        # 9. store e0
+        swap.1 mem_store             # []
     end
+end
+
+# Write `count` copies of `value` to memory, starting at `dst`.
+#
+# * `dst` is expected to be an address in byte-addressable space, _not_ an element address.
+# * `value` must be a 32-bit value or smaller
+export.memset_sw # [size, dst, count, value]
+    # prepare to loop until `count` iterations have been performed
+    push.0        # [i, dst, size, count, value]
+    dup.3         # [count, i, dst, size, count, value]
+    push.0 u32gte # [count > 0, i, dst, size, count, value]
+
+    # compute address for next value to be written
+    while.true  # [i, dst, size, count, value]
+        # offset the pointer by the current iteration count * aligned size of value, and trap
+        # if it overflows
+        dup.1  # [dst, i, dst, size, count, value]
+        dup.1  # [i, dst, i, dst, size, count, value]
+        dup.4  # [size, i, dst, i, dst, size, count, value]
+        u32overflowing_madd assertz # [size * i + dst, i, dst, size, count, value]
+
+        # copy value to top of stack, swap with pointer
+        dup.5     # [value, dst', i, dst, size, count, value]
+        swap.1    # [dst', value, i, dst, size, count, value]
+
+        # convert pointer to native representation
+        u32divmod.4 swap.1  # [dst', dst_offset', value, i, dst, size, count, value]
+
+        # write value to destination
+        exec.store_sw       # [i, dst, size, count, value]
+
+        # increment iteration count, determine whether to continue the loop
+        push.1 u32overflowing_add assertz  # [i++, dst, size, count, value]
+        dup.0     # [i++, i++, dst, size, count, value]
+        dup.4     # [count, i++, i++, dst, size, count, value]
+        u32gte    # [i++ >= count, i++, dst, size, count, value]
+    end
+
+    # cleanup operand stack
+    dropw drop
+end
+
+# Write `count` copies of `value` to memory, starting at `dst`.
+#
+# * `dst` is expected to be an address in byte-addressable space, _not_ an element address.
+# * `value` must be a 64-bit value or smaller
+export.memset_dw # [size, dst, count, value_hi, value_lo]
+    # prepare to loop until `count` iterations have been performed
+    push.0        # [i, dst, size, count, value_hi, value_lo]
+    dup.3         # [count, i, dst, size, count, value_hi, value_lo]
+    push.0 u32gte # [count > 0, i, dst, size, count, value_hi, value_lo]
+
+    # compute address for next value to be written
+    while.true  # [i, dst, size, count, value_hi, value_lo]
+        # offset the pointer by the current iteration count * aligned size of value, and trap
+        # if it overflows
+        dup.1  # [dst, i, dst, size, count, value_hi, value_lo]
+        dup.1  # [i, dst, i, dst, size, count, value_hi, value_lo]
+        dup.4  # [size, i, dst, i, dst, size, count, value_hi, value_lo]
+        u32overflowing_madd assertz # [size * i + dst, i, dst, size, count, value_hi, value_lo]
+
+        # copy value to top of stack, swap with pointer
+        dup.6     # [value_lo, dst', i, dst, size, count, value_hi, value_lo]
+        dup.6     # [value_hi, value_lo, dst', i, dst, size, count, value_hi, value_lo]
+        movup.2   # [dst', value_hi, value_lo, i, dst, size, count, value_hi, value_lo]
+
+        # convert pointer to native representation
+        u32divmod.4 swap.1  # [dst', dst_offset', value_hi, value_lo, i, dst, size, count, vh, vl]
+
+        # write value to destination
+        exec.store_dw       # [i, dst, size, count, value_hi, value_lo]
+
+        # increment iteration count, determine whether to continue the loop
+        push.1 u32overflowing_add assertz  # [i++, dst, size, count, value_hi, value_lo]
+        dup.0     # [i++, i++, dst, size, count, value_hi, value_lo]
+        dup.4     # [count, i++, i++, dst, size, count, value_hi, value_lo]
+        u32gte    # [i++ >= count, i++, dst, size, count, value_hi, value_lo]
+    end
+
+    # cleanup operand stack
+    dropw drop drop
 end

--- a/codegen/masm/src/artifact.rs
+++ b/codegen/masm/src/artifact.rs
@@ -405,7 +405,7 @@ impl MasmComponent {
             block
                 .push(Op::Inst(Span::new(span, Inst::SysEvent(masm::SystemEventNode::PushMapVal))));
             // write_ptr
-            block.push(Op::Inst(Span::new(span, Inst::PushU32(rodata.start.waddr))));
+            block.push(Op::Inst(Span::new(span, Inst::PushU32(rodata.start.addr))));
             // num_words
             block.push(Op::Inst(Span::new(span, Inst::PushU32(rodata.size_in_words() as u32))));
             // [num_words, write_ptr, COM, ..] -> [write_ptr']

--- a/codegen/masm/src/artifact.rs
+++ b/codegen/masm/src/artifact.rs
@@ -79,17 +79,23 @@ impl Rodata {
 
     /// Attempt to convert this rodata object to its equivalent representation in felts
     ///
+    /// See [Self::bytes_to_elements] for more details.
+    pub fn to_elements(&self) -> Result<Vec<miden_processor::Felt>, String> {
+        Self::bytes_to_elements(self.data.as_slice())
+    }
+
+    /// Attempt to convert the given bytes to their equivalent representation in felts
+    ///
     /// The resulting felts will be in padded out to the nearest number of words, i.e. if the data
     /// only takes up 3 felts worth of bytes, then the resulting `Vec` will contain 4 felts, so that
     /// the total size is a valid number of words.
-    pub fn to_elements(&self) -> Result<Vec<miden_processor::Felt>, String> {
+    pub fn bytes_to_elements(bytes: &[u8]) -> Result<Vec<miden_processor::Felt>, String> {
         use miden_core::FieldElement;
         use miden_processor::Felt;
 
-        let data = self.data.as_slice();
-        let mut felts = Vec::with_capacity(data.len() / 4);
-        let mut iter = data.iter().copied().array_chunks::<4>();
-        felts.extend(iter.by_ref().map(|bytes| Felt::new(u32::from_le_bytes(bytes) as u64)));
+        let mut felts = Vec::with_capacity(bytes.len() / 4);
+        let mut iter = bytes.iter().copied().array_chunks::<4>();
+        felts.extend(iter.by_ref().map(|chunk| Felt::new(u32::from_le_bytes(chunk) as u64)));
         if let Some(remainder) = iter.into_remainder() {
             let mut chunk = [0u8; 4];
             for (i, byte) in remainder.into_iter().enumerate() {
@@ -98,7 +104,9 @@ impl Rodata {
             felts.push(Felt::new(u32::from_le_bytes(chunk) as u64));
         }
 
-        let padding = (self.size_in_words() * 4).abs_diff(felts.len());
+        let size_in_felts = bytes.len().next_multiple_of(4) / 4;
+        let size_in_words = size_in_felts.next_multiple_of(4) / 4;
+        let padding = (size_in_words * 4).abs_diff(felts.len());
         felts.resize(felts.len() + padding, Felt::ZERO);
 
         Ok(felts)
@@ -174,6 +182,7 @@ impl MasmComponent {
         let debug_mode = session.options.emit_debug_decorators();
 
         log::debug!(
+            target: "assembly",
             "assembling executable with entrypoint '{}' (debug_mode={})",
             entrypoint,
             debug_mode
@@ -185,7 +194,7 @@ impl MasmComponent {
         // Link extra libraries
         for library in link_libraries.iter().cloned() {
             for module in library.module_infos() {
-                log::debug!("registering '{}' with assembler", module.path());
+                log::debug!(target: "assembly", "registering '{}' with assembler", module.path());
                 lib_modules.insert(module.path().clone());
             }
             assembler.add_library(library)?;
@@ -202,13 +211,14 @@ impl MasmComponent {
         for module in modules.iter().cloned() {
             if lib_modules.contains(module.path()) {
                 log::warn!(
+                    target: "assembly",
                     "module '{}' is already registered with the assembler as library's module, \
                      skipping",
                     module.path()
                 );
                 continue;
             }
-            log::debug!("adding '{}' to assembler", module.path());
+            log::debug!(target: "assembly", "adding '{}' to assembler", module.path());
             let kind = module.kind();
             assembler.add_module_with_options(
                 module,
@@ -222,6 +232,7 @@ impl MasmComponent {
 
         let emit_test_harness = session.get_flag("test_harness");
         let main = self.generate_main(entrypoint, emit_test_harness)?;
+        log::debug!(target: "assembly", "generated executable module:\n{main}");
         let program = assembler.assemble_program(main)?;
         let advice_map: miden_core::AdviceMap = self
             .rodata
@@ -243,6 +254,7 @@ impl MasmComponent {
 
         let debug_mode = session.options.emit_debug_decorators();
         log::debug!(
+            target: "assembly",
             "assembling library of {} modules (debug_mode={})",
             self.modules.len(),
             debug_mode
@@ -255,7 +267,7 @@ impl MasmComponent {
         // Link extra libraries
         for library in link_libraries.iter().cloned() {
             for module in library.module_infos() {
-                log::debug!("registering '{}' with assembler", module.path());
+                log::debug!(target: "assembly", "registering '{}' with assembler", module.path());
                 lib_modules.push(module.path().clone());
             }
             assembler.add_library(library)?;
@@ -266,13 +278,14 @@ impl MasmComponent {
         for module in self.modules.iter().cloned() {
             if lib_modules.contains(module.path()) {
                 log::warn!(
+                    target: "assembly",
                     "module '{}' is already registered with the assembler as library's module, \
                      skipping",
                     module.path()
                 );
                 continue;
             }
-            log::debug!("adding '{}' to assembler", module.path());
+            log::debug!(target: "assembly", "adding '{}' to assembler", module.path());
             modules.push(module);
         }
         let lib = assembler.assemble_library(modules)?;
@@ -313,25 +326,19 @@ impl MasmComponent {
         let span = SourceSpan::default();
         let body = {
             let mut block = masm::Block::new(span, Vec::with_capacity(64));
-            // Initialize dynamic heap
-            block.push(Op::Inst(Span::new(span, Inst::PushU32(self.heap_base))));
-            let heap_init = masm::ProcedureName::new("heap_init").unwrap();
-            let memory_intrinsics = masm::LibraryPath::new("intrinsics::mem").unwrap();
-            block.push(Op::Inst(Span::new(
-                span,
-                Inst::Exec(InvocationTarget::AbsoluteProcedurePath {
-                    name: heap_init,
-                    path: memory_intrinsics,
-                }),
-            )));
-            // Initialize data segments from advice stack
-            self.emit_data_segment_initialization(&mut block);
-            // Possibly initialize test harness
+            // Invoke component initializer, if present
+            if let Some(init) = self.init.as_ref() {
+                block.push(Op::Inst(Span::new(span, Inst::Exec(init.clone()))));
+            }
+
+            // Initialize test harness, if requested
             if emit_test_harness {
                 self.emit_test_harness(&mut block);
             }
+
             // Invoke the program entrypoint
             block.push(Op::Inst(Span::new(span, Inst::Exec(entrypoint.clone()))));
+
             // Truncate the stack to 16 elements on exit
             let truncate_stack = InvocationTarget::AbsoluteProcedurePath {
                 name: ProcedureName::new("truncate_stack").unwrap(),
@@ -366,6 +373,7 @@ impl MasmComponent {
 
         // => [num_words, dest_ptr] on operand stack
         block.push(Op::Inst(Span::new(span, Inst::AdvPush(2.into()))));
+        // => [C, B, A, dest_ptr] on operand stack
         block.push(Op::Inst(Span::new(
             span,
             Inst::Exec(InvocationTarget::AbsoluteProcedurePath {
@@ -373,52 +381,12 @@ impl MasmComponent {
                 path: std_mem,
             }),
         )));
-        // Drop HASH
+        // Drop C, B, A
+        block.push(Op::Inst(Span::new(span, Inst::DropW)));
+        block.push(Op::Inst(Span::new(span, Inst::DropW)));
         block.push(Op::Inst(Span::new(span, Inst::DropW)));
         // Drop dest_ptr
         block.push(Op::Inst(Span::new(span, Inst::Drop)));
-    }
-
-    /// Emit the sequence of instructions necessary to consume rodata from the advice stack and
-    /// populate the global heap with the data segments of this program, verifying that the
-    /// commitments match.
-    fn emit_data_segment_initialization(&self, block: &mut masm::Block) {
-        use masm::{Instruction as Inst, Op};
-
-        // Emit data segment initialization code
-        //
-        // NOTE: This depends on the program being executed with the data for all data
-        // segments having been placed in the advice map with the same commitment and
-        // encoding used here. The program will fail to execute if this is not set up
-        // correctly.
-        //
-        // TODO(pauls): To facilitate automation of this, we should emit an inputs file to
-        // disk that maps each segment to a commitment and its data encoded as binary. This
-        // can then be loaded into the advice provider during VM init.
-        let pipe_preimage_to_memory = masm::ProcedureName::new("pipe_preimage_to_memory").unwrap();
-        let std_mem = masm::LibraryPath::new("std::mem").unwrap();
-
-        let span = SourceSpan::default();
-        for rodata in self.rodata.iter() {
-            // Move rodata from advice map to advice stack
-            block.push(Op::Inst(Span::new(span, Inst::PushWord(rodata.digest.into())))); // COM
-            block
-                .push(Op::Inst(Span::new(span, Inst::SysEvent(masm::SystemEventNode::PushMapVal))));
-            // write_ptr
-            block.push(Op::Inst(Span::new(span, Inst::PushU32(rodata.start.addr))));
-            // num_words
-            block.push(Op::Inst(Span::new(span, Inst::PushU32(rodata.size_in_words() as u32))));
-            // [num_words, write_ptr, COM, ..] -> [write_ptr']
-            block.push(Op::Inst(Span::new(
-                span,
-                Inst::Exec(InvocationTarget::AbsoluteProcedurePath {
-                    name: pipe_preimage_to_memory.clone(),
-                    path: std_mem.clone(),
-                }),
-            )));
-            // drop write_ptr'
-            block.push(Op::Inst(Span::new(span, Inst::Drop)));
-        }
     }
 }
 

--- a/codegen/masm/src/emit/mem.rs
+++ b/codegen/masm/src/emit/mem.rs
@@ -623,7 +623,7 @@ impl OpEmitter<'_> {
                     ],
                     span,
                 );
-                self.raw_exec("std::mem::memcopy", span);
+                self.raw_exec("std::mem::memcopy_words", span);
                 return;
             }
             // Values which can be broken up into word-sized chunks can piggy-back on the
@@ -652,7 +652,7 @@ impl OpEmitter<'_> {
                     ],
                     span,
                 );
-                self.raw_exec("std::mem::memcopy", span);
+                self.raw_exec("std::mem::memcopy_words", span);
                 return;
             }
             // For now, all other values fallback to the default implementation

--- a/codegen/masm/src/emitter.rs
+++ b/codegen/masm/src/emitter.rs
@@ -1,7 +1,7 @@
 use alloc::collections::BTreeSet;
 
 use miden_assembly::diagnostics::WrapErr;
-use midenc_hir::{dialects::builtin, Block, Operation, ProgramPoint, ValueRange, ValueRef};
+use midenc_hir::{Block, Operation, ProgramPoint, ValueRange, ValueRef};
 use midenc_hir_analysis::analyses::LivenessAnalysis;
 use midenc_session::diagnostics::{SourceSpan, Spanned};
 use smallvec::SmallVec;
@@ -15,7 +15,6 @@ use crate::{
 };
 
 pub(crate) struct BlockEmitter<'b> {
-    pub function: &'b builtin::Function,
     pub liveness: &'b LivenessAnalysis,
     pub link_info: &'b LinkInfo,
     pub invoked: &'b mut BTreeSet<masm::Invoke>,
@@ -26,7 +25,6 @@ pub(crate) struct BlockEmitter<'b> {
 impl BlockEmitter<'_> {
     pub fn nest<'nested, 'current: 'nested>(&'current mut self) -> BlockEmitter<'nested> {
         BlockEmitter {
-            function: self.function,
             liveness: self.liveness,
             link_info: self.link_info,
             invoked: self.invoked,

--- a/codegen/masm/src/lower/utils.rs
+++ b/codegen/masm/src/lower/utils.rs
@@ -553,8 +553,7 @@ mod tests {
 
         // Obtain liveness
         let analysis_manager = AnalysisManager::new(function_ref.as_operation_ref(), None);
-        let liveness =
-            analysis_manager.get_analysis_for::<LivenessAnalysis, builtin::Function>()?;
+        let liveness = analysis_manager.get_analysis::<LivenessAnalysis>()?;
 
         // Generate linker info
         let link_info = LinkInfo::new(builtin::ComponentId {
@@ -569,9 +568,7 @@ mod tests {
 
         // Instantiate block emitter
         let mut invoked = Default::default();
-        let function = function_ref.borrow();
         let emitter = BlockEmitter {
-            function: &function,
             liveness: &liveness,
             link_info: &link_info,
             invoked: &mut invoked,
@@ -580,6 +577,7 @@ mod tests {
         };
 
         // Lower input
+        let function = function_ref.borrow();
         let entry = function.entry_block();
         let body = emitter.emit(&entry.borrow());
 
@@ -654,8 +652,7 @@ mod tests {
 
         // Obtain liveness
         let analysis_manager = AnalysisManager::new(function_ref.as_operation_ref(), None);
-        let liveness =
-            analysis_manager.get_analysis_for::<LivenessAnalysis, builtin::Function>()?;
+        let liveness = analysis_manager.get_analysis::<LivenessAnalysis>()?;
 
         // Generate linker info
         let link_info = LinkInfo::new(builtin::ComponentId {
@@ -670,9 +667,7 @@ mod tests {
 
         // Instantiate block emitter
         let mut invoked = Default::default();
-        let function = function_ref.borrow();
         let emitter = BlockEmitter {
-            function: &function,
             liveness: &liveness,
             link_info: &link_info,
             invoked: &mut invoked,
@@ -681,6 +676,7 @@ mod tests {
         };
 
         // Lower input
+        let function = function_ref.borrow();
         let entry = function.entry_block();
         let body = emitter.emit(&entry.borrow());
 
@@ -874,8 +870,7 @@ mod tests {
 
         // Obtain liveness
         let analysis_manager = AnalysisManager::new(function_ref.as_operation_ref(), None);
-        let liveness =
-            analysis_manager.get_analysis_for::<LivenessAnalysis, builtin::Function>()?;
+        let liveness = analysis_manager.get_analysis::<LivenessAnalysis>()?;
 
         // Generate linker info
         let link_info = LinkInfo::new(builtin::ComponentId {
@@ -890,9 +885,7 @@ mod tests {
 
         // Instantiate block emitter
         let mut invoked = Default::default();
-        let function = function_ref.borrow();
         let emitter = BlockEmitter {
-            function: &function,
             liveness: &liveness,
             link_info: &link_info,
             invoked: &mut invoked,
@@ -901,6 +894,7 @@ mod tests {
         };
 
         // Lower input
+        let function = function_ref.borrow();
         let entry = function.entry_block();
         let body = emitter.emit(&entry.borrow());
 

--- a/frontend/wasm/src/code_translator/expected/globals.hir
+++ b/frontend/wasm/src/code_translator/expected/globals.hir
@@ -1,11 +1,11 @@
 public builtin.function @test_wrapper() {
 ^block4:
-    builtin.global_symbol @root_ns:root@1.0.0/noname/MyGlobalVal : (ptr u8)
+    v0 = builtin.global_symbol @root_ns:root@1.0.0/noname/MyGlobalVal : (ptr u8)
     v1 = hir.bitcast v0 : (ptr i32);
     v2 = hir.load v1 : i32;
     v3 = arith.constant 9 : i32;
     v4 = arith.add v2, v3 : i32 #[overflow = wrapping];
-    builtin.global_symbol @root_ns:root@1.0.0/noname/MyGlobalVal : (ptr u8)
+    v5 = builtin.global_symbol @root_ns:root@1.0.0/noname/MyGlobalVal : (ptr u8)
     v6 = hir.bitcast v5 : (ptr i32);
     hir.store v6, v4;
     cf.br ^block5;

--- a/hir-analysis/src/analyses.rs
+++ b/hir-analysis/src/analyses.rs
@@ -7,7 +7,7 @@ pub mod spills;
 pub use self::{
     constant_propagation::SparseConstantPropagation,
     dce::DeadCodeAnalysis,
-    liveness::{LivenessAnalysis, LivenessAnalysisAdaptor},
+    liveness::LivenessAnalysis,
     loops::{LoopAction, LoopState},
     spills::SpillAnalysis,
 };

--- a/hir-analysis/src/analyses/spills.rs
+++ b/hir-analysis/src/analyses/spills.rs
@@ -443,7 +443,7 @@ impl Analysis for SpillAnalysis {
     ) -> Result<(), Report> {
         log::debug!(target: "spills", "running spills analysis for {}", op.as_operation());
 
-        let liveness = analysis_manager.get_analysis_for::<LivenessAnalysis, Function>()?;
+        let liveness = analysis_manager.get_analysis::<LivenessAnalysis>()?;
         self.compute(op, &liveness, analysis_manager)
     }
 

--- a/hir/src/dialects/builtin/ops/global_variable.rs
+++ b/hir/src/dialects/builtin/ops/global_variable.rs
@@ -13,7 +13,7 @@ use crate::{
         InferTypeOpInterface, IsolatedFromAbove, NoRegionArguments, PointerOf, SingleBlock,
         SingleRegion, UInt8,
     },
-    AsSymbolRef, Context, Ident, OpPrinter, Operation, Report, Spanned, Symbol, SymbolName,
+    AsSymbolRef, Context, Ident, Op, OpPrinter, Operation, Report, Spanned, Symbol, SymbolName,
     SymbolRef, SymbolUseList, Type, UnsafeIntrusiveEntityRef, Usable, Value, Visibility,
 };
 
@@ -166,7 +166,9 @@ impl OpPrinter for GlobalSymbol {
     ) -> crate::formatter::Document {
         use crate::formatter::*;
 
-        let prefix = display(self.op.name())
+        let results = crate::print::render_operation_results(self.as_operation());
+        let prefix = results
+            + display(self.op.name())
             + const_text(" ")
             + const_text("@")
             + display(&self.symbol().path);

--- a/midenc-debug/src/debug/memory.rs
+++ b/midenc-debug/src/debug/memory.rs
@@ -25,7 +25,7 @@ impl FromStr for ReadMemoryExpr {
 
         let ty = args.ty.unwrap_or_else(|| Type::Array(Box::new(Type::Felt), 4));
         let addr = match args.mode {
-            MemoryMode::Word => NativePtr::new(args.addr, 0, 0),
+            MemoryMode::Word => NativePtr::new(args.addr, 0),
             MemoryMode::Byte => NativePtr::from_ptr(args.addr),
         };
         Ok(Self {

--- a/midenc-debug/src/exec/mod.rs
+++ b/midenc-debug/src/exec/mod.rs
@@ -6,6 +6,6 @@ mod trace;
 pub use self::{
     executor::Executor,
     host::DebuggerHost,
-    state::{Chiplets, DebugExecutor},
+    state::{DebugExecutor, MemoryChiplet},
     trace::{ExecutionTrace, TraceEvent, TraceHandler},
 };

--- a/midenc-debug/src/exec/state.rs
+++ b/midenc-debug/src/exec/state.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeSet, VecDeque};
+use std::{
+    collections::{BTreeSet, VecDeque},
+    rc::Rc,
+};
 
 use miden_core::Word;
 use miden_processor::{
@@ -85,10 +88,24 @@ impl DebugExecutor {
         let last_cycle = self.cycle;
         let trace_len_summary = *self.iter.trace_len_summary();
         let (_, _, _, chiplets, _) = self.iter.into_parts();
+        let chiplets = Rc::new(chiplets);
+
+        let chiplets0 = chiplets.clone();
+        let get_state_at = move |context, clk| chiplets0.memory.get_state_at(context, clk);
+        let chiplets1 = chiplets.clone();
+        let get_word = move |context, addr| chiplets1.memory.get_word(context, addr);
+        let get_value = move |context, addr| chiplets.memory.get_value(context, addr);
+
+        let memory = MemoryChiplet {
+            get_value: Box::new(get_value),
+            get_word: Box::new(get_word),
+            get_state_at: Box::new(get_state_at),
+        };
+
         ExecutionTrace {
             root_context: self.root_context,
             last_cycle: RowIndex::from(last_cycle),
-            chiplets: Chiplets::new(move |context, clk| chiplets.get_mem_state_at(context, clk)),
+            memory,
             outputs: self.stack_outputs,
             trace_len_summary,
         }
@@ -111,17 +128,30 @@ impl Iterator for DebugExecutor {
 }
 
 // Dirty, gross, horrible hack until miden_processor::chiplets::Chiplets is exported
-#[allow(clippy::type_complexity)]
-pub struct Chiplets(Box<dyn Fn(ContextId, RowIndex) -> Vec<(u64, Word)>>);
-impl Chiplets {
-    pub fn new<F>(callback: F) -> Self
-    where
-        F: Fn(ContextId, RowIndex) -> Vec<(u64, Word)> + 'static,
-    {
-        Self(Box::new(callback))
+pub struct MemoryChiplet {
+    get_value: Box<dyn Fn(ContextId, u32) -> Option<miden_core::Felt>>,
+    get_word: Box<dyn Fn(ContextId, u32) -> Result<Option<miden_core::Word>, ExecutionError>>,
+    #[allow(clippy::type_complexity)]
+    get_state_at: Box<dyn Fn(ContextId, RowIndex) -> Vec<(u64, miden_core::Felt)>>,
+}
+
+impl MemoryChiplet {
+    #[inline]
+    pub fn get_value(&self, context: ContextId, addr: u32) -> Option<miden_core::Felt> {
+        (self.get_value)(context, addr)
     }
 
-    pub fn get_mem_state_at(&self, context: ContextId, clk: RowIndex) -> Vec<(u64, Word)> {
-        (self.0)(context, clk)
+    #[inline]
+    pub fn get_word(&self, context: ContextId, addr: u32) -> Result<Option<Word>, ExecutionError> {
+        (self.get_word)(context, addr)
+    }
+
+    #[inline]
+    pub fn get_mem_state_at(
+        &self,
+        context: ContextId,
+        clk: RowIndex,
+    ) -> Vec<(u64, miden_core::Felt)> {
+        (self.get_state_at)(context, clk)
     }
 }

--- a/midenc-debug/src/felt.rs
+++ b/midenc-debug/src/felt.rs
@@ -288,8 +288,8 @@ impl<const N: usize> PopFromStack for [u8; N] {
 ///
 /// [[{b0, ..b3}, {b4, ..b7}, {b8..b11}, {b12, ..b15}], ..]
 ///
-/// In other words, it produces words that when placed on the stack and written to memory
-/// word-by-word, that memory will be laid out in the correct byte order.
+/// In short, it produces words that when placed on the stack and written to memory word-by-word,
+/// the original bytes will be laid out in Miden's memory in the correct order.
 pub fn bytes_to_words(bytes: &[u8]) -> Vec<[RawFelt; 4]> {
     // 1. Chunk bytes up into felts
     let mut iter = bytes.iter().array_chunks::<4>();

--- a/midenc-debug/src/ui/state.rs
+++ b/midenc-debug/src/ui/state.rs
@@ -192,7 +192,7 @@ impl State {
             }
             let felt = self
                 .execution_trace
-                .read_memory_element_in_context(expr.addr.waddr, expr.addr.index, context, cycle)
+                .read_memory_element_in_context(expr.addr.addr, context, cycle)
                 .unwrap_or(Felt::ZERO);
             write_with_format_type!(output, expr, felt.as_int());
         } else if matches!(expr.ty, Type::Array(ref elem_ty, 4) if elem_ty.as_ref() == &Type::Felt)
@@ -200,7 +200,7 @@ impl State {
             if !expr.addr.is_word_aligned() {
                 return Err("read failed: type 'word' must be aligned to a word boundary".into());
             }
-            let word = self.execution_trace.read_memory_word(expr.addr.waddr).unwrap_or_default();
+            let word = self.execution_trace.read_memory_word(expr.addr.addr).unwrap_or_default();
             output.push('[');
             for (i, elem) in word.iter().enumerate() {
                 if i > 0 {

--- a/tests/integration/expected/abi_transform_stdlib_blake3_hash.hir
+++ b/tests/integration/expected/abi_transform_stdlib_blake3_hash.hir
@@ -39,14 +39,14 @@ builtin.component root_ns:root@1.0.0 {
 
         public builtin.function @entrypoint(v40: i32, v41: i32) {
         ^block10(v40: i32, v41: i32):
-            builtin.global_symbol @root_ns:root@1.0.0/abi_transform_stdlib_blake3_hash/__stack_pointer : (ptr u8)
+            v43 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_stdlib_blake3_hash/__stack_pointer : (ptr u8)
             v44 = hir.bitcast v43 : (ptr i32);
             v45 = hir.load v44 : i32;
             v48 = arith.constant -32 : i32;
             v46 = arith.constant 32 : i32;
             v47 = arith.sub v45, v46 : i32 #[overflow = wrapping];
             v49 = arith.band v47, v48 : i32;
-            builtin.global_symbol @root_ns:root@1.0.0/abi_transform_stdlib_blake3_hash/__stack_pointer : (ptr u8)
+            v50 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_stdlib_blake3_hash/__stack_pointer : (ptr u8)
             v51 = hir.bitcast v50 : (ptr i32);
             hir.store v51, v49;
             v52 = hir.bitcast v41 : u32;
@@ -136,7 +136,7 @@ builtin.component root_ns:root@1.0.0 {
             v128 = hir.bitcast v40 : u32;
             v129 = hir.int_to_ptr v128 : (ptr i64);
             hir.store v129, v127;
-            builtin.global_symbol @root_ns:root@1.0.0/abi_transform_stdlib_blake3_hash/__stack_pointer : (ptr u8)
+            v130 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_stdlib_blake3_hash/__stack_pointer : (ptr u8)
             v131 = hir.bitcast v130 : (ptr i32);
             hir.store v131, v45;
             builtin.ret ;

--- a/tests/integration/expected/abi_transform_stdlib_blake3_hash.masm
+++ b/tests/integration/expected/abi_transform_stdlib_blake3_hash.masm
@@ -7,14 +7,8 @@ proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
         dup.0
         movup.2
         swap.1
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::store_sw
         push.4
         dup.1
@@ -23,14 +17,8 @@ proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
         u32assert
         movup.2
         swap.1
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::store_sw
         push.8
         dup.1
@@ -39,14 +27,8 @@ proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
         u32assert
         movup.2
         swap.1
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::store_sw
         push.12
         dup.1
@@ -55,14 +37,8 @@ proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
         u32assert
         movup.2
         swap.1
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::store_sw
         push.16
         dup.1
@@ -71,14 +47,8 @@ proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
         u32assert
         movup.2
         swap.1
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::store_sw
         push.20
         dup.1
@@ -87,14 +57,8 @@ proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
         u32assert
         movup.2
         swap.1
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::store_sw
         push.24
         dup.1
@@ -103,26 +67,14 @@ proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
         u32assert
         movup.2
         swap.1
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::store_sw
         push.28
         add
         u32assert
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::store_sw
 end
 
@@ -130,14 +82,8 @@ end
 export.entrypoint
 
         push.0
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::load_sw
         push.4294967264
         push.32
@@ -148,115 +94,61 @@ export.entrypoint
         push.0
         dup.1
         swap.1
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::store_sw
         dup.3
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::load_sw
         push.4
         dup.5
         add
         u32assert
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::load_sw
         push.8
         dup.6
         add
         u32assert
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::load_sw
         push.12
         dup.7
         add
         u32assert
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::load_sw
         push.16
         dup.8
         add
         u32assert
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::load_sw
         push.20
         dup.9
         add
         u32assert
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::load_sw
         push.24
         dup.10
         add
         u32assert
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::load_sw
         push.28
         movup.11
         add
         u32assert
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::load_sw
         dup.8
         movup.3
@@ -280,27 +172,15 @@ export.entrypoint
         u32mod
         u32assert
         assertz.err=250
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::load_dw
         push.24
         dup.5
         swap.1
         u32wrapping_add
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::store_dw
         push.16
         dup.1
@@ -312,27 +192,15 @@ export.entrypoint
         u32mod
         u32assert
         assertz.err=250
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::load_dw
         push.16
         dup.5
         swap.1
         u32wrapping_add
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::store_dw
         push.8
         dup.1
@@ -344,27 +212,15 @@ export.entrypoint
         u32mod
         u32assert
         assertz.err=250
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::load_dw
         push.8
         dup.5
         swap.1
         u32wrapping_add
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::store_dw
         push.8
         dup.1
@@ -372,34 +228,16 @@ export.entrypoint
         u32mod
         u32assert
         assertz.err=250
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::load_dw
         movup.3
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::store_dw
         push.0
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::store_sw
 end
 

--- a/tests/integration/expected/abi_transform_stdlib_blake3_hash.masm
+++ b/tests/integration/expected/abi_transform_stdlib_blake3_hash.masm
@@ -1,3 +1,15 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+end
+
+
 # mod root_ns:root@1.0.0::abi_transform_stdlib_blake3_hash
 
 proc.miden_stdlib_sys::stdlib::crypto::hashes::extern_blake3_hash_1to1
@@ -81,7 +93,7 @@ end
 
 export.entrypoint
 
-        push.0
+        push.1048576
         u32divmod.4
         swap.1
         exec.::intrinsics::mem::load_sw
@@ -91,7 +103,7 @@ export.entrypoint
         swap.1
         u32wrapping_sub
         u32and
-        push.0
+        push.1048576
         dup.1
         swap.1
         u32divmod.4
@@ -235,7 +247,7 @@ export.entrypoint
         u32divmod.4
         swap.1
         exec.::intrinsics::mem::store_dw
-        push.0
+        push.1048576
         u32divmod.4
         swap.1
         exec.::intrinsics::mem::store_sw

--- a/tests/integration/expected/add_felt.masm
+++ b/tests/integration/expected/add_felt.masm
@@ -1,3 +1,15 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+end
+
+
 # mod root_ns:root@1.0.0::add_felt
 
 export.entrypoint

--- a/tests/integration/expected/add_i16.masm
+++ b/tests/integration/expected/add_i16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_06c525756fe79253a5d667de4160df5c89e45269648c98bb21fd9430caec0b19
 
 export.entrypoint

--- a/tests/integration/expected/add_i32.masm
+++ b/tests/integration/expected/add_i32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_e52816950d9b2deff10441c5aff28d88268e921c4c01a207c8743d871bd3a69f
 
 export.entrypoint

--- a/tests/integration/expected/add_i64.masm
+++ b/tests/integration/expected/add_i64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_cc1ebe8ed410a033febcc7c6a7e1b2473b2337e0dff32b08d3c91be5bbc2cc0a
 
 export.entrypoint

--- a/tests/integration/expected/add_i8.masm
+++ b/tests/integration/expected/add_i8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_62ba1afb3113b5a2557098b909eff557cd716bf21b07843db3bfb765ff41e9f7
 
 export.entrypoint

--- a/tests/integration/expected/add_u16.masm
+++ b/tests/integration/expected/add_u16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_41c5fa21fe36fdf84a953669187b56426048e7b2f08e8de91e3e989c579ed46f
 
 export.entrypoint

--- a/tests/integration/expected/add_u32.masm
+++ b/tests/integration/expected/add_u32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_2aac0275c4e31b615b4d6bf7d39869ccab374d5df702b3ef708ea7f981b4073c
 
 export.entrypoint

--- a/tests/integration/expected/add_u64.masm
+++ b/tests/integration/expected/add_u64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_2c24c814fbf0c5ee22a60f52279e8f7639d56708da347e071f1130dc19dc9c07
 
 export.entrypoint

--- a/tests/integration/expected/add_u8.masm
+++ b/tests/integration/expected/add_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_9c74aa9695b645cec4339ff01ac3e35e31b39b1feb0dfeef6ee7c94789fbcfce
 
 export.entrypoint

--- a/tests/integration/expected/and_bool.masm
+++ b/tests/integration/expected/and_bool.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_f19303d702f807a0f2b8aebdfd8b2b6ae52ee927040711d5dfd94aac9e67f2c7
 
 export.entrypoint

--- a/tests/integration/expected/band_i16.masm
+++ b/tests/integration/expected/band_i16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_34638703ab78fea8050898ab92e28a6a09cade611d4a9a3601c8667b275e57ee
 
 export.entrypoint

--- a/tests/integration/expected/band_i32.masm
+++ b/tests/integration/expected/band_i32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_9ee88137407daefa6fa252f24e800d9fc4690951edfe7f8303f2f5225ed6eea3
 
 export.entrypoint

--- a/tests/integration/expected/band_i64.masm
+++ b/tests/integration/expected/band_i64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_fdee33d480318f3f6165aabcaf90e290011f2d459d009ce9a6ea019e73b0e6b4
 
 export.entrypoint

--- a/tests/integration/expected/band_i8.masm
+++ b/tests/integration/expected/band_i8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_a20ca31834cfb559286ab8bbb00ce2e657f38ec95d8459342621bc218581241d
 
 export.entrypoint

--- a/tests/integration/expected/band_u16.masm
+++ b/tests/integration/expected/band_u16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_41457a077e1338454c33613079552cd2abe9d4fd50975cf8d2d8d9ee664dfbb6
 
 export.entrypoint

--- a/tests/integration/expected/band_u32.masm
+++ b/tests/integration/expected/band_u32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_82d1878f26a40c75c635298e80f65f7a5aac492ad99eb90909a97ab273f4c1ad
 
 export.entrypoint

--- a/tests/integration/expected/band_u64.masm
+++ b/tests/integration/expected/band_u64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_8509e2e84a91835b60f651a4adb33e43024ab7f31520e5ee5b5a97f181859a40
 
 export.entrypoint

--- a/tests/integration/expected/band_u8.masm
+++ b/tests/integration/expected/band_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_3be102ea36db2b23b9f6f0e34bfb210f4f562d75c14b2d53d64bdcc630a44aa6
 
 export.entrypoint

--- a/tests/integration/expected/bnot_bool.masm
+++ b/tests/integration/expected/bnot_bool.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_77ff166ebf5be0d308b881f765d5f8ef913f838ea7e86a97499b030fa1c0f3f4
 
 export.entrypoint

--- a/tests/integration/expected/bnot_i16.masm
+++ b/tests/integration/expected/bnot_i16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_e24d4ca783335c84dc5ae676aec479bda06baf4852fc00f30dac4021d07cf59f
 
 export.entrypoint

--- a/tests/integration/expected/bnot_i32.masm
+++ b/tests/integration/expected/bnot_i32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_0d63a98a6809a92584f1dbaab4dfd841caaf9cab88744275bd4ed034006fc6ed
 
 export.entrypoint

--- a/tests/integration/expected/bnot_i64.masm
+++ b/tests/integration/expected/bnot_i64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_b907170bd28f219043267cdd24dc67337632f05fcaab8f9a4efb14def28e8e3e
 
 export.entrypoint

--- a/tests/integration/expected/bnot_i8.masm
+++ b/tests/integration/expected/bnot_i8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_1f608e193c7b4c41422a7e789e491655410126a59a757a5572c1ed81892c7c0b
 
 export.entrypoint

--- a/tests/integration/expected/bnot_u16.masm
+++ b/tests/integration/expected/bnot_u16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_801b0e92eabaaba12053c65b60b81c5cb57e2d5bf386ab548321cf375005baea
 
 export.entrypoint

--- a/tests/integration/expected/bnot_u32.masm
+++ b/tests/integration/expected/bnot_u32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_dc5405fd1533a0bda8a8715a70ef89a33300844687446825e2ae7bfc5a34655a
 
 export.entrypoint

--- a/tests/integration/expected/bnot_u64.masm
+++ b/tests/integration/expected/bnot_u64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_345f3c1e58fe5c9ef31421da6a362d9cadbf519ad68045840229e8b76f58a4f4
 
 export.entrypoint

--- a/tests/integration/expected/bnot_u8.masm
+++ b/tests/integration/expected/bnot_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_5e3a237ba6b351b72bc4ac66517613ffe85ccd4b728c40b405f3a9ff93506063
 
 export.entrypoint

--- a/tests/integration/expected/bor_i16.masm
+++ b/tests/integration/expected/bor_i16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_44e33b9e14fa2be1f40cdd20712edb995a941e3a1a153b46fb87e39dcbcdebc1
 
 export.entrypoint

--- a/tests/integration/expected/bor_i32.masm
+++ b/tests/integration/expected/bor_i32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_e24b176dbd0fa5b54e01370fc307f6f1a06748cd8946e58e7d1469dceadc6d92
 
 export.entrypoint

--- a/tests/integration/expected/bor_i64.masm
+++ b/tests/integration/expected/bor_i64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_19d92981d2d7f148eaa97011bd0bd979fbc793cadadb334c67791824f38e7bf8
 
 export.entrypoint

--- a/tests/integration/expected/bor_i8.masm
+++ b/tests/integration/expected/bor_i8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_6b279a51e04f2b6fc0be10e9ad685e34fcfc2cbc2c726847699f4721f48e3713
 
 export.entrypoint

--- a/tests/integration/expected/bor_u16.masm
+++ b/tests/integration/expected/bor_u16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_fe8fe146eac1710c2c8529e4df4810118e471d0c279c48e765ff28ad800d1aab
 
 export.entrypoint

--- a/tests/integration/expected/bor_u32.masm
+++ b/tests/integration/expected/bor_u32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_e3bb04a56c487ecfc0dd1c57e0d354745ffb321466dc47bd02d51513cc6980d1
 
 export.entrypoint

--- a/tests/integration/expected/bor_u64.masm
+++ b/tests/integration/expected/bor_u64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_e8616ef7e15d87b491a1dbcccfe42b1dcb7a90b965c27549b2b5d9604d28acee
 
 export.entrypoint

--- a/tests/integration/expected/bor_u8.masm
+++ b/tests/integration/expected/bor_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_a0d8359c86d6548c3cdc5448b2a38351e3498e1db98a8d3d4bbbc27afa05af09
 
 export.entrypoint

--- a/tests/integration/expected/bxor_i16.masm
+++ b/tests/integration/expected/bxor_i16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_cb1e0c1a18c279735e94c50dd925290caa430ac65188eb20eb437a4391d25640
 
 export.entrypoint

--- a/tests/integration/expected/bxor_i32.masm
+++ b/tests/integration/expected/bxor_i32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_1c4d375403281e14e710bf442e5556c06e5933dce447f206252657b1345611f0
 
 export.entrypoint

--- a/tests/integration/expected/bxor_i64.masm
+++ b/tests/integration/expected/bxor_i64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_bbe2169ccd3bb4080a705f38ed5ef633d3af9e172e8f9b41ae4ee10f8059e176
 
 export.entrypoint

--- a/tests/integration/expected/bxor_i8.masm
+++ b/tests/integration/expected/bxor_i8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_da1dfc177b6a72c28237264497437ada8ba555111d180be7b99b1d60791da41c
 
 export.entrypoint

--- a/tests/integration/expected/bxor_u16.masm
+++ b/tests/integration/expected/bxor_u16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_255d3558f03d3b3be3d933d40e9ae32b53db7dd904e40aafd5677d694056c91b
 
 export.entrypoint

--- a/tests/integration/expected/bxor_u32.masm
+++ b/tests/integration/expected/bxor_u32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_b25131cea5088f57eb35dec78eb814ce753ab95c1f4faf8447870d9b6d1525dd
 
 export.entrypoint

--- a/tests/integration/expected/bxor_u64.masm
+++ b/tests/integration/expected/bxor_u64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_ab1d59bc3952451e2ac6a22333bf5458760622594546976d2d1488d607497ae7
 
 export.entrypoint

--- a/tests/integration/expected/bxor_u8.masm
+++ b/tests/integration/expected/bxor_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_e442bdf6f0faa5b55270b06bb284534cce773aa9180fde57cdeeeddf42bb21e6
 
 export.entrypoint

--- a/tests/integration/expected/collatz.masm
+++ b/tests/integration/expected/collatz.masm
@@ -1,3 +1,15 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+end
+
+
 # mod root_ns:root@1.0.0::collatz
 
 export.entrypoint

--- a/tests/integration/expected/core::cmp::max_u8_u8.masm
+++ b/tests/integration/expected/core::cmp::max_u8_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_adcf2f13ea1f22958c5a92d1674643acc093416b0b2de0fee390636adfcf090a
 
 export.entrypoint

--- a/tests/integration/expected/core::cmp::min_i32_i32.masm
+++ b/tests/integration/expected/core::cmp::min_i32_i32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_473cae57ec6aea1b2fa1e6ffdabf82016fbf6e38e3acdf12f2f612d1044a9d0c
 
 export.entrypoint

--- a/tests/integration/expected/core::cmp::min_u32_u32.masm
+++ b/tests/integration/expected/core::cmp::min_u32_u32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_d58f2727da94ef76690ba318a633249545f9e38779d69d96f04c561d52921cd4
 
 export.entrypoint

--- a/tests/integration/expected/core::cmp::min_u8_u8.masm
+++ b/tests/integration/expected/core::cmp::min_u8_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_86004120286ad9607be152901a86f66a999ee9dd70f4520b4ba4d6af29300327
 
 export.entrypoint

--- a/tests/integration/expected/div_felt.masm
+++ b/tests/integration/expected/div_felt.masm
@@ -1,3 +1,15 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+end
+
+
 # mod root_ns:root@1.0.0::div_felt
 
 export.entrypoint

--- a/tests/integration/expected/eq_felt.masm
+++ b/tests/integration/expected/eq_felt.masm
@@ -1,3 +1,15 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+end
+
+
 # mod root_ns:root@1.0.0::eq_felt
 
 export.entrypoint

--- a/tests/integration/expected/eq_i16.masm
+++ b/tests/integration/expected/eq_i16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_517fb449f17b407495bba1888d666bc76885dc2541249b2f6cfe05173973099e
 
 export.entrypoint

--- a/tests/integration/expected/eq_i32.masm
+++ b/tests/integration/expected/eq_i32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_3a92b0607377b819decb1029f8199a70990302e258cc8ee55f612c4d879c74f4
 
 export.entrypoint

--- a/tests/integration/expected/eq_i64.masm
+++ b/tests/integration/expected/eq_i64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_bcf098a70fb61198130acb429b0b2900b9c9d11c5cab0241410bb862be7ce2a8
 
 export.entrypoint

--- a/tests/integration/expected/eq_i8.masm
+++ b/tests/integration/expected/eq_i8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_c2c2ad0caabf21644314027afcbfb75555fa063ab09504517a70196ddd47c892
 
 export.entrypoint

--- a/tests/integration/expected/eq_u16.masm
+++ b/tests/integration/expected/eq_u16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_5e53494a4e3a0adfb638a6e562baf4c446d2f54c63ea6d33dec923896f12cea8
 
 export.entrypoint

--- a/tests/integration/expected/eq_u32.masm
+++ b/tests/integration/expected/eq_u32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_528be949250a0d0dcd9cd0e4c74a012863f8f305b2ac8043a575d81640315ac0
 
 export.entrypoint

--- a/tests/integration/expected/eq_u64.masm
+++ b/tests/integration/expected/eq_u64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_90e3e1f038c3b9b7ba2a8c0e9313f59dc3bc3f54fe235a4c5c325df06e46d3b0
 
 export.entrypoint

--- a/tests/integration/expected/eq_u8.masm
+++ b/tests/integration/expected/eq_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_909444ffebd8fe6b867a4d7833f385ece2e4ae4363fd04241342e9bef1affc93
 
 export.entrypoint

--- a/tests/integration/expected/examples/fib.masm
+++ b/tests/integration/expected/examples/fib.masm
@@ -1,3 +1,15 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+end
+
+
 # mod root_ns:root@1.0.0::fibonacci
 
 export.entrypoint

--- a/tests/integration/expected/examples/storage_example.hir
+++ b/tests/integration/expected/examples/storage_example.hir
@@ -301,14 +301,14 @@ builtin.component miden:storage-example/foo@1.0.0 {
 
         public builtin.function @miden:storage-example/foo@1.0.0#test-storage-item(v919: i32, v920: felt, v921: felt, v922: felt, v923: felt) -> felt {
         ^block113(v919: i32, v920: felt, v921: felt, v922: felt, v923: felt):
-            builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
+            v926 = builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
             v927 = hir.bitcast v926 : (ptr i32);
             v928 = hir.load v927 : i32;
             v931 = arith.constant -32 : i32;
             v929 = arith.constant 96 : i32;
             v930 = arith.sub v928, v929 : i32 #[overflow = wrapping];
             v932 = arith.band v930, v931 : i32;
-            builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
+            v933 = builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
             v934 = hir.bitcast v933 : (ptr i32);
             hir.store v934, v932;
             hir.exec @miden:storage-example/foo@1.0.0/storage_example/wit_bindgen_rt::run_ctors_once()
@@ -363,7 +363,7 @@ builtin.component miden:storage-example/foo@1.0.0 {
             hir.assertz v970 #[code = 250];
             v971 = hir.int_to_ptr v968 : (ptr felt);
             v972 = hir.load v971 : felt;
-            builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
+            v973 = builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
             v974 = hir.bitcast v973 : (ptr i32);
             hir.store v974, v928;
             builtin.ret v972;
@@ -373,14 +373,14 @@ builtin.component miden:storage-example/foo@1.0.0 {
 
         public builtin.function @miden:storage-example/foo@1.0.0#test-storage-map-item(v975: i32, v976: felt, v977: felt, v978: felt, v979: felt, v980: felt, v981: felt, v982: felt, v983: felt) -> felt {
         ^block117(v975: i32, v976: felt, v977: felt, v978: felt, v979: felt, v980: felt, v981: felt, v982: felt, v983: felt):
-            builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
+            v986 = builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
             v987 = hir.bitcast v986 : (ptr i32);
             v988 = hir.load v987 : i32;
             v991 = arith.constant -32 : i32;
             v989 = arith.constant 128 : i32;
             v990 = arith.sub v988, v989 : i32 #[overflow = wrapping];
             v992 = arith.band v990, v991 : i32;
-            builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
+            v993 = builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
             v994 = hir.bitcast v993 : (ptr i32);
             hir.store v994, v992;
             hir.exec @miden:storage-example/foo@1.0.0/storage_example/wit_bindgen_rt::run_ctors_once()
@@ -471,7 +471,7 @@ builtin.component miden:storage-example/foo@1.0.0 {
             hir.assertz v1058 #[code = 250];
             v1059 = hir.int_to_ptr v1056 : (ptr felt);
             v1060 = hir.load v1059 : felt;
-            builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
+            v1061 = builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
             v1062 = hir.bitcast v1061 : (ptr i32);
             hir.store v1062, v988;
             builtin.ret v1060;

--- a/tests/integration/expected/examples/storage_example_unoptimized.hir
+++ b/tests/integration/expected/examples/storage_example_unoptimized.hir
@@ -298,14 +298,14 @@ builtin.component miden:storage-example/foo@1.0.0 {
         public builtin.function @miden:storage-example/foo@1.0.0#test-storage-item(v242: i32, v243: felt, v244: felt, v245: felt, v246: felt) -> felt {
         ^block33(v242: i32, v243: felt, v244: felt, v245: felt, v246: felt):
             v248 = arith.constant 0 : i32;
-            builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
+            v249 = builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
             v250 = hir.bitcast v249 : (ptr i32);
             v251 = hir.load v250 : i32;
             v252 = arith.constant 96 : i32;
             v253 = arith.sub v251, v252 : i32 #[overflow = wrapping];
             v254 = arith.constant -32 : i32;
             v255 = arith.band v253, v254 : i32;
-            builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
+            v256 = builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
             v257 = hir.bitcast v256 : (ptr i32);
             hir.store v257, v255;
             hir.exec @miden:storage-example/foo@1.0.0/storage_example/wit_bindgen_rt::run_ctors_once()
@@ -362,7 +362,7 @@ builtin.component miden:storage-example/foo@1.0.0 {
             hir.assertz v293 #[code = 250];
             v294 = hir.int_to_ptr v291 : (ptr felt);
             v295 = hir.load v294 : felt;
-            builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
+            v296 = builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
             v297 = hir.bitcast v296 : (ptr i32);
             hir.store v297, v251;
             cf.br ^block34(v295);
@@ -373,14 +373,14 @@ builtin.component miden:storage-example/foo@1.0.0 {
         public builtin.function @miden:storage-example/foo@1.0.0#test-storage-map-item(v298: i32, v299: felt, v300: felt, v301: felt, v302: felt, v303: felt, v304: felt, v305: felt, v306: felt) -> felt {
         ^block37(v298: i32, v299: felt, v300: felt, v301: felt, v302: felt, v303: felt, v304: felt, v305: felt, v306: felt):
             v308 = arith.constant 0 : i32;
-            builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
+            v309 = builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
             v310 = hir.bitcast v309 : (ptr i32);
             v311 = hir.load v310 : i32;
             v312 = arith.constant 128 : i32;
             v313 = arith.sub v311, v312 : i32 #[overflow = wrapping];
             v314 = arith.constant -32 : i32;
             v315 = arith.band v313, v314 : i32;
-            builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
+            v316 = builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
             v317 = hir.bitcast v316 : (ptr i32);
             hir.store v317, v315;
             hir.exec @miden:storage-example/foo@1.0.0/storage_example/wit_bindgen_rt::run_ctors_once()
@@ -473,7 +473,7 @@ builtin.component miden:storage-example/foo@1.0.0 {
             hir.assertz v381 #[code = 250];
             v382 = hir.int_to_ptr v379 : (ptr felt);
             v383 = hir.load v382 : felt;
-            builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
+            v384 = builtin.global_symbol @miden:storage-example/foo@1.0.0/storage_example/__stack_pointer : (ptr u8)
             v385 = hir.bitcast v384 : (ptr i32);
             hir.store v385, v311;
             cf.br ^block38(v383);

--- a/tests/integration/expected/ge_felt.masm
+++ b/tests/integration/expected/ge_felt.masm
@@ -1,3 +1,15 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+end
+
+
 # mod root_ns:root@1.0.0::ge_felt
 
 export.entrypoint

--- a/tests/integration/expected/ge_i32.masm
+++ b/tests/integration/expected/ge_i32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_1e76175a91b5fc3090baafa017f5a38c53c37f1e1a73be7ebaa886f57b9f86fb
 
 export.entrypoint

--- a/tests/integration/expected/ge_i64.masm
+++ b/tests/integration/expected/ge_i64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_9edabb66d927b03a3d0e64c65bad79cd5488a5bf59a9059a832f3582c7184d6b
 
 export.entrypoint

--- a/tests/integration/expected/ge_u16.masm
+++ b/tests/integration/expected/ge_u16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_6b89d656eff2711a9ee50d11f22845c4cbbc0df54339492d30dcf628910850d2
 
 export.entrypoint

--- a/tests/integration/expected/ge_u32.masm
+++ b/tests/integration/expected/ge_u32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_a6a04660dda2007e5b39d22340b438c2120c4114b075c90883d9b212365eb5fe
 
 export.entrypoint

--- a/tests/integration/expected/ge_u64.masm
+++ b/tests/integration/expected/ge_u64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_b008d40be4d6e94465c1a26de42c380b06e09a3774e7a937bf5c338fd437b333
 
 export.entrypoint

--- a/tests/integration/expected/ge_u8.masm
+++ b/tests/integration/expected/ge_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_a7d66021fee4ca04dff85edcc2a0482cfea1494683ab39c1ae381746dfbf0d98
 
 export.entrypoint

--- a/tests/integration/expected/gt_felt.masm
+++ b/tests/integration/expected/gt_felt.masm
@@ -1,3 +1,15 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+end
+
+
 # mod root_ns:root@1.0.0::gt_felt
 
 export.entrypoint

--- a/tests/integration/expected/gt_i32.masm
+++ b/tests/integration/expected/gt_i32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_9d2e8775109dcfc1c935f1f5d3649375cc140aedefb7659a7c1d3720c82086ec
 
 export.entrypoint

--- a/tests/integration/expected/gt_i64.masm
+++ b/tests/integration/expected/gt_i64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_7d82f2e08b811f59ed036f725c1b72ca685b95ee301d765a74b8f7da3048058b
 
 export.entrypoint

--- a/tests/integration/expected/gt_u16.masm
+++ b/tests/integration/expected/gt_u16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_cacaae112ac2013d020f0f82f9c334edde1d01c5854d6174ba2ebf34c2a8fc37
 
 export.entrypoint

--- a/tests/integration/expected/gt_u32.masm
+++ b/tests/integration/expected/gt_u32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_35873b6ce3c76e068032779fcd1e75617c26429a13cc7bcd687d3302885cf1f1
 
 export.entrypoint

--- a/tests/integration/expected/gt_u64.masm
+++ b/tests/integration/expected/gt_u64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_6489ee5460bd7aa58670638ded1591ff3f7c6abbcc5423cc0a2f5a4feb1ca663
 
 export.entrypoint

--- a/tests/integration/expected/gt_u8.masm
+++ b/tests/integration/expected/gt_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_455aa9bc12d63425df846020b1734fc76252696200bb44305ecdb2dacce6f789
 
 export.entrypoint

--- a/tests/integration/expected/is_prime.masm
+++ b/tests/integration/expected/is_prime.masm
@@ -1,3 +1,15 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+end
+
+
 # mod root_ns:root@1.0.0::is_prime
 
 export.entrypoint

--- a/tests/integration/expected/le_felt.masm
+++ b/tests/integration/expected/le_felt.masm
@@ -1,3 +1,15 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+end
+
+
 # mod root_ns:root@1.0.0::le_felt
 
 export.entrypoint

--- a/tests/integration/expected/le_i32.masm
+++ b/tests/integration/expected/le_i32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_92cb575434e29cb53446988749bb020eaeee06891c154db71ddd9e1df57a151a
 
 export.entrypoint

--- a/tests/integration/expected/le_i64.masm
+++ b/tests/integration/expected/le_i64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_d1d5c9c08b80e76c14cb392695a30c0d0f06df4b14bd1301c713918bb7259fd5
 
 export.entrypoint

--- a/tests/integration/expected/le_u16.masm
+++ b/tests/integration/expected/le_u16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_8e5b56cf449e682f0de4180f5e5ed7f7dd36f7d96e84a0c17bc979aa91efca6e
 
 export.entrypoint

--- a/tests/integration/expected/le_u32.masm
+++ b/tests/integration/expected/le_u32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_bb7287e639f21ae334cbe77ea9953a6971d3586eb3527866fb5a973c6a9d7999
 
 export.entrypoint

--- a/tests/integration/expected/le_u64.masm
+++ b/tests/integration/expected/le_u64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_175cf1929f30f3603a14a8443c3a31ee62ac12c89cd674c497750d11c4b1fcb6
 
 export.entrypoint

--- a/tests/integration/expected/le_u8.masm
+++ b/tests/integration/expected/le_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_6b31118a71e100e1653e01e16012428a3ef4b388ea4b8aa8f00a0e4ff40c4ad9
 
 export.entrypoint

--- a/tests/integration/expected/lt_felt.masm
+++ b/tests/integration/expected/lt_felt.masm
@@ -1,3 +1,15 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+end
+
+
 # mod root_ns:root@1.0.0::lt_felt
 
 export.entrypoint

--- a/tests/integration/expected/lt_i32.masm
+++ b/tests/integration/expected/lt_i32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_5693119d28cd4640a4976d9000775e22d586752187efa219aae5739cf37d894a
 
 export.entrypoint

--- a/tests/integration/expected/lt_i64.masm
+++ b/tests/integration/expected/lt_i64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_193ef2ef135ab65a9e3987e493e8cf00a81359975e6bffaf693a15c44afbf24b
 
 export.entrypoint

--- a/tests/integration/expected/lt_u16.masm
+++ b/tests/integration/expected/lt_u16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_66380427a6137e56f56ac9060dff040ec50d21b1cf2dab70538313874bc4a594
 
 export.entrypoint

--- a/tests/integration/expected/lt_u32.masm
+++ b/tests/integration/expected/lt_u32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_1fcb2f151e54a93413cfbf27b720161db50a02b59d060ed448c3ffe2c3c9cc6c
 
 export.entrypoint

--- a/tests/integration/expected/lt_u64.masm
+++ b/tests/integration/expected/lt_u64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_416d83d84b3ae500f053222602966b59099d85bd2706dbbaf20b4eb34e76cf0e
 
 export.entrypoint

--- a/tests/integration/expected/lt_u8.masm
+++ b/tests/integration/expected/lt_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_b8700ecc87997bcf6eefb8bf0b6e645582a0ad9339bbe24fccc168e4c61e746e
 
 export.entrypoint

--- a/tests/integration/expected/mul_felt.masm
+++ b/tests/integration/expected/mul_felt.masm
@@ -1,3 +1,15 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+end
+
+
 # mod root_ns:root@1.0.0::mul_felt
 
 export.entrypoint

--- a/tests/integration/expected/mul_i32.masm
+++ b/tests/integration/expected/mul_i32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_4a870fe7a144fba5513f0d246ed1179aba172aab8f12afb574634dd1bb298024
 
 export.entrypoint

--- a/tests/integration/expected/mul_i64.masm
+++ b/tests/integration/expected/mul_i64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_ee95318918a451f864b66b576532b422841bcd75ad8a62c4d4d3489a9158c08d
 
 export.entrypoint

--- a/tests/integration/expected/mul_u16.masm
+++ b/tests/integration/expected/mul_u16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_1503849cd0d258094fa54f6a7e16334db70e5daa56a5858f344d2a2c90b757d6
 
 export.entrypoint

--- a/tests/integration/expected/mul_u32.masm
+++ b/tests/integration/expected/mul_u32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_774ac315a535180c25b481293c43de2ad5b38b8ed718ccd906a367b8df969453
 
 export.entrypoint

--- a/tests/integration/expected/mul_u64.masm
+++ b/tests/integration/expected/mul_u64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_ef43647914852c132ded20e7ab9569f69610af521a6074095544ea088f8908ae
 
 export.entrypoint

--- a/tests/integration/expected/mul_u8.masm
+++ b/tests/integration/expected/mul_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_3332f4e22611553fee6834bdfb5edc7af11b545fb7a55941be9fef2efaecf059
 
 export.entrypoint

--- a/tests/integration/expected/neg_felt.masm
+++ b/tests/integration/expected/neg_felt.masm
@@ -1,3 +1,15 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+end
+
+
 # mod root_ns:root@1.0.0::neg_felt
 
 export.entrypoint

--- a/tests/integration/expected/neg_i16.masm
+++ b/tests/integration/expected/neg_i16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_ff799fd5021c298afc16f98dda4d174c028df9b4ad9e425d365d3c1fb3cef25a
 
 export.entrypoint

--- a/tests/integration/expected/neg_i32.masm
+++ b/tests/integration/expected/neg_i32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_ad225f3904404156f79b92bcde2daa108dc69c4c2e00a61030a898c2fcb6f87c
 
 export.entrypoint

--- a/tests/integration/expected/neg_i64.masm
+++ b/tests/integration/expected/neg_i64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_7e6ecbf37c062a73130e37145b77eb9dd3cce8aa16128ac9fcca7dc837ca562c
 
 export.entrypoint

--- a/tests/integration/expected/neg_i8.masm
+++ b/tests/integration/expected/neg_i8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_7564589530886ab89f7963543a4d7e1529e7436aaa330e5e742ddde3149deefe
 
 export.entrypoint

--- a/tests/integration/expected/or_bool.masm
+++ b/tests/integration/expected/or_bool.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_f1d36010a1862f085dfb5f246228723fc87e291a764ca76107b03554afd7db26
 
 export.entrypoint

--- a/tests/integration/expected/rust_sdk/cross_ctx_account.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_account.masm
@@ -6,6 +6,25 @@ export.process-felt
 end
 
 
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.5121323707957172480
+        push.16385291266171272914
+        push.3612753469884014922
+        push.8597705872349702967
+        adv.push_mapval
+        push.262144
+        push.3
+        exec.::std::mem::pipe_preimage_to_memory
+        drop
+        push.1048576
+        u32assert
+        mem_store.262144
+end
+
+
 # mod miden:cross-ctx-account/foo@1.0.0::cross_ctx_account
 
 proc.__wasm_call_ctors

--- a/tests/integration/expected/rust_sdk/cross_ctx_account.masm
+++ b/tests/integration/expected/rust_sdk/cross_ctx_account.masm
@@ -91,26 +91,14 @@ proc.__rustc::__rust_realloc
                     push.1
                     u32overflowing_madd
                     assertz
-                    dup.0
-                    u32mod.16
-                    dup.0
-                    u32mod.4
+                    u32divmod.4
                     swap.1
-                    u32div.4
-                    movup.2
-                    u32div.16
                     exec.::intrinsics::mem::load_sw
                     push.128
                     u32and
                     swap.1
-                    dup.0
-                    u32mod.16
-                    dup.0
-                    u32mod.4
+                    u32divmod.4
                     swap.1
-                    u32div.4
-                    movup.2
-                    u32div.16
                     dup.2
                     dup.2
                     dup.2
@@ -233,14 +221,8 @@ proc.wit_bindgen_rt::run_ctors_once
         push.0
         add
         u32assert
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::load_sw
         push.128
         u32and
@@ -258,14 +240,8 @@ proc.wit_bindgen_rt::run_ctors_once
             push.0
             add
             u32assert
-            dup.0
-            u32mod.16
-            dup.0
-            u32mod.4
+            u32divmod.4
             swap.1
-            u32div.4
-            movup.2
-            u32div.16
             dup.2
             dup.2
             dup.2
@@ -344,14 +320,8 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
                 u32mod
                 u32assert
                 assertz.err=250
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
+                u32divmod.4
                 swap.1
-                u32div.4
-                movup.2
-                u32div.16
                 exec.::intrinsics::mem::load_sw
                 push.0
                 neq
@@ -378,14 +348,8 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
                     swap.1
                     u32wrapping_add
                     swap.1
-                    dup.0
-                    u32mod.16
-                    dup.0
-                    u32mod.4
+                    u32divmod.4
                     swap.1
-                    u32div.4
-                    movup.2
-                    u32div.16
                     exec.::intrinsics::mem::store_sw
                     push.0
                     swap.3
@@ -397,14 +361,8 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
                 u32mod
                 u32assert
                 assertz.err=250
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
+                u32divmod.4
                 swap.1
-                u32div.4
-                movup.2
-                u32div.16
                 exec.::intrinsics::mem::load_sw
                 push.0
                 dup.3
@@ -434,14 +392,8 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
                     movup.3
                     u32wrapping_add
                     swap.1
-                    dup.0
-                    u32mod.16
-                    dup.0
-                    u32mod.4
+                    u32divmod.4
                     swap.1
-                    u32div.4
-                    movup.2
-                    u32div.16
                     exec.::intrinsics::mem::store_sw
                     push.1
                     swap.1

--- a/tests/integration/expected/shl_i16.masm
+++ b/tests/integration/expected/shl_i16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_c3eed17236100365f8c1660de046d9d6663a7b82697275884d4fcb6fa25a7447
 
 export.entrypoint

--- a/tests/integration/expected/shl_i32.masm
+++ b/tests/integration/expected/shl_i32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_bb1e5acff11c647800da7bb67237f59cfa6dcc846fe64b76bfdce3d151cb1de9
 
 export.entrypoint

--- a/tests/integration/expected/shl_i64.masm
+++ b/tests/integration/expected/shl_i64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_9d7fa5c817c0e8ad40aeb12756fb108047ae365f6bc8c673617a6bc264b3917a
 
 export.entrypoint

--- a/tests/integration/expected/shl_i8.masm
+++ b/tests/integration/expected/shl_i8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_64d9b2f2c2b5e80b282b2d87195903012daf88be2507d12d0bc75d869a811922
 
 export.entrypoint

--- a/tests/integration/expected/shl_u16.masm
+++ b/tests/integration/expected/shl_u16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_3ab387e5fafe4f8316074728a13b9c62413b6215a11492c80aa3e1d10383e008
 
 export.entrypoint

--- a/tests/integration/expected/shl_u32.masm
+++ b/tests/integration/expected/shl_u32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_3618ee9a49fe14195a2097b20a230da5249d5b99ab7da35b402a7c16f4fa5609
 
 export.entrypoint

--- a/tests/integration/expected/shl_u64.masm
+++ b/tests/integration/expected/shl_u64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_ef9c837ab7c2bd11aacdf5ad41eb9264c0daecd169f2b4cfe73fd928059744bb
 
 export.entrypoint

--- a/tests/integration/expected/shl_u8.masm
+++ b/tests/integration/expected/shl_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_b211bf2251e0ca4732fe0f4b9390e5838c61a0ef97c8b47f099f8c5ab3657e7f
 
 export.entrypoint

--- a/tests/integration/expected/shr_i64.masm
+++ b/tests/integration/expected/shr_i64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_186d93d83b74a241eb99ffa0ead88d2435a288695c19f22c9c35eecfda978717
 
 export.entrypoint

--- a/tests/integration/expected/shr_u16.masm
+++ b/tests/integration/expected/shr_u16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_96d61f728452f9b581e6c765749adb51e9f48ad7e7527bde3c25a5943fa1a541
 
 export.entrypoint

--- a/tests/integration/expected/shr_u32.masm
+++ b/tests/integration/expected/shr_u32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_98363f37c9b0fb3dc27cafaa81c0eb63c6a764c82cbedfc0da3e37a43e1d2331
 
 export.entrypoint

--- a/tests/integration/expected/shr_u64.masm
+++ b/tests/integration/expected/shr_u64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_9efc7a825f7a743a5fc284e5d1f0d3fc1bb239f780841274be29a84565e75592
 
 export.entrypoint

--- a/tests/integration/expected/shr_u8.masm
+++ b/tests/integration/expected/shr_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_04fd0cb7f25bc890cc2570ad64142734f4731c48e1507938bd1b769f028cf2c4
 
 export.entrypoint

--- a/tests/integration/expected/sub_felt.masm
+++ b/tests/integration/expected/sub_felt.masm
@@ -1,3 +1,15 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+end
+
+
 # mod root_ns:root@1.0.0::sub_felt
 
 export.entrypoint

--- a/tests/integration/expected/sub_i16.masm
+++ b/tests/integration/expected/sub_i16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_b6360a7c4709c8e140b5433c6b25904ac7efbab248a7f37933a33b31d5f40c49
 
 export.entrypoint

--- a/tests/integration/expected/sub_i32.masm
+++ b/tests/integration/expected/sub_i32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_6fc6fd0b2e86628d32094545ba25215329fcd62cd1f981d0dbdd2c989eed3a52
 
 export.entrypoint

--- a/tests/integration/expected/sub_i64.masm
+++ b/tests/integration/expected/sub_i64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_c2e6cec606b20447e4c5accdc801c32098f0d7cda3811f8c4e38f16911210b8f
 
 export.entrypoint

--- a/tests/integration/expected/sub_i8.masm
+++ b/tests/integration/expected/sub_i8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_c22e1496a88c74570b0e64374e0cf2e7a89efbbc6ead48d3e0471d8654d2afdc
 
 export.entrypoint

--- a/tests/integration/expected/sub_u16.masm
+++ b/tests/integration/expected/sub_u16.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_d8aa82f0674d72cf16435a3b3f6c248ab8b08b77539ac08b01e393fd53f96cb7
 
 export.entrypoint

--- a/tests/integration/expected/sub_u32.masm
+++ b/tests/integration/expected/sub_u32.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_19bb93ff4625e8bdb6a3470a0b61a142a94458a4ee602822cb8360bf1f07368f
 
 export.entrypoint

--- a/tests/integration/expected/sub_u64.masm
+++ b/tests/integration/expected/sub_u64.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_07a967cd239987abbfb9236f41c9268dd55be09bc1efb30f1e4684134ef772b0
 
 export.entrypoint

--- a/tests/integration/expected/sub_u8.masm
+++ b/tests/integration/expected/sub_u8.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_be0120d0a160e710cbd53bd6dc4ac525bbb3596615ae6ec2d5f88c74c069aabe
 
 export.entrypoint

--- a/tests/integration/expected/types/array.masm
+++ b/tests/integration/expected/types/array.masm
@@ -1,3 +1,30 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.2552035692683956824
+        push.5323511717551755022
+        push.6168074652703322390
+        push.2298154438505521656
+        adv.push_mapval
+        push.262144
+        push.3
+        exec.::std::mem::pipe_preimage_to_memory
+        drop
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048616
+        u32assert
+        mem_store.262145
+        push.1048624
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_d63291a98b435c53f58385d5782fb46f0b0b78bee8e860843e7223106d66f7d6
 
 export.sum_arr

--- a/tests/integration/expected/types/array.masm
+++ b/tests/integration/expected/types/array.masm
@@ -31,14 +31,8 @@ export.sum_arr
                 u32mod
                 u32assert
                 assertz.err=250
-                dup.0
-                u32mod.16
-                dup.0
-                u32mod.4
+                u32divmod.4
                 swap.1
-                u32div.4
-                movup.2
-                u32div.16
                 exec.::intrinsics::mem::load_sw
                 movup.2
                 u32wrapping_add

--- a/tests/integration/expected/types/static_mut.masm
+++ b/tests/integration/expected/types/static_mut.masm
@@ -1,3 +1,30 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.11434542961250426374
+        push.12905227908764935604
+        push.12374698099726530180
+        push.495727412639301595
+        adv.push_mapval
+        push.262144
+        push.1
+        exec.::std::mem::pipe_preimage_to_memory
+        drop
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048585
+        u32assert
+        mem_store.262145
+        push.1048592
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_e6d553fb1c80aef6e5d6f2891701197bedac471cf510bd2495f99889d9543cd4
 
 export.global_var_update

--- a/tests/integration/expected/types/static_mut.masm
+++ b/tests/integration/expected/types/static_mut.masm
@@ -6,14 +6,8 @@ export.global_var_update
         push.0
         add
         u32assert
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         exec.::intrinsics::mem::load_sw
         push.128
         u32and
@@ -26,14 +20,8 @@ export.global_var_update
         push.0
         add
         u32assert
-        dup.0
-        u32mod.16
-        dup.0
-        u32mod.4
+        u32divmod.4
         swap.1
-        u32div.4
-        movup.2
-        u32div.16
         dup.2
         dup.2
         dup.2
@@ -62,14 +50,8 @@ export.__main
             dup.1
             swap.1
             u32wrapping_add
-            dup.0
-            u32mod.16
-            dup.0
-            u32mod.4
+            u32divmod.4
             swap.1
-            u32div.4
-            movup.2
-            u32div.16
             exec.::intrinsics::mem::load_sw
             push.128
             u32and

--- a/tests/integration/expected/xor_bool.masm
+++ b/tests/integration/expected/xor_bool.masm
@@ -1,3 +1,21 @@
+# mod root_ns:root@1.0.0
+
+export.init
+
+        push.2162688
+        exec.::intrinsics::mem::heap_init
+        push.1048576
+        u32assert
+        mem_store.262144
+        push.1048576
+        u32assert
+        mem_store.262145
+        push.1048576
+        u32assert
+        mem_store.262146
+end
+
+
 # mod root_ns:root@1.0.0::test_rust_12478c1c469cdb8e5c0d08223b9ea0b6f7c1cade83ed772fb79969d2af3004cb
 
 export.entrypoint

--- a/tests/integration/src/rust_masm_tests/abi_transform/stdlib.rs
+++ b/tests/integration/src/rust_masm_tests/abi_transform/stdlib.rs
@@ -32,56 +32,69 @@ fn test_blake3_hash() {
     test.expect_ir(expect_file![format!("../../../expected/{artifact_name}.hir")]);
     test.expect_masm(expect_file![format!("../../../expected/{artifact_name}.masm")]);
 
-    // FIX: uncomment when https://github.com/0xPolygonMiden/compiler/issues/352 is fixed
-    //
-    // let package = test.compiled_package();
-    //
-    // // Run the Rust and compiled MASM code against a bunch of random inputs and compare the results
-    // let res = TestRunner::default().run(&any::<[u8; 32]>(), move |ibytes| {
-    //     let hash_bytes = blake3::hash(&ibytes);
-    //     let rs_out = hash_bytes.as_bytes();
-    //     let in_addr = 21u32 * 65536;
-    //     let out_addr = 20u32 * 65536;
-    //     let mut frame = Vec::<Felt>::default();
-    //     // Convert input bytes to words
-    //     let words = midenc_debug::bytes_to_words(&ibytes);
-    //     for word in words.into_iter().rev() {
-    //         PushToStack::try_push(&word, &mut frame);
-    //     }
-    //     PushToStack::try_push(&2u32, &mut frame); // num_words
-    //     PushToStack::try_push(&(in_addr / 16), &mut frame); // dest_ptr
-    //     dbg!(&ibytes, &frame, rs_out);
-    //     // Arguments are: [hash_output_ptr, hash_input_ptr]
-    //     let mut exec = Executor::for_package(
-    //         &package,
-    //         // Place the hash output at 20 * PAGE_SIZE, and the hash input at 21 * PAGE_SIZE
-    //         vec![Felt::new(in_addr as u64), Felt::new(out_addr as u64)],
-    //         &test.session,
-    //     )
-    //     .map_err(|err| TestCaseError::fail(err.to_string()))?;
-    //     // Reverse the stack contents, so that the correct order is preserved after
-    //     // MemAdviceProvider does its own reverse
-    //     frame.reverse();
-    //     let advice_inputs = AdviceInputs::default().with_stack(frame);
-    //     exec.with_advice_inputs(advice_inputs);
-    //     let trace = exec.execute(&package.unwrap_program(), &test.session);
-    //     let vm_in: [u8; 32] = trace
-    //         .read_from_rust_memory(in_addr)
-    //         .expect("expected memory to have been written");
-    //     dbg!(&vm_in);
-    //     let vm_out: [u8; 32] = trace
-    //         .read_from_rust_memory(out_addr)
-    //         .expect("expected memory to have been written");
-    //     dbg!(&vm_out);
-    //     prop_assert_eq!(rs_out, &vm_out, "VM output mismatch");
-    //     Ok(())
-    // });
-    //
-    // match res {
-    //     Err(TestError::Fail(_, value)) => {
-    //         panic!("Found minimal(shrinked) failing case: {:?}", value);
-    //     }
-    //     Ok(_) => (),
-    //     _ => panic!("Unexpected test result: {:?}", res),
-    // }
+    let package = test.compiled_package();
+
+    // Run the Rust and compiled MASM code against a bunch of random inputs and compare the results
+    let config = proptest::test_runner::Config::with_cases(10);
+    let res = TestRunner::new(config).run(&any::<[u8; 32]>(), move |ibytes| {
+        let hash_bytes = blake3::hash(&ibytes);
+        let rs_out = hash_bytes.as_bytes();
+        let in_addr = 21u32 * 65536;
+        let out_addr = 20u32 * 65536;
+        let mut advice_stack = Vec::<Felt>::default();
+        // Provide input bytes via the advice stack
+        //
+        // NOTE: This relies on MasmComponent to emit a test harness via `emit_test_harness` during
+        // assembly of the package.
+        //
+        // First, convert the input bytes to words, zero-padding as needed; and push on to the
+        // advice stack in reverse.
+        let words = midenc_debug::bytes_to_words(&ibytes);
+        for word in words.into_iter().rev() {
+            PushToStack::try_push(&word, &mut advice_stack);
+        }
+        // The test harness invokes std::mem::pipe_words_to_memory, which expects the operand stack
+        // to look like: `[num_words, write_ptr]`.
+        //
+        // Since we're feeding this data in via the advice stack, the test harness code will expect
+        // these values on the advice stack in the opposite order, as the `adv_push` instruction
+        // will pop each element off the advice stack, and push on to the operand stack, after which
+        // these two values will be in the expected order.
+        PushToStack::try_push(&2u32, &mut advice_stack); // [num_words]
+        PushToStack::try_push(&(in_addr / 4), &mut advice_stack); // [dest_ptr, num_words]
+        dbg!(&ibytes, &advice_stack, rs_out);
+        // Arguments are: [hash_output_ptr, hash_input_ptr]
+        let mut exec = Executor::for_package(
+            &package,
+            // Place the hash output at 20 * PAGE_SIZE, and the hash input at 21 * PAGE_SIZE
+            vec![Felt::new(in_addr as u64), Felt::new(out_addr as u64)],
+            &test.session,
+        )
+        .map_err(|err| TestCaseError::fail(err.to_string()))?;
+
+        // Reverse the stack contents, so that the correct order is preserved after
+        // MemAdviceProvider does its own reverse
+        advice_stack.reverse();
+        let advice_inputs = AdviceInputs::default().with_stack(advice_stack);
+        exec.with_advice_inputs(advice_inputs);
+        let trace = exec.execute(&package.unwrap_program(), &test.session);
+        let vm_in: [u8; 32] = trace
+            .read_from_rust_memory(in_addr)
+            .expect("expected memory to have been written");
+        dbg!(&vm_in);
+        let vm_out: [u8; 32] = trace
+            .read_from_rust_memory(out_addr)
+            .expect("expected memory to have been written");
+        dbg!(&vm_out);
+        prop_assert_eq!(rs_out, &vm_out, "VM output mismatch");
+        Ok(())
+    });
+
+    match res {
+        Err(TestError::Fail(_, value)) => {
+            panic!("Found minimal(shrinked) failing case: {:?}", value);
+        }
+        Ok(_) => (),
+        _ => panic!("Unexpected test result: {:?}", res),
+    }
 }

--- a/tests/integration/src/rust_masm_tests/rust_sdk.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk.rs
@@ -148,9 +148,14 @@ fn rust_sdk_cross_ctx_account() {
         .map(|e| format!("{}::{}", e.module, e.name.as_str()))
         .collect::<Vec<_>>();
     dbg!(&exports);
-    assert!(lib.exports().any(|export| {
-        export.module.to_string() == expected_module && export.name.as_str() == expected_function
-    }));
+    assert!(
+        lib.exports().any(|export| {
+            export.module.to_string() == expected_module
+                && export.name.as_str() == expected_function
+        }),
+        "expected one of the exports to contain module '{expected_module}' and function \
+         '{expected_function}"
+    );
     // TODO: uncomment after https://github.com/0xPolygonMiden/compiler/issues/441 is resolved
     //
     // Test that the package loads


### PR DESCRIPTION
This PR does the following:

1. Refactors the code generator to emit memory operations based on a element-oriented address space, rather than word-oriented.
2. Updates our dependency on the various Miden VM crates we depend on to use the latest stable release (i.e. 0.13.1)
3. Fixes the incomplete handling of global variables and data segments in the code generator and linker. This was the reason why #352 occurred, and that issue is fixed by these changes and the test re-enabled. It would have affected any program relying on global variables/data segments though, so it was a big oversight on my part. I hadn't caught it earlier because I thought the full blake3 test was still being run, but it was actually partially commented out, and our other tests apparently don't use globals/segments, so it never caused failures elsewhere (at least, not that are caught by our tests currently).

Closes #374 
