### PR TITLE
fix: make `HEAP_END` in `BumpAlloc` to be `u32::MAX`

### DIFF
--- a/sdk/alloc/src/lib.rs
+++ b/sdk/alloc/src/lib.rs
@@ -18,9 +18,8 @@ const MIN_ALIGN: usize = 16;
 
 /// The linear memory heap must not spill over into the region reserved for procedure locals, which
 /// begins at 2^30 in Miden's address space. In Rust address space it should be 2^30 * 4 but since
-/// it overflows the usize which is 32-bit on wasm32 we use u32::MAX. "-1" is to avoid `xor` op in
-/// the compiled Wasm.
-const HEAP_END: *mut u8 = (u32::MAX - 1) as *mut u8;
+/// it overflows the usize which is 32-bit on wasm32 we use u32::MAX.
+const HEAP_END: *mut u8 = u32::MAX as *mut u8;
 
 /// A very simple allocator for Miden SDK-based programs.
 ///

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.hir
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.hir
@@ -220,11 +220,11 @@ builtin.component root_ns:root@1.0.0 {
             v141 = hir.bitcast v140 : i32;
             v143 = arith.neq v141, v134 : i1;
             v144 = cf.select v143, v131, v135 : i32;
-            v742 = arith.constant 0 : i32;
+            v743 = arith.constant 0 : i32;
             v145 = arith.constant -1 : i32;
             v146 = arith.add v144, v145 : i32 #[overflow = wrapping];
             v147 = arith.band v144, v146 : i32;
-            v149 = arith.neq v147, v742 : i1;
+            v149 = arith.neq v147, v743 : i1;
             v712, v713 = scf.if v149 : i32, u32 {
             ^block99:
                 v704 = arith.constant 0 : u32;
@@ -233,7 +233,7 @@ builtin.component root_ns:root@1.0.0 {
             } else {
             ^block31:
                 v151 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/core::ptr::alignment::Alignment::max(v131, v144) : i32
-                v741 = arith.constant 0 : i32;
+                v742 = arith.constant 0 : i32;
                 v150 = arith.constant -2147483648 : i32;
                 v152 = arith.sub v150, v151 : i32 #[overflow = wrapping];
                 v154 = hir.bitcast v152 : u32;
@@ -241,18 +241,18 @@ builtin.component root_ns:root@1.0.0 {
                 v155 = arith.gt v153, v154 : i1;
                 v156 = arith.zext v155 : u32;
                 v157 = hir.bitcast v156 : i32;
-                v159 = arith.neq v157, v741 : i1;
+                v159 = arith.neq v157, v742 : i1;
                 v727 = scf.if v159 : i32 {
                 ^block98:
-                    v740 = ub.poison i32 : i32;
-                    scf.yield v740;
+                    v741 = ub.poison i32 : i32;
+                    scf.yield v741;
                 } else {
                 ^block32:
-                    v738 = arith.constant 0 : i32;
-                    v165 = arith.sub v738, v151 : i32 #[overflow = wrapping];
-                    v739 = arith.constant -1 : i32;
+                    v739 = arith.constant 0 : i32;
+                    v165 = arith.sub v739, v151 : i32 #[overflow = wrapping];
+                    v740 = arith.constant -1 : i32;
                     v161 = arith.add v132, v151 : i32 #[overflow = wrapping];
-                    v163 = arith.add v161, v739 : i32 #[overflow = wrapping];
+                    v163 = arith.add v161, v740 : i32 #[overflow = wrapping];
                     v166 = arith.band v163, v165 : i32;
                     v167 = hir.bitcast v130 : u32;
                     v168 = arith.constant 4 : u32;
@@ -260,8 +260,8 @@ builtin.component root_ns:root@1.0.0 {
                     hir.assertz v169 #[code = 250];
                     v170 = hir.int_to_ptr v167 : ptr<byte, i32>;
                     v171 = hir.load v170 : i32;
-                    v737 = arith.constant 0 : i32;
-                    v173 = arith.neq v171, v737 : i1;
+                    v738 = arith.constant 0 : i32;
+                    v173 = arith.neq v171, v738 : i1;
                     scf.if v173{
                     ^block97:
                         scf.yield ;
@@ -270,29 +270,29 @@ builtin.component root_ns:root@1.0.0 {
                         v174 = hir.exec @intrinsics/mem/heap_base() : i32
                         v175 = hir.mem_size  : u32;
                         v181 = hir.bitcast v130 : u32;
-                        v736 = arith.constant 4 : u32;
-                        v183 = arith.mod v181, v736 : u32;
+                        v737 = arith.constant 4 : u32;
+                        v183 = arith.mod v181, v737 : u32;
                         hir.assertz v183 #[code = 250];
-                        v735 = arith.constant 16 : u32;
+                        v736 = arith.constant 16 : u32;
                         v176 = hir.bitcast v175 : i32;
-                        v179 = arith.shl v176, v735 : i32;
+                        v179 = arith.shl v176, v736 : i32;
                         v180 = arith.add v174, v179 : i32 #[overflow = wrapping];
                         v184 = hir.int_to_ptr v181 : ptr<byte, i32>;
                         hir.store v184, v180;
                         scf.yield ;
                     };
                     v187 = hir.bitcast v130 : u32;
-                    v734 = arith.constant 4 : u32;
-                    v189 = arith.mod v187, v734 : u32;
+                    v735 = arith.constant 4 : u32;
+                    v189 = arith.mod v187, v735 : u32;
                     hir.assertz v189 #[code = 250];
                     v190 = hir.int_to_ptr v187 : ptr<byte, i32>;
                     v191 = hir.load v190 : i32;
                     v733 = arith.constant 0 : i32;
-                    v195 = hir.bitcast v166 : u32;
-                    v185 = arith.constant -2 : i32;
-                    v192 = arith.sub v185, v191 : i32 #[overflow = wrapping];
-                    v194 = hir.bitcast v192 : u32;
-                    v196 = arith.lt v194, v195 : i1;
+                    v734 = arith.constant -1 : i32;
+                    v193 = arith.bxor v191, v734 : i32;
+                    v195 = hir.bitcast v193 : u32;
+                    v194 = hir.bitcast v166 : u32;
+                    v196 = arith.gt v194, v195 : i1;
                     v197 = arith.zext v196 : u32;
                     v198 = hir.bitcast v197 : i32;
                     v200 = arith.neq v198, v733 : i1;
@@ -351,56 +351,56 @@ builtin.component root_ns:root@1.0.0 {
             hir.assertz v230 #[code = 250];
             v231 = hir.int_to_ptr v228 : ptr<byte, i32>;
             v232 = hir.load v231 : i32;
-            v753 = arith.constant 4 : u32;
+            v754 = arith.constant 4 : u32;
             v233 = hir.bitcast v219 : u32;
-            v235 = arith.add v233, v753 : u32 #[overflow = checked];
-            v752 = arith.constant 4 : u32;
-            v237 = arith.mod v235, v752 : u32;
+            v235 = arith.add v233, v754 : u32 #[overflow = checked];
+            v753 = arith.constant 4 : u32;
+            v237 = arith.mod v235, v753 : u32;
             hir.assertz v237 #[code = 250];
             v238 = hir.int_to_ptr v235 : ptr<byte, i32>;
             v239 = hir.load v238 : i32;
-            v751 = arith.constant 0 : i32;
+            v752 = arith.constant 0 : i32;
             v240 = arith.constant 1 : i32;
             v241 = arith.neq v239, v240 : i1;
             v242 = arith.zext v241 : u32;
             v243 = hir.bitcast v242 : i32;
-            v245 = arith.neq v243, v751 : i1;
+            v245 = arith.neq v243, v752 : i1;
             cf.cond_br v245 ^block39, ^block40;
         ^block39:
             v254 = arith.constant 12 : u32;
             v253 = hir.bitcast v219 : u32;
             v255 = arith.add v253, v254 : u32 #[overflow = checked];
-            v750 = arith.constant 4 : u32;
-            v257 = arith.mod v255, v750 : u32;
+            v751 = arith.constant 4 : u32;
+            v257 = arith.mod v255, v751 : u32;
             hir.assertz v257 #[code = 250];
             v258 = hir.int_to_ptr v255 : ptr<byte, i32>;
             v259 = hir.load v258 : i32;
-            v749 = arith.constant 4 : u32;
+            v750 = arith.constant 4 : u32;
             v260 = hir.bitcast v210 : u32;
-            v262 = arith.add v260, v749 : u32 #[overflow = checked];
-            v748 = arith.constant 4 : u32;
-            v264 = arith.mod v262, v748 : u32;
+            v262 = arith.add v260, v750 : u32 #[overflow = checked];
+            v749 = arith.constant 4 : u32;
+            v264 = arith.mod v262, v749 : u32;
             hir.assertz v264 #[code = 250];
             v265 = hir.int_to_ptr v262 : ptr<byte, i32>;
             hir.store v265, v259;
             v266 = hir.bitcast v210 : u32;
-            v747 = arith.constant 4 : u32;
-            v268 = arith.mod v266, v747 : u32;
+            v748 = arith.constant 4 : u32;
+            v268 = arith.mod v266, v748 : u32;
             hir.assertz v268 #[code = 250];
             v269 = hir.int_to_ptr v266 : ptr<byte, i32>;
             hir.store v269, v232;
-            v746 = arith.constant 16 : i32;
-            v271 = arith.add v219, v746 : i32 #[overflow = wrapping];
+            v747 = arith.constant 16 : i32;
+            v271 = arith.add v219, v747 : i32 #[overflow = wrapping];
             v272 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
             v273 = hir.bitcast v272 : ptr<byte, i32>;
             hir.store v273, v271;
             builtin.ret ;
         ^block40:
-            v745 = arith.constant 12 : u32;
+            v746 = arith.constant 12 : u32;
             v246 = hir.bitcast v219 : u32;
-            v248 = arith.add v246, v745 : u32 #[overflow = checked];
-            v744 = arith.constant 4 : u32;
-            v250 = arith.mod v248, v744 : u32;
+            v248 = arith.add v246, v746 : u32 #[overflow = checked];
+            v745 = arith.constant 4 : u32;
+            v250 = arith.mod v248, v745 : u32;
             hir.assertz v250 #[code = 250];
             v251 = hir.int_to_ptr v248 : ptr<byte, i32>;
             v252 = hir.load v251 : i32;
@@ -434,40 +434,40 @@ builtin.component root_ns:root@1.0.0 {
             v296 = arith.constant 12 : u32;
             v295 = hir.bitcast v280 : u32;
             v297 = arith.add v295, v296 : u32 #[overflow = checked];
-            v761 = arith.constant 4 : u32;
-            v299 = arith.mod v297, v761 : u32;
+            v762 = arith.constant 4 : u32;
+            v299 = arith.mod v297, v762 : u32;
             hir.assertz v299 #[code = 250];
             v300 = hir.int_to_ptr v297 : ptr<byte, i32>;
             v301 = hir.load v300 : i32;
-            v754 = arith.constant 2 : u32;
+            v755 = arith.constant 2 : u32;
             v303 = hir.bitcast v301 : u32;
-            v305 = arith.shr v303, v754 : u32;
+            v305 = arith.shr v303, v755 : u32;
             v306 = hir.bitcast v305 : i32;
             v307 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/miden_base_sys::bindings::note::extern_note_get_inputs(v306) : i32
-            v760 = arith.constant 8 : u32;
+            v761 = arith.constant 8 : u32;
             v308 = hir.bitcast v274 : u32;
-            v310 = arith.add v308, v760 : u32 #[overflow = checked];
-            v759 = arith.constant 4 : u32;
-            v312 = arith.mod v310, v759 : u32;
+            v310 = arith.add v308, v761 : u32 #[overflow = checked];
+            v760 = arith.constant 4 : u32;
+            v312 = arith.mod v310, v760 : u32;
             hir.assertz v312 #[code = 250];
             v313 = hir.int_to_ptr v310 : ptr<byte, i32>;
             hir.store v313, v307;
-            v758 = arith.constant 4 : u32;
+            v759 = arith.constant 4 : u32;
             v314 = hir.bitcast v274 : u32;
-            v316 = arith.add v314, v758 : u32 #[overflow = checked];
-            v757 = arith.constant 4 : u32;
-            v318 = arith.mod v316, v757 : u32;
+            v316 = arith.add v314, v759 : u32 #[overflow = checked];
+            v758 = arith.constant 4 : u32;
+            v318 = arith.mod v316, v758 : u32;
             hir.assertz v318 #[code = 250];
             v319 = hir.int_to_ptr v316 : ptr<byte, i32>;
             hir.store v319, v301;
             v320 = hir.bitcast v274 : u32;
-            v756 = arith.constant 4 : u32;
-            v322 = arith.mod v320, v756 : u32;
+            v757 = arith.constant 4 : u32;
+            v322 = arith.mod v320, v757 : u32;
             hir.assertz v322 #[code = 250];
             v323 = hir.int_to_ptr v320 : ptr<byte, i32>;
             hir.store v323, v294;
-            v755 = arith.constant 16 : i32;
-            v325 = arith.add v280, v755 : i32 #[overflow = wrapping];
+            v756 = arith.constant 16 : i32;
+            v325 = arith.add v280, v756 : i32 #[overflow = wrapping];
             v326 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
             v327 = hir.bitcast v326 : ptr<byte, i32>;
             hir.store v327, v325;
@@ -501,38 +501,38 @@ builtin.component root_ns:root@1.0.0 {
             hir.assertz v348 #[code = 250];
             v349 = hir.int_to_ptr v346 : ptr<byte, i32>;
             v350 = hir.load v349 : i32;
-            v768 = arith.constant 0 : i32;
+            v769 = arith.constant 0 : i32;
             v334 = arith.constant 0 : i32;
             v352 = arith.eq v350, v334 : i1;
             v353 = arith.zext v352 : u32;
             v354 = hir.bitcast v353 : i32;
-            v356 = arith.neq v354, v768 : i1;
+            v356 = arith.neq v354, v769 : i1;
             scf.if v356{
             ^block107:
                 scf.yield ;
             } else {
             ^block48:
-                v767 = arith.constant 4 : u32;
+                v768 = arith.constant 4 : u32;
                 v357 = hir.bitcast v339 : u32;
-                v359 = arith.add v357, v767 : u32 #[overflow = checked];
-                v766 = arith.constant 4 : u32;
-                v361 = arith.mod v359, v766 : u32;
+                v359 = arith.add v357, v768 : u32 #[overflow = checked];
+                v767 = arith.constant 4 : u32;
+                v361 = arith.mod v359, v767 : u32;
                 hir.assertz v361 #[code = 250];
                 v362 = hir.int_to_ptr v359 : ptr<byte, i32>;
                 v363 = hir.load v362 : i32;
                 v365 = arith.constant 12 : u32;
                 v364 = hir.bitcast v339 : u32;
                 v366 = arith.add v364, v365 : u32 #[overflow = checked];
-                v765 = arith.constant 4 : u32;
-                v368 = arith.mod v366, v765 : u32;
+                v766 = arith.constant 4 : u32;
+                v368 = arith.mod v366, v766 : u32;
                 hir.assertz v368 #[code = 250];
                 v369 = hir.int_to_ptr v366 : ptr<byte, i32>;
                 v370 = hir.load v369 : i32;
                 hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v363, v350, v370)
                 scf.yield ;
             };
-            v764 = arith.constant 16 : i32;
-            v373 = arith.add v339, v764 : i32 #[overflow = wrapping];
+            v765 = arith.constant 16 : i32;
+            v373 = arith.add v339, v765 : i32 #[overflow = wrapping];
             v374 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
             v375 = hir.bitcast v374 : ptr<byte, i32>;
             hir.store v375, v373;
@@ -562,23 +562,23 @@ builtin.component root_ns:root@1.0.0 {
             v397 = arith.zext v396 : u64;
             v398 = hir.bitcast v397 : i64;
             v402 = arith.mul v398, v401 : i64 #[overflow = wrapping];
-            v872 = arith.constant 0 : i32;
+            v873 = arith.constant 0 : i32;
             v403 = arith.constant 32 : i64;
             v405 = hir.cast v403 : u32;
             v404 = hir.bitcast v402 : u64;
             v406 = arith.shr v404, v405 : u64;
             v407 = hir.bitcast v406 : i64;
             v408 = arith.trunc v407 : i32;
-            v410 = arith.neq v408, v872 : i1;
-            v784, v785, v786, v787, v788, v789 = scf.if v410 : i32, i32, i32, i32, i32, u32 {
+            v410 = arith.neq v408, v873 : i1;
+            v785, v786, v787, v788, v789, v790 = scf.if v410 : i32, i32, i32, i32, i32, u32 {
             ^block109:
-                v769 = arith.constant 0 : u32;
-                v776 = ub.poison i32 : i32;
-                scf.yield v376, v387, v776, v776, v776, v769;
+                v770 = arith.constant 0 : u32;
+                v777 = ub.poison i32 : i32;
+                scf.yield v376, v387, v777, v777, v777, v770;
             } else {
             ^block54:
                 v411 = arith.trunc v402 : i32;
-                v871 = arith.constant 0 : i32;
+                v872 = arith.constant 0 : i32;
                 v412 = arith.constant -2147483648 : i32;
                 v413 = arith.sub v412, v379 : i32 #[overflow = wrapping];
                 v415 = hir.bitcast v413 : u32;
@@ -586,16 +586,16 @@ builtin.component root_ns:root@1.0.0 {
                 v416 = arith.lte v414, v415 : i1;
                 v417 = arith.zext v416 : u32;
                 v418 = hir.bitcast v417 : i32;
-                v420 = arith.neq v418, v871 : i1;
-                v832 = scf.if v420 : i32 {
+                v420 = arith.neq v418, v872 : i1;
+                v833 = scf.if v420 : i32 {
                 ^block52:
-                    v870 = arith.constant 0 : i32;
-                    v431 = arith.neq v411, v870 : i1;
-                    v831 = scf.if v431 : i32 {
+                    v871 = arith.constant 0 : i32;
+                    v431 = arith.neq v411, v871 : i1;
+                    v832 = scf.if v431 : i32 {
                     ^block56:
-                        v869 = arith.constant 0 : i32;
-                        v447 = arith.neq v378, v869 : i1;
-                        v830 = scf.if v447 : i32 {
+                        v870 = arith.constant 0 : i32;
+                        v447 = arith.neq v378, v870 : i1;
+                        v831 = scf.if v447 : i32 {
                         ^block59:
                             v429 = arith.constant 1 : i32;
                             hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::alloc::Global::alloc_impl(v387, v379, v411, v429)
@@ -614,130 +614,130 @@ builtin.component root_ns:root@1.0.0 {
                             v433 = arith.constant 8 : u32;
                             v450 = hir.bitcast v387 : u32;
                             v452 = arith.add v450, v433 : u32 #[overflow = checked];
-                            v868 = arith.constant 4 : u32;
-                            v454 = arith.mod v452, v868 : u32;
+                            v869 = arith.constant 4 : u32;
+                            v454 = arith.mod v452, v869 : u32;
                             hir.assertz v454 #[code = 250];
                             v455 = hir.int_to_ptr v452 : ptr<byte, i32>;
                             v456 = hir.load v455 : i32;
                             scf.yield v456;
                         };
-                        v866 = arith.constant 0 : i32;
                         v867 = arith.constant 0 : i32;
-                        v465 = arith.eq v830, v867 : i1;
+                        v868 = arith.constant 0 : i32;
+                        v465 = arith.eq v831, v868 : i1;
                         v466 = arith.zext v465 : u32;
                         v467 = hir.bitcast v466 : i32;
-                        v469 = arith.neq v467, v866 : i1;
+                        v469 = arith.neq v467, v867 : i1;
                         scf.if v469{
                         ^block61:
-                            v865 = arith.constant 8 : u32;
+                            v866 = arith.constant 8 : u32;
                             v486 = hir.bitcast v376 : u32;
-                            v488 = arith.add v486, v865 : u32 #[overflow = checked];
-                            v864 = arith.constant 4 : u32;
-                            v490 = arith.mod v488, v864 : u32;
+                            v488 = arith.add v486, v866 : u32 #[overflow = checked];
+                            v865 = arith.constant 4 : u32;
+                            v490 = arith.mod v488, v865 : u32;
                             hir.assertz v490 #[code = 250];
                             v491 = hir.int_to_ptr v488 : ptr<byte, i32>;
                             hir.store v491, v411;
-                            v863 = arith.constant 4 : u32;
+                            v864 = arith.constant 4 : u32;
                             v493 = hir.bitcast v376 : u32;
-                            v495 = arith.add v493, v863 : u32 #[overflow = checked];
-                            v862 = arith.constant 4 : u32;
-                            v497 = arith.mod v495, v862 : u32;
+                            v495 = arith.add v493, v864 : u32 #[overflow = checked];
+                            v863 = arith.constant 4 : u32;
+                            v497 = arith.mod v495, v863 : u32;
                             hir.assertz v497 #[code = 250];
                             v498 = hir.int_to_ptr v495 : ptr<byte, i32>;
                             hir.store v498, v379;
                             scf.yield ;
                         } else {
                         ^block62:
-                            v861 = arith.constant 8 : u32;
+                            v862 = arith.constant 8 : u32;
                             v471 = hir.bitcast v376 : u32;
-                            v473 = arith.add v471, v861 : u32 #[overflow = checked];
-                            v860 = arith.constant 4 : u32;
-                            v475 = arith.mod v473, v860 : u32;
+                            v473 = arith.add v471, v862 : u32 #[overflow = checked];
+                            v861 = arith.constant 4 : u32;
+                            v475 = arith.mod v473, v861 : u32;
                             hir.assertz v475 #[code = 250];
                             v476 = hir.int_to_ptr v473 : ptr<byte, i32>;
-                            hir.store v476, v830;
-                            v859 = arith.constant 4 : u32;
+                            hir.store v476, v831;
+                            v860 = arith.constant 4 : u32;
                             v478 = hir.bitcast v376 : u32;
-                            v480 = arith.add v478, v859 : u32 #[overflow = checked];
-                            v858 = arith.constant 4 : u32;
-                            v482 = arith.mod v480, v858 : u32;
+                            v480 = arith.add v478, v860 : u32 #[overflow = checked];
+                            v859 = arith.constant 4 : u32;
+                            v482 = arith.mod v480, v859 : u32;
                             hir.assertz v482 #[code = 250];
                             v483 = hir.int_to_ptr v480 : ptr<byte, i32>;
                             hir.store v483, v377;
                             scf.yield ;
                         };
-                        v856 = arith.constant 0 : i32;
-                        v857 = arith.constant 1 : i32;
-                        v829 = cf.select v469, v857, v856 : i32;
-                        scf.yield v829;
+                        v857 = arith.constant 0 : i32;
+                        v858 = arith.constant 1 : i32;
+                        v830 = cf.select v469, v858, v857 : i32;
+                        scf.yield v830;
                     } else {
                     ^block57:
-                        v855 = arith.constant 8 : u32;
+                        v856 = arith.constant 8 : u32;
                         v432 = hir.bitcast v376 : u32;
-                        v434 = arith.add v432, v855 : u32 #[overflow = checked];
-                        v854 = arith.constant 4 : u32;
-                        v436 = arith.mod v434, v854 : u32;
+                        v434 = arith.add v432, v856 : u32 #[overflow = checked];
+                        v855 = arith.constant 4 : u32;
+                        v436 = arith.mod v434, v855 : u32;
                         hir.assertz v436 #[code = 250];
                         v437 = hir.int_to_ptr v434 : ptr<byte, i32>;
                         hir.store v437, v379;
-                        v853 = arith.constant 4 : u32;
+                        v854 = arith.constant 4 : u32;
                         v440 = hir.bitcast v376 : u32;
-                        v442 = arith.add v440, v853 : u32 #[overflow = checked];
-                        v852 = arith.constant 4 : u32;
-                        v444 = arith.mod v442, v852 : u32;
+                        v442 = arith.add v440, v854 : u32 #[overflow = checked];
+                        v853 = arith.constant 4 : u32;
+                        v444 = arith.mod v442, v853 : u32;
                         hir.assertz v444 #[code = 250];
-                        v851 = arith.constant 0 : i32;
+                        v852 = arith.constant 0 : i32;
                         v445 = hir.int_to_ptr v442 : ptr<byte, i32>;
-                        hir.store v445, v851;
-                        v850 = arith.constant 0 : i32;
-                        scf.yield v850;
+                        hir.store v445, v852;
+                        v851 = arith.constant 0 : i32;
+                        scf.yield v851;
                     };
-                    scf.yield v831;
+                    scf.yield v832;
                 } else {
                 ^block55:
-                    v849 = ub.poison i32 : i32;
-                    scf.yield v849;
+                    v850 = ub.poison i32 : i32;
+                    scf.yield v850;
                 };
-                v844 = arith.constant 0 : u32;
-                v777 = arith.constant 1 : u32;
-                v837 = cf.select v420, v777, v844 : u32;
-                v845 = ub.poison i32 : i32;
-                v836 = cf.select v420, v387, v845 : i32;
+                v845 = arith.constant 0 : u32;
+                v778 = arith.constant 1 : u32;
+                v838 = cf.select v420, v778, v845 : u32;
                 v846 = ub.poison i32 : i32;
-                v835 = cf.select v420, v376, v846 : i32;
+                v837 = cf.select v420, v387, v846 : i32;
                 v847 = ub.poison i32 : i32;
-                v834 = cf.select v420, v847, v387 : i32;
+                v836 = cf.select v420, v376, v847 : i32;
                 v848 = ub.poison i32 : i32;
-                v833 = cf.select v420, v848, v376 : i32;
-                scf.yield v833, v834, v835, v832, v836, v837;
+                v835 = cf.select v420, v848, v387 : i32;
+                v849 = ub.poison i32 : i32;
+                v834 = cf.select v420, v849, v376 : i32;
+                scf.yield v834, v835, v836, v833, v837, v838;
             };
-            v790, v791, v792 = scf.index_switch v789 : i32, i32, i32 
+            v791, v792, v793 = scf.index_switch v790 : i32, i32, i32 
             case 0 {
             ^block53:
+                v844 = arith.constant 4 : u32;
+                v423 = hir.bitcast v785 : u32;
+                v425 = arith.add v423, v844 : u32 #[overflow = checked];
                 v843 = arith.constant 4 : u32;
-                v423 = hir.bitcast v784 : u32;
-                v425 = arith.add v423, v843 : u32 #[overflow = checked];
-                v842 = arith.constant 4 : u32;
-                v427 = arith.mod v425, v842 : u32;
+                v427 = arith.mod v425, v843 : u32;
                 hir.assertz v427 #[code = 250];
-                v841 = arith.constant 0 : i32;
+                v842 = arith.constant 0 : i32;
                 v428 = hir.int_to_ptr v425 : ptr<byte, i32>;
-                hir.store v428, v841;
-                v840 = arith.constant 1 : i32;
-                scf.yield v784, v840, v785;
+                hir.store v428, v842;
+                v841 = arith.constant 1 : i32;
+                scf.yield v785, v841, v786;
             }
             default {
             ^block113:
-                scf.yield v786, v787, v788;
+                scf.yield v787, v788, v789;
             };
-            v502 = hir.bitcast v790 : u32;
-            v839 = arith.constant 4 : u32;
-            v504 = arith.mod v502, v839 : u32;
+            v502 = hir.bitcast v791 : u32;
+            v840 = arith.constant 4 : u32;
+            v504 = arith.mod v502, v840 : u32;
             hir.assertz v504 #[code = 250];
             v505 = hir.int_to_ptr v502 : ptr<byte, i32>;
-            hir.store v505, v791;
-            v838 = arith.constant 16 : i32;
-            v510 = arith.add v792, v838 : i32 #[overflow = wrapping];
+            hir.store v505, v792;
+            v839 = arith.constant 16 : i32;
+            v510 = arith.add v793, v839 : i32 #[overflow = wrapping];
             v511 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
             v512 = hir.bitcast v511 : ptr<byte, i32>;
             hir.store v512, v510;
@@ -769,27 +769,27 @@ builtin.component root_ns:root@1.0.0 {
             v535 = arith.constant 8 : u32;
             v534 = hir.bitcast v521 : u32;
             v536 = arith.add v534, v535 : u32 #[overflow = checked];
-            v877 = arith.constant 4 : u32;
-            v538 = arith.mod v536, v877 : u32;
+            v878 = arith.constant 4 : u32;
+            v538 = arith.mod v536, v878 : u32;
             hir.assertz v538 #[code = 250];
             v539 = hir.int_to_ptr v536 : ptr<byte, i32>;
             v540 = hir.load v539 : i32;
             v541 = hir.bitcast v513 : u32;
-            v876 = arith.constant 4 : u32;
-            v543 = arith.mod v541, v876 : u32;
+            v877 = arith.constant 4 : u32;
+            v543 = arith.mod v541, v877 : u32;
             hir.assertz v543 #[code = 250];
             v544 = hir.int_to_ptr v541 : ptr<byte, i32>;
             hir.store v544, v540;
-            v875 = arith.constant 4 : u32;
+            v876 = arith.constant 4 : u32;
             v545 = hir.bitcast v513 : u32;
-            v547 = arith.add v545, v875 : u32 #[overflow = checked];
-            v874 = arith.constant 4 : u32;
-            v549 = arith.mod v547, v874 : u32;
+            v547 = arith.add v545, v876 : u32 #[overflow = checked];
+            v875 = arith.constant 4 : u32;
+            v549 = arith.mod v547, v875 : u32;
             hir.assertz v549 #[code = 250];
             v550 = hir.int_to_ptr v547 : ptr<byte, i32>;
             hir.store v550, v533;
-            v873 = arith.constant 16 : i32;
-            v552 = arith.add v521, v873 : i32 #[overflow = wrapping];
+            v874 = arith.constant 16 : i32;
+            v552 = arith.add v521, v874 : i32 #[overflow = wrapping];
             v553 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
             v554 = hir.bitcast v553 : ptr<byte, i32>;
             hir.store v554, v552;
@@ -798,21 +798,21 @@ builtin.component root_ns:root@1.0.0 {
 
         private builtin.function @alloc::alloc::Global::alloc_impl(v555: i32, v556: i32, v557: i32, v558: i32) {
         ^block65(v555: i32, v556: i32, v557: i32, v558: i32):
-            v893 = arith.constant 0 : i32;
+            v894 = arith.constant 0 : i32;
             v559 = arith.constant 0 : i32;
             v560 = arith.eq v557, v559 : i1;
             v561 = arith.zext v560 : u32;
             v562 = hir.bitcast v561 : i32;
-            v564 = arith.neq v562, v893 : i1;
-            v889 = scf.if v564 : i32 {
+            v564 = arith.neq v562, v894 : i1;
+            v890 = scf.if v564 : i32 {
             ^block116:
                 scf.yield v556;
             } else {
             ^block68:
                 hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_no_alloc_shim_is_unstable_v2()
-                v892 = arith.constant 0 : i32;
-                v566 = arith.neq v558, v892 : i1;
-                v888 = scf.if v566 : i32 {
+                v893 = arith.constant 0 : i32;
+                v566 = arith.neq v558, v893 : i1;
+                v889 = scf.if v566 : i32 {
                 ^block69:
                     v568 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_alloc_zeroed(v557, v556) : i32
                     scf.yield v568;
@@ -821,38 +821,38 @@ builtin.component root_ns:root@1.0.0 {
                     v567 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_alloc(v557, v556) : i32
                     scf.yield v567;
                 };
-                scf.yield v888;
+                scf.yield v889;
             };
             v572 = arith.constant 4 : u32;
             v571 = hir.bitcast v555 : u32;
             v573 = arith.add v571, v572 : u32 #[overflow = checked];
-            v891 = arith.constant 4 : u32;
-            v575 = arith.mod v573, v891 : u32;
+            v892 = arith.constant 4 : u32;
+            v575 = arith.mod v573, v892 : u32;
             hir.assertz v575 #[code = 250];
             v576 = hir.int_to_ptr v573 : ptr<byte, i32>;
             hir.store v576, v557;
             v578 = hir.bitcast v555 : u32;
-            v890 = arith.constant 4 : u32;
-            v580 = arith.mod v578, v890 : u32;
+            v891 = arith.constant 4 : u32;
+            v580 = arith.mod v578, v891 : u32;
             hir.assertz v580 #[code = 250];
             v581 = hir.int_to_ptr v578 : ptr<byte, i32>;
-            hir.store v581, v889;
+            hir.store v581, v890;
             builtin.ret ;
         };
 
         private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v582: i32, v583: i32, v584: i32, v585: i32) {
         ^block71(v582: i32, v583: i32, v584: i32, v585: i32):
-            v919 = arith.constant 0 : i32;
+            v920 = arith.constant 0 : i32;
             v586 = arith.constant 0 : i32;
             v590 = arith.eq v585, v586 : i1;
             v591 = arith.zext v590 : u32;
             v592 = hir.bitcast v591 : i32;
-            v594 = arith.neq v592, v919 : i1;
-            v906, v907 = scf.if v594 : i32, i32 {
+            v594 = arith.neq v592, v920 : i1;
+            v907, v908 = scf.if v594 : i32, i32 {
             ^block120:
-                v918 = arith.constant 0 : i32;
+                v919 = arith.constant 0 : i32;
                 v588 = arith.constant 4 : i32;
-                scf.yield v588, v918;
+                scf.yield v588, v919;
             } else {
             ^block74:
                 v595 = hir.bitcast v583 : u32;
@@ -861,37 +861,37 @@ builtin.component root_ns:root@1.0.0 {
                 hir.assertz v597 #[code = 250];
                 v598 = hir.int_to_ptr v595 : ptr<byte, i32>;
                 v599 = hir.load v598 : i32;
-                v916 = arith.constant 0 : i32;
                 v917 = arith.constant 0 : i32;
-                v601 = arith.eq v599, v917 : i1;
+                v918 = arith.constant 0 : i32;
+                v601 = arith.eq v599, v918 : i1;
                 v602 = arith.zext v601 : u32;
                 v603 = hir.bitcast v602 : i32;
-                v605 = arith.neq v603, v916 : i1;
-                v904 = scf.if v605 : i32 {
+                v605 = arith.neq v603, v917 : i1;
+                v905 = scf.if v605 : i32 {
                 ^block119:
-                    v915 = arith.constant 0 : i32;
-                    scf.yield v915;
+                    v916 = arith.constant 0 : i32;
+                    scf.yield v916;
                 } else {
                 ^block75:
-                    v914 = arith.constant 4 : u32;
+                    v915 = arith.constant 4 : u32;
                     v606 = hir.bitcast v582 : u32;
-                    v608 = arith.add v606, v914 : u32 #[overflow = checked];
-                    v913 = arith.constant 4 : u32;
-                    v610 = arith.mod v608, v913 : u32;
+                    v608 = arith.add v606, v915 : u32 #[overflow = checked];
+                    v914 = arith.constant 4 : u32;
+                    v610 = arith.mod v608, v914 : u32;
                     hir.assertz v610 #[code = 250];
                     v611 = hir.int_to_ptr v608 : ptr<byte, i32>;
                     hir.store v611, v584;
-                    v912 = arith.constant 4 : u32;
+                    v913 = arith.constant 4 : u32;
                     v612 = hir.bitcast v583 : u32;
-                    v614 = arith.add v612, v912 : u32 #[overflow = checked];
-                    v911 = arith.constant 4 : u32;
-                    v616 = arith.mod v614, v911 : u32;
+                    v614 = arith.add v612, v913 : u32 #[overflow = checked];
+                    v912 = arith.constant 4 : u32;
+                    v616 = arith.mod v614, v912 : u32;
                     hir.assertz v616 #[code = 250];
                     v617 = hir.int_to_ptr v614 : ptr<byte, i32>;
                     v618 = hir.load v617 : i32;
                     v619 = hir.bitcast v582 : u32;
-                    v910 = arith.constant 4 : u32;
-                    v621 = arith.mod v619, v910 : u32;
+                    v911 = arith.constant 4 : u32;
+                    v621 = arith.mod v619, v911 : u32;
                     hir.assertz v621 #[code = 250];
                     v622 = hir.int_to_ptr v619 : ptr<byte, i32>;
                     hir.store v622, v618;
@@ -899,28 +899,28 @@ builtin.component root_ns:root@1.0.0 {
                     scf.yield v623;
                 };
                 v624 = arith.constant 8 : i32;
-                v909 = arith.constant 4 : i32;
-                v905 = cf.select v605, v909, v624 : i32;
-                scf.yield v905, v904;
+                v910 = arith.constant 4 : i32;
+                v906 = cf.select v605, v910, v624 : i32;
+                scf.yield v906, v905;
             };
-            v627 = arith.add v582, v906 : i32 #[overflow = wrapping];
+            v627 = arith.add v582, v907 : i32 #[overflow = wrapping];
             v629 = hir.bitcast v627 : u32;
-            v908 = arith.constant 4 : u32;
-            v631 = arith.mod v629, v908 : u32;
+            v909 = arith.constant 4 : u32;
+            v631 = arith.mod v629, v909 : u32;
             hir.assertz v631 #[code = 250];
             v632 = hir.int_to_ptr v629 : ptr<byte, i32>;
-            hir.store v632, v907;
+            hir.store v632, v908;
             builtin.ret ;
         };
 
         private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v633: i32, v634: i32, v635: i32) {
         ^block76(v633: i32, v634: i32, v635: i32):
-            v921 = arith.constant 0 : i32;
+            v922 = arith.constant 0 : i32;
             v636 = arith.constant 0 : i32;
             v637 = arith.eq v635, v636 : i1;
             v638 = arith.zext v637 : u32;
             v639 = hir.bitcast v638 : i32;
-            v641 = arith.neq v639, v921 : i1;
+            v641 = arith.neq v639, v922 : i1;
             scf.if v641{
             ^block78:
                 scf.yield ;

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
@@ -489,12 +489,13 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
             trace.252
             nop
             push.0
+            push.4294967295
             dup.2
-            push.4294967294
-            dup.3
-            u32wrapping_sub
             swap.1
-            u32lt
+            u32xor
+            dup.3
+            swap.1
+            u32gt
             neq
             if.true
                 drop

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.wat
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.wat
@@ -167,13 +167,13 @@
         i32.store
       end
       block ;; label = @2
-        i32.const -2
+        local.get 2
         local.get 0
         i32.load
         local.tee 4
-        i32.sub
-        local.get 2
-        i32.lt_u
+        i32.const -1
+        i32.xor
+        i32.gt_u
         br_if 0 (;@2;)
         local.get 0
         local.get 4

--- a/tests/integration/expected/adv_load_preimage.hir
+++ b/tests/integration/expected/adv_load_preimage.hir
@@ -179,11 +179,11 @@ builtin.component root_ns:root@1.0.0 {
             v148 = hir.bitcast v147 : i32;
             v150 = arith.neq v148, v141 : i1;
             v151 = cf.select v150, v138, v142 : i32;
-            v504 = arith.constant 0 : i32;
+            v505 = arith.constant 0 : i32;
             v152 = arith.constant -1 : i32;
             v153 = arith.add v151, v152 : i32 #[overflow = wrapping];
             v154 = arith.band v151, v153 : i32;
-            v156 = arith.neq v154, v504 : i1;
+            v156 = arith.neq v154, v505 : i1;
             v474, v475 = scf.if v156 : i32, u32 {
             ^block66:
                 v466 = arith.constant 0 : u32;
@@ -192,7 +192,7 @@ builtin.component root_ns:root@1.0.0 {
             } else {
             ^block27:
                 v158 = hir.exec @root_ns:root@1.0.0/adv_load_preimage/core::ptr::alignment::Alignment::max(v138, v151) : i32
-                v503 = arith.constant 0 : i32;
+                v504 = arith.constant 0 : i32;
                 v157 = arith.constant -2147483648 : i32;
                 v159 = arith.sub v157, v158 : i32 #[overflow = wrapping];
                 v161 = hir.bitcast v159 : u32;
@@ -200,18 +200,18 @@ builtin.component root_ns:root@1.0.0 {
                 v162 = arith.gt v160, v161 : i1;
                 v163 = arith.zext v162 : u32;
                 v164 = hir.bitcast v163 : i32;
-                v166 = arith.neq v164, v503 : i1;
+                v166 = arith.neq v164, v504 : i1;
                 v489 = scf.if v166 : i32 {
                 ^block65:
-                    v502 = ub.poison i32 : i32;
-                    scf.yield v502;
+                    v503 = ub.poison i32 : i32;
+                    scf.yield v503;
                 } else {
                 ^block28:
-                    v500 = arith.constant 0 : i32;
-                    v172 = arith.sub v500, v158 : i32 #[overflow = wrapping];
-                    v501 = arith.constant -1 : i32;
+                    v501 = arith.constant 0 : i32;
+                    v172 = arith.sub v501, v158 : i32 #[overflow = wrapping];
+                    v502 = arith.constant -1 : i32;
                     v168 = arith.add v139, v158 : i32 #[overflow = wrapping];
-                    v170 = arith.add v168, v501 : i32 #[overflow = wrapping];
+                    v170 = arith.add v168, v502 : i32 #[overflow = wrapping];
                     v173 = arith.band v170, v172 : i32;
                     v174 = hir.bitcast v137 : u32;
                     v175 = arith.constant 4 : u32;
@@ -219,8 +219,8 @@ builtin.component root_ns:root@1.0.0 {
                     hir.assertz v176 #[code = 250];
                     v177 = hir.int_to_ptr v174 : ptr<byte, i32>;
                     v178 = hir.load v177 : i32;
-                    v499 = arith.constant 0 : i32;
-                    v180 = arith.neq v178, v499 : i1;
+                    v500 = arith.constant 0 : i32;
+                    v180 = arith.neq v178, v500 : i1;
                     scf.if v180{
                     ^block64:
                         scf.yield ;
@@ -229,29 +229,29 @@ builtin.component root_ns:root@1.0.0 {
                         v181 = hir.exec @intrinsics/mem/heap_base() : i32
                         v182 = hir.mem_size  : u32;
                         v188 = hir.bitcast v137 : u32;
-                        v498 = arith.constant 4 : u32;
-                        v190 = arith.mod v188, v498 : u32;
+                        v499 = arith.constant 4 : u32;
+                        v190 = arith.mod v188, v499 : u32;
                         hir.assertz v190 #[code = 250];
-                        v497 = arith.constant 16 : u32;
+                        v498 = arith.constant 16 : u32;
                         v183 = hir.bitcast v182 : i32;
-                        v186 = arith.shl v183, v497 : i32;
+                        v186 = arith.shl v183, v498 : i32;
                         v187 = arith.add v181, v186 : i32 #[overflow = wrapping];
                         v191 = hir.int_to_ptr v188 : ptr<byte, i32>;
                         hir.store v191, v187;
                         scf.yield ;
                     };
                     v194 = hir.bitcast v137 : u32;
-                    v496 = arith.constant 4 : u32;
-                    v196 = arith.mod v194, v496 : u32;
+                    v497 = arith.constant 4 : u32;
+                    v196 = arith.mod v194, v497 : u32;
                     hir.assertz v196 #[code = 250];
                     v197 = hir.int_to_ptr v194 : ptr<byte, i32>;
                     v198 = hir.load v197 : i32;
                     v495 = arith.constant 0 : i32;
-                    v202 = hir.bitcast v173 : u32;
-                    v192 = arith.constant 268435456 : i32;
-                    v199 = arith.sub v192, v198 : i32 #[overflow = wrapping];
-                    v201 = hir.bitcast v199 : u32;
-                    v203 = arith.lt v201, v202 : i1;
+                    v496 = arith.constant -1 : i32;
+                    v200 = arith.bxor v198, v496 : i32;
+                    v202 = hir.bitcast v200 : u32;
+                    v201 = hir.bitcast v173 : u32;
+                    v203 = arith.gt v201, v202 : i1;
                     v204 = arith.zext v203 : u32;
                     v205 = hir.bitcast v204 : i32;
                     v207 = arith.neq v205, v495 : i1;
@@ -310,23 +310,23 @@ builtin.component root_ns:root@1.0.0 {
             v238 = arith.zext v237 : u64;
             v239 = hir.bitcast v238 : i64;
             v243 = arith.mul v239, v242 : i64 #[overflow = wrapping];
-            v608 = arith.constant 0 : i32;
+            v609 = arith.constant 0 : i32;
             v244 = arith.constant 32 : i64;
             v246 = hir.cast v244 : u32;
             v245 = hir.bitcast v243 : u64;
             v247 = arith.shr v245, v246 : u64;
             v248 = hir.bitcast v247 : i64;
             v249 = arith.trunc v248 : i32;
-            v251 = arith.neq v249, v608 : i1;
-            v520, v521, v522, v523, v524, v525 = scf.if v251 : i32, i32, i32, i32, i32, u32 {
+            v251 = arith.neq v249, v609 : i1;
+            v521, v522, v523, v524, v525, v526 = scf.if v251 : i32, i32, i32, i32, i32, u32 {
             ^block72:
-                v505 = arith.constant 0 : u32;
-                v512 = ub.poison i32 : i32;
-                scf.yield v217, v228, v512, v512, v512, v505;
+                v506 = arith.constant 0 : u32;
+                v513 = ub.poison i32 : i32;
+                scf.yield v217, v228, v513, v513, v513, v506;
             } else {
             ^block38:
                 v252 = arith.trunc v243 : i32;
-                v607 = arith.constant 0 : i32;
+                v608 = arith.constant 0 : i32;
                 v253 = arith.constant -2147483648 : i32;
                 v254 = arith.sub v253, v220 : i32 #[overflow = wrapping];
                 v256 = hir.bitcast v254 : u32;
@@ -334,16 +334,16 @@ builtin.component root_ns:root@1.0.0 {
                 v257 = arith.lte v255, v256 : i1;
                 v258 = arith.zext v257 : u32;
                 v259 = hir.bitcast v258 : i32;
-                v261 = arith.neq v259, v607 : i1;
-                v568 = scf.if v261 : i32 {
+                v261 = arith.neq v259, v608 : i1;
+                v569 = scf.if v261 : i32 {
                 ^block36:
-                    v606 = arith.constant 0 : i32;
-                    v272 = arith.neq v252, v606 : i1;
-                    v567 = scf.if v272 : i32 {
+                    v607 = arith.constant 0 : i32;
+                    v272 = arith.neq v252, v607 : i1;
+                    v568 = scf.if v272 : i32 {
                     ^block40:
-                        v605 = arith.constant 0 : i32;
-                        v288 = arith.neq v219, v605 : i1;
-                        v566 = scf.if v288 : i32 {
+                        v606 = arith.constant 0 : i32;
+                        v288 = arith.neq v219, v606 : i1;
+                        v567 = scf.if v288 : i32 {
                         ^block43:
                             v270 = arith.constant 1 : i32;
                             hir.exec @root_ns:root@1.0.0/adv_load_preimage/alloc::alloc::Global::alloc_impl(v228, v220, v252, v270)
@@ -362,130 +362,130 @@ builtin.component root_ns:root@1.0.0 {
                             v274 = arith.constant 8 : u32;
                             v291 = hir.bitcast v228 : u32;
                             v293 = arith.add v291, v274 : u32 #[overflow = checked];
-                            v604 = arith.constant 4 : u32;
-                            v295 = arith.mod v293, v604 : u32;
+                            v605 = arith.constant 4 : u32;
+                            v295 = arith.mod v293, v605 : u32;
                             hir.assertz v295 #[code = 250];
                             v296 = hir.int_to_ptr v293 : ptr<byte, i32>;
                             v297 = hir.load v296 : i32;
                             scf.yield v297;
                         };
-                        v602 = arith.constant 0 : i32;
                         v603 = arith.constant 0 : i32;
-                        v306 = arith.eq v566, v603 : i1;
+                        v604 = arith.constant 0 : i32;
+                        v306 = arith.eq v567, v604 : i1;
                         v307 = arith.zext v306 : u32;
                         v308 = hir.bitcast v307 : i32;
-                        v310 = arith.neq v308, v602 : i1;
+                        v310 = arith.neq v308, v603 : i1;
                         scf.if v310{
                         ^block45:
-                            v601 = arith.constant 8 : u32;
+                            v602 = arith.constant 8 : u32;
                             v327 = hir.bitcast v217 : u32;
-                            v329 = arith.add v327, v601 : u32 #[overflow = checked];
-                            v600 = arith.constant 4 : u32;
-                            v331 = arith.mod v329, v600 : u32;
+                            v329 = arith.add v327, v602 : u32 #[overflow = checked];
+                            v601 = arith.constant 4 : u32;
+                            v331 = arith.mod v329, v601 : u32;
                             hir.assertz v331 #[code = 250];
                             v332 = hir.int_to_ptr v329 : ptr<byte, i32>;
                             hir.store v332, v252;
-                            v599 = arith.constant 4 : u32;
+                            v600 = arith.constant 4 : u32;
                             v334 = hir.bitcast v217 : u32;
-                            v336 = arith.add v334, v599 : u32 #[overflow = checked];
-                            v598 = arith.constant 4 : u32;
-                            v338 = arith.mod v336, v598 : u32;
+                            v336 = arith.add v334, v600 : u32 #[overflow = checked];
+                            v599 = arith.constant 4 : u32;
+                            v338 = arith.mod v336, v599 : u32;
                             hir.assertz v338 #[code = 250];
                             v339 = hir.int_to_ptr v336 : ptr<byte, i32>;
                             hir.store v339, v220;
                             scf.yield ;
                         } else {
                         ^block46:
-                            v597 = arith.constant 8 : u32;
+                            v598 = arith.constant 8 : u32;
                             v312 = hir.bitcast v217 : u32;
-                            v314 = arith.add v312, v597 : u32 #[overflow = checked];
-                            v596 = arith.constant 4 : u32;
-                            v316 = arith.mod v314, v596 : u32;
+                            v314 = arith.add v312, v598 : u32 #[overflow = checked];
+                            v597 = arith.constant 4 : u32;
+                            v316 = arith.mod v314, v597 : u32;
                             hir.assertz v316 #[code = 250];
                             v317 = hir.int_to_ptr v314 : ptr<byte, i32>;
-                            hir.store v317, v566;
-                            v595 = arith.constant 4 : u32;
+                            hir.store v317, v567;
+                            v596 = arith.constant 4 : u32;
                             v319 = hir.bitcast v217 : u32;
-                            v321 = arith.add v319, v595 : u32 #[overflow = checked];
-                            v594 = arith.constant 4 : u32;
-                            v323 = arith.mod v321, v594 : u32;
+                            v321 = arith.add v319, v596 : u32 #[overflow = checked];
+                            v595 = arith.constant 4 : u32;
+                            v323 = arith.mod v321, v595 : u32;
                             hir.assertz v323 #[code = 250];
                             v324 = hir.int_to_ptr v321 : ptr<byte, i32>;
                             hir.store v324, v218;
                             scf.yield ;
                         };
-                        v592 = arith.constant 0 : i32;
-                        v593 = arith.constant 1 : i32;
-                        v565 = cf.select v310, v593, v592 : i32;
-                        scf.yield v565;
+                        v593 = arith.constant 0 : i32;
+                        v594 = arith.constant 1 : i32;
+                        v566 = cf.select v310, v594, v593 : i32;
+                        scf.yield v566;
                     } else {
                     ^block41:
-                        v591 = arith.constant 8 : u32;
+                        v592 = arith.constant 8 : u32;
                         v273 = hir.bitcast v217 : u32;
-                        v275 = arith.add v273, v591 : u32 #[overflow = checked];
-                        v590 = arith.constant 4 : u32;
-                        v277 = arith.mod v275, v590 : u32;
+                        v275 = arith.add v273, v592 : u32 #[overflow = checked];
+                        v591 = arith.constant 4 : u32;
+                        v277 = arith.mod v275, v591 : u32;
                         hir.assertz v277 #[code = 250];
                         v278 = hir.int_to_ptr v275 : ptr<byte, i32>;
                         hir.store v278, v220;
-                        v589 = arith.constant 4 : u32;
+                        v590 = arith.constant 4 : u32;
                         v281 = hir.bitcast v217 : u32;
-                        v283 = arith.add v281, v589 : u32 #[overflow = checked];
-                        v588 = arith.constant 4 : u32;
-                        v285 = arith.mod v283, v588 : u32;
+                        v283 = arith.add v281, v590 : u32 #[overflow = checked];
+                        v589 = arith.constant 4 : u32;
+                        v285 = arith.mod v283, v589 : u32;
                         hir.assertz v285 #[code = 250];
-                        v587 = arith.constant 0 : i32;
+                        v588 = arith.constant 0 : i32;
                         v286 = hir.int_to_ptr v283 : ptr<byte, i32>;
-                        hir.store v286, v587;
-                        v586 = arith.constant 0 : i32;
-                        scf.yield v586;
+                        hir.store v286, v588;
+                        v587 = arith.constant 0 : i32;
+                        scf.yield v587;
                     };
-                    scf.yield v567;
+                    scf.yield v568;
                 } else {
                 ^block39:
-                    v585 = ub.poison i32 : i32;
-                    scf.yield v585;
+                    v586 = ub.poison i32 : i32;
+                    scf.yield v586;
                 };
-                v580 = arith.constant 0 : u32;
-                v513 = arith.constant 1 : u32;
-                v573 = cf.select v261, v513, v580 : u32;
-                v581 = ub.poison i32 : i32;
-                v572 = cf.select v261, v228, v581 : i32;
+                v581 = arith.constant 0 : u32;
+                v514 = arith.constant 1 : u32;
+                v574 = cf.select v261, v514, v581 : u32;
                 v582 = ub.poison i32 : i32;
-                v571 = cf.select v261, v217, v582 : i32;
+                v573 = cf.select v261, v228, v582 : i32;
                 v583 = ub.poison i32 : i32;
-                v570 = cf.select v261, v583, v228 : i32;
+                v572 = cf.select v261, v217, v583 : i32;
                 v584 = ub.poison i32 : i32;
-                v569 = cf.select v261, v584, v217 : i32;
-                scf.yield v569, v570, v571, v568, v572, v573;
+                v571 = cf.select v261, v584, v228 : i32;
+                v585 = ub.poison i32 : i32;
+                v570 = cf.select v261, v585, v217 : i32;
+                scf.yield v570, v571, v572, v569, v573, v574;
             };
-            v526, v527, v528 = scf.index_switch v525 : i32, i32, i32 
+            v527, v528, v529 = scf.index_switch v526 : i32, i32, i32 
             case 0 {
             ^block37:
+                v580 = arith.constant 4 : u32;
+                v264 = hir.bitcast v521 : u32;
+                v266 = arith.add v264, v580 : u32 #[overflow = checked];
                 v579 = arith.constant 4 : u32;
-                v264 = hir.bitcast v520 : u32;
-                v266 = arith.add v264, v579 : u32 #[overflow = checked];
-                v578 = arith.constant 4 : u32;
-                v268 = arith.mod v266, v578 : u32;
+                v268 = arith.mod v266, v579 : u32;
                 hir.assertz v268 #[code = 250];
-                v577 = arith.constant 0 : i32;
+                v578 = arith.constant 0 : i32;
                 v269 = hir.int_to_ptr v266 : ptr<byte, i32>;
-                hir.store v269, v577;
-                v576 = arith.constant 1 : i32;
-                scf.yield v520, v576, v521;
+                hir.store v269, v578;
+                v577 = arith.constant 1 : i32;
+                scf.yield v521, v577, v522;
             }
             default {
             ^block76:
-                scf.yield v522, v523, v524;
+                scf.yield v523, v524, v525;
             };
-            v343 = hir.bitcast v526 : u32;
-            v575 = arith.constant 4 : u32;
-            v345 = arith.mod v343, v575 : u32;
+            v343 = hir.bitcast v527 : u32;
+            v576 = arith.constant 4 : u32;
+            v345 = arith.mod v343, v576 : u32;
             hir.assertz v345 #[code = 250];
             v346 = hir.int_to_ptr v343 : ptr<byte, i32>;
-            hir.store v346, v527;
-            v574 = arith.constant 16 : i32;
-            v351 = arith.add v528, v574 : i32 #[overflow = wrapping];
+            hir.store v346, v528;
+            v575 = arith.constant 16 : i32;
+            v351 = arith.add v529, v575 : i32 #[overflow = wrapping];
             v352 = builtin.global_symbol @root_ns:root@1.0.0/adv_load_preimage/__stack_pointer : ptr<byte, u8>
             v353 = hir.bitcast v352 : ptr<byte, i32>;
             hir.store v353, v351;
@@ -517,27 +517,27 @@ builtin.component root_ns:root@1.0.0 {
             v376 = arith.constant 8 : u32;
             v375 = hir.bitcast v362 : u32;
             v377 = arith.add v375, v376 : u32 #[overflow = checked];
-            v613 = arith.constant 4 : u32;
-            v379 = arith.mod v377, v613 : u32;
+            v614 = arith.constant 4 : u32;
+            v379 = arith.mod v377, v614 : u32;
             hir.assertz v379 #[code = 250];
             v380 = hir.int_to_ptr v377 : ptr<byte, i32>;
             v381 = hir.load v380 : i32;
             v382 = hir.bitcast v354 : u32;
-            v612 = arith.constant 4 : u32;
-            v384 = arith.mod v382, v612 : u32;
+            v613 = arith.constant 4 : u32;
+            v384 = arith.mod v382, v613 : u32;
             hir.assertz v384 #[code = 250];
             v385 = hir.int_to_ptr v382 : ptr<byte, i32>;
             hir.store v385, v381;
-            v611 = arith.constant 4 : u32;
+            v612 = arith.constant 4 : u32;
             v386 = hir.bitcast v354 : u32;
-            v388 = arith.add v386, v611 : u32 #[overflow = checked];
-            v610 = arith.constant 4 : u32;
-            v390 = arith.mod v388, v610 : u32;
+            v388 = arith.add v386, v612 : u32 #[overflow = checked];
+            v611 = arith.constant 4 : u32;
+            v390 = arith.mod v388, v611 : u32;
             hir.assertz v390 #[code = 250];
             v391 = hir.int_to_ptr v388 : ptr<byte, i32>;
             hir.store v391, v374;
-            v609 = arith.constant 16 : i32;
-            v393 = arith.add v362, v609 : i32 #[overflow = wrapping];
+            v610 = arith.constant 16 : i32;
+            v393 = arith.add v362, v610 : i32 #[overflow = wrapping];
             v394 = builtin.global_symbol @root_ns:root@1.0.0/adv_load_preimage/__stack_pointer : ptr<byte, u8>
             v395 = hir.bitcast v394 : ptr<byte, i32>;
             hir.store v395, v393;
@@ -546,21 +546,21 @@ builtin.component root_ns:root@1.0.0 {
 
         private builtin.function @alloc::alloc::Global::alloc_impl(v396: i32, v397: i32, v398: i32, v399: i32) {
         ^block49(v396: i32, v397: i32, v398: i32, v399: i32):
-            v629 = arith.constant 0 : i32;
+            v630 = arith.constant 0 : i32;
             v400 = arith.constant 0 : i32;
             v401 = arith.eq v398, v400 : i1;
             v402 = arith.zext v401 : u32;
             v403 = hir.bitcast v402 : i32;
-            v405 = arith.neq v403, v629 : i1;
-            v625 = scf.if v405 : i32 {
+            v405 = arith.neq v403, v630 : i1;
+            v626 = scf.if v405 : i32 {
             ^block79:
                 scf.yield v397;
             } else {
             ^block52:
                 hir.exec @root_ns:root@1.0.0/adv_load_preimage/__rustc::__rust_no_alloc_shim_is_unstable_v2()
-                v628 = arith.constant 0 : i32;
-                v407 = arith.neq v399, v628 : i1;
-                v624 = scf.if v407 : i32 {
+                v629 = arith.constant 0 : i32;
+                v407 = arith.neq v399, v629 : i1;
+                v625 = scf.if v407 : i32 {
                 ^block53:
                     v409 = hir.exec @root_ns:root@1.0.0/adv_load_preimage/__rustc::__rust_alloc_zeroed(v398, v397) : i32
                     scf.yield v409;
@@ -569,22 +569,22 @@ builtin.component root_ns:root@1.0.0 {
                     v408 = hir.exec @root_ns:root@1.0.0/adv_load_preimage/__rustc::__rust_alloc(v398, v397) : i32
                     scf.yield v408;
                 };
-                scf.yield v624;
+                scf.yield v625;
             };
             v413 = arith.constant 4 : u32;
             v412 = hir.bitcast v396 : u32;
             v414 = arith.add v412, v413 : u32 #[overflow = checked];
-            v627 = arith.constant 4 : u32;
-            v416 = arith.mod v414, v627 : u32;
+            v628 = arith.constant 4 : u32;
+            v416 = arith.mod v414, v628 : u32;
             hir.assertz v416 #[code = 250];
             v417 = hir.int_to_ptr v414 : ptr<byte, i32>;
             hir.store v417, v398;
             v419 = hir.bitcast v396 : u32;
-            v626 = arith.constant 4 : u32;
-            v421 = arith.mod v419, v626 : u32;
+            v627 = arith.constant 4 : u32;
+            v421 = arith.mod v419, v627 : u32;
             hir.assertz v421 #[code = 250];
             v422 = hir.int_to_ptr v419 : ptr<byte, i32>;
-            hir.store v422, v625;
+            hir.store v422, v626;
             builtin.ret ;
         };
 

--- a/tests/integration/expected/adv_load_preimage.masm
+++ b/tests/integration/expected/adv_load_preimage.masm
@@ -523,12 +523,13 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
             trace.252
             nop
             push.0
+            push.4294967295
             dup.2
-            push.268435456
-            dup.3
-            u32wrapping_sub
             swap.1
-            u32lt
+            u32xor
+            dup.3
+            swap.1
+            u32gt
             neq
             if.true
                 drop

--- a/tests/integration/expected/adv_load_preimage.wat
+++ b/tests/integration/expected/adv_load_preimage.wat
@@ -182,13 +182,13 @@
         i32.store
       end
       block ;; label = @2
-        i32.const 268435456
+        local.get 2
         local.get 0
         i32.load
         local.tee 4
-        i32.sub
-        local.get 2
-        i32.lt_u
+        i32.const -1
+        i32.xor
+        i32.gt_u
         br_if 0 (;@2;)
         local.get 0
         local.get 4

--- a/tests/integration/expected/examples/p2id.hir
+++ b/tests/integration/expected/examples/p2id.hir
@@ -364,11 +364,11 @@ builtin.component miden:base/note-script@1.0.0 {
             v239 = hir.bitcast v238 : i32;
             v241 = arith.neq v239, v232 : i1;
             v242 = cf.select v241, v229, v233 : i32;
-            v1017 = arith.constant 0 : i32;
+            v1018 = arith.constant 0 : i32;
             v243 = arith.constant -1 : i32;
             v244 = arith.add v242, v243 : i32 #[overflow = wrapping];
             v245 = arith.band v242, v244 : i32;
-            v247 = arith.neq v245, v1017 : i1;
+            v247 = arith.neq v245, v1018 : i1;
             v987, v988 = scf.if v247 : i32, u32 {
             ^block125:
                 v979 = arith.constant 0 : u32;
@@ -377,7 +377,7 @@ builtin.component miden:base/note-script@1.0.0 {
             } else {
             ^block49:
                 v249 = hir.exec @miden:base/note-script@1.0.0/p2id/core::ptr::alignment::Alignment::max(v229, v242) : i32
-                v1016 = arith.constant 0 : i32;
+                v1017 = arith.constant 0 : i32;
                 v248 = arith.constant -2147483648 : i32;
                 v250 = arith.sub v248, v249 : i32 #[overflow = wrapping];
                 v252 = hir.bitcast v250 : u32;
@@ -385,18 +385,18 @@ builtin.component miden:base/note-script@1.0.0 {
                 v253 = arith.gt v251, v252 : i1;
                 v254 = arith.zext v253 : u32;
                 v255 = hir.bitcast v254 : i32;
-                v257 = arith.neq v255, v1016 : i1;
+                v257 = arith.neq v255, v1017 : i1;
                 v1002 = scf.if v257 : i32 {
                 ^block124:
-                    v1015 = ub.poison i32 : i32;
-                    scf.yield v1015;
+                    v1016 = ub.poison i32 : i32;
+                    scf.yield v1016;
                 } else {
                 ^block50:
-                    v1013 = arith.constant 0 : i32;
-                    v263 = arith.sub v1013, v249 : i32 #[overflow = wrapping];
-                    v1014 = arith.constant -1 : i32;
+                    v1014 = arith.constant 0 : i32;
+                    v263 = arith.sub v1014, v249 : i32 #[overflow = wrapping];
+                    v1015 = arith.constant -1 : i32;
                     v259 = arith.add v230, v249 : i32 #[overflow = wrapping];
-                    v261 = arith.add v259, v1014 : i32 #[overflow = wrapping];
+                    v261 = arith.add v259, v1015 : i32 #[overflow = wrapping];
                     v264 = arith.band v261, v263 : i32;
                     v265 = hir.bitcast v228 : u32;
                     v266 = arith.constant 4 : u32;
@@ -404,8 +404,8 @@ builtin.component miden:base/note-script@1.0.0 {
                     hir.assertz v267 #[code = 250];
                     v268 = hir.int_to_ptr v265 : ptr<byte, i32>;
                     v269 = hir.load v268 : i32;
-                    v1012 = arith.constant 0 : i32;
-                    v271 = arith.neq v269, v1012 : i1;
+                    v1013 = arith.constant 0 : i32;
+                    v271 = arith.neq v269, v1013 : i1;
                     scf.if v271{
                     ^block123:
                         scf.yield ;
@@ -414,29 +414,29 @@ builtin.component miden:base/note-script@1.0.0 {
                         v272 = hir.exec @intrinsics/mem/heap_base() : i32
                         v273 = hir.mem_size  : u32;
                         v279 = hir.bitcast v228 : u32;
-                        v1011 = arith.constant 4 : u32;
-                        v281 = arith.mod v279, v1011 : u32;
+                        v1012 = arith.constant 4 : u32;
+                        v281 = arith.mod v279, v1012 : u32;
                         hir.assertz v281 #[code = 250];
-                        v1010 = arith.constant 16 : u32;
+                        v1011 = arith.constant 16 : u32;
                         v274 = hir.bitcast v273 : i32;
-                        v277 = arith.shl v274, v1010 : i32;
+                        v277 = arith.shl v274, v1011 : i32;
                         v278 = arith.add v272, v277 : i32 #[overflow = wrapping];
                         v282 = hir.int_to_ptr v279 : ptr<byte, i32>;
                         hir.store v282, v278;
                         scf.yield ;
                     };
                     v285 = hir.bitcast v228 : u32;
-                    v1009 = arith.constant 4 : u32;
-                    v287 = arith.mod v285, v1009 : u32;
+                    v1010 = arith.constant 4 : u32;
+                    v287 = arith.mod v285, v1010 : u32;
                     hir.assertz v287 #[code = 250];
                     v288 = hir.int_to_ptr v285 : ptr<byte, i32>;
                     v289 = hir.load v288 : i32;
                     v1008 = arith.constant 0 : i32;
-                    v293 = hir.bitcast v264 : u32;
-                    v283 = arith.constant -2 : i32;
-                    v290 = arith.sub v283, v289 : i32 #[overflow = wrapping];
-                    v292 = hir.bitcast v290 : u32;
-                    v294 = arith.lt v292, v293 : i1;
+                    v1009 = arith.constant -1 : i32;
+                    v291 = arith.bxor v289, v1009 : i32;
+                    v293 = hir.bitcast v291 : u32;
+                    v292 = hir.bitcast v264 : u32;
+                    v294 = arith.gt v292, v293 : i1;
                     v295 = arith.zext v294 : u32;
                     v296 = hir.bitcast v295 : i32;
                     v298 = arith.neq v296, v1008 : i1;
@@ -495,56 +495,56 @@ builtin.component miden:base/note-script@1.0.0 {
             hir.assertz v328 #[code = 250];
             v329 = hir.int_to_ptr v326 : ptr<byte, i32>;
             v330 = hir.load v329 : i32;
-            v1028 = arith.constant 4 : u32;
+            v1029 = arith.constant 4 : u32;
             v331 = hir.bitcast v317 : u32;
-            v333 = arith.add v331, v1028 : u32 #[overflow = checked];
-            v1027 = arith.constant 4 : u32;
-            v335 = arith.mod v333, v1027 : u32;
+            v333 = arith.add v331, v1029 : u32 #[overflow = checked];
+            v1028 = arith.constant 4 : u32;
+            v335 = arith.mod v333, v1028 : u32;
             hir.assertz v335 #[code = 250];
             v336 = hir.int_to_ptr v333 : ptr<byte, i32>;
             v337 = hir.load v336 : i32;
-            v1026 = arith.constant 0 : i32;
+            v1027 = arith.constant 0 : i32;
             v338 = arith.constant 1 : i32;
             v339 = arith.neq v337, v338 : i1;
             v340 = arith.zext v339 : u32;
             v341 = hir.bitcast v340 : i32;
-            v343 = arith.neq v341, v1026 : i1;
+            v343 = arith.neq v341, v1027 : i1;
             cf.cond_br v343 ^block57, ^block58;
         ^block57:
             v352 = arith.constant 12 : u32;
             v351 = hir.bitcast v317 : u32;
             v353 = arith.add v351, v352 : u32 #[overflow = checked];
-            v1025 = arith.constant 4 : u32;
-            v355 = arith.mod v353, v1025 : u32;
+            v1026 = arith.constant 4 : u32;
+            v355 = arith.mod v353, v1026 : u32;
             hir.assertz v355 #[code = 250];
             v356 = hir.int_to_ptr v353 : ptr<byte, i32>;
             v357 = hir.load v356 : i32;
-            v1024 = arith.constant 4 : u32;
+            v1025 = arith.constant 4 : u32;
             v358 = hir.bitcast v308 : u32;
-            v360 = arith.add v358, v1024 : u32 #[overflow = checked];
-            v1023 = arith.constant 4 : u32;
-            v362 = arith.mod v360, v1023 : u32;
+            v360 = arith.add v358, v1025 : u32 #[overflow = checked];
+            v1024 = arith.constant 4 : u32;
+            v362 = arith.mod v360, v1024 : u32;
             hir.assertz v362 #[code = 250];
             v363 = hir.int_to_ptr v360 : ptr<byte, i32>;
             hir.store v363, v357;
             v364 = hir.bitcast v308 : u32;
-            v1022 = arith.constant 4 : u32;
-            v366 = arith.mod v364, v1022 : u32;
+            v1023 = arith.constant 4 : u32;
+            v366 = arith.mod v364, v1023 : u32;
             hir.assertz v366 #[code = 250];
             v367 = hir.int_to_ptr v364 : ptr<byte, i32>;
             hir.store v367, v330;
-            v1021 = arith.constant 16 : i32;
-            v369 = arith.add v317, v1021 : i32 #[overflow = wrapping];
+            v1022 = arith.constant 16 : i32;
+            v369 = arith.add v317, v1022 : i32 #[overflow = wrapping];
             v370 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
             v371 = hir.bitcast v370 : ptr<byte, i32>;
             hir.store v371, v369;
             builtin.ret ;
         ^block58:
-            v1020 = arith.constant 12 : u32;
+            v1021 = arith.constant 12 : u32;
             v344 = hir.bitcast v317 : u32;
-            v346 = arith.add v344, v1020 : u32 #[overflow = checked];
-            v1019 = arith.constant 4 : u32;
-            v348 = arith.mod v346, v1019 : u32;
+            v346 = arith.add v344, v1021 : u32 #[overflow = checked];
+            v1020 = arith.constant 4 : u32;
+            v348 = arith.mod v346, v1020 : u32;
             hir.assertz v348 #[code = 250];
             v349 = hir.int_to_ptr v346 : ptr<byte, i32>;
             v350 = hir.load v349 : i32;
@@ -574,13 +574,13 @@ builtin.component miden:base/note-script@1.0.0 {
             v388 = hir.int_to_ptr v385 : ptr<byte, i64>;
             v389 = hir.load v388 : i64;
             v390 = hir.bitcast v372 : u32;
-            v1030 = arith.constant 8 : u32;
-            v392 = arith.mod v390, v1030 : u32;
+            v1031 = arith.constant 8 : u32;
+            v392 = arith.mod v390, v1031 : u32;
             hir.assertz v392 #[code = 250];
             v393 = hir.int_to_ptr v390 : ptr<byte, i64>;
             hir.store v393, v389;
-            v1029 = arith.constant 16 : i32;
-            v395 = arith.add v378, v1029 : i32 #[overflow = wrapping];
+            v1030 = arith.constant 16 : i32;
+            v395 = arith.add v378, v1030 : i32 #[overflow = wrapping];
             v396 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
             v397 = hir.bitcast v396 : ptr<byte, i32>;
             hir.store v397, v395;
@@ -617,40 +617,40 @@ builtin.component miden:base/note-script@1.0.0 {
             v424 = arith.constant 12 : u32;
             v423 = hir.bitcast v404 : u32;
             v425 = arith.add v423, v424 : u32 #[overflow = checked];
-            v1038 = arith.constant 4 : u32;
-            v427 = arith.mod v425, v1038 : u32;
+            v1039 = arith.constant 4 : u32;
+            v427 = arith.mod v425, v1039 : u32;
             hir.assertz v427 #[code = 250];
             v428 = hir.int_to_ptr v425 : ptr<byte, i32>;
             v429 = hir.load v428 : i32;
-            v1031 = arith.constant 2 : u32;
+            v1032 = arith.constant 2 : u32;
             v431 = hir.bitcast v429 : u32;
-            v433 = arith.shr v431, v1031 : u32;
+            v433 = arith.shr v431, v1032 : u32;
             v434 = hir.bitcast v433 : i32;
             v435 = hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::note::extern_note_get_inputs(v434) : i32
-            v1037 = arith.constant 8 : u32;
+            v1038 = arith.constant 8 : u32;
             v436 = hir.bitcast v398 : u32;
-            v438 = arith.add v436, v1037 : u32 #[overflow = checked];
-            v1036 = arith.constant 4 : u32;
-            v440 = arith.mod v438, v1036 : u32;
+            v438 = arith.add v436, v1038 : u32 #[overflow = checked];
+            v1037 = arith.constant 4 : u32;
+            v440 = arith.mod v438, v1037 : u32;
             hir.assertz v440 #[code = 250];
             v441 = hir.int_to_ptr v438 : ptr<byte, i32>;
             hir.store v441, v435;
-            v1035 = arith.constant 4 : u32;
+            v1036 = arith.constant 4 : u32;
             v442 = hir.bitcast v398 : u32;
-            v444 = arith.add v442, v1035 : u32 #[overflow = checked];
-            v1034 = arith.constant 4 : u32;
-            v446 = arith.mod v444, v1034 : u32;
+            v444 = arith.add v442, v1036 : u32 #[overflow = checked];
+            v1035 = arith.constant 4 : u32;
+            v446 = arith.mod v444, v1035 : u32;
             hir.assertz v446 #[code = 250];
             v447 = hir.int_to_ptr v444 : ptr<byte, i32>;
             hir.store v447, v429;
             v448 = hir.bitcast v398 : u32;
-            v1033 = arith.constant 4 : u32;
-            v450 = arith.mod v448, v1033 : u32;
+            v1034 = arith.constant 4 : u32;
+            v450 = arith.mod v448, v1034 : u32;
             hir.assertz v450 #[code = 250];
             v451 = hir.int_to_ptr v448 : ptr<byte, i32>;
             hir.store v451, v422;
-            v1032 = arith.constant 16 : i32;
-            v453 = arith.add v404, v1032 : i32 #[overflow = wrapping];
+            v1033 = arith.constant 16 : i32;
+            v453 = arith.add v404, v1033 : i32 #[overflow = wrapping];
             v454 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
             v455 = hir.bitcast v454 : ptr<byte, i32>;
             hir.store v455, v453;
@@ -672,10 +672,10 @@ builtin.component miden:base/note-script@1.0.0 {
             v471 = hir.load v470 : i32;
             v472 = arith.constant 1048684 : i32;
             v473 = arith.add v471, v472 : i32 #[overflow = wrapping];
-            v1047 = arith.constant 16 : i32;
+            v1048 = arith.constant 16 : i32;
             v465 = arith.constant 8 : i32;
             v466 = arith.add v462, v465 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v466, v1047, v1047, v473)
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v466, v1048, v1048, v473)
             v475 = arith.constant 8 : u32;
             v474 = hir.bitcast v462 : u32;
             v476 = arith.add v474, v475 : u32 #[overflow = checked];
@@ -687,40 +687,40 @@ builtin.component miden:base/note-script@1.0.0 {
             v482 = arith.constant 12 : u32;
             v481 = hir.bitcast v462 : u32;
             v483 = arith.add v481, v482 : u32 #[overflow = checked];
-            v1046 = arith.constant 4 : u32;
-            v485 = arith.mod v483, v1046 : u32;
+            v1047 = arith.constant 4 : u32;
+            v485 = arith.mod v483, v1047 : u32;
             hir.assertz v485 #[code = 250];
             v486 = hir.int_to_ptr v483 : ptr<byte, i32>;
             v487 = hir.load v486 : i32;
-            v1039 = arith.constant 2 : u32;
+            v1040 = arith.constant 2 : u32;
             v489 = hir.bitcast v487 : u32;
-            v491 = arith.shr v489, v1039 : u32;
+            v491 = arith.shr v489, v1040 : u32;
             v492 = hir.bitcast v491 : i32;
             v493 = hir.exec @miden:base/note-script@1.0.0/p2id/miden_base_sys::bindings::note::extern_note_get_assets(v492) : i32
-            v1045 = arith.constant 8 : u32;
+            v1046 = arith.constant 8 : u32;
             v494 = hir.bitcast v456 : u32;
-            v496 = arith.add v494, v1045 : u32 #[overflow = checked];
-            v1044 = arith.constant 4 : u32;
-            v498 = arith.mod v496, v1044 : u32;
+            v496 = arith.add v494, v1046 : u32 #[overflow = checked];
+            v1045 = arith.constant 4 : u32;
+            v498 = arith.mod v496, v1045 : u32;
             hir.assertz v498 #[code = 250];
             v499 = hir.int_to_ptr v496 : ptr<byte, i32>;
             hir.store v499, v493;
-            v1043 = arith.constant 4 : u32;
+            v1044 = arith.constant 4 : u32;
             v500 = hir.bitcast v456 : u32;
-            v502 = arith.add v500, v1043 : u32 #[overflow = checked];
-            v1042 = arith.constant 4 : u32;
-            v504 = arith.mod v502, v1042 : u32;
+            v502 = arith.add v500, v1044 : u32 #[overflow = checked];
+            v1043 = arith.constant 4 : u32;
+            v504 = arith.mod v502, v1043 : u32;
             hir.assertz v504 #[code = 250];
             v505 = hir.int_to_ptr v502 : ptr<byte, i32>;
             hir.store v505, v487;
             v506 = hir.bitcast v456 : u32;
-            v1041 = arith.constant 4 : u32;
-            v508 = arith.mod v506, v1041 : u32;
+            v1042 = arith.constant 4 : u32;
+            v508 = arith.mod v506, v1042 : u32;
             hir.assertz v508 #[code = 250];
             v509 = hir.int_to_ptr v506 : ptr<byte, i32>;
             hir.store v509, v480;
-            v1040 = arith.constant 16 : i32;
-            v511 = arith.add v462, v1040 : i32 #[overflow = wrapping];
+            v1041 = arith.constant 16 : i32;
+            v511 = arith.add v462, v1041 : i32 #[overflow = wrapping];
             v512 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
             v513 = hir.bitcast v512 : ptr<byte, i32>;
             hir.store v513, v511;
@@ -748,38 +748,38 @@ builtin.component miden:base/note-script@1.0.0 {
             hir.assertz v531 #[code = 250];
             v532 = hir.int_to_ptr v529 : ptr<byte, i32>;
             v533 = hir.load v532 : i32;
-            v1054 = arith.constant 0 : i32;
+            v1055 = arith.constant 0 : i32;
             v517 = arith.constant 0 : i32;
             v535 = arith.eq v533, v517 : i1;
             v536 = arith.zext v535 : u32;
             v537 = hir.bitcast v536 : i32;
-            v539 = arith.neq v537, v1054 : i1;
+            v539 = arith.neq v537, v1055 : i1;
             scf.if v539{
             ^block133:
                 scf.yield ;
             } else {
             ^block68:
-                v1053 = arith.constant 4 : u32;
+                v1054 = arith.constant 4 : u32;
                 v540 = hir.bitcast v522 : u32;
-                v542 = arith.add v540, v1053 : u32 #[overflow = checked];
-                v1052 = arith.constant 4 : u32;
-                v544 = arith.mod v542, v1052 : u32;
+                v542 = arith.add v540, v1054 : u32 #[overflow = checked];
+                v1053 = arith.constant 4 : u32;
+                v544 = arith.mod v542, v1053 : u32;
                 hir.assertz v544 #[code = 250];
                 v545 = hir.int_to_ptr v542 : ptr<byte, i32>;
                 v546 = hir.load v545 : i32;
                 v548 = arith.constant 12 : u32;
                 v547 = hir.bitcast v522 : u32;
                 v549 = arith.add v547, v548 : u32 #[overflow = checked];
-                v1051 = arith.constant 4 : u32;
-                v551 = arith.mod v549, v1051 : u32;
+                v1052 = arith.constant 4 : u32;
+                v551 = arith.mod v549, v1052 : u32;
                 hir.assertz v551 #[code = 250];
                 v552 = hir.int_to_ptr v549 : ptr<byte, i32>;
                 v553 = hir.load v552 : i32;
                 hir.exec @miden:base/note-script@1.0.0/p2id/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v546, v533, v553)
                 scf.yield ;
             };
-            v1050 = arith.constant 16 : i32;
-            v556 = arith.add v522, v1050 : i32 #[overflow = wrapping];
+            v1051 = arith.constant 16 : i32;
+            v556 = arith.add v522, v1051 : i32 #[overflow = wrapping];
             v557 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
             v558 = hir.bitcast v557 : ptr<byte, i32>;
             hir.store v558, v556;
@@ -809,23 +809,23 @@ builtin.component miden:base/note-script@1.0.0 {
             v580 = arith.zext v579 : u64;
             v581 = hir.bitcast v580 : i64;
             v585 = arith.mul v581, v584 : i64 #[overflow = wrapping];
-            v1158 = arith.constant 0 : i32;
+            v1159 = arith.constant 0 : i32;
             v586 = arith.constant 32 : i64;
             v588 = hir.cast v586 : u32;
             v587 = hir.bitcast v585 : u64;
             v589 = arith.shr v587, v588 : u64;
             v590 = hir.bitcast v589 : i64;
             v591 = arith.trunc v590 : i32;
-            v593 = arith.neq v591, v1158 : i1;
-            v1070, v1071, v1072, v1073, v1074, v1075 = scf.if v593 : i32, i32, i32, i32, i32, u32 {
+            v593 = arith.neq v591, v1159 : i1;
+            v1071, v1072, v1073, v1074, v1075, v1076 = scf.if v593 : i32, i32, i32, i32, i32, u32 {
             ^block135:
-                v1055 = arith.constant 0 : u32;
-                v1062 = ub.poison i32 : i32;
-                scf.yield v559, v570, v1062, v1062, v1062, v1055;
+                v1056 = arith.constant 0 : u32;
+                v1063 = ub.poison i32 : i32;
+                scf.yield v559, v570, v1063, v1063, v1063, v1056;
             } else {
             ^block74:
                 v594 = arith.trunc v585 : i32;
-                v1157 = arith.constant 0 : i32;
+                v1158 = arith.constant 0 : i32;
                 v595 = arith.constant -2147483648 : i32;
                 v596 = arith.sub v595, v562 : i32 #[overflow = wrapping];
                 v598 = hir.bitcast v596 : u32;
@@ -833,16 +833,16 @@ builtin.component miden:base/note-script@1.0.0 {
                 v599 = arith.lte v597, v598 : i1;
                 v600 = arith.zext v599 : u32;
                 v601 = hir.bitcast v600 : i32;
-                v603 = arith.neq v601, v1157 : i1;
-                v1118 = scf.if v603 : i32 {
+                v603 = arith.neq v601, v1158 : i1;
+                v1119 = scf.if v603 : i32 {
                 ^block72:
-                    v1156 = arith.constant 0 : i32;
-                    v614 = arith.neq v594, v1156 : i1;
-                    v1117 = scf.if v614 : i32 {
+                    v1157 = arith.constant 0 : i32;
+                    v614 = arith.neq v594, v1157 : i1;
+                    v1118 = scf.if v614 : i32 {
                     ^block76:
-                        v1155 = arith.constant 0 : i32;
-                        v630 = arith.neq v561, v1155 : i1;
-                        v1116 = scf.if v630 : i32 {
+                        v1156 = arith.constant 0 : i32;
+                        v630 = arith.neq v561, v1156 : i1;
+                        v1117 = scf.if v630 : i32 {
                         ^block79:
                             v612 = arith.constant 1 : i32;
                             hir.exec @miden:base/note-script@1.0.0/p2id/alloc::alloc::Global::alloc_impl(v570, v562, v594, v612)
@@ -861,130 +861,130 @@ builtin.component miden:base/note-script@1.0.0 {
                             v616 = arith.constant 8 : u32;
                             v633 = hir.bitcast v570 : u32;
                             v635 = arith.add v633, v616 : u32 #[overflow = checked];
-                            v1154 = arith.constant 4 : u32;
-                            v637 = arith.mod v635, v1154 : u32;
+                            v1155 = arith.constant 4 : u32;
+                            v637 = arith.mod v635, v1155 : u32;
                             hir.assertz v637 #[code = 250];
                             v638 = hir.int_to_ptr v635 : ptr<byte, i32>;
                             v639 = hir.load v638 : i32;
                             scf.yield v639;
                         };
-                        v1152 = arith.constant 0 : i32;
                         v1153 = arith.constant 0 : i32;
-                        v648 = arith.eq v1116, v1153 : i1;
+                        v1154 = arith.constant 0 : i32;
+                        v648 = arith.eq v1117, v1154 : i1;
                         v649 = arith.zext v648 : u32;
                         v650 = hir.bitcast v649 : i32;
-                        v652 = arith.neq v650, v1152 : i1;
+                        v652 = arith.neq v650, v1153 : i1;
                         scf.if v652{
                         ^block81:
-                            v1151 = arith.constant 8 : u32;
+                            v1152 = arith.constant 8 : u32;
                             v669 = hir.bitcast v559 : u32;
-                            v671 = arith.add v669, v1151 : u32 #[overflow = checked];
-                            v1150 = arith.constant 4 : u32;
-                            v673 = arith.mod v671, v1150 : u32;
+                            v671 = arith.add v669, v1152 : u32 #[overflow = checked];
+                            v1151 = arith.constant 4 : u32;
+                            v673 = arith.mod v671, v1151 : u32;
                             hir.assertz v673 #[code = 250];
                             v674 = hir.int_to_ptr v671 : ptr<byte, i32>;
                             hir.store v674, v594;
-                            v1149 = arith.constant 4 : u32;
+                            v1150 = arith.constant 4 : u32;
                             v676 = hir.bitcast v559 : u32;
-                            v678 = arith.add v676, v1149 : u32 #[overflow = checked];
-                            v1148 = arith.constant 4 : u32;
-                            v680 = arith.mod v678, v1148 : u32;
+                            v678 = arith.add v676, v1150 : u32 #[overflow = checked];
+                            v1149 = arith.constant 4 : u32;
+                            v680 = arith.mod v678, v1149 : u32;
                             hir.assertz v680 #[code = 250];
                             v681 = hir.int_to_ptr v678 : ptr<byte, i32>;
                             hir.store v681, v562;
                             scf.yield ;
                         } else {
                         ^block82:
-                            v1147 = arith.constant 8 : u32;
+                            v1148 = arith.constant 8 : u32;
                             v654 = hir.bitcast v559 : u32;
-                            v656 = arith.add v654, v1147 : u32 #[overflow = checked];
-                            v1146 = arith.constant 4 : u32;
-                            v658 = arith.mod v656, v1146 : u32;
+                            v656 = arith.add v654, v1148 : u32 #[overflow = checked];
+                            v1147 = arith.constant 4 : u32;
+                            v658 = arith.mod v656, v1147 : u32;
                             hir.assertz v658 #[code = 250];
                             v659 = hir.int_to_ptr v656 : ptr<byte, i32>;
-                            hir.store v659, v1116;
-                            v1145 = arith.constant 4 : u32;
+                            hir.store v659, v1117;
+                            v1146 = arith.constant 4 : u32;
                             v661 = hir.bitcast v559 : u32;
-                            v663 = arith.add v661, v1145 : u32 #[overflow = checked];
-                            v1144 = arith.constant 4 : u32;
-                            v665 = arith.mod v663, v1144 : u32;
+                            v663 = arith.add v661, v1146 : u32 #[overflow = checked];
+                            v1145 = arith.constant 4 : u32;
+                            v665 = arith.mod v663, v1145 : u32;
                             hir.assertz v665 #[code = 250];
                             v666 = hir.int_to_ptr v663 : ptr<byte, i32>;
                             hir.store v666, v560;
                             scf.yield ;
                         };
-                        v1142 = arith.constant 0 : i32;
-                        v1143 = arith.constant 1 : i32;
-                        v1115 = cf.select v652, v1143, v1142 : i32;
-                        scf.yield v1115;
+                        v1143 = arith.constant 0 : i32;
+                        v1144 = arith.constant 1 : i32;
+                        v1116 = cf.select v652, v1144, v1143 : i32;
+                        scf.yield v1116;
                     } else {
                     ^block77:
-                        v1141 = arith.constant 8 : u32;
+                        v1142 = arith.constant 8 : u32;
                         v615 = hir.bitcast v559 : u32;
-                        v617 = arith.add v615, v1141 : u32 #[overflow = checked];
-                        v1140 = arith.constant 4 : u32;
-                        v619 = arith.mod v617, v1140 : u32;
+                        v617 = arith.add v615, v1142 : u32 #[overflow = checked];
+                        v1141 = arith.constant 4 : u32;
+                        v619 = arith.mod v617, v1141 : u32;
                         hir.assertz v619 #[code = 250];
                         v620 = hir.int_to_ptr v617 : ptr<byte, i32>;
                         hir.store v620, v562;
-                        v1139 = arith.constant 4 : u32;
+                        v1140 = arith.constant 4 : u32;
                         v623 = hir.bitcast v559 : u32;
-                        v625 = arith.add v623, v1139 : u32 #[overflow = checked];
-                        v1138 = arith.constant 4 : u32;
-                        v627 = arith.mod v625, v1138 : u32;
+                        v625 = arith.add v623, v1140 : u32 #[overflow = checked];
+                        v1139 = arith.constant 4 : u32;
+                        v627 = arith.mod v625, v1139 : u32;
                         hir.assertz v627 #[code = 250];
-                        v1137 = arith.constant 0 : i32;
+                        v1138 = arith.constant 0 : i32;
                         v628 = hir.int_to_ptr v625 : ptr<byte, i32>;
-                        hir.store v628, v1137;
-                        v1136 = arith.constant 0 : i32;
-                        scf.yield v1136;
+                        hir.store v628, v1138;
+                        v1137 = arith.constant 0 : i32;
+                        scf.yield v1137;
                     };
-                    scf.yield v1117;
+                    scf.yield v1118;
                 } else {
                 ^block75:
-                    v1135 = ub.poison i32 : i32;
-                    scf.yield v1135;
+                    v1136 = ub.poison i32 : i32;
+                    scf.yield v1136;
                 };
-                v1130 = arith.constant 0 : u32;
-                v1063 = arith.constant 1 : u32;
-                v1123 = cf.select v603, v1063, v1130 : u32;
-                v1131 = ub.poison i32 : i32;
-                v1122 = cf.select v603, v570, v1131 : i32;
+                v1131 = arith.constant 0 : u32;
+                v1064 = arith.constant 1 : u32;
+                v1124 = cf.select v603, v1064, v1131 : u32;
                 v1132 = ub.poison i32 : i32;
-                v1121 = cf.select v603, v559, v1132 : i32;
+                v1123 = cf.select v603, v570, v1132 : i32;
                 v1133 = ub.poison i32 : i32;
-                v1120 = cf.select v603, v1133, v570 : i32;
+                v1122 = cf.select v603, v559, v1133 : i32;
                 v1134 = ub.poison i32 : i32;
-                v1119 = cf.select v603, v1134, v559 : i32;
-                scf.yield v1119, v1120, v1121, v1118, v1122, v1123;
+                v1121 = cf.select v603, v1134, v570 : i32;
+                v1135 = ub.poison i32 : i32;
+                v1120 = cf.select v603, v1135, v559 : i32;
+                scf.yield v1120, v1121, v1122, v1119, v1123, v1124;
             };
-            v1076, v1077, v1078 = scf.index_switch v1075 : i32, i32, i32 
+            v1077, v1078, v1079 = scf.index_switch v1076 : i32, i32, i32 
             case 0 {
             ^block73:
+                v1130 = arith.constant 4 : u32;
+                v606 = hir.bitcast v1071 : u32;
+                v608 = arith.add v606, v1130 : u32 #[overflow = checked];
                 v1129 = arith.constant 4 : u32;
-                v606 = hir.bitcast v1070 : u32;
-                v608 = arith.add v606, v1129 : u32 #[overflow = checked];
-                v1128 = arith.constant 4 : u32;
-                v610 = arith.mod v608, v1128 : u32;
+                v610 = arith.mod v608, v1129 : u32;
                 hir.assertz v610 #[code = 250];
-                v1127 = arith.constant 0 : i32;
+                v1128 = arith.constant 0 : i32;
                 v611 = hir.int_to_ptr v608 : ptr<byte, i32>;
-                hir.store v611, v1127;
-                v1126 = arith.constant 1 : i32;
-                scf.yield v1070, v1126, v1071;
+                hir.store v611, v1128;
+                v1127 = arith.constant 1 : i32;
+                scf.yield v1071, v1127, v1072;
             }
             default {
             ^block139:
-                scf.yield v1072, v1073, v1074;
+                scf.yield v1073, v1074, v1075;
             };
-            v685 = hir.bitcast v1076 : u32;
-            v1125 = arith.constant 4 : u32;
-            v687 = arith.mod v685, v1125 : u32;
+            v685 = hir.bitcast v1077 : u32;
+            v1126 = arith.constant 4 : u32;
+            v687 = arith.mod v685, v1126 : u32;
             hir.assertz v687 #[code = 250];
             v688 = hir.int_to_ptr v685 : ptr<byte, i32>;
-            hir.store v688, v1077;
-            v1124 = arith.constant 16 : i32;
-            v693 = arith.add v1078, v1124 : i32 #[overflow = wrapping];
+            hir.store v688, v1078;
+            v1125 = arith.constant 16 : i32;
+            v693 = arith.add v1079, v1125 : i32 #[overflow = wrapping];
             v694 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
             v695 = hir.bitcast v694 : ptr<byte, i32>;
             hir.store v695, v693;
@@ -1016,27 +1016,27 @@ builtin.component miden:base/note-script@1.0.0 {
             v718 = arith.constant 8 : u32;
             v717 = hir.bitcast v704 : u32;
             v719 = arith.add v717, v718 : u32 #[overflow = checked];
-            v1163 = arith.constant 4 : u32;
-            v721 = arith.mod v719, v1163 : u32;
+            v1164 = arith.constant 4 : u32;
+            v721 = arith.mod v719, v1164 : u32;
             hir.assertz v721 #[code = 250];
             v722 = hir.int_to_ptr v719 : ptr<byte, i32>;
             v723 = hir.load v722 : i32;
             v724 = hir.bitcast v696 : u32;
-            v1162 = arith.constant 4 : u32;
-            v726 = arith.mod v724, v1162 : u32;
+            v1163 = arith.constant 4 : u32;
+            v726 = arith.mod v724, v1163 : u32;
             hir.assertz v726 #[code = 250];
             v727 = hir.int_to_ptr v724 : ptr<byte, i32>;
             hir.store v727, v723;
-            v1161 = arith.constant 4 : u32;
+            v1162 = arith.constant 4 : u32;
             v728 = hir.bitcast v696 : u32;
-            v730 = arith.add v728, v1161 : u32 #[overflow = checked];
-            v1160 = arith.constant 4 : u32;
-            v732 = arith.mod v730, v1160 : u32;
+            v730 = arith.add v728, v1162 : u32 #[overflow = checked];
+            v1161 = arith.constant 4 : u32;
+            v732 = arith.mod v730, v1161 : u32;
             hir.assertz v732 #[code = 250];
             v733 = hir.int_to_ptr v730 : ptr<byte, i32>;
             hir.store v733, v716;
-            v1159 = arith.constant 16 : i32;
-            v735 = arith.add v704, v1159 : i32 #[overflow = wrapping];
+            v1160 = arith.constant 16 : i32;
+            v735 = arith.add v704, v1160 : i32 #[overflow = wrapping];
             v736 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
             v737 = hir.bitcast v736 : ptr<byte, i32>;
             hir.store v737, v735;
@@ -1045,21 +1045,21 @@ builtin.component miden:base/note-script@1.0.0 {
 
         private builtin.function @alloc::alloc::Global::alloc_impl(v738: i32, v739: i32, v740: i32, v741: i32) {
         ^block85(v738: i32, v739: i32, v740: i32, v741: i32):
-            v1179 = arith.constant 0 : i32;
+            v1180 = arith.constant 0 : i32;
             v742 = arith.constant 0 : i32;
             v743 = arith.eq v740, v742 : i1;
             v744 = arith.zext v743 : u32;
             v745 = hir.bitcast v744 : i32;
-            v747 = arith.neq v745, v1179 : i1;
-            v1175 = scf.if v747 : i32 {
+            v747 = arith.neq v745, v1180 : i1;
+            v1176 = scf.if v747 : i32 {
             ^block142:
                 scf.yield v739;
             } else {
             ^block88:
                 hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_no_alloc_shim_is_unstable_v2()
-                v1178 = arith.constant 0 : i32;
-                v749 = arith.neq v741, v1178 : i1;
-                v1174 = scf.if v749 : i32 {
+                v1179 = arith.constant 0 : i32;
+                v749 = arith.neq v741, v1179 : i1;
+                v1175 = scf.if v749 : i32 {
                 ^block89:
                     v751 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc_zeroed(v740, v739) : i32
                     scf.yield v751;
@@ -1068,38 +1068,38 @@ builtin.component miden:base/note-script@1.0.0 {
                     v750 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc(v740, v739) : i32
                     scf.yield v750;
                 };
-                scf.yield v1174;
+                scf.yield v1175;
             };
             v755 = arith.constant 4 : u32;
             v754 = hir.bitcast v738 : u32;
             v756 = arith.add v754, v755 : u32 #[overflow = checked];
-            v1177 = arith.constant 4 : u32;
-            v758 = arith.mod v756, v1177 : u32;
+            v1178 = arith.constant 4 : u32;
+            v758 = arith.mod v756, v1178 : u32;
             hir.assertz v758 #[code = 250];
             v759 = hir.int_to_ptr v756 : ptr<byte, i32>;
             hir.store v759, v740;
             v761 = hir.bitcast v738 : u32;
-            v1176 = arith.constant 4 : u32;
-            v763 = arith.mod v761, v1176 : u32;
+            v1177 = arith.constant 4 : u32;
+            v763 = arith.mod v761, v1177 : u32;
             hir.assertz v763 #[code = 250];
             v764 = hir.int_to_ptr v761 : ptr<byte, i32>;
-            hir.store v764, v1175;
+            hir.store v764, v1176;
             builtin.ret ;
         };
 
         private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v765: i32, v766: i32, v767: i32, v768: i32) {
         ^block91(v765: i32, v766: i32, v767: i32, v768: i32):
-            v1205 = arith.constant 0 : i32;
+            v1206 = arith.constant 0 : i32;
             v769 = arith.constant 0 : i32;
             v773 = arith.eq v768, v769 : i1;
             v774 = arith.zext v773 : u32;
             v775 = hir.bitcast v774 : i32;
-            v777 = arith.neq v775, v1205 : i1;
-            v1192, v1193 = scf.if v777 : i32, i32 {
+            v777 = arith.neq v775, v1206 : i1;
+            v1193, v1194 = scf.if v777 : i32, i32 {
             ^block146:
-                v1204 = arith.constant 0 : i32;
+                v1205 = arith.constant 0 : i32;
                 v771 = arith.constant 4 : i32;
-                scf.yield v771, v1204;
+                scf.yield v771, v1205;
             } else {
             ^block94:
                 v778 = hir.bitcast v766 : u32;
@@ -1108,37 +1108,37 @@ builtin.component miden:base/note-script@1.0.0 {
                 hir.assertz v780 #[code = 250];
                 v781 = hir.int_to_ptr v778 : ptr<byte, i32>;
                 v782 = hir.load v781 : i32;
-                v1202 = arith.constant 0 : i32;
                 v1203 = arith.constant 0 : i32;
-                v784 = arith.eq v782, v1203 : i1;
+                v1204 = arith.constant 0 : i32;
+                v784 = arith.eq v782, v1204 : i1;
                 v785 = arith.zext v784 : u32;
                 v786 = hir.bitcast v785 : i32;
-                v788 = arith.neq v786, v1202 : i1;
-                v1190 = scf.if v788 : i32 {
+                v788 = arith.neq v786, v1203 : i1;
+                v1191 = scf.if v788 : i32 {
                 ^block145:
-                    v1201 = arith.constant 0 : i32;
-                    scf.yield v1201;
+                    v1202 = arith.constant 0 : i32;
+                    scf.yield v1202;
                 } else {
                 ^block95:
-                    v1200 = arith.constant 4 : u32;
+                    v1201 = arith.constant 4 : u32;
                     v789 = hir.bitcast v765 : u32;
-                    v791 = arith.add v789, v1200 : u32 #[overflow = checked];
-                    v1199 = arith.constant 4 : u32;
-                    v793 = arith.mod v791, v1199 : u32;
+                    v791 = arith.add v789, v1201 : u32 #[overflow = checked];
+                    v1200 = arith.constant 4 : u32;
+                    v793 = arith.mod v791, v1200 : u32;
                     hir.assertz v793 #[code = 250];
                     v794 = hir.int_to_ptr v791 : ptr<byte, i32>;
                     hir.store v794, v767;
-                    v1198 = arith.constant 4 : u32;
+                    v1199 = arith.constant 4 : u32;
                     v795 = hir.bitcast v766 : u32;
-                    v797 = arith.add v795, v1198 : u32 #[overflow = checked];
-                    v1197 = arith.constant 4 : u32;
-                    v799 = arith.mod v797, v1197 : u32;
+                    v797 = arith.add v795, v1199 : u32 #[overflow = checked];
+                    v1198 = arith.constant 4 : u32;
+                    v799 = arith.mod v797, v1198 : u32;
                     hir.assertz v799 #[code = 250];
                     v800 = hir.int_to_ptr v797 : ptr<byte, i32>;
                     v801 = hir.load v800 : i32;
                     v802 = hir.bitcast v765 : u32;
-                    v1196 = arith.constant 4 : u32;
-                    v804 = arith.mod v802, v1196 : u32;
+                    v1197 = arith.constant 4 : u32;
+                    v804 = arith.mod v802, v1197 : u32;
                     hir.assertz v804 #[code = 250];
                     v805 = hir.int_to_ptr v802 : ptr<byte, i32>;
                     hir.store v805, v801;
@@ -1146,28 +1146,28 @@ builtin.component miden:base/note-script@1.0.0 {
                     scf.yield v806;
                 };
                 v807 = arith.constant 8 : i32;
-                v1195 = arith.constant 4 : i32;
-                v1191 = cf.select v788, v1195, v807 : i32;
-                scf.yield v1191, v1190;
+                v1196 = arith.constant 4 : i32;
+                v1192 = cf.select v788, v1196, v807 : i32;
+                scf.yield v1192, v1191;
             };
-            v810 = arith.add v765, v1192 : i32 #[overflow = wrapping];
+            v810 = arith.add v765, v1193 : i32 #[overflow = wrapping];
             v812 = hir.bitcast v810 : u32;
-            v1194 = arith.constant 4 : u32;
-            v814 = arith.mod v812, v1194 : u32;
+            v1195 = arith.constant 4 : u32;
+            v814 = arith.mod v812, v1195 : u32;
             hir.assertz v814 #[code = 250];
             v815 = hir.int_to_ptr v812 : ptr<byte, i32>;
-            hir.store v815, v1193;
+            hir.store v815, v1194;
             builtin.ret ;
         };
 
         private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v816: i32, v817: i32, v818: i32) {
         ^block96(v816: i32, v817: i32, v818: i32):
-            v1207 = arith.constant 0 : i32;
+            v1208 = arith.constant 0 : i32;
             v819 = arith.constant 0 : i32;
             v820 = arith.eq v818, v819 : i1;
             v821 = arith.zext v820 : u32;
             v822 = hir.bitcast v821 : i32;
-            v824 = arith.neq v822, v1207 : i1;
+            v824 = arith.neq v822, v1208 : i1;
             scf.if v824{
             ^block98:
                 scf.yield ;

--- a/tests/integration/expected/examples/p2id.masm
+++ b/tests/integration/expected/examples/p2id.masm
@@ -875,12 +875,13 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
             trace.252
             nop
             push.0
+            push.4294967295
             dup.2
-            push.4294967294
-            dup.3
-            u32wrapping_sub
             swap.1
-            u32lt
+            u32xor
+            dup.3
+            swap.1
+            u32gt
             neq
             if.true
                 drop

--- a/tests/integration/expected/examples/p2id.wat
+++ b/tests/integration/expected/examples/p2id.wat
@@ -283,13 +283,13 @@
           i32.store
         end
         block ;; label = @2
-          i32.const -2
+          local.get 2
           local.get 0
           i32.load
           local.tee 4
-          i32.sub
-          local.get 2
-          i32.lt_u
+          i32.const -1
+          i32.xor
+          i32.gt_u
           br_if 0 (;@2;)
           local.get 0
           local.get 4

--- a/tests/integration/expected/mem_intrinsics_heap_base.hir
+++ b/tests/integration/expected/mem_intrinsics_heap_base.hir
@@ -71,11 +71,11 @@ builtin.component root_ns:root@1.0.0 {
             v51 = hir.bitcast v50 : i32;
             v53 = arith.neq v51, v44 : i1;
             v54 = cf.select v53, v41, v45 : i32;
-            v181 = arith.constant 0 : i32;
+            v182 = arith.constant 0 : i32;
             v55 = arith.constant -1 : i32;
             v56 = arith.add v54, v55 : i32 #[overflow = wrapping];
             v57 = arith.band v54, v56 : i32;
-            v59 = arith.neq v57, v181 : i1;
+            v59 = arith.neq v57, v182 : i1;
             v151, v152 = scf.if v59 : i32, u32 {
             ^block31:
                 v143 = arith.constant 0 : u32;
@@ -84,7 +84,7 @@ builtin.component root_ns:root@1.0.0 {
             } else {
             ^block17:
                 v61 = hir.exec @root_ns:root@1.0.0/mem_intrinsics_heap_base/core::ptr::alignment::Alignment::max(v41, v54) : i32
-                v180 = arith.constant 0 : i32;
+                v181 = arith.constant 0 : i32;
                 v60 = arith.constant -2147483648 : i32;
                 v62 = arith.sub v60, v61 : i32 #[overflow = wrapping];
                 v64 = hir.bitcast v62 : u32;
@@ -92,18 +92,18 @@ builtin.component root_ns:root@1.0.0 {
                 v65 = arith.gt v63, v64 : i1;
                 v66 = arith.zext v65 : u32;
                 v67 = hir.bitcast v66 : i32;
-                v69 = arith.neq v67, v180 : i1;
+                v69 = arith.neq v67, v181 : i1;
                 v166 = scf.if v69 : i32 {
                 ^block30:
-                    v179 = ub.poison i32 : i32;
-                    scf.yield v179;
+                    v180 = ub.poison i32 : i32;
+                    scf.yield v180;
                 } else {
                 ^block18:
-                    v177 = arith.constant 0 : i32;
-                    v75 = arith.sub v177, v61 : i32 #[overflow = wrapping];
-                    v178 = arith.constant -1 : i32;
+                    v178 = arith.constant 0 : i32;
+                    v75 = arith.sub v178, v61 : i32 #[overflow = wrapping];
+                    v179 = arith.constant -1 : i32;
                     v71 = arith.add v42, v61 : i32 #[overflow = wrapping];
-                    v73 = arith.add v71, v178 : i32 #[overflow = wrapping];
+                    v73 = arith.add v71, v179 : i32 #[overflow = wrapping];
                     v76 = arith.band v73, v75 : i32;
                     v77 = hir.bitcast v40 : u32;
                     v78 = arith.constant 4 : u32;
@@ -111,8 +111,8 @@ builtin.component root_ns:root@1.0.0 {
                     hir.assertz v79 #[code = 250];
                     v80 = hir.int_to_ptr v77 : ptr<byte, i32>;
                     v81 = hir.load v80 : i32;
-                    v176 = arith.constant 0 : i32;
-                    v83 = arith.neq v81, v176 : i1;
+                    v177 = arith.constant 0 : i32;
+                    v83 = arith.neq v81, v177 : i1;
                     scf.if v83{
                     ^block29:
                         scf.yield ;
@@ -121,29 +121,29 @@ builtin.component root_ns:root@1.0.0 {
                         v84 = hir.exec @intrinsics/mem/heap_base() : i32
                         v85 = hir.mem_size  : u32;
                         v91 = hir.bitcast v40 : u32;
-                        v175 = arith.constant 4 : u32;
-                        v93 = arith.mod v91, v175 : u32;
+                        v176 = arith.constant 4 : u32;
+                        v93 = arith.mod v91, v176 : u32;
                         hir.assertz v93 #[code = 250];
-                        v174 = arith.constant 16 : u32;
+                        v175 = arith.constant 16 : u32;
                         v86 = hir.bitcast v85 : i32;
-                        v89 = arith.shl v86, v174 : i32;
+                        v89 = arith.shl v86, v175 : i32;
                         v90 = arith.add v84, v89 : i32 #[overflow = wrapping];
                         v94 = hir.int_to_ptr v91 : ptr<byte, i32>;
                         hir.store v94, v90;
                         scf.yield ;
                     };
                     v97 = hir.bitcast v40 : u32;
-                    v173 = arith.constant 4 : u32;
-                    v99 = arith.mod v97, v173 : u32;
+                    v174 = arith.constant 4 : u32;
+                    v99 = arith.mod v97, v174 : u32;
                     hir.assertz v99 #[code = 250];
                     v100 = hir.int_to_ptr v97 : ptr<byte, i32>;
                     v101 = hir.load v100 : i32;
                     v172 = arith.constant 0 : i32;
-                    v105 = hir.bitcast v76 : u32;
-                    v95 = arith.constant -2 : i32;
-                    v102 = arith.sub v95, v101 : i32 #[overflow = wrapping];
-                    v104 = hir.bitcast v102 : u32;
-                    v106 = arith.lt v104, v105 : i1;
+                    v173 = arith.constant -1 : i32;
+                    v103 = arith.bxor v101, v173 : i32;
+                    v105 = hir.bitcast v103 : u32;
+                    v104 = hir.bitcast v76 : u32;
+                    v106 = arith.gt v104, v105 : i1;
                     v107 = arith.zext v106 : u32;
                     v108 = hir.bitcast v107 : i32;
                     v110 = arith.neq v108, v172 : i1;

--- a/tests/integration/expected/mem_intrinsics_heap_base.wat
+++ b/tests/integration/expected/mem_intrinsics_heap_base.wat
@@ -97,13 +97,13 @@
         i32.store
       end
       block ;; label = @2
-        i32.const -2
+        local.get 2
         local.get 0
         i32.load
         local.tee 4
-        i32.sub
-        local.get 2
-        i32.lt_u
+        i32.const -1
+        i32.xor
+        i32.gt_u
         br_if 0 (;@2;)
         local.get 0
         local.get 4

--- a/tests/integration/expected/vec_alloc_vec.hir
+++ b/tests/integration/expected/vec_alloc_vec.hir
@@ -156,11 +156,11 @@ builtin.component root_ns:root@1.0.0 {
             v108 = hir.bitcast v107 : i32;
             v110 = arith.neq v108, v101 : i1;
             v111 = cf.select v110, v98, v102 : i32;
-            v376 = arith.constant 0 : i32;
+            v377 = arith.constant 0 : i32;
             v112 = arith.constant -1 : i32;
             v113 = arith.add v111, v112 : i32 #[overflow = wrapping];
             v114 = arith.band v111, v113 : i32;
-            v116 = arith.neq v114, v376 : i1;
+            v116 = arith.neq v114, v377 : i1;
             v346, v347 = scf.if v116 : i32, u32 {
             ^block51:
                 v338 = arith.constant 0 : u32;
@@ -169,7 +169,7 @@ builtin.component root_ns:root@1.0.0 {
             } else {
             ^block21:
                 v118 = hir.exec @root_ns:root@1.0.0/vec_alloc_vec/core::ptr::alignment::Alignment::max(v98, v111) : i32
-                v375 = arith.constant 0 : i32;
+                v376 = arith.constant 0 : i32;
                 v117 = arith.constant -2147483648 : i32;
                 v119 = arith.sub v117, v118 : i32 #[overflow = wrapping];
                 v121 = hir.bitcast v119 : u32;
@@ -177,18 +177,18 @@ builtin.component root_ns:root@1.0.0 {
                 v122 = arith.gt v120, v121 : i1;
                 v123 = arith.zext v122 : u32;
                 v124 = hir.bitcast v123 : i32;
-                v126 = arith.neq v124, v375 : i1;
+                v126 = arith.neq v124, v376 : i1;
                 v361 = scf.if v126 : i32 {
                 ^block50:
-                    v374 = ub.poison i32 : i32;
-                    scf.yield v374;
+                    v375 = ub.poison i32 : i32;
+                    scf.yield v375;
                 } else {
                 ^block22:
-                    v372 = arith.constant 0 : i32;
-                    v132 = arith.sub v372, v118 : i32 #[overflow = wrapping];
-                    v373 = arith.constant -1 : i32;
+                    v373 = arith.constant 0 : i32;
+                    v132 = arith.sub v373, v118 : i32 #[overflow = wrapping];
+                    v374 = arith.constant -1 : i32;
                     v128 = arith.add v99, v118 : i32 #[overflow = wrapping];
-                    v130 = arith.add v128, v373 : i32 #[overflow = wrapping];
+                    v130 = arith.add v128, v374 : i32 #[overflow = wrapping];
                     v133 = arith.band v130, v132 : i32;
                     v134 = hir.bitcast v97 : u32;
                     v135 = arith.constant 4 : u32;
@@ -196,8 +196,8 @@ builtin.component root_ns:root@1.0.0 {
                     hir.assertz v136 #[code = 250];
                     v137 = hir.int_to_ptr v134 : ptr<byte, i32>;
                     v138 = hir.load v137 : i32;
-                    v371 = arith.constant 0 : i32;
-                    v140 = arith.neq v138, v371 : i1;
+                    v372 = arith.constant 0 : i32;
+                    v140 = arith.neq v138, v372 : i1;
                     scf.if v140{
                     ^block49:
                         scf.yield ;
@@ -206,29 +206,29 @@ builtin.component root_ns:root@1.0.0 {
                         v141 = hir.exec @intrinsics/mem/heap_base() : i32
                         v142 = hir.mem_size  : u32;
                         v148 = hir.bitcast v97 : u32;
-                        v370 = arith.constant 4 : u32;
-                        v150 = arith.mod v148, v370 : u32;
+                        v371 = arith.constant 4 : u32;
+                        v150 = arith.mod v148, v371 : u32;
                         hir.assertz v150 #[code = 250];
-                        v369 = arith.constant 16 : u32;
+                        v370 = arith.constant 16 : u32;
                         v143 = hir.bitcast v142 : i32;
-                        v146 = arith.shl v143, v369 : i32;
+                        v146 = arith.shl v143, v370 : i32;
                         v147 = arith.add v141, v146 : i32 #[overflow = wrapping];
                         v151 = hir.int_to_ptr v148 : ptr<byte, i32>;
                         hir.store v151, v147;
                         scf.yield ;
                     };
                     v154 = hir.bitcast v97 : u32;
-                    v368 = arith.constant 4 : u32;
-                    v156 = arith.mod v154, v368 : u32;
+                    v369 = arith.constant 4 : u32;
+                    v156 = arith.mod v154, v369 : u32;
                     hir.assertz v156 #[code = 250];
                     v157 = hir.int_to_ptr v154 : ptr<byte, i32>;
                     v158 = hir.load v157 : i32;
                     v367 = arith.constant 0 : i32;
-                    v162 = hir.bitcast v133 : u32;
-                    v152 = arith.constant -2 : i32;
-                    v159 = arith.sub v152, v158 : i32 #[overflow = wrapping];
-                    v161 = hir.bitcast v159 : u32;
-                    v163 = arith.lt v161, v162 : i1;
+                    v368 = arith.constant -1 : i32;
+                    v160 = arith.bxor v158, v368 : i32;
+                    v162 = hir.bitcast v160 : u32;
+                    v161 = hir.bitcast v133 : u32;
+                    v163 = arith.gt v161, v162 : i1;
                     v164 = arith.zext v163 : u32;
                     v165 = hir.bitcast v164 : i32;
                     v167 = arith.neq v165, v367 : i1;
@@ -285,38 +285,38 @@ builtin.component root_ns:root@1.0.0 {
             hir.assertz v194 #[code = 250];
             v195 = hir.int_to_ptr v192 : ptr<byte, i32>;
             v196 = hir.load v195 : i32;
-            v383 = arith.constant 0 : i32;
+            v384 = arith.constant 0 : i32;
             v180 = arith.constant 0 : i32;
             v198 = arith.eq v196, v180 : i1;
             v199 = arith.zext v198 : u32;
             v200 = hir.bitcast v199 : i32;
-            v202 = arith.neq v200, v383 : i1;
+            v202 = arith.neq v200, v384 : i1;
             scf.if v202{
             ^block57:
                 scf.yield ;
             } else {
             ^block30:
-                v382 = arith.constant 4 : u32;
+                v383 = arith.constant 4 : u32;
                 v203 = hir.bitcast v185 : u32;
-                v205 = arith.add v203, v382 : u32 #[overflow = checked];
-                v381 = arith.constant 4 : u32;
-                v207 = arith.mod v205, v381 : u32;
+                v205 = arith.add v203, v383 : u32 #[overflow = checked];
+                v382 = arith.constant 4 : u32;
+                v207 = arith.mod v205, v382 : u32;
                 hir.assertz v207 #[code = 250];
                 v208 = hir.int_to_ptr v205 : ptr<byte, i32>;
                 v209 = hir.load v208 : i32;
                 v211 = arith.constant 12 : u32;
                 v210 = hir.bitcast v185 : u32;
                 v212 = arith.add v210, v211 : u32 #[overflow = checked];
-                v380 = arith.constant 4 : u32;
-                v214 = arith.mod v212, v380 : u32;
+                v381 = arith.constant 4 : u32;
+                v214 = arith.mod v212, v381 : u32;
                 hir.assertz v214 #[code = 250];
                 v215 = hir.int_to_ptr v212 : ptr<byte, i32>;
                 v216 = hir.load v215 : i32;
                 hir.exec @root_ns:root@1.0.0/vec_alloc_vec/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v209, v196, v216)
                 scf.yield ;
             };
-            v379 = arith.constant 16 : i32;
-            v219 = arith.add v185, v379 : i32 #[overflow = wrapping];
+            v380 = arith.constant 16 : i32;
+            v219 = arith.add v185, v380 : i32 #[overflow = wrapping];
             v220 = builtin.global_symbol @root_ns:root@1.0.0/vec_alloc_vec/__stack_pointer : ptr<byte, u8>
             v221 = hir.bitcast v220 : ptr<byte, i32>;
             hir.store v221, v219;
@@ -325,17 +325,17 @@ builtin.component root_ns:root@1.0.0 {
 
         private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v222: i32, v223: i32, v224: i32, v225: i32) {
         ^block31(v222: i32, v223: i32, v224: i32, v225: i32):
-            v409 = arith.constant 0 : i32;
+            v410 = arith.constant 0 : i32;
             v226 = arith.constant 0 : i32;
             v230 = arith.eq v225, v226 : i1;
             v231 = arith.zext v230 : u32;
             v232 = hir.bitcast v231 : i32;
-            v234 = arith.neq v232, v409 : i1;
-            v396, v397 = scf.if v234 : i32, i32 {
+            v234 = arith.neq v232, v410 : i1;
+            v397, v398 = scf.if v234 : i32, i32 {
             ^block60:
-                v408 = arith.constant 0 : i32;
+                v409 = arith.constant 0 : i32;
                 v228 = arith.constant 4 : i32;
-                scf.yield v228, v408;
+                scf.yield v228, v409;
             } else {
             ^block34:
                 v235 = hir.bitcast v223 : u32;
@@ -344,37 +344,37 @@ builtin.component root_ns:root@1.0.0 {
                 hir.assertz v237 #[code = 250];
                 v238 = hir.int_to_ptr v235 : ptr<byte, i32>;
                 v239 = hir.load v238 : i32;
-                v406 = arith.constant 0 : i32;
                 v407 = arith.constant 0 : i32;
-                v241 = arith.eq v239, v407 : i1;
+                v408 = arith.constant 0 : i32;
+                v241 = arith.eq v239, v408 : i1;
                 v242 = arith.zext v241 : u32;
                 v243 = hir.bitcast v242 : i32;
-                v245 = arith.neq v243, v406 : i1;
-                v394 = scf.if v245 : i32 {
+                v245 = arith.neq v243, v407 : i1;
+                v395 = scf.if v245 : i32 {
                 ^block59:
-                    v405 = arith.constant 0 : i32;
-                    scf.yield v405;
+                    v406 = arith.constant 0 : i32;
+                    scf.yield v406;
                 } else {
                 ^block35:
-                    v404 = arith.constant 4 : u32;
+                    v405 = arith.constant 4 : u32;
                     v246 = hir.bitcast v222 : u32;
-                    v248 = arith.add v246, v404 : u32 #[overflow = checked];
-                    v403 = arith.constant 4 : u32;
-                    v250 = arith.mod v248, v403 : u32;
+                    v248 = arith.add v246, v405 : u32 #[overflow = checked];
+                    v404 = arith.constant 4 : u32;
+                    v250 = arith.mod v248, v404 : u32;
                     hir.assertz v250 #[code = 250];
                     v251 = hir.int_to_ptr v248 : ptr<byte, i32>;
                     hir.store v251, v224;
-                    v402 = arith.constant 4 : u32;
+                    v403 = arith.constant 4 : u32;
                     v252 = hir.bitcast v223 : u32;
-                    v254 = arith.add v252, v402 : u32 #[overflow = checked];
-                    v401 = arith.constant 4 : u32;
-                    v256 = arith.mod v254, v401 : u32;
+                    v254 = arith.add v252, v403 : u32 #[overflow = checked];
+                    v402 = arith.constant 4 : u32;
+                    v256 = arith.mod v254, v402 : u32;
                     hir.assertz v256 #[code = 250];
                     v257 = hir.int_to_ptr v254 : ptr<byte, i32>;
                     v258 = hir.load v257 : i32;
                     v259 = hir.bitcast v222 : u32;
-                    v400 = arith.constant 4 : u32;
-                    v261 = arith.mod v259, v400 : u32;
+                    v401 = arith.constant 4 : u32;
+                    v261 = arith.mod v259, v401 : u32;
                     hir.assertz v261 #[code = 250];
                     v262 = hir.int_to_ptr v259 : ptr<byte, i32>;
                     hir.store v262, v258;
@@ -382,28 +382,28 @@ builtin.component root_ns:root@1.0.0 {
                     scf.yield v263;
                 };
                 v264 = arith.constant 8 : i32;
-                v399 = arith.constant 4 : i32;
-                v395 = cf.select v245, v399, v264 : i32;
-                scf.yield v395, v394;
+                v400 = arith.constant 4 : i32;
+                v396 = cf.select v245, v400, v264 : i32;
+                scf.yield v396, v395;
             };
-            v267 = arith.add v222, v396 : i32 #[overflow = wrapping];
+            v267 = arith.add v222, v397 : i32 #[overflow = wrapping];
             v269 = hir.bitcast v267 : u32;
-            v398 = arith.constant 4 : u32;
-            v271 = arith.mod v269, v398 : u32;
+            v399 = arith.constant 4 : u32;
+            v271 = arith.mod v269, v399 : u32;
             hir.assertz v271 #[code = 250];
             v272 = hir.int_to_ptr v269 : ptr<byte, i32>;
-            hir.store v272, v397;
+            hir.store v272, v398;
             builtin.ret ;
         };
 
         private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v273: i32, v274: i32, v275: i32) {
         ^block36(v273: i32, v274: i32, v275: i32):
-            v411 = arith.constant 0 : i32;
+            v412 = arith.constant 0 : i32;
             v276 = arith.constant 0 : i32;
             v277 = arith.eq v275, v276 : i1;
             v278 = arith.zext v277 : u32;
             v279 = hir.bitcast v278 : i32;
-            v281 = arith.neq v279, v411 : i1;
+            v281 = arith.neq v279, v412 : i1;
             scf.if v281{
             ^block38:
                 scf.yield ;

--- a/tests/integration/expected/vec_alloc_vec.masm
+++ b/tests/integration/expected/vec_alloc_vec.masm
@@ -399,12 +399,13 @@ proc.<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
             trace.252
             nop
             push.0
+            push.4294967295
             dup.2
-            push.4294967294
-            dup.3
-            u32wrapping_sub
             swap.1
-            u32lt
+            u32xor
+            dup.3
+            swap.1
+            u32gt
             neq
             if.true
                 drop

--- a/tests/integration/expected/vec_alloc_vec.wat
+++ b/tests/integration/expected/vec_alloc_vec.wat
@@ -144,13 +144,13 @@
         i32.store
       end
       block ;; label = @2
-        i32.const -2
+        local.get 2
         local.get 0
         i32.load
         local.tee 4
-        i32.sub
-        local.get 2
-        i32.lt_u
+        i32.const -1
+        i32.xor
+        i32.gt_u
         br_if 0 (;@2;)
         local.get 0
         local.get 4


### PR DESCRIPTION
Following https://github.com/0xMiden/compiler/pull/630#discussion_r2266079023
