### PR TITLE
fix: execute all subtasks in Makefile.toml

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -192,7 +192,12 @@ run_task = [{ name = ["midenc"] }]
 [tasks.install]
 category = "Install"
 description = "Installs the compiler via cargo"
-run_task = [{ name = ["install-midenc"] }, { name = ["install-cargo-miden"] }]
+run_task = [
+    { name = [
+       "install-midenc",
+       "install-cargo-miden",
+    ] },
+]
 
 [tasks.check]
 category = "Build"
@@ -231,11 +236,7 @@ description = "Check dependencies for lack of use, duplicates, vulnerabilities, 
 run_task = [
     { name = [
         "unused",
-    ] },
-    { name = [
         "duplicates",
-    ] },
-    { name = [
         "audit",
     ] },
 ]


### PR DESCRIPTION
Close #638 

Tasks `install` and `check-deps` were only running one of the listed sub-tasks. 
With this change:
- `cargo make install` will install both the compiler and the cargo extension.
- `cargo make check-deps` will run all the listed subtasks