### PR TITLE
chore: update new project templates tag to use the version with SDK v0.6

### DIFF
--- a/tools/cargo-miden/src/commands/new_project.rs
+++ b/tools/cargo-miden/src/commands/new_project.rs
@@ -11,7 +11,7 @@ use clap::Args;
 ///
 /// Before changing it make sure the new tag exists in the rust-templates repo and points to the
 /// desired commit.
-const TEMPLATES_REPO_TAG: &str = "v0.18.0";
+const TEMPLATES_REPO_TAG: &str = "v0.19.0";
 
 // This should have been an enum but I could not bend `clap` to expose variants as flags
 /// Project template


### PR DESCRIPTION
Close #677 

Corresponding templates repo PR - https://github.com/0xMiden/rust-templates/pull/29