### PR TITLE
[1/x] fix: `cargo-miden` picks the correct package from cargo metadata

### DIFF
--- a/tools/cargo-miden/tests/workspace.rs
+++ b/tools/cargo-miden/tests/workspace.rs
@@ -126,7 +126,7 @@ fn build_from_workspace_root_is_rejected() {
         .expect_err("expected workspace root build to be rejected");
     let msg = err.to_string();
     assert!(
-        msg.contains("workspace root") && msg.contains("Build a single member"),
+        msg.contains("unable to determine package") && msg.contains("member"),
         "unexpected error message: {msg}"
     );
 


### PR DESCRIPTION
Close #738 

This PR removes using the root package in the cargo metadata to determine the package that we are compiling right now. 

Now, we use only the following 2 methods:

1. Look for a package for which the manifest path points to the current directory;
2. What user provided in the `--manifest-path` option.