### PR TITLE
[2/x] feature: `cargo miden new` without options creates a Miden project

### DIFF
--- a/tools/cargo-miden/src/cli.rs
+++ b/tools/cargo-miden/src/cli.rs
@@ -19,7 +19,7 @@ pub struct CargoMidenCli {
 /// Subcommands supported by `cargo-miden`.
 #[derive(Debug, Subcommand)]
 pub enum CargoMidenCommand {
-    /// Create a new Miden project from a template.
+    /// Create a new Miden project (default) or a contract from a template (see Options).
     New(NewCommand),
     /// Compile the current crate to Miden package.
     Build(BuildCommand),

--- a/tools/cargo-miden/src/commands/new_project.rs
+++ b/tools/cargo-miden/src/commands/new_project.rs
@@ -115,13 +115,13 @@ impl fmt::Display for ProjectTemplate {
 #[derive(Debug, Args)]
 #[clap(disable_version_flag = true)]
 pub struct NewCommand {
-    /// The path for the generated package (the directory name is used for project name)
+    /// The pash for the generated project
     #[clap()]
     pub path: PathBuf,
     /// The template name to use to generate the package
     #[clap(flatten)]
     pub template: Option<ProjectTemplate>,
-    /// The path to the template to use to generate the package
+    /// The path to the template to use to generate the project
     #[clap(long, conflicts_with("template"))]
     pub template_path: Option<PathBuf>,
     /// Use a locally cloned compiler in the generated package
@@ -183,18 +183,19 @@ impl NewCommand {
                 path: Some(template_path.display().to_string()),
                 ..Default::default()
             },
-            None => {
-                let project_kind_str = match self.template.as_ref() {
-                    Some(kind) => kind.to_string(),
-                    None => ProjectTemplate::default().to_string(),
-                };
-                TemplatePath {
+            None => match self.template.as_ref() {
+                Some(project_template) => TemplatePath {
                     git: Some("https://github.com/0xMiden/rust-templates".into()),
                     tag: Some(TEMPLATES_REPO_TAG.into()),
-                    auto_path: Some(project_kind_str),
+                    auto_path: Some(project_template.to_string()),
                     ..Default::default()
-                }
-            }
+                },
+                None => TemplatePath {
+                    git: Some("https://github.com/Keinberger/miden-project-environment".into()),
+                    tag: None,
+                    ..Default::default()
+                },
+            },
         };
 
         let destination = self

--- a/tools/cargo-miden/tests/build.rs
+++ b/tools/cargo-miden/tests/build.rs
@@ -132,9 +132,8 @@ fn test_all_templates_and_examples() {
     assert_eq!(p2id3.name, "p2id");
 
     // Test new project templates
-    // empty template means no template option is passing, thus using the default project template (account)
-    let r#default = build_new_project_from_template("");
-    assert!(r#default.is_library());
+    let account = build_new_project_from_template("--account");
+    assert!(account.is_library());
 
     let note = build_new_project_from_template("--note");
     assert!(note.is_program());


### PR DESCRIPTION
Close #737 

**This PR is stacked on #739 and should be merged after it.**

This PR changes the behavior of the `cargo miden new` so without options it creates a Miden project (workspace) by taking `https://github.com/Keinberger/miden-project-environment`. The ability of create new contracts is preserved via options (`--account`, `--note`, etc.).