### PR TITLE
chore: use v0.22.0 git tag for new project templates (SDK v0.7)

### DIFF
--- a/tools/cargo-miden/src/commands/new_project.rs
+++ b/tools/cargo-miden/src/commands/new_project.rs
@@ -11,7 +11,7 @@ use clap::Args;
 ///
 /// Before changing it make sure the new tag exists in the rust-templates repo and points to the
 /// desired commit.
-const TEMPLATES_REPO_TAG: &str = "v0.21.0";
+const TEMPLATES_REPO_TAG: &str = "v0.22.0";
 
 // This should have been an enum but I could not bend `clap` to expose variants as flags
 /// Project template


### PR DESCRIPTION
Close #740 