### PR TITLE
chore: `write` permissions for the `publish` job in the `release.yml` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == '0xMiden' }}
     permissions:
-      contents: read
+      contents: write
     outputs:
       releases: ${{ steps.publish.outputs.releases }}
       releases_created: ${{ steps.publish.outputs.releases_created }}


### PR DESCRIPTION
To fix the error in https://github.com/0xMiden/compiler/actions/runs/19130811525/job/54688986389 (failed to create git tag).