### PR TITLE
chore: fix permissions for the release workflow to trigger CI checks on release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false


### PR DESCRIPTION
This should fix the https://github.com/0xMiden/compiler/actions/runs/19319407081/job/55257520243 error.