### PR TITLE
[2/x] chore: remove the panic source file location in the data segment

### DIFF
--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.hir
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.hir
@@ -22,130 +22,130 @@ builtin.component root_ns:root@1.0.0 {
             v15 = hir.int_to_ptr v12 : ptr<byte, i32>;
             v16 = hir.load v15 : i32;
             v17 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/<miden_stdlib_sys::intrinsics::felt::Felt as core::convert::From<u32>>::from(v16) : felt
-            v766 = arith.constant 4 : i32;
-            v19 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/intrinsics::felt::from_u32(v766) : felt
+            v765 = arith.constant 4 : i32;
+            v19 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/intrinsics::felt::from_u32(v765) : felt
             hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/intrinsics::felt::assert_eq(v17, v19)
-            v765 = arith.constant 0 : i32;
+            v764 = arith.constant 0 : i32;
             v0 = arith.constant 0 : i32;
             v21 = arith.eq v16, v0 : i1;
             v22 = arith.zext v21 : u32;
             v23 = hir.bitcast v22 : i32;
-            v25 = arith.neq v23, v765 : i1;
-            v736 = scf.if v25 : u32 {
+            v25 = arith.neq v23, v764 : i1;
+            v735 = scf.if v25 : u32 {
             ^block112:
-                v732 = arith.constant 0 : u32;
-                scf.yield v732;
+                v731 = arith.constant 0 : u32;
+                scf.yield v731;
             } else {
             ^block7:
                 v27 = arith.constant 8 : u32;
                 v26 = hir.bitcast v5 : u32;
                 v28 = arith.add v26, v27 : u32 #[overflow = checked];
-                v764 = arith.constant 4 : u32;
-                v30 = arith.mod v28, v764 : u32;
+                v763 = arith.constant 4 : u32;
+                v30 = arith.mod v28, v763 : u32;
                 hir.assertz v30 #[code = 250];
                 v31 = hir.int_to_ptr v28 : ptr<byte, i32>;
                 v32 = hir.load v31 : i32;
                 v33 = hir.bitcast v32 : u32;
-                v763 = arith.constant 4 : u32;
-                v35 = arith.mod v33, v763 : u32;
+                v762 = arith.constant 4 : u32;
+                v35 = arith.mod v33, v762 : u32;
                 hir.assertz v35 #[code = 250];
                 v36 = hir.int_to_ptr v33 : ptr<byte, felt>;
                 v37 = hir.load v36 : felt;
                 v38 = arith.constant -1 : i32;
                 v39 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/intrinsics::felt::from_u32(v38) : felt
                 hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/intrinsics::felt::assert_eq(v37, v39)
-                v762 = arith.constant 0 : i32;
+                v761 = arith.constant 0 : i32;
                 v40 = arith.constant 1 : i32;
                 v41 = arith.eq v16, v40 : i1;
                 v42 = arith.zext v41 : u32;
                 v43 = hir.bitcast v42 : i32;
-                v45 = arith.neq v43, v762 : i1;
-                v738 = scf.if v45 : u32 {
+                v45 = arith.neq v43, v761 : i1;
+                v737 = scf.if v45 : u32 {
                 ^block111:
-                    v761 = arith.constant 0 : u32;
-                    scf.yield v761;
+                    v760 = arith.constant 0 : u32;
+                    scf.yield v760;
                 } else {
                 ^block8:
-                    v760 = arith.constant 4 : u32;
-                    v46 = hir.bitcast v32 : u32;
-                    v48 = arith.add v46, v760 : u32 #[overflow = checked];
                     v759 = arith.constant 4 : u32;
-                    v50 = arith.mod v48, v759 : u32;
+                    v46 = hir.bitcast v32 : u32;
+                    v48 = arith.add v46, v759 : u32 #[overflow = checked];
+                    v758 = arith.constant 4 : u32;
+                    v50 = arith.mod v48, v758 : u32;
                     hir.assertz v50 #[code = 250];
                     v51 = hir.int_to_ptr v48 : ptr<byte, felt>;
                     v52 = hir.load v51 : felt;
-                    v758 = arith.constant 1 : i32;
-                    v54 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/intrinsics::felt::from_u32(v758) : felt
+                    v757 = arith.constant 1 : i32;
+                    v54 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/intrinsics::felt::from_u32(v757) : felt
                     hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/intrinsics::felt::assert_eq(v52, v54)
-                    v757 = arith.constant 0 : i32;
-                    v731 = arith.constant 2 : u32;
+                    v756 = arith.constant 0 : i32;
+                    v730 = arith.constant 2 : u32;
                     v56 = hir.bitcast v16 : u32;
-                    v58 = arith.lte v56, v731 : i1;
+                    v58 = arith.lte v56, v730 : i1;
                     v59 = arith.zext v58 : u32;
                     v60 = hir.bitcast v59 : i32;
-                    v62 = arith.neq v60, v757 : i1;
-                    v740 = scf.if v62 : u32 {
+                    v62 = arith.neq v60, v756 : i1;
+                    v739 = scf.if v62 : u32 {
                     ^block110:
-                        v756 = arith.constant 0 : u32;
-                        scf.yield v756;
+                        v755 = arith.constant 0 : u32;
+                        scf.yield v755;
                     } else {
                     ^block9:
-                        v755 = arith.constant 8 : u32;
+                        v754 = arith.constant 8 : u32;
                         v63 = hir.bitcast v32 : u32;
-                        v65 = arith.add v63, v755 : u32 #[overflow = checked];
-                        v754 = arith.constant 4 : u32;
-                        v67 = arith.mod v65, v754 : u32;
+                        v65 = arith.add v63, v754 : u32 #[overflow = checked];
+                        v753 = arith.constant 4 : u32;
+                        v67 = arith.mod v65, v753 : u32;
                         hir.assertz v67 #[code = 250];
                         v68 = hir.int_to_ptr v65 : ptr<byte, felt>;
                         v69 = hir.load v68 : felt;
                         v55 = arith.constant 2 : i32;
                         v71 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/intrinsics::felt::from_u32(v55) : felt
                         hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/intrinsics::felt::assert_eq(v69, v71)
-                        v753 = arith.constant 0 : i32;
+                        v752 = arith.constant 0 : i32;
                         v72 = arith.constant 3 : i32;
                         v73 = arith.eq v16, v72 : i1;
                         v74 = arith.zext v73 : u32;
                         v75 = hir.bitcast v74 : i32;
-                        v77 = arith.neq v75, v753 : i1;
+                        v77 = arith.neq v75, v752 : i1;
                         scf.if v77{
                         ^block109:
                             scf.yield ;
                         } else {
                         ^block10:
-                            v752 = arith.constant 12 : u32;
+                            v751 = arith.constant 12 : u32;
                             v78 = hir.bitcast v32 : u32;
-                            v80 = arith.add v78, v752 : u32 #[overflow = checked];
-                            v751 = arith.constant 4 : u32;
-                            v82 = arith.mod v80, v751 : u32;
+                            v80 = arith.add v78, v751 : u32 #[overflow = checked];
+                            v750 = arith.constant 4 : u32;
+                            v82 = arith.mod v80, v750 : u32;
                             hir.assertz v82 #[code = 250];
                             v83 = hir.int_to_ptr v80 : ptr<byte, felt>;
                             v84 = hir.load v83 : felt;
-                            v750 = arith.constant 3 : i32;
-                            v86 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/intrinsics::felt::from_u32(v750) : felt
+                            v749 = arith.constant 3 : i32;
+                            v86 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/intrinsics::felt::from_u32(v749) : felt
                             hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/intrinsics::felt::assert_eq(v84, v86)
+                            v747 = arith.constant 4 : i32;
                             v748 = arith.constant 4 : i32;
-                            v749 = arith.constant 4 : i32;
-                            v88 = arith.add v5, v749 : i32 #[overflow = wrapping];
-                            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::RawVecInner<A>::deallocate(v88, v748, v748)
-                            v747 = arith.constant 16 : i32;
-                            v92 = arith.add v5, v747 : i32 #[overflow = wrapping];
+                            v88 = arith.add v5, v748 : i32 #[overflow = wrapping];
+                            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::RawVecInner<A>::deallocate(v88, v747, v747)
+                            v746 = arith.constant 16 : i32;
+                            v92 = arith.add v5, v746 : i32 #[overflow = wrapping];
                             v93 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
                             v94 = hir.bitcast v93 : ptr<byte, i32>;
                             hir.store v94, v92;
                             scf.yield ;
                         };
-                        v734 = arith.constant 1 : u32;
-                        v746 = arith.constant 0 : u32;
-                        v744 = cf.select v77, v746, v734 : u32;
-                        scf.yield v744;
+                        v733 = arith.constant 1 : u32;
+                        v745 = arith.constant 0 : u32;
+                        v743 = cf.select v77, v745, v733 : u32;
+                        scf.yield v743;
                     };
-                    scf.yield v740;
+                    scf.yield v739;
                 };
-                scf.yield v738;
+                scf.yield v737;
             };
-            v745 = arith.constant 0 : u32;
-            v743 = arith.eq v736, v745 : i1;
-            cf.cond_br v743 ^block6, ^block114;
+            v744 = arith.constant 0 : u32;
+            v742 = arith.eq v735, v744 : i1;
+            cf.cond_br v742 ^block6, ^block114;
         ^block6:
             ub.unreachable ;
         ^block114:
@@ -154,7 +154,7 @@ builtin.component root_ns:root@1.0.0 {
 
         private builtin.function @__rustc::__rust_alloc(v95: i32, v96: i32) -> i32 {
         ^block11(v95: i32, v96: i32):
-            v98 = arith.constant 1048648 : i32;
+            v98 = arith.constant 1048608 : i32;
             v99 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v98, v96, v95) : i32
             builtin.ret v99;
         };
@@ -166,33 +166,33 @@ builtin.component root_ns:root@1.0.0 {
 
         private builtin.function @__rustc::__rust_realloc(v103: i32, v104: i32, v105: i32, v106: i32) -> i32 {
         ^block15(v103: i32, v104: i32, v105: i32, v106: i32):
-            v108 = arith.constant 1048648 : i32;
+            v108 = arith.constant 1048608 : i32;
             v109 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v108, v105, v106) : i32
-            v775 = arith.constant 0 : i32;
+            v774 = arith.constant 0 : i32;
             v110 = arith.constant 0 : i32;
             v111 = arith.eq v109, v110 : i1;
             v112 = arith.zext v111 : u32;
             v113 = hir.bitcast v112 : i32;
-            v115 = arith.neq v113, v775 : i1;
+            v115 = arith.neq v113, v774 : i1;
             scf.if v115{
             ^block17:
                 scf.yield ;
             } else {
             ^block18:
-                v774 = arith.constant 0 : i32;
+                v773 = arith.constant 0 : i32;
                 v117 = hir.bitcast v104 : u32;
                 v116 = hir.bitcast v106 : u32;
                 v118 = arith.lt v116, v117 : i1;
                 v119 = arith.zext v118 : u32;
                 v120 = hir.bitcast v119 : i32;
-                v122 = arith.neq v120, v774 : i1;
+                v122 = arith.neq v120, v773 : i1;
                 v123 = cf.select v122, v106, v104 : i32;
+                v771 = arith.constant 0 : i32;
                 v772 = arith.constant 0 : i32;
-                v773 = arith.constant 0 : i32;
-                v125 = arith.eq v123, v773 : i1;
+                v125 = arith.eq v123, v772 : i1;
                 v126 = arith.zext v125 : u32;
                 v127 = hir.bitcast v126 : i32;
-                v129 = arith.neq v127, v772 : i1;
+                v129 = arith.neq v127, v771 : i1;
                 scf.if v129{
                 ^block119:
                     scf.yield ;
@@ -213,35 +213,35 @@ builtin.component root_ns:root@1.0.0 {
 
         private builtin.function @__rustc::__rust_alloc_zeroed(v136: i32, v137: i32) -> i32 {
         ^block20(v136: i32, v137: i32):
-            v139 = arith.constant 1048648 : i32;
+            v139 = arith.constant 1048608 : i32;
             v140 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v139, v137, v136) : i32
-            v784 = arith.constant 0 : i32;
+            v783 = arith.constant 0 : i32;
             v141 = arith.constant 0 : i32;
             v142 = arith.eq v140, v141 : i1;
             v143 = arith.zext v142 : u32;
             v144 = hir.bitcast v143 : i32;
-            v146 = arith.neq v144, v784 : i1;
+            v146 = arith.neq v144, v783 : i1;
             scf.if v146{
             ^block22:
                 scf.yield ;
             } else {
             ^block23:
+                v781 = arith.constant 0 : i32;
                 v782 = arith.constant 0 : i32;
-                v783 = arith.constant 0 : i32;
-                v148 = arith.eq v136, v783 : i1;
+                v148 = arith.eq v136, v782 : i1;
                 v149 = arith.zext v148 : u32;
                 v150 = hir.bitcast v149 : i32;
-                v152 = arith.neq v150, v782 : i1;
+                v152 = arith.neq v150, v781 : i1;
                 scf.if v152{
                 ^block122:
                     scf.yield ;
                 } else {
                 ^block24:
-                    v776 = arith.constant 0 : u8;
+                    v775 = arith.constant 0 : u8;
                     v155 = hir.bitcast v136 : u32;
                     v156 = hir.bitcast v140 : u32;
                     v157 = hir.int_to_ptr v156 : ptr<byte, u8>;
-                    hir.mem_set v157, v155, v776;
+                    hir.mem_set v157, v155, v775;
                     scf.yield ;
                 };
                 scf.yield ;
@@ -258,27 +258,27 @@ builtin.component root_ns:root@1.0.0 {
         ^block27(v159: i32, v160: i32, v161: i32):
             v164 = arith.constant 16 : i32;
             v163 = arith.constant 0 : i32;
-            v786 = arith.constant 16 : u32;
+            v785 = arith.constant 16 : u32;
             v166 = hir.bitcast v160 : u32;
-            v168 = arith.gt v166, v786 : i1;
+            v168 = arith.gt v166, v785 : i1;
             v169 = arith.zext v168 : u32;
             v170 = hir.bitcast v169 : i32;
             v172 = arith.neq v170, v163 : i1;
             v173 = cf.select v172, v160, v164 : i32;
-            v826 = arith.constant 0 : i32;
+            v825 = arith.constant 0 : i32;
             v174 = arith.constant -1 : i32;
             v175 = arith.add v173, v174 : i32 #[overflow = wrapping];
             v176 = arith.band v173, v175 : i32;
-            v178 = arith.neq v176, v826 : i1;
-            v795, v796 = scf.if v178 : i32, u32 {
+            v178 = arith.neq v176, v825 : i1;
+            v794, v795 = scf.if v178 : i32, u32 {
             ^block127:
-                v787 = arith.constant 0 : u32;
-                v791 = ub.poison i32 : i32;
-                scf.yield v791, v787;
+                v786 = arith.constant 0 : u32;
+                v790 = ub.poison i32 : i32;
+                scf.yield v790, v786;
             } else {
             ^block30:
                 v180 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/core::ptr::alignment::Alignment::max(v160, v173) : i32
-                v825 = arith.constant 0 : i32;
+                v824 = arith.constant 0 : i32;
                 v179 = arith.constant -2147483648 : i32;
                 v181 = arith.sub v179, v180 : i32 #[overflow = wrapping];
                 v183 = hir.bitcast v181 : u32;
@@ -286,18 +286,18 @@ builtin.component root_ns:root@1.0.0 {
                 v184 = arith.gt v182, v183 : i1;
                 v185 = arith.zext v184 : u32;
                 v186 = hir.bitcast v185 : i32;
-                v188 = arith.neq v186, v825 : i1;
-                v810 = scf.if v188 : i32 {
+                v188 = arith.neq v186, v824 : i1;
+                v809 = scf.if v188 : i32 {
                 ^block126:
-                    v824 = ub.poison i32 : i32;
-                    scf.yield v824;
+                    v823 = ub.poison i32 : i32;
+                    scf.yield v823;
                 } else {
                 ^block31:
-                    v822 = arith.constant 0 : i32;
-                    v194 = arith.sub v822, v180 : i32 #[overflow = wrapping];
-                    v823 = arith.constant -1 : i32;
+                    v821 = arith.constant 0 : i32;
+                    v194 = arith.sub v821, v180 : i32 #[overflow = wrapping];
+                    v822 = arith.constant -1 : i32;
                     v190 = arith.add v161, v180 : i32 #[overflow = wrapping];
-                    v192 = arith.add v190, v823 : i32 #[overflow = wrapping];
+                    v192 = arith.add v190, v822 : i32 #[overflow = wrapping];
                     v195 = arith.band v192, v194 : i32;
                     v196 = hir.bitcast v159 : u32;
                     v197 = arith.constant 4 : u32;
@@ -305,8 +305,8 @@ builtin.component root_ns:root@1.0.0 {
                     hir.assertz v198 #[code = 250];
                     v199 = hir.int_to_ptr v196 : ptr<byte, i32>;
                     v200 = hir.load v199 : i32;
-                    v821 = arith.constant 0 : i32;
-                    v202 = arith.neq v200, v821 : i1;
+                    v820 = arith.constant 0 : i32;
+                    v202 = arith.neq v200, v820 : i1;
                     scf.if v202{
                     ^block125:
                         scf.yield ;
@@ -315,41 +315,41 @@ builtin.component root_ns:root@1.0.0 {
                         v203 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/intrinsics::mem::heap_base() : i32
                         v204 = hir.mem_size  : u32;
                         v210 = hir.bitcast v159 : u32;
-                        v820 = arith.constant 4 : u32;
-                        v212 = arith.mod v210, v820 : u32;
+                        v819 = arith.constant 4 : u32;
+                        v212 = arith.mod v210, v819 : u32;
                         hir.assertz v212 #[code = 250];
-                        v819 = arith.constant 16 : u32;
+                        v818 = arith.constant 16 : u32;
                         v205 = hir.bitcast v204 : i32;
-                        v208 = arith.shl v205, v819 : i32;
+                        v208 = arith.shl v205, v818 : i32;
                         v209 = arith.add v203, v208 : i32 #[overflow = wrapping];
                         v213 = hir.int_to_ptr v210 : ptr<byte, i32>;
                         hir.store v213, v209;
                         scf.yield ;
                     };
                     v216 = hir.bitcast v159 : u32;
-                    v818 = arith.constant 4 : u32;
-                    v218 = arith.mod v216, v818 : u32;
+                    v817 = arith.constant 4 : u32;
+                    v218 = arith.mod v216, v817 : u32;
                     hir.assertz v218 #[code = 250];
                     v219 = hir.int_to_ptr v216 : ptr<byte, i32>;
                     v220 = hir.load v219 : i32;
-                    v816 = arith.constant 0 : i32;
-                    v817 = arith.constant -1 : i32;
-                    v222 = arith.bxor v220, v817 : i32;
+                    v815 = arith.constant 0 : i32;
+                    v816 = arith.constant -1 : i32;
+                    v222 = arith.bxor v220, v816 : i32;
                     v224 = hir.bitcast v222 : u32;
                     v223 = hir.bitcast v195 : u32;
                     v225 = arith.gt v223, v224 : i1;
                     v226 = arith.zext v225 : u32;
                     v227 = hir.bitcast v226 : i32;
-                    v229 = arith.neq v227, v816 : i1;
-                    v809 = scf.if v229 : i32 {
+                    v229 = arith.neq v227, v815 : i1;
+                    v808 = scf.if v229 : i32 {
                     ^block34:
-                        v815 = arith.constant 0 : i32;
-                        scf.yield v815;
+                        v814 = arith.constant 0 : i32;
+                        scf.yield v814;
                     } else {
                     ^block35:
                         v231 = hir.bitcast v159 : u32;
-                        v814 = arith.constant 4 : u32;
-                        v233 = arith.mod v231, v814 : u32;
+                        v813 = arith.constant 4 : u32;
+                        v233 = arith.mod v231, v813 : u32;
                         hir.assertz v233 #[code = 250];
                         v230 = arith.add v220, v195 : i32 #[overflow = wrapping];
                         v234 = hir.int_to_ptr v231 : ptr<byte, i32>;
@@ -357,20 +357,20 @@ builtin.component root_ns:root@1.0.0 {
                         v236 = arith.add v220, v180 : i32 #[overflow = wrapping];
                         scf.yield v236;
                     };
-                    scf.yield v809;
+                    scf.yield v808;
                 };
-                v792 = arith.constant 1 : u32;
-                v813 = arith.constant 0 : u32;
-                v811 = cf.select v188, v813, v792 : u32;
-                scf.yield v810, v811;
+                v791 = arith.constant 1 : u32;
+                v812 = arith.constant 0 : u32;
+                v810 = cf.select v188, v812, v791 : u32;
+                scf.yield v809, v810;
             };
-            v812 = arith.constant 0 : u32;
-            v808 = arith.eq v796, v812 : i1;
-            cf.cond_br v808 ^block29, ^block129(v795);
+            v811 = arith.constant 0 : u32;
+            v807 = arith.eq v795, v811 : i1;
+            cf.cond_br v807 ^block29, ^block129(v794);
         ^block29:
             ub.unreachable ;
-        ^block129(v788: i32):
-            builtin.ret v788;
+        ^block129(v787: i32):
+            builtin.ret v787;
         };
 
         private builtin.function @intrinsics::mem::heap_base() -> i32 {
@@ -379,83 +379,84 @@ builtin.component root_ns:root@1.0.0 {
             builtin.ret v239;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::with_capacity_in(v241: i32, v242: i32, v243: i32, v244: i32) {
-        ^block40(v241: i32, v242: i32, v243: i32, v244: i32):
-            v246 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
-            v247 = hir.bitcast v246 : ptr<byte, i32>;
-            v248 = hir.load v247 : i32;
-            v249 = arith.constant 16 : i32;
-            v250 = arith.sub v248, v249 : i32 #[overflow = wrapping];
-            v251 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
-            v252 = hir.bitcast v251 : ptr<byte, i32>;
-            hir.store v252, v250;
-            v245 = arith.constant 0 : i32;
-            v255 = arith.constant 256 : i32;
-            v253 = arith.constant 4 : i32;
-            v254 = arith.add v250, v253 : i32 #[overflow = wrapping];
-            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::RawVecInner<A>::try_allocate_in(v254, v255, v245, v242, v243)
-            v258 = arith.constant 8 : u32;
-            v257 = hir.bitcast v250 : u32;
-            v259 = arith.add v257, v258 : u32 #[overflow = checked];
-            v260 = arith.constant 4 : u32;
-            v261 = arith.mod v259, v260 : u32;
-            hir.assertz v261 #[code = 250];
-            v262 = hir.int_to_ptr v259 : ptr<byte, i32>;
-            v263 = hir.load v262 : i32;
-            v837 = arith.constant 4 : u32;
-            v264 = hir.bitcast v250 : u32;
-            v266 = arith.add v264, v837 : u32 #[overflow = checked];
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::with_capacity_in(v241: i32, v242: i32, v243: i32) {
+        ^block40(v241: i32, v242: i32, v243: i32):
+            v245 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
+            v246 = hir.bitcast v245 : ptr<byte, i32>;
+            v247 = hir.load v246 : i32;
+            v248 = arith.constant 16 : i32;
+            v249 = arith.sub v247, v248 : i32 #[overflow = wrapping];
+            v250 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
+            v251 = hir.bitcast v250 : ptr<byte, i32>;
+            hir.store v251, v249;
+            v244 = arith.constant 0 : i32;
+            v254 = arith.constant 256 : i32;
+            v252 = arith.constant 4 : i32;
+            v253 = arith.add v249, v252 : i32 #[overflow = wrapping];
+            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::RawVecInner<A>::try_allocate_in(v253, v254, v244, v242, v243)
+            v257 = arith.constant 8 : u32;
+            v256 = hir.bitcast v249 : u32;
+            v258 = arith.add v256, v257 : u32 #[overflow = checked];
+            v259 = arith.constant 4 : u32;
+            v260 = arith.mod v258, v259 : u32;
+            hir.assertz v260 #[code = 250];
+            v261 = hir.int_to_ptr v258 : ptr<byte, i32>;
+            v262 = hir.load v261 : i32;
             v836 = arith.constant 4 : u32;
-            v268 = arith.mod v266, v836 : u32;
-            hir.assertz v268 #[code = 250];
-            v269 = hir.int_to_ptr v266 : ptr<byte, i32>;
-            v270 = hir.load v269 : i32;
-            v835 = arith.constant 0 : i32;
-            v271 = arith.constant 1 : i32;
-            v272 = arith.neq v270, v271 : i1;
-            v273 = arith.zext v272 : u32;
-            v274 = hir.bitcast v273 : i32;
-            v276 = arith.neq v274, v835 : i1;
-            cf.cond_br v276 ^block42, ^block43;
+            v263 = hir.bitcast v249 : u32;
+            v265 = arith.add v263, v836 : u32 #[overflow = checked];
+            v835 = arith.constant 4 : u32;
+            v267 = arith.mod v265, v835 : u32;
+            hir.assertz v267 #[code = 250];
+            v268 = hir.int_to_ptr v265 : ptr<byte, i32>;
+            v269 = hir.load v268 : i32;
+            v834 = arith.constant 0 : i32;
+            v270 = arith.constant 1 : i32;
+            v271 = arith.neq v269, v270 : i1;
+            v272 = arith.zext v271 : u32;
+            v273 = hir.bitcast v272 : i32;
+            v275 = arith.neq v273, v834 : i1;
+            cf.cond_br v275 ^block42, ^block43;
         ^block42:
             v285 = arith.constant 12 : u32;
-            v284 = hir.bitcast v250 : u32;
+            v284 = hir.bitcast v249 : u32;
             v286 = arith.add v284, v285 : u32 #[overflow = checked];
-            v834 = arith.constant 4 : u32;
-            v288 = arith.mod v286, v834 : u32;
+            v833 = arith.constant 4 : u32;
+            v288 = arith.mod v286, v833 : u32;
             hir.assertz v288 #[code = 250];
             v289 = hir.int_to_ptr v286 : ptr<byte, i32>;
             v290 = hir.load v289 : i32;
-            v833 = arith.constant 4 : u32;
-            v291 = hir.bitcast v241 : u32;
-            v293 = arith.add v291, v833 : u32 #[overflow = checked];
             v832 = arith.constant 4 : u32;
-            v295 = arith.mod v293, v832 : u32;
+            v291 = hir.bitcast v241 : u32;
+            v293 = arith.add v291, v832 : u32 #[overflow = checked];
+            v831 = arith.constant 4 : u32;
+            v295 = arith.mod v293, v831 : u32;
             hir.assertz v295 #[code = 250];
             v296 = hir.int_to_ptr v293 : ptr<byte, i32>;
             hir.store v296, v290;
             v297 = hir.bitcast v241 : u32;
-            v831 = arith.constant 4 : u32;
-            v299 = arith.mod v297, v831 : u32;
+            v830 = arith.constant 4 : u32;
+            v299 = arith.mod v297, v830 : u32;
             hir.assertz v299 #[code = 250];
             v300 = hir.int_to_ptr v297 : ptr<byte, i32>;
-            hir.store v300, v263;
-            v830 = arith.constant 16 : i32;
-            v302 = arith.add v250, v830 : i32 #[overflow = wrapping];
+            hir.store v300, v262;
+            v829 = arith.constant 16 : i32;
+            v302 = arith.add v249, v829 : i32 #[overflow = wrapping];
             v303 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
             v304 = hir.bitcast v303 : ptr<byte, i32>;
             hir.store v304, v302;
             builtin.ret ;
         ^block43:
-            v829 = arith.constant 12 : u32;
-            v277 = hir.bitcast v250 : u32;
-            v279 = arith.add v277, v829 : u32 #[overflow = checked];
-            v828 = arith.constant 4 : u32;
-            v281 = arith.mod v279, v828 : u32;
-            hir.assertz v281 #[code = 250];
-            v282 = hir.int_to_ptr v279 : ptr<byte, i32>;
-            v283 = hir.load v282 : i32;
-            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::handle_error(v263, v283, v244)
+            v828 = arith.constant 12 : u32;
+            v276 = hir.bitcast v249 : u32;
+            v278 = arith.add v276, v828 : u32 #[overflow = checked];
+            v827 = arith.constant 4 : u32;
+            v280 = arith.mod v278, v827 : u32;
+            hir.assertz v280 #[code = 250];
+            v281 = hir.int_to_ptr v278 : ptr<byte, i32>;
+            v282 = hir.load v281 : i32;
+            v283 = arith.constant 1048588 : i32;
+            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::handle_error(v262, v282, v283)
             ub.unreachable ;
         };
 
@@ -469,631 +470,630 @@ builtin.component root_ns:root@1.0.0 {
             v312 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
             v313 = hir.bitcast v312 : ptr<byte, i32>;
             hir.store v313, v311;
-            v318 = arith.constant 1048628 : i32;
             v316 = arith.constant 4 : i32;
             v314 = arith.constant 8 : i32;
             v315 = arith.add v311, v314 : i32 #[overflow = wrapping];
-            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v315, v316, v316, v318)
-            v320 = arith.constant 8 : u32;
-            v319 = hir.bitcast v311 : u32;
-            v321 = arith.add v319, v320 : u32 #[overflow = checked];
-            v322 = arith.constant 4 : u32;
-            v323 = arith.mod v321, v322 : u32;
-            hir.assertz v323 #[code = 250];
-            v324 = hir.int_to_ptr v321 : ptr<byte, i32>;
-            v325 = hir.load v324 : i32;
-            v327 = arith.constant 12 : u32;
-            v326 = hir.bitcast v311 : u32;
-            v328 = arith.add v326, v327 : u32 #[overflow = checked];
-            v845 = arith.constant 4 : u32;
-            v330 = arith.mod v328, v845 : u32;
-            hir.assertz v330 #[code = 250];
-            v331 = hir.int_to_ptr v328 : ptr<byte, i32>;
-            v332 = hir.load v331 : i32;
-            v838 = arith.constant 2 : u32;
-            v334 = hir.bitcast v332 : u32;
-            v336 = arith.shr v334, v838 : u32;
-            v337 = hir.bitcast v336 : i32;
-            v338 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/miden::active_note::get_inputs(v337) : i32
-            v844 = arith.constant 8 : u32;
-            v339 = hir.bitcast v305 : u32;
-            v341 = arith.add v339, v844 : u32 #[overflow = checked];
-            v843 = arith.constant 4 : u32;
-            v343 = arith.mod v341, v843 : u32;
-            hir.assertz v343 #[code = 250];
-            v344 = hir.int_to_ptr v341 : ptr<byte, i32>;
-            hir.store v344, v338;
+            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v315, v316, v316)
+            v319 = arith.constant 8 : u32;
+            v318 = hir.bitcast v311 : u32;
+            v320 = arith.add v318, v319 : u32 #[overflow = checked];
+            v321 = arith.constant 4 : u32;
+            v322 = arith.mod v320, v321 : u32;
+            hir.assertz v322 #[code = 250];
+            v323 = hir.int_to_ptr v320 : ptr<byte, i32>;
+            v324 = hir.load v323 : i32;
+            v326 = arith.constant 12 : u32;
+            v325 = hir.bitcast v311 : u32;
+            v327 = arith.add v325, v326 : u32 #[overflow = checked];
+            v844 = arith.constant 4 : u32;
+            v329 = arith.mod v327, v844 : u32;
+            hir.assertz v329 #[code = 250];
+            v330 = hir.int_to_ptr v327 : ptr<byte, i32>;
+            v331 = hir.load v330 : i32;
+            v837 = arith.constant 2 : u32;
+            v333 = hir.bitcast v331 : u32;
+            v335 = arith.shr v333, v837 : u32;
+            v336 = hir.bitcast v335 : i32;
+            v337 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/miden::active_note::get_inputs(v336) : i32
+            v843 = arith.constant 8 : u32;
+            v338 = hir.bitcast v305 : u32;
+            v340 = arith.add v338, v843 : u32 #[overflow = checked];
             v842 = arith.constant 4 : u32;
-            v345 = hir.bitcast v305 : u32;
-            v347 = arith.add v345, v842 : u32 #[overflow = checked];
+            v342 = arith.mod v340, v842 : u32;
+            hir.assertz v342 #[code = 250];
+            v343 = hir.int_to_ptr v340 : ptr<byte, i32>;
+            hir.store v343, v337;
             v841 = arith.constant 4 : u32;
-            v349 = arith.mod v347, v841 : u32;
-            hir.assertz v349 #[code = 250];
-            v350 = hir.int_to_ptr v347 : ptr<byte, i32>;
-            hir.store v350, v332;
-            v351 = hir.bitcast v305 : u32;
+            v344 = hir.bitcast v305 : u32;
+            v346 = arith.add v344, v841 : u32 #[overflow = checked];
             v840 = arith.constant 4 : u32;
-            v353 = arith.mod v351, v840 : u32;
-            hir.assertz v353 #[code = 250];
-            v354 = hir.int_to_ptr v351 : ptr<byte, i32>;
-            hir.store v354, v325;
-            v839 = arith.constant 16 : i32;
-            v356 = arith.add v311, v839 : i32 #[overflow = wrapping];
-            v357 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
-            v358 = hir.bitcast v357 : ptr<byte, i32>;
-            hir.store v358, v356;
+            v348 = arith.mod v346, v840 : u32;
+            hir.assertz v348 #[code = 250];
+            v349 = hir.int_to_ptr v346 : ptr<byte, i32>;
+            hir.store v349, v331;
+            v350 = hir.bitcast v305 : u32;
+            v839 = arith.constant 4 : u32;
+            v352 = arith.mod v350, v839 : u32;
+            hir.assertz v352 #[code = 250];
+            v353 = hir.int_to_ptr v350 : ptr<byte, i32>;
+            hir.store v353, v324;
+            v838 = arith.constant 16 : i32;
+            v355 = arith.add v311, v838 : i32 #[overflow = wrapping];
+            v356 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
+            v357 = hir.bitcast v356 : ptr<byte, i32>;
+            hir.store v357, v355;
             builtin.ret ;
         };
 
-        private builtin.function @<miden_stdlib_sys::intrinsics::felt::Felt as core::convert::From<u32>>::from(v359: i32) -> felt {
-        ^block46(v359: i32):
-            v361 = hir.bitcast v359 : felt;
-            builtin.ret v361;
+        private builtin.function @<miden_stdlib_sys::intrinsics::felt::Felt as core::convert::From<u32>>::from(v358: i32) -> felt {
+        ^block46(v358: i32):
+            v360 = hir.bitcast v358 : felt;
+            builtin.ret v360;
         };
 
-        private builtin.function @intrinsics::felt::from_u32(v362: i32) -> felt {
-        ^block48(v362: i32):
-            v363 = hir.bitcast v362 : felt;
-            builtin.ret v363;
+        private builtin.function @intrinsics::felt::from_u32(v361: i32) -> felt {
+        ^block48(v361: i32):
+            v362 = hir.bitcast v361 : felt;
+            builtin.ret v362;
         };
 
-        private builtin.function @intrinsics::felt::assert_eq(v365: felt, v366: felt) {
-        ^block50(v365: felt, v366: felt):
-            hir.assert_eq v365, v366;
+        private builtin.function @intrinsics::felt::assert_eq(v364: felt, v365: felt) {
+        ^block50(v364: felt, v365: felt):
+            hir.assert_eq v364, v365;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v367: i32, v368: i32, v369: i32) {
-        ^block52(v367: i32, v368: i32, v369: i32):
-            v371 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
-            v372 = hir.bitcast v371 : ptr<byte, i32>;
-            v373 = hir.load v372 : i32;
-            v374 = arith.constant 16 : i32;
-            v375 = arith.sub v373, v374 : i32 #[overflow = wrapping];
-            v376 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
-            v377 = hir.bitcast v376 : ptr<byte, i32>;
-            hir.store v377, v375;
-            v378 = arith.constant 4 : i32;
-            v379 = arith.add v375, v378 : i32 #[overflow = wrapping];
-            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::RawVecInner<A>::current_memory(v379, v367, v368, v369)
-            v381 = arith.constant 8 : u32;
-            v380 = hir.bitcast v375 : u32;
-            v382 = arith.add v380, v381 : u32 #[overflow = checked];
-            v383 = arith.constant 4 : u32;
-            v384 = arith.mod v382, v383 : u32;
-            hir.assertz v384 #[code = 250];
-            v385 = hir.int_to_ptr v382 : ptr<byte, i32>;
-            v386 = hir.load v385 : i32;
-            v852 = arith.constant 0 : i32;
-            v370 = arith.constant 0 : i32;
-            v388 = arith.eq v386, v370 : i1;
-            v389 = arith.zext v388 : u32;
-            v390 = hir.bitcast v389 : i32;
-            v392 = arith.neq v390, v852 : i1;
-            scf.if v392{
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v366: i32, v367: i32, v368: i32) {
+        ^block52(v366: i32, v367: i32, v368: i32):
+            v370 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
+            v371 = hir.bitcast v370 : ptr<byte, i32>;
+            v372 = hir.load v371 : i32;
+            v373 = arith.constant 16 : i32;
+            v374 = arith.sub v372, v373 : i32 #[overflow = wrapping];
+            v375 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
+            v376 = hir.bitcast v375 : ptr<byte, i32>;
+            hir.store v376, v374;
+            v377 = arith.constant 4 : i32;
+            v378 = arith.add v374, v377 : i32 #[overflow = wrapping];
+            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::raw_vec::RawVecInner<A>::current_memory(v378, v366, v367, v368)
+            v380 = arith.constant 8 : u32;
+            v379 = hir.bitcast v374 : u32;
+            v381 = arith.add v379, v380 : u32 #[overflow = checked];
+            v382 = arith.constant 4 : u32;
+            v383 = arith.mod v381, v382 : u32;
+            hir.assertz v383 #[code = 250];
+            v384 = hir.int_to_ptr v381 : ptr<byte, i32>;
+            v385 = hir.load v384 : i32;
+            v851 = arith.constant 0 : i32;
+            v369 = arith.constant 0 : i32;
+            v387 = arith.eq v385, v369 : i1;
+            v388 = arith.zext v387 : u32;
+            v389 = hir.bitcast v388 : i32;
+            v391 = arith.neq v389, v851 : i1;
+            scf.if v391{
             ^block135:
                 scf.yield ;
             } else {
             ^block55:
-                v851 = arith.constant 4 : u32;
-                v393 = hir.bitcast v375 : u32;
-                v395 = arith.add v393, v851 : u32 #[overflow = checked];
                 v850 = arith.constant 4 : u32;
-                v397 = arith.mod v395, v850 : u32;
-                hir.assertz v397 #[code = 250];
-                v398 = hir.int_to_ptr v395 : ptr<byte, i32>;
-                v399 = hir.load v398 : i32;
-                v401 = arith.constant 12 : u32;
-                v400 = hir.bitcast v375 : u32;
-                v402 = arith.add v400, v401 : u32 #[overflow = checked];
+                v392 = hir.bitcast v374 : u32;
+                v394 = arith.add v392, v850 : u32 #[overflow = checked];
                 v849 = arith.constant 4 : u32;
-                v404 = arith.mod v402, v849 : u32;
-                hir.assertz v404 #[code = 250];
-                v405 = hir.int_to_ptr v402 : ptr<byte, i32>;
-                v406 = hir.load v405 : i32;
-                hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v399, v386, v406)
+                v396 = arith.mod v394, v849 : u32;
+                hir.assertz v396 #[code = 250];
+                v397 = hir.int_to_ptr v394 : ptr<byte, i32>;
+                v398 = hir.load v397 : i32;
+                v400 = arith.constant 12 : u32;
+                v399 = hir.bitcast v374 : u32;
+                v401 = arith.add v399, v400 : u32 #[overflow = checked];
+                v848 = arith.constant 4 : u32;
+                v403 = arith.mod v401, v848 : u32;
+                hir.assertz v403 #[code = 250];
+                v404 = hir.int_to_ptr v401 : ptr<byte, i32>;
+                v405 = hir.load v404 : i32;
+                hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v398, v385, v405)
                 scf.yield ;
             };
-            v848 = arith.constant 16 : i32;
-            v409 = arith.add v375, v848 : i32 #[overflow = wrapping];
-            v410 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
-            v411 = hir.bitcast v410 : ptr<byte, i32>;
-            hir.store v411, v409;
+            v847 = arith.constant 16 : i32;
+            v408 = arith.add v374, v847 : i32 #[overflow = wrapping];
+            v409 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
+            v410 = hir.bitcast v409 : ptr<byte, i32>;
+            hir.store v410, v408;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v412: i32, v413: i32, v414: i32, v415: i32, v416: i32) {
-        ^block56(v412: i32, v413: i32, v414: i32, v415: i32, v416: i32):
-            v419 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
-            v420 = hir.bitcast v419 : ptr<byte, i32>;
-            v421 = hir.load v420 : i32;
-            v422 = arith.constant 16 : i32;
-            v423 = arith.sub v421, v422 : i32 #[overflow = wrapping];
-            v424 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
-            v425 = hir.bitcast v424 : ptr<byte, i32>;
-            hir.store v425, v423;
-            v435 = hir.bitcast v413 : u32;
-            v436 = arith.zext v435 : u64;
-            v437 = hir.bitcast v436 : i64;
-            v417 = arith.constant 0 : i32;
-            v430 = arith.sub v417, v415 : i32 #[overflow = wrapping];
-            v427 = arith.constant -1 : i32;
-            v426 = arith.add v415, v416 : i32 #[overflow = wrapping];
-            v428 = arith.add v426, v427 : i32 #[overflow = wrapping];
-            v431 = arith.band v428, v430 : i32;
-            v432 = hir.bitcast v431 : u32;
-            v433 = arith.zext v432 : u64;
-            v434 = hir.bitcast v433 : i64;
-            v438 = arith.mul v434, v437 : i64 #[overflow = wrapping];
-            v956 = arith.constant 0 : i32;
-            v439 = arith.constant 32 : i64;
-            v441 = hir.cast v439 : u32;
-            v440 = hir.bitcast v438 : u64;
-            v442 = arith.shr v440, v441 : u64;
-            v443 = hir.bitcast v442 : i64;
-            v444 = arith.trunc v443 : i32;
-            v446 = arith.neq v444, v956 : i1;
-            v868, v869, v870, v871, v872, v873 = scf.if v446 : i32, i32, i32, i32, i32, u32 {
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v411: i32, v412: i32, v413: i32, v414: i32, v415: i32) {
+        ^block56(v411: i32, v412: i32, v413: i32, v414: i32, v415: i32):
+            v418 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
+            v419 = hir.bitcast v418 : ptr<byte, i32>;
+            v420 = hir.load v419 : i32;
+            v421 = arith.constant 16 : i32;
+            v422 = arith.sub v420, v421 : i32 #[overflow = wrapping];
+            v423 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
+            v424 = hir.bitcast v423 : ptr<byte, i32>;
+            hir.store v424, v422;
+            v434 = hir.bitcast v412 : u32;
+            v435 = arith.zext v434 : u64;
+            v436 = hir.bitcast v435 : i64;
+            v416 = arith.constant 0 : i32;
+            v429 = arith.sub v416, v414 : i32 #[overflow = wrapping];
+            v426 = arith.constant -1 : i32;
+            v425 = arith.add v414, v415 : i32 #[overflow = wrapping];
+            v427 = arith.add v425, v426 : i32 #[overflow = wrapping];
+            v430 = arith.band v427, v429 : i32;
+            v431 = hir.bitcast v430 : u32;
+            v432 = arith.zext v431 : u64;
+            v433 = hir.bitcast v432 : i64;
+            v437 = arith.mul v433, v436 : i64 #[overflow = wrapping];
+            v955 = arith.constant 0 : i32;
+            v438 = arith.constant 32 : i64;
+            v440 = hir.cast v438 : u32;
+            v439 = hir.bitcast v437 : u64;
+            v441 = arith.shr v439, v440 : u64;
+            v442 = hir.bitcast v441 : i64;
+            v443 = arith.trunc v442 : i32;
+            v445 = arith.neq v443, v955 : i1;
+            v867, v868, v869, v870, v871, v872 = scf.if v445 : i32, i32, i32, i32, i32, u32 {
             ^block137:
-                v853 = arith.constant 0 : u32;
-                v860 = ub.poison i32 : i32;
-                scf.yield v412, v423, v860, v860, v860, v853;
+                v852 = arith.constant 0 : u32;
+                v859 = ub.poison i32 : i32;
+                scf.yield v411, v422, v859, v859, v859, v852;
             } else {
             ^block61:
-                v447 = arith.trunc v438 : i32;
-                v955 = arith.constant 0 : i32;
-                v448 = arith.constant -2147483648 : i32;
-                v449 = arith.sub v448, v415 : i32 #[overflow = wrapping];
-                v451 = hir.bitcast v449 : u32;
-                v450 = hir.bitcast v447 : u32;
-                v452 = arith.lte v450, v451 : i1;
-                v453 = arith.zext v452 : u32;
-                v454 = hir.bitcast v453 : i32;
-                v456 = arith.neq v454, v955 : i1;
-                v916 = scf.if v456 : i32 {
+                v446 = arith.trunc v437 : i32;
+                v954 = arith.constant 0 : i32;
+                v447 = arith.constant -2147483648 : i32;
+                v448 = arith.sub v447, v414 : i32 #[overflow = wrapping];
+                v450 = hir.bitcast v448 : u32;
+                v449 = hir.bitcast v446 : u32;
+                v451 = arith.lte v449, v450 : i1;
+                v452 = arith.zext v451 : u32;
+                v453 = hir.bitcast v452 : i32;
+                v455 = arith.neq v453, v954 : i1;
+                v915 = scf.if v455 : i32 {
                 ^block59:
-                    v954 = arith.constant 0 : i32;
-                    v467 = arith.neq v447, v954 : i1;
-                    v915 = scf.if v467 : i32 {
+                    v953 = arith.constant 0 : i32;
+                    v466 = arith.neq v446, v953 : i1;
+                    v914 = scf.if v466 : i32 {
                     ^block63:
-                        v953 = arith.constant 0 : i32;
-                        v483 = arith.neq v414, v953 : i1;
-                        v914 = scf.if v483 : i32 {
+                        v952 = arith.constant 0 : i32;
+                        v482 = arith.neq v413, v952 : i1;
+                        v913 = scf.if v482 : i32 {
                         ^block66:
-                            v465 = arith.constant 1 : i32;
-                            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::alloc::Global::alloc_impl(v423, v415, v447, v465)
-                            v494 = hir.bitcast v423 : u32;
-                            v539 = arith.constant 4 : u32;
-                            v496 = arith.mod v494, v539 : u32;
-                            hir.assertz v496 #[code = 250];
-                            v497 = hir.int_to_ptr v494 : ptr<byte, i32>;
-                            v498 = hir.load v497 : i32;
-                            scf.yield v498;
+                            v464 = arith.constant 1 : i32;
+                            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::alloc::Global::alloc_impl(v422, v414, v446, v464)
+                            v493 = hir.bitcast v422 : u32;
+                            v538 = arith.constant 4 : u32;
+                            v495 = arith.mod v493, v538 : u32;
+                            hir.assertz v495 #[code = 250];
+                            v496 = hir.int_to_ptr v493 : ptr<byte, i32>;
+                            v497 = hir.load v496 : i32;
+                            scf.yield v497;
                         } else {
                         ^block67:
-                            v484 = arith.constant 8 : i32;
-                            v485 = arith.add v423, v484 : i32 #[overflow = wrapping];
-                            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/<alloc::alloc::Global as core::alloc::Allocator>::allocate(v485, v415, v447)
-                            v469 = arith.constant 8 : u32;
-                            v486 = hir.bitcast v423 : u32;
-                            v488 = arith.add v486, v469 : u32 #[overflow = checked];
-                            v952 = arith.constant 4 : u32;
-                            v490 = arith.mod v488, v952 : u32;
-                            hir.assertz v490 #[code = 250];
-                            v491 = hir.int_to_ptr v488 : ptr<byte, i32>;
-                            v492 = hir.load v491 : i32;
-                            scf.yield v492;
+                            v483 = arith.constant 8 : i32;
+                            v484 = arith.add v422, v483 : i32 #[overflow = wrapping];
+                            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/<alloc::alloc::Global as core::alloc::Allocator>::allocate(v484, v414, v446)
+                            v468 = arith.constant 8 : u32;
+                            v485 = hir.bitcast v422 : u32;
+                            v487 = arith.add v485, v468 : u32 #[overflow = checked];
+                            v951 = arith.constant 4 : u32;
+                            v489 = arith.mod v487, v951 : u32;
+                            hir.assertz v489 #[code = 250];
+                            v490 = hir.int_to_ptr v487 : ptr<byte, i32>;
+                            v491 = hir.load v490 : i32;
+                            scf.yield v491;
                         };
+                        v949 = arith.constant 0 : i32;
                         v950 = arith.constant 0 : i32;
-                        v951 = arith.constant 0 : i32;
-                        v501 = arith.eq v914, v951 : i1;
-                        v502 = arith.zext v501 : u32;
-                        v503 = hir.bitcast v502 : i32;
-                        v505 = arith.neq v503, v950 : i1;
-                        scf.if v505{
+                        v500 = arith.eq v913, v950 : i1;
+                        v501 = arith.zext v500 : u32;
+                        v502 = hir.bitcast v501 : i32;
+                        v504 = arith.neq v502, v949 : i1;
+                        scf.if v504{
                         ^block68:
-                            v949 = arith.constant 8 : u32;
-                            v522 = hir.bitcast v412 : u32;
-                            v524 = arith.add v522, v949 : u32 #[overflow = checked];
-                            v948 = arith.constant 4 : u32;
-                            v526 = arith.mod v524, v948 : u32;
-                            hir.assertz v526 #[code = 250];
-                            v527 = hir.int_to_ptr v524 : ptr<byte, i32>;
-                            hir.store v527, v447;
+                            v948 = arith.constant 8 : u32;
+                            v521 = hir.bitcast v411 : u32;
+                            v523 = arith.add v521, v948 : u32 #[overflow = checked];
                             v947 = arith.constant 4 : u32;
-                            v529 = hir.bitcast v412 : u32;
-                            v531 = arith.add v529, v947 : u32 #[overflow = checked];
+                            v525 = arith.mod v523, v947 : u32;
+                            hir.assertz v525 #[code = 250];
+                            v526 = hir.int_to_ptr v523 : ptr<byte, i32>;
+                            hir.store v526, v446;
                             v946 = arith.constant 4 : u32;
-                            v533 = arith.mod v531, v946 : u32;
-                            hir.assertz v533 #[code = 250];
-                            v534 = hir.int_to_ptr v531 : ptr<byte, i32>;
-                            hir.store v534, v415;
+                            v528 = hir.bitcast v411 : u32;
+                            v530 = arith.add v528, v946 : u32 #[overflow = checked];
+                            v945 = arith.constant 4 : u32;
+                            v532 = arith.mod v530, v945 : u32;
+                            hir.assertz v532 #[code = 250];
+                            v533 = hir.int_to_ptr v530 : ptr<byte, i32>;
+                            hir.store v533, v414;
                             scf.yield ;
                         } else {
                         ^block69:
-                            v945 = arith.constant 8 : u32;
-                            v507 = hir.bitcast v412 : u32;
-                            v509 = arith.add v507, v945 : u32 #[overflow = checked];
-                            v944 = arith.constant 4 : u32;
-                            v511 = arith.mod v509, v944 : u32;
-                            hir.assertz v511 #[code = 250];
-                            v512 = hir.int_to_ptr v509 : ptr<byte, i32>;
-                            hir.store v512, v914;
+                            v944 = arith.constant 8 : u32;
+                            v506 = hir.bitcast v411 : u32;
+                            v508 = arith.add v506, v944 : u32 #[overflow = checked];
                             v943 = arith.constant 4 : u32;
-                            v514 = hir.bitcast v412 : u32;
-                            v516 = arith.add v514, v943 : u32 #[overflow = checked];
+                            v510 = arith.mod v508, v943 : u32;
+                            hir.assertz v510 #[code = 250];
+                            v511 = hir.int_to_ptr v508 : ptr<byte, i32>;
+                            hir.store v511, v913;
                             v942 = arith.constant 4 : u32;
-                            v518 = arith.mod v516, v942 : u32;
-                            hir.assertz v518 #[code = 250];
-                            v519 = hir.int_to_ptr v516 : ptr<byte, i32>;
-                            hir.store v519, v413;
+                            v513 = hir.bitcast v411 : u32;
+                            v515 = arith.add v513, v942 : u32 #[overflow = checked];
+                            v941 = arith.constant 4 : u32;
+                            v517 = arith.mod v515, v941 : u32;
+                            hir.assertz v517 #[code = 250];
+                            v518 = hir.int_to_ptr v515 : ptr<byte, i32>;
+                            hir.store v518, v412;
                             scf.yield ;
                         };
-                        v940 = arith.constant 0 : i32;
-                        v941 = arith.constant 1 : i32;
-                        v913 = cf.select v505, v941, v940 : i32;
-                        scf.yield v913;
+                        v939 = arith.constant 0 : i32;
+                        v940 = arith.constant 1 : i32;
+                        v912 = cf.select v504, v940, v939 : i32;
+                        scf.yield v912;
                     } else {
                     ^block64:
-                        v939 = arith.constant 8 : u32;
-                        v468 = hir.bitcast v412 : u32;
-                        v470 = arith.add v468, v939 : u32 #[overflow = checked];
-                        v938 = arith.constant 4 : u32;
-                        v472 = arith.mod v470, v938 : u32;
-                        hir.assertz v472 #[code = 250];
-                        v473 = hir.int_to_ptr v470 : ptr<byte, i32>;
-                        hir.store v473, v415;
+                        v938 = arith.constant 8 : u32;
+                        v467 = hir.bitcast v411 : u32;
+                        v469 = arith.add v467, v938 : u32 #[overflow = checked];
                         v937 = arith.constant 4 : u32;
-                        v476 = hir.bitcast v412 : u32;
-                        v478 = arith.add v476, v937 : u32 #[overflow = checked];
+                        v471 = arith.mod v469, v937 : u32;
+                        hir.assertz v471 #[code = 250];
+                        v472 = hir.int_to_ptr v469 : ptr<byte, i32>;
+                        hir.store v472, v414;
                         v936 = arith.constant 4 : u32;
-                        v480 = arith.mod v478, v936 : u32;
-                        hir.assertz v480 #[code = 250];
-                        v935 = arith.constant 0 : i32;
-                        v481 = hir.int_to_ptr v478 : ptr<byte, i32>;
-                        hir.store v481, v935;
+                        v475 = hir.bitcast v411 : u32;
+                        v477 = arith.add v475, v936 : u32 #[overflow = checked];
+                        v935 = arith.constant 4 : u32;
+                        v479 = arith.mod v477, v935 : u32;
+                        hir.assertz v479 #[code = 250];
                         v934 = arith.constant 0 : i32;
-                        scf.yield v934;
+                        v480 = hir.int_to_ptr v477 : ptr<byte, i32>;
+                        hir.store v480, v934;
+                        v933 = arith.constant 0 : i32;
+                        scf.yield v933;
                     };
-                    scf.yield v915;
+                    scf.yield v914;
                 } else {
                 ^block62:
-                    v933 = ub.poison i32 : i32;
-                    scf.yield v933;
+                    v932 = ub.poison i32 : i32;
+                    scf.yield v932;
                 };
-                v928 = arith.constant 0 : u32;
-                v861 = arith.constant 1 : u32;
-                v921 = cf.select v456, v861, v928 : u32;
+                v927 = arith.constant 0 : u32;
+                v860 = arith.constant 1 : u32;
+                v920 = cf.select v455, v860, v927 : u32;
+                v928 = ub.poison i32 : i32;
+                v919 = cf.select v455, v422, v928 : i32;
                 v929 = ub.poison i32 : i32;
-                v920 = cf.select v456, v423, v929 : i32;
+                v918 = cf.select v455, v411, v929 : i32;
                 v930 = ub.poison i32 : i32;
-                v919 = cf.select v456, v412, v930 : i32;
+                v917 = cf.select v455, v930, v422 : i32;
                 v931 = ub.poison i32 : i32;
-                v918 = cf.select v456, v931, v423 : i32;
-                v932 = ub.poison i32 : i32;
-                v917 = cf.select v456, v932, v412 : i32;
-                scf.yield v917, v918, v919, v916, v920, v921;
+                v916 = cf.select v455, v931, v411 : i32;
+                scf.yield v916, v917, v918, v915, v919, v920;
             };
-            v874, v875, v876 = scf.index_switch v873 : i32, i32, i32 
+            v873, v874, v875 = scf.index_switch v872 : i32, i32, i32 
             case 0 {
             ^block60:
-                v927 = arith.constant 4 : u32;
-                v459 = hir.bitcast v868 : u32;
-                v461 = arith.add v459, v927 : u32 #[overflow = checked];
                 v926 = arith.constant 4 : u32;
-                v463 = arith.mod v461, v926 : u32;
-                hir.assertz v463 #[code = 250];
-                v925 = arith.constant 0 : i32;
-                v464 = hir.int_to_ptr v461 : ptr<byte, i32>;
-                hir.store v464, v925;
-                v924 = arith.constant 1 : i32;
-                scf.yield v868, v924, v869;
+                v458 = hir.bitcast v867 : u32;
+                v460 = arith.add v458, v926 : u32 #[overflow = checked];
+                v925 = arith.constant 4 : u32;
+                v462 = arith.mod v460, v925 : u32;
+                hir.assertz v462 #[code = 250];
+                v924 = arith.constant 0 : i32;
+                v463 = hir.int_to_ptr v460 : ptr<byte, i32>;
+                hir.store v463, v924;
+                v923 = arith.constant 1 : i32;
+                scf.yield v867, v923, v868;
             }
             default {
             ^block141:
-                scf.yield v870, v871, v872;
+                scf.yield v869, v870, v871;
             };
-            v538 = hir.bitcast v874 : u32;
-            v923 = arith.constant 4 : u32;
-            v540 = arith.mod v538, v923 : u32;
-            hir.assertz v540 #[code = 250];
-            v541 = hir.int_to_ptr v538 : ptr<byte, i32>;
-            hir.store v541, v875;
-            v922 = arith.constant 16 : i32;
-            v546 = arith.add v876, v922 : i32 #[overflow = wrapping];
-            v547 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
-            v548 = hir.bitcast v547 : ptr<byte, i32>;
-            hir.store v548, v546;
+            v537 = hir.bitcast v873 : u32;
+            v922 = arith.constant 4 : u32;
+            v539 = arith.mod v537, v922 : u32;
+            hir.assertz v539 #[code = 250];
+            v540 = hir.int_to_ptr v537 : ptr<byte, i32>;
+            hir.store v540, v874;
+            v921 = arith.constant 16 : i32;
+            v545 = arith.add v875, v921 : i32 #[overflow = wrapping];
+            v546 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
+            v547 = hir.bitcast v546 : ptr<byte, i32>;
+            hir.store v547, v545;
             builtin.ret ;
         };
 
-        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v549: i32, v550: i32, v551: i32) {
-        ^block70(v549: i32, v550: i32, v551: i32):
-            v553 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
-            v554 = hir.bitcast v553 : ptr<byte, i32>;
-            v555 = hir.load v554 : i32;
-            v556 = arith.constant 16 : i32;
-            v557 = arith.sub v555, v556 : i32 #[overflow = wrapping];
-            v558 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
-            v559 = hir.bitcast v558 : ptr<byte, i32>;
-            hir.store v559, v557;
-            v552 = arith.constant 0 : i32;
-            v560 = arith.constant 8 : i32;
-            v561 = arith.add v557, v560 : i32 #[overflow = wrapping];
-            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::alloc::Global::alloc_impl(v561, v550, v551, v552)
-            v564 = arith.constant 12 : u32;
-            v563 = hir.bitcast v557 : u32;
-            v565 = arith.add v563, v564 : u32 #[overflow = checked];
-            v566 = arith.constant 4 : u32;
-            v567 = arith.mod v565, v566 : u32;
-            hir.assertz v567 #[code = 250];
-            v568 = hir.int_to_ptr v565 : ptr<byte, i32>;
-            v569 = hir.load v568 : i32;
-            v571 = arith.constant 8 : u32;
-            v570 = hir.bitcast v557 : u32;
-            v572 = arith.add v570, v571 : u32 #[overflow = checked];
-            v961 = arith.constant 4 : u32;
-            v574 = arith.mod v572, v961 : u32;
-            hir.assertz v574 #[code = 250];
-            v575 = hir.int_to_ptr v572 : ptr<byte, i32>;
-            v576 = hir.load v575 : i32;
-            v577 = hir.bitcast v549 : u32;
+        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v548: i32, v549: i32, v550: i32) {
+        ^block70(v548: i32, v549: i32, v550: i32):
+            v552 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
+            v553 = hir.bitcast v552 : ptr<byte, i32>;
+            v554 = hir.load v553 : i32;
+            v555 = arith.constant 16 : i32;
+            v556 = arith.sub v554, v555 : i32 #[overflow = wrapping];
+            v557 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
+            v558 = hir.bitcast v557 : ptr<byte, i32>;
+            hir.store v558, v556;
+            v551 = arith.constant 0 : i32;
+            v559 = arith.constant 8 : i32;
+            v560 = arith.add v556, v559 : i32 #[overflow = wrapping];
+            hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::alloc::Global::alloc_impl(v560, v549, v550, v551)
+            v563 = arith.constant 12 : u32;
+            v562 = hir.bitcast v556 : u32;
+            v564 = arith.add v562, v563 : u32 #[overflow = checked];
+            v565 = arith.constant 4 : u32;
+            v566 = arith.mod v564, v565 : u32;
+            hir.assertz v566 #[code = 250];
+            v567 = hir.int_to_ptr v564 : ptr<byte, i32>;
+            v568 = hir.load v567 : i32;
+            v570 = arith.constant 8 : u32;
+            v569 = hir.bitcast v556 : u32;
+            v571 = arith.add v569, v570 : u32 #[overflow = checked];
             v960 = arith.constant 4 : u32;
-            v579 = arith.mod v577, v960 : u32;
-            hir.assertz v579 #[code = 250];
-            v580 = hir.int_to_ptr v577 : ptr<byte, i32>;
-            hir.store v580, v576;
+            v573 = arith.mod v571, v960 : u32;
+            hir.assertz v573 #[code = 250];
+            v574 = hir.int_to_ptr v571 : ptr<byte, i32>;
+            v575 = hir.load v574 : i32;
+            v576 = hir.bitcast v548 : u32;
             v959 = arith.constant 4 : u32;
-            v581 = hir.bitcast v549 : u32;
-            v583 = arith.add v581, v959 : u32 #[overflow = checked];
+            v578 = arith.mod v576, v959 : u32;
+            hir.assertz v578 #[code = 250];
+            v579 = hir.int_to_ptr v576 : ptr<byte, i32>;
+            hir.store v579, v575;
             v958 = arith.constant 4 : u32;
-            v585 = arith.mod v583, v958 : u32;
-            hir.assertz v585 #[code = 250];
-            v586 = hir.int_to_ptr v583 : ptr<byte, i32>;
-            hir.store v586, v569;
-            v957 = arith.constant 16 : i32;
-            v588 = arith.add v557, v957 : i32 #[overflow = wrapping];
-            v589 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
-            v590 = hir.bitcast v589 : ptr<byte, i32>;
-            hir.store v590, v588;
+            v580 = hir.bitcast v548 : u32;
+            v582 = arith.add v580, v958 : u32 #[overflow = checked];
+            v957 = arith.constant 4 : u32;
+            v584 = arith.mod v582, v957 : u32;
+            hir.assertz v584 #[code = 250];
+            v585 = hir.int_to_ptr v582 : ptr<byte, i32>;
+            hir.store v585, v568;
+            v956 = arith.constant 16 : i32;
+            v587 = arith.add v556, v956 : i32 #[overflow = wrapping];
+            v588 = builtin.global_symbol @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__stack_pointer : ptr<byte, u8>
+            v589 = hir.bitcast v588 : ptr<byte, i32>;
+            hir.store v589, v587;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::alloc::Global::alloc_impl(v591: i32, v592: i32, v593: i32, v594: i32) {
-        ^block72(v591: i32, v592: i32, v593: i32, v594: i32):
-            v977 = arith.constant 0 : i32;
-            v595 = arith.constant 0 : i32;
-            v596 = arith.eq v593, v595 : i1;
-            v597 = arith.zext v596 : u32;
-            v598 = hir.bitcast v597 : i32;
-            v600 = arith.neq v598, v977 : i1;
-            v973 = scf.if v600 : i32 {
+        private builtin.function @alloc::alloc::Global::alloc_impl(v590: i32, v591: i32, v592: i32, v593: i32) {
+        ^block72(v590: i32, v591: i32, v592: i32, v593: i32):
+            v976 = arith.constant 0 : i32;
+            v594 = arith.constant 0 : i32;
+            v595 = arith.eq v592, v594 : i1;
+            v596 = arith.zext v595 : u32;
+            v597 = hir.bitcast v596 : i32;
+            v599 = arith.neq v597, v976 : i1;
+            v972 = scf.if v599 : i32 {
             ^block144:
-                scf.yield v592;
+                scf.yield v591;
             } else {
             ^block75:
                 hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_no_alloc_shim_is_unstable_v2()
-                v976 = arith.constant 0 : i32;
-                v602 = arith.neq v594, v976 : i1;
-                v972 = scf.if v602 : i32 {
+                v975 = arith.constant 0 : i32;
+                v601 = arith.neq v593, v975 : i1;
+                v971 = scf.if v601 : i32 {
                 ^block76:
-                    v604 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_alloc_zeroed(v593, v592) : i32
-                    scf.yield v604;
+                    v603 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_alloc_zeroed(v592, v591) : i32
+                    scf.yield v603;
                 } else {
                 ^block77:
-                    v603 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_alloc(v593, v592) : i32
-                    scf.yield v603;
+                    v602 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_alloc(v592, v591) : i32
+                    scf.yield v602;
                 };
-                scf.yield v972;
+                scf.yield v971;
             };
-            v608 = arith.constant 4 : u32;
-            v607 = hir.bitcast v591 : u32;
-            v609 = arith.add v607, v608 : u32 #[overflow = checked];
-            v975 = arith.constant 4 : u32;
-            v611 = arith.mod v609, v975 : u32;
-            hir.assertz v611 #[code = 250];
-            v612 = hir.int_to_ptr v609 : ptr<byte, i32>;
-            hir.store v612, v593;
-            v614 = hir.bitcast v591 : u32;
+            v607 = arith.constant 4 : u32;
+            v606 = hir.bitcast v590 : u32;
+            v608 = arith.add v606, v607 : u32 #[overflow = checked];
             v974 = arith.constant 4 : u32;
-            v616 = arith.mod v614, v974 : u32;
-            hir.assertz v616 #[code = 250];
-            v617 = hir.int_to_ptr v614 : ptr<byte, i32>;
-            hir.store v617, v973;
+            v610 = arith.mod v608, v974 : u32;
+            hir.assertz v610 #[code = 250];
+            v611 = hir.int_to_ptr v608 : ptr<byte, i32>;
+            hir.store v611, v592;
+            v613 = hir.bitcast v590 : u32;
+            v973 = arith.constant 4 : u32;
+            v615 = arith.mod v613, v973 : u32;
+            hir.assertz v615 #[code = 250];
+            v616 = hir.int_to_ptr v613 : ptr<byte, i32>;
+            hir.store v616, v972;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v618: i32, v619: i32, v620: i32, v621: i32) {
-        ^block78(v618: i32, v619: i32, v620: i32, v621: i32):
-            v1003 = arith.constant 0 : i32;
-            v622 = arith.constant 0 : i32;
-            v626 = arith.eq v621, v622 : i1;
-            v627 = arith.zext v626 : u32;
-            v628 = hir.bitcast v627 : i32;
-            v630 = arith.neq v628, v1003 : i1;
-            v990, v991 = scf.if v630 : i32, i32 {
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v617: i32, v618: i32, v619: i32, v620: i32) {
+        ^block78(v617: i32, v618: i32, v619: i32, v620: i32):
+            v1002 = arith.constant 0 : i32;
+            v621 = arith.constant 0 : i32;
+            v625 = arith.eq v620, v621 : i1;
+            v626 = arith.zext v625 : u32;
+            v627 = hir.bitcast v626 : i32;
+            v629 = arith.neq v627, v1002 : i1;
+            v989, v990 = scf.if v629 : i32, i32 {
             ^block148:
-                v1002 = arith.constant 0 : i32;
-                v624 = arith.constant 4 : i32;
-                scf.yield v624, v1002;
+                v1001 = arith.constant 0 : i32;
+                v623 = arith.constant 4 : i32;
+                scf.yield v623, v1001;
             } else {
             ^block81:
-                v631 = hir.bitcast v619 : u32;
-                v666 = arith.constant 4 : u32;
-                v633 = arith.mod v631, v666 : u32;
-                hir.assertz v633 #[code = 250];
-                v634 = hir.int_to_ptr v631 : ptr<byte, i32>;
-                v635 = hir.load v634 : i32;
+                v630 = hir.bitcast v618 : u32;
+                v665 = arith.constant 4 : u32;
+                v632 = arith.mod v630, v665 : u32;
+                hir.assertz v632 #[code = 250];
+                v633 = hir.int_to_ptr v630 : ptr<byte, i32>;
+                v634 = hir.load v633 : i32;
+                v999 = arith.constant 0 : i32;
                 v1000 = arith.constant 0 : i32;
-                v1001 = arith.constant 0 : i32;
-                v637 = arith.eq v635, v1001 : i1;
-                v638 = arith.zext v637 : u32;
-                v639 = hir.bitcast v638 : i32;
-                v641 = arith.neq v639, v1000 : i1;
-                v988 = scf.if v641 : i32 {
+                v636 = arith.eq v634, v1000 : i1;
+                v637 = arith.zext v636 : u32;
+                v638 = hir.bitcast v637 : i32;
+                v640 = arith.neq v638, v999 : i1;
+                v987 = scf.if v640 : i32 {
                 ^block147:
-                    v999 = arith.constant 0 : i32;
-                    scf.yield v999;
+                    v998 = arith.constant 0 : i32;
+                    scf.yield v998;
                 } else {
                 ^block82:
-                    v998 = arith.constant 4 : u32;
-                    v642 = hir.bitcast v618 : u32;
-                    v644 = arith.add v642, v998 : u32 #[overflow = checked];
                     v997 = arith.constant 4 : u32;
-                    v646 = arith.mod v644, v997 : u32;
-                    hir.assertz v646 #[code = 250];
-                    v647 = hir.int_to_ptr v644 : ptr<byte, i32>;
-                    hir.store v647, v620;
+                    v641 = hir.bitcast v617 : u32;
+                    v643 = arith.add v641, v997 : u32 #[overflow = checked];
                     v996 = arith.constant 4 : u32;
-                    v648 = hir.bitcast v619 : u32;
-                    v650 = arith.add v648, v996 : u32 #[overflow = checked];
+                    v645 = arith.mod v643, v996 : u32;
+                    hir.assertz v645 #[code = 250];
+                    v646 = hir.int_to_ptr v643 : ptr<byte, i32>;
+                    hir.store v646, v619;
                     v995 = arith.constant 4 : u32;
-                    v652 = arith.mod v650, v995 : u32;
-                    hir.assertz v652 #[code = 250];
-                    v653 = hir.int_to_ptr v650 : ptr<byte, i32>;
-                    v654 = hir.load v653 : i32;
-                    v655 = hir.bitcast v618 : u32;
+                    v647 = hir.bitcast v618 : u32;
+                    v649 = arith.add v647, v995 : u32 #[overflow = checked];
                     v994 = arith.constant 4 : u32;
-                    v657 = arith.mod v655, v994 : u32;
-                    hir.assertz v657 #[code = 250];
-                    v658 = hir.int_to_ptr v655 : ptr<byte, i32>;
-                    hir.store v658, v654;
-                    v659 = arith.mul v635, v621 : i32 #[overflow = wrapping];
-                    scf.yield v659;
+                    v651 = arith.mod v649, v994 : u32;
+                    hir.assertz v651 #[code = 250];
+                    v652 = hir.int_to_ptr v649 : ptr<byte, i32>;
+                    v653 = hir.load v652 : i32;
+                    v654 = hir.bitcast v617 : u32;
+                    v993 = arith.constant 4 : u32;
+                    v656 = arith.mod v654, v993 : u32;
+                    hir.assertz v656 #[code = 250];
+                    v657 = hir.int_to_ptr v654 : ptr<byte, i32>;
+                    hir.store v657, v653;
+                    v658 = arith.mul v634, v620 : i32 #[overflow = wrapping];
+                    scf.yield v658;
                 };
-                v660 = arith.constant 8 : i32;
-                v993 = arith.constant 4 : i32;
-                v989 = cf.select v641, v993, v660 : i32;
-                scf.yield v989, v988;
+                v659 = arith.constant 8 : i32;
+                v992 = arith.constant 4 : i32;
+                v988 = cf.select v640, v992, v659 : i32;
+                scf.yield v988, v987;
             };
-            v663 = arith.add v618, v990 : i32 #[overflow = wrapping];
-            v665 = hir.bitcast v663 : u32;
-            v992 = arith.constant 4 : u32;
-            v667 = arith.mod v665, v992 : u32;
-            hir.assertz v667 #[code = 250];
-            v668 = hir.int_to_ptr v665 : ptr<byte, i32>;
-            hir.store v668, v991;
+            v662 = arith.add v617, v989 : i32 #[overflow = wrapping];
+            v664 = hir.bitcast v662 : u32;
+            v991 = arith.constant 4 : u32;
+            v666 = arith.mod v664, v991 : u32;
+            hir.assertz v666 #[code = 250];
+            v667 = hir.int_to_ptr v664 : ptr<byte, i32>;
+            hir.store v667, v990;
             builtin.ret ;
         };
 
-        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v669: i32, v670: i32, v671: i32) {
-        ^block83(v669: i32, v670: i32, v671: i32):
-            v1005 = arith.constant 0 : i32;
-            v672 = arith.constant 0 : i32;
-            v673 = arith.eq v671, v672 : i1;
-            v674 = arith.zext v673 : u32;
-            v675 = hir.bitcast v674 : i32;
-            v677 = arith.neq v675, v1005 : i1;
-            scf.if v677{
+        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v668: i32, v669: i32, v670: i32) {
+        ^block83(v668: i32, v669: i32, v670: i32):
+            v1004 = arith.constant 0 : i32;
+            v671 = arith.constant 0 : i32;
+            v672 = arith.eq v670, v671 : i1;
+            v673 = arith.zext v672 : u32;
+            v674 = hir.bitcast v673 : i32;
+            v676 = arith.neq v674, v1004 : i1;
+            scf.if v676{
             ^block85:
                 scf.yield ;
             } else {
             ^block86:
-                hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_dealloc(v669, v671, v670)
+                hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_dealloc(v668, v670, v669)
                 scf.yield ;
             };
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::handle_error(v678: i32, v679: i32, v680: i32) {
-        ^block87(v678: i32, v679: i32, v680: i32):
+        private builtin.function @alloc::raw_vec::handle_error(v677: i32, v678: i32, v679: i32) {
+        ^block87(v677: i32, v678: i32, v679: i32):
             ub.unreachable ;
         };
 
-        private builtin.function @core::ptr::alignment::Alignment::max(v681: i32, v682: i32) -> i32 {
-        ^block89(v681: i32, v682: i32):
-            v689 = arith.constant 0 : i32;
-            v685 = hir.bitcast v682 : u32;
+        private builtin.function @core::ptr::alignment::Alignment::max(v680: i32, v681: i32) -> i32 {
+        ^block89(v680: i32, v681: i32):
+            v688 = arith.constant 0 : i32;
             v684 = hir.bitcast v681 : u32;
-            v686 = arith.gt v684, v685 : i1;
-            v687 = arith.zext v686 : u32;
-            v688 = hir.bitcast v687 : i32;
-            v690 = arith.neq v688, v689 : i1;
-            v691 = cf.select v690, v681, v682 : i32;
-            builtin.ret v691;
+            v683 = hir.bitcast v680 : u32;
+            v685 = arith.gt v683, v684 : i1;
+            v686 = arith.zext v685 : u32;
+            v687 = hir.bitcast v686 : i32;
+            v689 = arith.neq v687, v688 : i1;
+            v690 = cf.select v689, v680, v681 : i32;
+            builtin.ret v690;
         };
 
-        private builtin.function @miden::active_note::get_inputs(v692: i32) -> i32 {
-        ^block91(v692: i32):
-            v693, v694 = hir.exec @miden/active_note/get_inputs(v692) : i32, i32
-            builtin.ret v693;
+        private builtin.function @miden::active_note::get_inputs(v691: i32) -> i32 {
+        ^block91(v691: i32):
+            v692, v693 = hir.exec @miden/active_note/get_inputs(v691) : i32, i32
+            builtin.ret v692;
         };
 
-        public builtin.function @cabi_realloc(v696: i32, v697: i32, v698: i32, v699: i32) -> i32 {
-        ^block95(v696: i32, v697: i32, v698: i32, v699: i32):
-            v701 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/cabi_realloc_wit_bindgen_0_46_0(v696, v697, v698, v699) : i32
-            builtin.ret v701;
+        public builtin.function @cabi_realloc(v695: i32, v696: i32, v697: i32, v698: i32) -> i32 {
+        ^block95(v695: i32, v696: i32, v697: i32, v698: i32):
+            v700 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/cabi_realloc_wit_bindgen_0_46_0(v695, v696, v697, v698) : i32
+            builtin.ret v700;
         };
 
-        private builtin.function @alloc::alloc::alloc(v702: i32, v703: i32) -> i32 {
-        ^block97(v702: i32, v703: i32):
+        private builtin.function @alloc::alloc::alloc(v701: i32, v702: i32) -> i32 {
+        ^block97(v701: i32, v702: i32):
             hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_no_alloc_shim_is_unstable_v2()
-            v705 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_alloc(v703, v702) : i32
-            builtin.ret v705;
+            v704 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_alloc(v702, v701) : i32
+            builtin.ret v704;
         };
 
-        public builtin.function @cabi_realloc_wit_bindgen_0_46_0(v706: i32, v707: i32, v708: i32, v709: i32) -> i32 {
-        ^block99(v706: i32, v707: i32, v708: i32, v709: i32):
-            v711 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/wit_bindgen::rt::cabi_realloc(v706, v707, v708, v709) : i32
-            builtin.ret v711;
+        public builtin.function @cabi_realloc_wit_bindgen_0_46_0(v705: i32, v706: i32, v707: i32, v708: i32) -> i32 {
+        ^block99(v705: i32, v706: i32, v707: i32, v708: i32):
+            v710 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/wit_bindgen::rt::cabi_realloc(v705, v706, v707, v708) : i32
+            builtin.ret v710;
         };
 
-        private builtin.function @wit_bindgen::rt::cabi_realloc(v712: i32, v713: i32, v714: i32, v715: i32) -> i32 {
-        ^block101(v712: i32, v713: i32, v714: i32, v715: i32):
-            v717 = arith.constant 0 : i32;
-            v718 = arith.neq v713, v717 : i1;
-            v1016, v1017, v1018 = scf.if v718 : i32, i32, u32 {
+        private builtin.function @wit_bindgen::rt::cabi_realloc(v711: i32, v712: i32, v713: i32, v714: i32) -> i32 {
+        ^block101(v711: i32, v712: i32, v713: i32, v714: i32):
+            v716 = arith.constant 0 : i32;
+            v717 = arith.neq v712, v716 : i1;
+            v1015, v1016, v1017 = scf.if v717 : i32, i32, u32 {
             ^block105:
-                v726 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_realloc(v712, v713, v714, v715) : i32
-                v1007 = arith.constant 0 : u32;
-                v1011 = ub.poison i32 : i32;
-                scf.yield v726, v1011, v1007;
+                v725 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/__rustc::__rust_realloc(v711, v712, v713, v714) : i32
+                v1006 = arith.constant 0 : u32;
+                v1010 = ub.poison i32 : i32;
+                scf.yield v725, v1010, v1006;
             } else {
             ^block106:
+                v1045 = arith.constant 0 : i32;
                 v1046 = arith.constant 0 : i32;
-                v1047 = arith.constant 0 : i32;
-                v720 = arith.eq v715, v1047 : i1;
-                v721 = arith.zext v720 : u32;
-                v722 = hir.bitcast v721 : i32;
-                v724 = arith.neq v722, v1046 : i1;
-                v1034 = scf.if v724 : i32 {
+                v719 = arith.eq v714, v1046 : i1;
+                v720 = arith.zext v719 : u32;
+                v721 = hir.bitcast v720 : i32;
+                v723 = arith.neq v721, v1045 : i1;
+                v1033 = scf.if v723 : i32 {
                 ^block152:
-                    v1045 = ub.poison i32 : i32;
-                    scf.yield v1045;
+                    v1044 = ub.poison i32 : i32;
+                    scf.yield v1044;
                 } else {
                 ^block107:
-                    v725 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::alloc::alloc(v714, v715) : i32
-                    scf.yield v725;
+                    v724 = hir.exec @root_ns:root@1.0.0/abi_transform_tx_kernel_get_inputs_4/alloc::alloc::alloc(v713, v714) : i32
+                    scf.yield v724;
                 };
-                v1043 = arith.constant 0 : u32;
-                v1012 = arith.constant 1 : u32;
-                v1036 = cf.select v724, v1012, v1043 : u32;
-                v1044 = ub.poison i32 : i32;
-                v1035 = cf.select v724, v714, v1044 : i32;
-                scf.yield v1034, v1035, v1036;
+                v1042 = arith.constant 0 : u32;
+                v1011 = arith.constant 1 : u32;
+                v1035 = cf.select v723, v1011, v1042 : u32;
+                v1043 = ub.poison i32 : i32;
+                v1034 = cf.select v723, v713, v1043 : i32;
+                scf.yield v1033, v1034, v1035;
             };
-            v1023, v1024 = scf.index_switch v1018 : i32, u32 
+            v1022, v1023 = scf.index_switch v1017 : i32, u32 
             case 0 {
             ^block104:
-                v1041 = arith.constant 0 : i32;
-                v729 = arith.neq v1016, v1041 : i1;
-                v1038 = arith.constant 1 : u32;
-                v1039 = arith.constant 0 : u32;
-                v1033 = cf.select v729, v1039, v1038 : u32;
-                v1040 = ub.poison i32 : i32;
-                v1032 = cf.select v729, v1016, v1040 : i32;
-                scf.yield v1032, v1033;
+                v1040 = arith.constant 0 : i32;
+                v728 = arith.neq v1015, v1040 : i1;
+                v1037 = arith.constant 1 : u32;
+                v1038 = arith.constant 0 : u32;
+                v1032 = cf.select v728, v1038, v1037 : u32;
+                v1039 = ub.poison i32 : i32;
+                v1031 = cf.select v728, v1015, v1039 : i32;
+                scf.yield v1031, v1032;
             }
             default {
             ^block159:
-                v1042 = arith.constant 0 : u32;
-                scf.yield v1017, v1042;
+                v1041 = arith.constant 0 : u32;
+                scf.yield v1016, v1041;
             };
-            v1037 = arith.constant 0 : u32;
-            v1031 = arith.eq v1024, v1037 : i1;
-            cf.cond_br v1031 ^block154, ^block155;
+            v1036 = arith.constant 0 : u32;
+            v1030 = arith.eq v1023, v1036 : i1;
+            cf.cond_br v1030 ^block154, ^block155;
         ^block154:
-            builtin.ret v1023;
+            builtin.ret v1022;
         ^block155:
             ub.unreachable ;
         };
@@ -1102,6 +1102,6 @@ builtin.component root_ns:root@1.0.0 {
             builtin.ret_imm 1048576;
         };
 
-        builtin.segment readonly @1048576 = 0x00000001000000210000001f00000030001000000000000073722e65746f6e5f6576697463612f73676e69646e69622f6372732f302e382e302d7379732d657361622d6e6564696d;
+        builtin.segment readonly @1048576 = 0x0000000100000000000000000000000a0010000000003e64657463616465723c;
     };
 };

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.masm
@@ -5,17 +5,17 @@ proc init
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
-    push.[1554473420111659168,832244429625754668,5418308924757320907,17702588667154917010]
+    push.[13303268137284580667,14000914427208839465,16230032807968224336,7923152364088757166]
     adv.push_mapval
     push.262144
-    push.5
+    push.2
     trace.240
     exec.::std::mem::pipe_preimage_to_memory
     trace.252
     drop
     push.1048576
     u32assert
-    mem_store.278552
+    mem_store.278536
 end
 
 # mod root_ns:root@1.0.0::abi_transform_tx_kernel_get_inputs_4
@@ -24,7 +24,7 @@ end
 pub proc entrypoint(
 
 )
-    push.1114208
+    push.1114144
     u32divmod.4
     swap.1
     trace.240
@@ -34,7 +34,7 @@ pub proc entrypoint(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114144
     dup.1
     swap.1
     u32divmod.4
@@ -276,7 +276,7 @@ pub proc entrypoint(
                     push.16
                     movup.2
                     u32wrapping_add
-                    push.1114208
+                    push.1114144
                     u32divmod.4
                     swap.1
                     trace.240
@@ -304,7 +304,7 @@ end
 
 @callconv("C")
 proc __rustc::__rust_alloc(i32, i32) -> i32
-    push.1048648
+    push.1048608
     movup.2
     swap.1
     trace.240
@@ -323,7 +323,7 @@ end
 
 @callconv("C")
 proc __rustc::__rust_realloc(i32, i32, i32, i32) -> i32
-    push.1048648
+    push.1048608
     dup.4
     swap.2
     swap.4
@@ -427,7 +427,7 @@ end
 
 @callconv("C")
 proc __rustc::__rust_alloc_zeroed(i32, i32) -> i32
-    push.1048648
+    push.1048608
     dup.1
     swap.2
     swap.3
@@ -703,10 +703,9 @@ end
 proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
     i32,
     i32,
-    i32,
     i32
 )
-    push.1114208
+    push.1114144
     u32divmod.4
     swap.1
     trace.240
@@ -716,7 +715,7 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114144
     dup.1
     swap.1
     u32divmod.4
@@ -782,8 +781,6 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
     neq
     neq
     if.true
-        movup.3
-        drop
         push.12
         dup.2
         add
@@ -834,7 +831,7 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
         nop
         push.16
         u32wrapping_add
-        push.1114208
+        push.1114144
         u32divmod.4
         swap.1
         trace.240
@@ -862,7 +859,8 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
         exec.::intrinsics::mem::load_sw
         trace.252
         nop
-        swap.1
+        push.1048588
+        swap.2
         trace.240
         nop
         exec.::root_ns:root@1.0.0::abi_transform_tx_kernel_get_inputs_4::alloc::raw_vec::handle_error
@@ -877,7 +875,7 @@ end
 proc miden_base_sys::bindings::active_note::get_inputs(
     i32
 )
-    push.1114208
+    push.1114144
     u32divmod.4
     swap.1
     trace.240
@@ -887,7 +885,7 @@ proc miden_base_sys::bindings::active_note::get_inputs(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114144
     dup.1
     swap.1
     u32divmod.4
@@ -897,10 +895,9 @@ proc miden_base_sys::bindings::active_note::get_inputs(
     exec.::intrinsics::mem::store_sw
     trace.252
     nop
-    push.1048628
     push.4
     push.8
-    dup.3
+    dup.2
     u32wrapping_add
     dup.1
     swap.2
@@ -1003,7 +1000,7 @@ proc miden_base_sys::bindings::active_note::get_inputs(
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114144
     u32divmod.4
     swap.1
     trace.240
@@ -1036,7 +1033,7 @@ proc alloc::raw_vec::RawVecInner<A>::deallocate(
     i32,
     i32
 )
-    push.1114208
+    push.1114144
     u32divmod.4
     swap.1
     trace.240
@@ -1046,7 +1043,7 @@ proc alloc::raw_vec::RawVecInner<A>::deallocate(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114144
     dup.1
     swap.1
     u32divmod.4
@@ -1137,7 +1134,7 @@ proc alloc::raw_vec::RawVecInner<A>::deallocate(
     end
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114144
     u32divmod.4
     swap.1
     trace.240
@@ -1155,7 +1152,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     i32,
     i32
 )
-    push.1114208
+    push.1114144
     u32divmod.4
     swap.1
     trace.240
@@ -1165,7 +1162,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114144
     dup.1
     swap.1
     u32divmod.4
@@ -1550,7 +1547,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114144
     u32divmod.4
     swap.1
     trace.240
@@ -1566,7 +1563,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     i32,
     i32
 )
-    push.1114208
+    push.1114144
     u32divmod.4
     swap.1
     trace.240
@@ -1576,7 +1573,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114144
     dup.1
     swap.1
     u32divmod.4
@@ -1669,7 +1666,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114144
     u32divmod.4
     swap.1
     trace.240

--- a/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.wat
+++ b/tests/integration/expected/abi_transform_tx_kernel_get_inputs_4.wat
@@ -5,11 +5,11 @@
   (type (;3;) (func (param i32 i32 i32 i32) (result i32)))
   (type (;4;) (func (param i32 i32 i32) (result i32)))
   (type (;5;) (func (result i32)))
-  (type (;6;) (func (param i32 i32 i32 i32)))
-  (type (;7;) (func (param i32)))
-  (type (;8;) (func (param i32) (result f32)))
-  (type (;9;) (func (param f32 f32)))
-  (type (;10;) (func (param i32 i32 i32 i32 i32)))
+  (type (;6;) (func (param i32)))
+  (type (;7;) (func (param i32) (result f32)))
+  (type (;8;) (func (param f32 f32)))
+  (type (;9;) (func (param i32 i32 i32 i32 i32)))
+  (type (;10;) (func (param i32 i32 i32 i32)))
   (type (;11;) (func (param i32) (result i32)))
   (table (;0;) 2 2 funcref)
   (memory (;0;) 17)
@@ -90,7 +90,7 @@
     unreachable
   )
   (func $__rustc::__rust_alloc (;1;) (type 1) (param i32 i32) (result i32)
-    i32.const 1048648
+    i32.const 1048608
     local.get 1
     local.get 0
     call $<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
@@ -98,7 +98,7 @@
   (func $__rustc::__rust_dealloc (;2;) (type 2) (param i32 i32 i32))
   (func $__rustc::__rust_realloc (;3;) (type 3) (param i32 i32 i32 i32) (result i32)
     block ;; label = @1
-      i32.const 1048648
+      i32.const 1048608
       local.get 2
       local.get 3
       call $<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
@@ -123,7 +123,7 @@
   )
   (func $__rustc::__rust_alloc_zeroed (;4;) (type 1) (param i32 i32) (result i32)
     block ;; label = @1
-      i32.const 1048648
+      i32.const 1048608
       local.get 1
       local.get 0
       call $<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
@@ -218,14 +218,14 @@
   (func $intrinsics::mem::heap_base (;7;) (type 5) (result i32)
     unreachable
   )
-  (func $alloc::raw_vec::RawVecInner<A>::with_capacity_in (;8;) (type 6) (param i32 i32 i32 i32)
+  (func $alloc::raw_vec::RawVecInner<A>::with_capacity_in (;8;) (type 2) (param i32 i32 i32)
     (local i32)
     global.get $__stack_pointer
     i32.const 16
     i32.sub
-    local.tee 4
+    local.tee 3
     global.set $__stack_pointer
-    local.get 4
+    local.get 3
     i32.const 4
     i32.add
     i32.const 256
@@ -233,35 +233,35 @@
     local.get 1
     local.get 2
     call $alloc::raw_vec::RawVecInner<A>::try_allocate_in
-    local.get 4
+    local.get 3
     i32.load offset=8
     local.set 2
     block ;; label = @1
-      local.get 4
+      local.get 3
       i32.load offset=4
       i32.const 1
       i32.ne
       br_if 0 (;@1;)
       local.get 2
-      local.get 4
-      i32.load offset=12
       local.get 3
+      i32.load offset=12
+      i32.const 1048588
       call $alloc::raw_vec::handle_error
       unreachable
     end
     local.get 0
-    local.get 4
+    local.get 3
     i32.load offset=12
     i32.store offset=4
     local.get 0
     local.get 2
     i32.store
-    local.get 4
+    local.get 3
     i32.const 16
     i32.add
     global.set $__stack_pointer
   )
-  (func $miden_base_sys::bindings::active_note::get_inputs (;9;) (type 7) (param i32)
+  (func $miden_base_sys::bindings::active_note::get_inputs (;9;) (type 6) (param i32)
     (local i32 i32 i32)
     global.get $__stack_pointer
     i32.const 16
@@ -273,7 +273,6 @@
     i32.add
     i32.const 4
     i32.const 4
-    i32.const 1048628
     call $alloc::raw_vec::RawVecInner<A>::with_capacity_in
     local.get 1
     i32.load offset=8
@@ -297,14 +296,14 @@
     i32.add
     global.set $__stack_pointer
   )
-  (func $<miden_stdlib_sys::intrinsics::felt::Felt as core::convert::From<u32>>::from (;10;) (type 8) (param i32) (result f32)
+  (func $<miden_stdlib_sys::intrinsics::felt::Felt as core::convert::From<u32>>::from (;10;) (type 7) (param i32) (result f32)
     local.get 0
     f32.reinterpret_i32
   )
-  (func $intrinsics::felt::from_u32 (;11;) (type 8) (param i32) (result f32)
+  (func $intrinsics::felt::from_u32 (;11;) (type 7) (param i32) (result f32)
     unreachable
   )
-  (func $intrinsics::felt::assert_eq (;12;) (type 9) (param f32 f32)
+  (func $intrinsics::felt::assert_eq (;12;) (type 8) (param f32 f32)
     unreachable
   )
   (func $alloc::raw_vec::RawVecInner<A>::deallocate (;13;) (type 2) (param i32 i32 i32)
@@ -339,7 +338,7 @@
     i32.add
     global.set $__stack_pointer
   )
-  (func $alloc::raw_vec::RawVecInner<A>::try_allocate_in (;14;) (type 10) (param i32 i32 i32 i32 i32)
+  (func $alloc::raw_vec::RawVecInner<A>::try_allocate_in (;14;) (type 9) (param i32 i32 i32 i32 i32)
     (local i32 i64)
     global.get $__stack_pointer
     i32.const 16
@@ -480,7 +479,7 @@
     i32.add
     global.set $__stack_pointer
   )
-  (func $alloc::alloc::Global::alloc_impl (;16;) (type 6) (param i32 i32 i32 i32)
+  (func $alloc::alloc::Global::alloc_impl (;16;) (type 10) (param i32 i32 i32 i32)
     block ;; label = @1
       local.get 2
       i32.eqz
@@ -507,7 +506,7 @@
     local.get 1
     i32.store
   )
-  (func $alloc::raw_vec::RawVecInner<A>::current_memory (;17;) (type 6) (param i32 i32 i32 i32)
+  (func $alloc::raw_vec::RawVecInner<A>::current_memory (;17;) (type 10) (param i32 i32 i32 i32)
     (local i32 i32 i32)
     i32.const 0
     local.set 4
@@ -615,5 +614,5 @@
     end
     local.get 2
   )
-  (data $.rodata (;0;) (i32.const 1048576) "miden-base-sys-0.8.0/src/bindings/active_note.rs\00\00\00\00\00\00\10\000\00\00\00\1f\00\00\00!\00\00\00\01\00\00\00")
+  (data $.rodata (;0;) (i32.const 1048576) "<redacted>\00\00\00\00\10\00\0a\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00")
 )

--- a/tests/integration/expected/adv_load_preimage.hir
+++ b/tests/integration/expected/adv_load_preimage.hir
@@ -66,7 +66,7 @@ builtin.component root_ns:root@1.0.0 {
                 hir.assertz v153 #[code = 250];
                 v154 = hir.int_to_ptr v151 : ptr<byte, i32>;
                 v155 = hir.load v154 : i32;
-                v156 = arith.constant 1048620 : i32;
+                v156 = arith.constant 1048588 : i32;
                 hir.exec @root_ns:root@1.0.0/adv_load_preimage/alloc::raw_vec::handle_error(v46, v155, v156)
                 v516 = arith.constant 0 : u32;
                 scf.yield v516;
@@ -213,14 +213,14 @@ builtin.component root_ns:root@1.0.0 {
 
         private builtin.function @__rustc::__rust_alloc(v157: i32, v158: i32) -> i32 {
         ^block12(v157: i32, v158: i32):
-            v160 = arith.constant 1048636 : i32;
+            v160 = arith.constant 1048604 : i32;
             v161 = hir.exec @root_ns:root@1.0.0/adv_load_preimage/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v160, v158, v157) : i32
             builtin.ret v161;
         };
 
         private builtin.function @__rustc::__rust_alloc_zeroed(v162: i32, v163: i32) -> i32 {
         ^block14(v162: i32, v163: i32):
-            v165 = arith.constant 1048636 : i32;
+            v165 = arith.constant 1048604 : i32;
             v166 = hir.exec @root_ns:root@1.0.0/adv_load_preimage/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v165, v163, v162) : i32
             v566 = arith.constant 0 : i32;
             v167 = arith.constant 0 : i32;
@@ -745,6 +745,6 @@ builtin.component root_ns:root@1.0.0 {
             builtin.ret_imm 1048576;
         };
 
-        builtin.segment readonly @1048576 = 0x000000210000009700000028001000000000000073722e6d656d2f62696c6474732f6372732f312e372e302d7379732d62696c6474732d6e6564696d;
+        builtin.segment readonly @1048576 = 0x00000000000000000000000a0010000000003e64657463616465723c;
     };
 };

--- a/tests/integration/expected/adv_load_preimage.masm
+++ b/tests/integration/expected/adv_load_preimage.masm
@@ -5,24 +5,24 @@ proc init
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
-    push.[9819768856120359178,13486156918318591171,2261048595876917691,16294779277798976606]
+    push.[5069684220085911070,12575515707502338447,6750708512266443820,15471277435400365850]
     adv.push_mapval
     push.262144
-    push.4
+    push.2
     trace.240
     exec.::std::mem::pipe_preimage_to_memory
     trace.252
     drop
     push.1048576
     u32assert
-    mem_store.278544
+    mem_store.278536
 end
 
 # mod root_ns:root@1.0.0::adv_load_preimage
 
 @callconv("C")
 pub proc entrypoint(i32, felt, felt, felt, felt)
-    push.1114176
+    push.1114144
     u32divmod.4
     swap.1
     trace.240
@@ -32,7 +32,7 @@ pub proc entrypoint(i32, felt, felt, felt, felt)
     nop
     push.16
     u32wrapping_sub
-    push.1114176
+    push.1114144
     dup.1
     swap.1
     u32divmod.4
@@ -198,7 +198,7 @@ pub proc entrypoint(i32, felt, felt, felt, felt)
         exec.::intrinsics::mem::load_sw
         trace.252
         nop
-        push.1048620
+        push.1048588
         swap.2
         trace.240
         nop
@@ -450,7 +450,7 @@ pub proc entrypoint(i32, felt, felt, felt, felt)
                     push.16
                     movup.2
                     u32wrapping_add
-                    push.1114176
+                    push.1114144
                     u32divmod.4
                     swap.1
                     trace.240
@@ -478,7 +478,7 @@ end
 
 @callconv("C")
 proc __rustc::__rust_alloc(i32, i32) -> i32
-    push.1048636
+    push.1048604
     movup.2
     swap.1
     trace.240
@@ -490,7 +490,7 @@ end
 
 @callconv("C")
 proc __rustc::__rust_alloc_zeroed(i32, i32) -> i32
-    push.1048636
+    push.1048604
     dup.1
     swap.2
     swap.3
@@ -819,7 +819,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     i32,
     i32
 )
-    push.1114176
+    push.1114144
     u32divmod.4
     swap.1
     trace.240
@@ -829,7 +829,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     nop
     push.16
     u32wrapping_sub
-    push.1114176
+    push.1114144
     dup.1
     swap.1
     u32divmod.4
@@ -1214,7 +1214,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     nop
     push.16
     u32wrapping_add
-    push.1114176
+    push.1114144
     u32divmod.4
     swap.1
     trace.240
@@ -1230,7 +1230,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     i32,
     i32
 )
-    push.1114176
+    push.1114144
     u32divmod.4
     swap.1
     trace.240
@@ -1240,7 +1240,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     nop
     push.16
     u32wrapping_sub
-    push.1114176
+    push.1114144
     dup.1
     swap.1
     u32divmod.4
@@ -1333,7 +1333,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     nop
     push.16
     u32wrapping_add
-    push.1114176
+    push.1114144
     u32divmod.4
     swap.1
     trace.240

--- a/tests/integration/expected/adv_load_preimage.wat
+++ b/tests/integration/expected/adv_load_preimage.wat
@@ -127,20 +127,20 @@
       local.get 9
       local.get 5
       i32.load offset=12
-      i32.const 1048620
+      i32.const 1048588
       call $alloc::raw_vec::handle_error
     end
     unreachable
   )
   (func $__rustc::__rust_alloc (;1;) (type 1) (param i32 i32) (result i32)
-    i32.const 1048636
+    i32.const 1048604
     local.get 1
     local.get 0
     call $<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
   )
   (func $__rustc::__rust_alloc_zeroed (;2;) (type 1) (param i32 i32) (result i32)
     block ;; label = @1
-      i32.const 1048636
+      i32.const 1048604
       local.get 1
       local.get 0
       call $<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
@@ -432,5 +432,5 @@
     i32.gt_u
     select
   )
-  (data $.rodata (;0;) (i32.const 1048576) "miden-stdlib-sys-0.7.1/src/stdlib/mem.rs\00\00\00\00\00\00\10\00(\00\00\00\97\00\00\00!\00\00\00")
+  (data $.rodata (;0;) (i32.const 1048576) "<redacted>\00\00\00\00\10\00\0a\00\00\00\00\00\00\00\00\00\00\00")
 )

--- a/tests/integration/expected/examples/basic_wallet_tx_script.hir
+++ b/tests/integration/expected/examples/basic_wallet_tx_script.hir
@@ -11,119 +11,124 @@ builtin.component miden:base/transaction-script@1.0.0 {
             builtin.ret ;
         };
 
-        private builtin.function @core::slice::index::slice_end_index_len_fail(v5: i32, v6: i32, v7: i32) {
-        ^block10(v5: i32, v6: i32, v7: i32):
-            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/core::slice::<impl [T]>::copy_from_slice::len_mismatch_fail::do_panic::runtime(v5, v6, v7)
+        private builtin.function @core::slice::index::slice_end_index_len_fail(v5: i32, v6: i32) {
+        ^block10(v5: i32, v6: i32):
+            v7 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v8 = hir.bitcast v7 : ptr<byte, i32>;
+            v9 = hir.load v8 : i32;
+            v10 = arith.constant 1048600 : i32;
+            v11 = arith.add v9, v10 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/core::slice::<impl [T]>::copy_from_slice::len_mismatch_fail::do_panic::runtime(v5, v6, v11)
             ub.unreachable ;
         };
 
-        private builtin.function @<alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index(v8: i32, v9: i32, v10: i32, v11: i32, v12: i32) {
-        ^block12(v8: i32, v9: i32, v10: i32, v11: i32, v12: i32):
-            v15 = arith.constant 8 : u32;
-            v14 = hir.bitcast v9 : u32;
-            v16 = arith.add v14, v15 : u32 #[overflow = checked];
-            v17 = arith.constant 4 : u32;
-            v18 = arith.mod v16, v17 : u32;
-            hir.assertz v18 #[code = 250];
-            v19 = hir.int_to_ptr v16 : ptr<byte, i32>;
-            v20 = hir.load v19 : i32;
-            v13 = arith.constant 0 : i32;
-            v22 = hir.bitcast v20 : u32;
-            v21 = hir.bitcast v11 : u32;
-            v23 = arith.lte v21, v22 : i1;
-            v24 = arith.zext v23 : u32;
-            v25 = hir.bitcast v24 : i32;
-            v27 = arith.neq v25, v13 : i1;
-            cf.cond_br v27 ^block14, ^block15;
+        private builtin.function @<alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index(v12: i32, v13: i32, v14: i32, v15: i32) {
+        ^block12(v12: i32, v13: i32, v14: i32, v15: i32):
+            v18 = arith.constant 8 : u32;
+            v17 = hir.bitcast v13 : u32;
+            v19 = arith.add v17, v18 : u32 #[overflow = checked];
+            v20 = arith.constant 4 : u32;
+            v21 = arith.mod v19, v20 : u32;
+            hir.assertz v21 #[code = 250];
+            v22 = hir.int_to_ptr v19 : ptr<byte, i32>;
+            v23 = hir.load v22 : i32;
+            v16 = arith.constant 0 : i32;
+            v25 = hir.bitcast v23 : u32;
+            v24 = hir.bitcast v15 : u32;
+            v26 = arith.lte v24, v25 : i1;
+            v27 = arith.zext v26 : u32;
+            v28 = hir.bitcast v27 : i32;
+            v30 = arith.neq v28, v16 : i1;
+            cf.cond_br v30 ^block14, ^block15;
         ^block14:
-            v915 = arith.constant 4 : u32;
-            v29 = hir.bitcast v8 : u32;
-            v31 = arith.add v29, v915 : u32 #[overflow = checked];
-            v914 = arith.constant 4 : u32;
-            v33 = arith.mod v31, v914 : u32;
-            hir.assertz v33 #[code = 250];
-            v28 = arith.sub v11, v10 : i32 #[overflow = wrapping];
-            v34 = hir.int_to_ptr v31 : ptr<byte, i32>;
-            hir.store v34, v28;
-            v913 = arith.constant 4 : u32;
-            v35 = hir.bitcast v9 : u32;
-            v37 = arith.add v35, v913 : u32 #[overflow = checked];
-            v912 = arith.constant 4 : u32;
-            v39 = arith.mod v37, v912 : u32;
-            hir.assertz v39 #[code = 250];
-            v40 = hir.int_to_ptr v37 : ptr<byte, i32>;
-            v41 = hir.load v40 : i32;
-            v46 = hir.bitcast v8 : u32;
-            v911 = arith.constant 4 : u32;
-            v48 = arith.mod v46, v911 : u32;
-            hir.assertz v48 #[code = 250];
-            v909 = arith.constant 2 : u32;
-            v44 = arith.shl v10, v909 : i32;
-            v45 = arith.add v41, v44 : i32 #[overflow = wrapping];
-            v49 = hir.int_to_ptr v46 : ptr<byte, i32>;
-            hir.store v49, v45;
+            v908 = arith.constant 4 : u32;
+            v32 = hir.bitcast v12 : u32;
+            v34 = arith.add v32, v908 : u32 #[overflow = checked];
+            v907 = arith.constant 4 : u32;
+            v36 = arith.mod v34, v907 : u32;
+            hir.assertz v36 #[code = 250];
+            v31 = arith.sub v15, v14 : i32 #[overflow = wrapping];
+            v37 = hir.int_to_ptr v34 : ptr<byte, i32>;
+            hir.store v37, v31;
+            v906 = arith.constant 4 : u32;
+            v38 = hir.bitcast v13 : u32;
+            v40 = arith.add v38, v906 : u32 #[overflow = checked];
+            v905 = arith.constant 4 : u32;
+            v42 = arith.mod v40, v905 : u32;
+            hir.assertz v42 #[code = 250];
+            v43 = hir.int_to_ptr v40 : ptr<byte, i32>;
+            v44 = hir.load v43 : i32;
+            v49 = hir.bitcast v12 : u32;
+            v904 = arith.constant 4 : u32;
+            v51 = arith.mod v49, v904 : u32;
+            hir.assertz v51 #[code = 250];
+            v902 = arith.constant 2 : u32;
+            v47 = arith.shl v14, v902 : i32;
+            v48 = arith.add v44, v47 : i32 #[overflow = wrapping];
+            v52 = hir.int_to_ptr v49 : ptr<byte, i32>;
+            hir.store v52, v48;
             builtin.ret ;
         ^block15:
-            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/core::slice::index::slice_end_index_len_fail(v11, v20, v12)
+            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/core::slice::index::slice_end_index_len_fail(v15, v23)
             ub.unreachable ;
         };
 
-        private builtin.function @__rustc::__rust_alloc(v50: i32, v51: i32) -> i32 {
-        ^block16(v50: i32, v51: i32):
-            v53 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v54 = hir.bitcast v53 : ptr<byte, i32>;
-            v55 = hir.load v54 : i32;
-            v56 = arith.constant 1048688 : i32;
-            v57 = arith.add v55, v56 : i32 #[overflow = wrapping];
-            v58 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v57, v51, v50) : i32
-            builtin.ret v58;
+        private builtin.function @__rustc::__rust_alloc(v53: i32, v54: i32) -> i32 {
+        ^block16(v53: i32, v54: i32):
+            v56 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v57 = hir.bitcast v56 : ptr<byte, i32>;
+            v58 = hir.load v57 : i32;
+            v59 = arith.constant 1048616 : i32;
+            v60 = arith.add v58, v59 : i32 #[overflow = wrapping];
+            v61 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v60, v54, v53) : i32
+            builtin.ret v61;
         };
 
-        private builtin.function @__rustc::__rust_dealloc(v59: i32, v60: i32, v61: i32) {
-        ^block18(v59: i32, v60: i32, v61: i32):
+        private builtin.function @__rustc::__rust_dealloc(v62: i32, v63: i32, v64: i32) {
+        ^block18(v62: i32, v63: i32, v64: i32):
             builtin.ret ;
         };
 
-        private builtin.function @__rustc::__rust_alloc_zeroed(v62: i32, v63: i32) -> i32 {
-        ^block20(v62: i32, v63: i32):
-            v65 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v66 = hir.bitcast v65 : ptr<byte, i32>;
-            v67 = hir.load v66 : i32;
-            v68 = arith.constant 1048688 : i32;
-            v69 = arith.add v67, v68 : i32 #[overflow = wrapping];
-            v70 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v69, v63, v62) : i32
-            v924 = arith.constant 0 : i32;
-            v71 = arith.constant 0 : i32;
-            v72 = arith.eq v70, v71 : i1;
-            v73 = arith.zext v72 : u32;
-            v74 = hir.bitcast v73 : i32;
-            v76 = arith.neq v74, v924 : i1;
-            scf.if v76{
+        private builtin.function @__rustc::__rust_alloc_zeroed(v65: i32, v66: i32) -> i32 {
+        ^block20(v65: i32, v66: i32):
+            v68 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v69 = hir.bitcast v68 : ptr<byte, i32>;
+            v70 = hir.load v69 : i32;
+            v71 = arith.constant 1048616 : i32;
+            v72 = arith.add v70, v71 : i32 #[overflow = wrapping];
+            v73 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v72, v66, v65) : i32
+            v917 = arith.constant 0 : i32;
+            v74 = arith.constant 0 : i32;
+            v75 = arith.eq v73, v74 : i1;
+            v76 = arith.zext v75 : u32;
+            v77 = hir.bitcast v76 : i32;
+            v79 = arith.neq v77, v917 : i1;
+            scf.if v79{
             ^block22:
                 scf.yield ;
             } else {
             ^block23:
-                v922 = arith.constant 0 : i32;
-                v923 = arith.constant 0 : i32;
-                v78 = arith.eq v62, v923 : i1;
-                v79 = arith.zext v78 : u32;
-                v80 = hir.bitcast v79 : i32;
-                v82 = arith.neq v80, v922 : i1;
-                scf.if v82{
+                v915 = arith.constant 0 : i32;
+                v916 = arith.constant 0 : i32;
+                v81 = arith.eq v65, v916 : i1;
+                v82 = arith.zext v81 : u32;
+                v83 = hir.bitcast v82 : i32;
+                v85 = arith.neq v83, v915 : i1;
+                scf.if v85{
                 ^block122:
                     scf.yield ;
                 } else {
                 ^block24:
-                    v916 = arith.constant 0 : u8;
-                    v85 = hir.bitcast v62 : u32;
-                    v86 = hir.bitcast v70 : u32;
-                    v87 = hir.int_to_ptr v86 : ptr<byte, u8>;
-                    hir.mem_set v87, v85, v916;
+                    v909 = arith.constant 0 : u8;
+                    v88 = hir.bitcast v65 : u32;
+                    v89 = hir.bitcast v73 : u32;
+                    v90 = hir.int_to_ptr v89 : ptr<byte, u8>;
+                    hir.mem_set v90, v88, v909;
                     scf.yield ;
                 };
                 scf.yield ;
             };
-            builtin.ret v70;
+            builtin.ret v73;
         };
 
         private builtin.function @basic_wallet_tx_script::bindings::__link_custom_section_describing_imports() {
@@ -131,370 +136,360 @@ builtin.component miden:base/transaction-script@1.0.0 {
             builtin.ret ;
         };
 
-        private builtin.function @miden:base/transaction-script@1.0.0#run(v89: felt, v90: felt, v91: felt, v92: felt) {
-        ^block27(v89: felt, v90: felt, v91: felt, v92: felt):
-            v97 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
-            v98 = hir.bitcast v97 : ptr<byte, i32>;
-            v99 = hir.load v98 : i32;
-            v100 = arith.constant 80 : i32;
-            v101 = arith.sub v99, v100 : i32 #[overflow = wrapping];
-            v102 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
-            v103 = hir.bitcast v102 : ptr<byte, i32>;
-            hir.store v103, v101;
+        private builtin.function @miden:base/transaction-script@1.0.0#run(v92: felt, v93: felt, v94: felt, v95: felt) {
+        ^block27(v92: felt, v93: felt, v94: felt, v95: felt):
+            v100 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
+            v101 = hir.bitcast v100 : ptr<byte, i32>;
+            v102 = hir.load v101 : i32;
+            v103 = arith.constant 80 : i32;
+            v104 = arith.sub v102, v103 : i32 #[overflow = wrapping];
+            v105 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
+            v106 = hir.bitcast v105 : ptr<byte, i32>;
+            hir.store v106, v104;
             hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/wit_bindgen::rt::run_ctors_once()
-            v104 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::advice::adv_push_mapvaln(v92, v91, v90, v89) : felt
-            v105 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::felt::as_u64(v104) : i64
-            v107 = arith.constant 3 : i32;
-            v106 = arith.trunc v105 : i32;
-            v108 = arith.band v106, v107 : i32;
-            v109 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::felt::from_u32(v108) : felt
-            v93 = arith.constant 0 : i32;
-            v111 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::felt::from_u32(v93) : felt
-            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::felt::assert_eq(v109, v111)
-            v114 = arith.constant 2 : i64;
-            v116 = hir.cast v114 : u32;
-            v115 = hir.bitcast v105 : u64;
-            v117 = arith.shr v115, v116 : u64;
-            v118 = hir.bitcast v117 : i64;
-            v119 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::felt::from_u64_unchecked(v118) : felt
-            v120 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::felt::as_u64(v119) : i64
-            v926 = arith.constant 2 : u32;
-            v121 = arith.trunc v120 : i32;
-            v124 = arith.shl v121, v926 : i32;
-            v126 = arith.constant 4 : i32;
-            v1002 = arith.constant 0 : i32;
-            v112 = arith.constant 64 : i32;
-            v113 = arith.add v101, v112 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/alloc::raw_vec::RawVecInner<A>::try_allocate_in(v113, v124, v1002, v126, v126)
-            v129 = arith.constant 68 : u32;
-            v128 = hir.bitcast v101 : u32;
-            v130 = arith.add v128, v129 : u32 #[overflow = checked];
-            v131 = arith.constant 4 : u32;
-            v132 = arith.mod v130, v131 : u32;
-            hir.assertz v132 #[code = 250];
-            v133 = hir.int_to_ptr v130 : ptr<byte, i32>;
-            v134 = hir.load v133 : i32;
-            v136 = arith.constant 64 : u32;
-            v135 = hir.bitcast v101 : u32;
-            v137 = arith.add v135, v136 : u32 #[overflow = checked];
-            v1001 = arith.constant 4 : u32;
-            v139 = arith.mod v137, v1001 : u32;
-            hir.assertz v139 #[code = 250];
-            v140 = hir.int_to_ptr v137 : ptr<byte, i32>;
-            v141 = hir.load v140 : i32;
-            v1000 = arith.constant 0 : i32;
-            v142 = arith.constant 1 : i32;
-            v143 = arith.eq v141, v142 : i1;
-            v144 = arith.zext v143 : u32;
-            v145 = hir.bitcast v144 : i32;
-            v147 = arith.neq v145, v1000 : i1;
-            v931 = scf.if v147 : u32 {
+            v107 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::advice::adv_push_mapvaln(v95, v94, v93, v92) : felt
+            v108 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::felt::as_u64(v107) : i64
+            v110 = arith.constant 3 : i32;
+            v109 = arith.trunc v108 : i32;
+            v111 = arith.band v109, v110 : i32;
+            v112 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::felt::from_u32(v111) : felt
+            v96 = arith.constant 0 : i32;
+            v114 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::felt::from_u32(v96) : felt
+            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::felt::assert_eq(v112, v114)
+            v117 = arith.constant 2 : i64;
+            v119 = hir.cast v117 : u32;
+            v118 = hir.bitcast v108 : u64;
+            v120 = arith.shr v118, v119 : u64;
+            v121 = hir.bitcast v120 : i64;
+            v122 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::felt::from_u64_unchecked(v121) : felt
+            v123 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::felt::as_u64(v122) : i64
+            v919 = arith.constant 2 : u32;
+            v124 = arith.trunc v123 : i32;
+            v127 = arith.shl v124, v919 : i32;
+            v129 = arith.constant 4 : i32;
+            v995 = arith.constant 0 : i32;
+            v115 = arith.constant 64 : i32;
+            v116 = arith.add v104, v115 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/alloc::raw_vec::RawVecInner<A>::try_allocate_in(v116, v127, v995, v129, v129)
+            v132 = arith.constant 68 : u32;
+            v131 = hir.bitcast v104 : u32;
+            v133 = arith.add v131, v132 : u32 #[overflow = checked];
+            v134 = arith.constant 4 : u32;
+            v135 = arith.mod v133, v134 : u32;
+            hir.assertz v135 #[code = 250];
+            v136 = hir.int_to_ptr v133 : ptr<byte, i32>;
+            v137 = hir.load v136 : i32;
+            v139 = arith.constant 64 : u32;
+            v138 = hir.bitcast v104 : u32;
+            v140 = arith.add v138, v139 : u32 #[overflow = checked];
+            v994 = arith.constant 4 : u32;
+            v142 = arith.mod v140, v994 : u32;
+            hir.assertz v142 #[code = 250];
+            v143 = hir.int_to_ptr v140 : ptr<byte, i32>;
+            v144 = hir.load v143 : i32;
+            v993 = arith.constant 0 : i32;
+            v145 = arith.constant 1 : i32;
+            v146 = arith.eq v144, v145 : i1;
+            v147 = arith.zext v146 : u32;
+            v148 = hir.bitcast v147 : i32;
+            v150 = arith.neq v148, v993 : i1;
+            v924 = scf.if v150 : u32 {
             ^block30:
-                v368 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/GOT.data.internal.__memory_base : ptr<byte, u8>
-                v369 = hir.bitcast v368 : ptr<byte, i32>;
+                v361 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/GOT.data.internal.__memory_base : ptr<byte, u8>
+                v362 = hir.bitcast v361 : ptr<byte, i32>;
+                v363 = hir.load v362 : i32;
+                v365 = arith.constant 72 : u32;
+                v364 = hir.bitcast v104 : u32;
+                v366 = arith.add v364, v365 : u32 #[overflow = checked];
+                v992 = arith.constant 4 : u32;
+                v368 = arith.mod v366, v992 : u32;
+                hir.assertz v368 #[code = 250];
+                v369 = hir.int_to_ptr v366 : ptr<byte, i32>;
                 v370 = hir.load v369 : i32;
-                v372 = arith.constant 72 : u32;
-                v371 = hir.bitcast v101 : u32;
-                v373 = arith.add v371, v372 : u32 #[overflow = checked];
-                v999 = arith.constant 4 : u32;
-                v375 = arith.mod v373, v999 : u32;
-                hir.assertz v375 #[code = 250];
-                v376 = hir.int_to_ptr v373 : ptr<byte, i32>;
-                v377 = hir.load v376 : i32;
-                v378 = arith.constant 1048640 : i32;
-                v379 = arith.add v370, v378 : i32 #[overflow = wrapping];
-                hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/alloc::raw_vec::handle_error(v134, v377, v379)
-                v927 = arith.constant 0 : u32;
-                scf.yield v927;
+                v371 = arith.constant 1048600 : i32;
+                v372 = arith.add v363, v371 : i32 #[overflow = wrapping];
+                hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/alloc::raw_vec::handle_error(v137, v370, v372)
+                v920 = arith.constant 0 : u32;
+                scf.yield v920;
             } else {
             ^block31:
-                v998 = arith.constant 72 : u32;
-                v148 = hir.bitcast v101 : u32;
-                v150 = arith.add v148, v998 : u32 #[overflow = checked];
-                v997 = arith.constant 4 : u32;
-                v152 = arith.mod v150, v997 : u32;
-                hir.assertz v152 #[code = 250];
-                v153 = hir.int_to_ptr v150 : ptr<byte, i32>;
-                v154 = hir.load v153 : i32;
-                v996 = arith.constant 2 : u32;
-                v156 = hir.bitcast v154 : u32;
-                v158 = arith.shr v156, v996 : u32;
-                v159 = hir.bitcast v158 : i32;
-                v160 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/std::mem::pipe_preimage_to_memory(v119, v159, v92, v91, v90, v89) : i32
-                v162 = arith.constant 28 : u32;
-                v161 = hir.bitcast v101 : u32;
-                v163 = arith.add v161, v162 : u32 #[overflow = checked];
-                v995 = arith.constant 4 : u32;
-                v165 = arith.mod v163, v995 : u32;
-                hir.assertz v165 #[code = 250];
-                v166 = hir.int_to_ptr v163 : ptr<byte, i32>;
-                hir.store v166, v124;
-                v168 = arith.constant 24 : u32;
-                v167 = hir.bitcast v101 : u32;
-                v169 = arith.add v167, v168 : u32 #[overflow = checked];
-                v994 = arith.constant 4 : u32;
-                v171 = arith.mod v169, v994 : u32;
-                hir.assertz v171 #[code = 250];
-                v172 = hir.int_to_ptr v169 : ptr<byte, i32>;
-                hir.store v172, v154;
-                v174 = arith.constant 20 : u32;
-                v173 = hir.bitcast v101 : u32;
-                v175 = arith.add v173, v174 : u32 #[overflow = checked];
-                v993 = arith.constant 4 : u32;
-                v177 = arith.mod v175, v993 : u32;
-                hir.assertz v177 #[code = 250];
-                v178 = hir.int_to_ptr v175 : ptr<byte, i32>;
-                hir.store v178, v134;
-                v991 = arith.constant 0 : i32;
-                v992 = arith.constant 0 : i32;
-                v180 = arith.eq v124, v992 : i1;
-                v181 = arith.zext v180 : u32;
-                v182 = hir.bitcast v181 : i32;
-                v184 = arith.neq v182, v991 : i1;
-                v933 = scf.if v184 : u32 {
+                v991 = arith.constant 72 : u32;
+                v151 = hir.bitcast v104 : u32;
+                v153 = arith.add v151, v991 : u32 #[overflow = checked];
+                v990 = arith.constant 4 : u32;
+                v155 = arith.mod v153, v990 : u32;
+                hir.assertz v155 #[code = 250];
+                v156 = hir.int_to_ptr v153 : ptr<byte, i32>;
+                v157 = hir.load v156 : i32;
+                v989 = arith.constant 2 : u32;
+                v159 = hir.bitcast v157 : u32;
+                v161 = arith.shr v159, v989 : u32;
+                v162 = hir.bitcast v161 : i32;
+                v163 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/std::mem::pipe_preimage_to_memory(v122, v162, v95, v94, v93, v92) : i32
+                v165 = arith.constant 28 : u32;
+                v164 = hir.bitcast v104 : u32;
+                v166 = arith.add v164, v165 : u32 #[overflow = checked];
+                v988 = arith.constant 4 : u32;
+                v168 = arith.mod v166, v988 : u32;
+                hir.assertz v168 #[code = 250];
+                v169 = hir.int_to_ptr v166 : ptr<byte, i32>;
+                hir.store v169, v127;
+                v171 = arith.constant 24 : u32;
+                v170 = hir.bitcast v104 : u32;
+                v172 = arith.add v170, v171 : u32 #[overflow = checked];
+                v987 = arith.constant 4 : u32;
+                v174 = arith.mod v172, v987 : u32;
+                hir.assertz v174 #[code = 250];
+                v175 = hir.int_to_ptr v172 : ptr<byte, i32>;
+                hir.store v175, v157;
+                v177 = arith.constant 20 : u32;
+                v176 = hir.bitcast v104 : u32;
+                v178 = arith.add v176, v177 : u32 #[overflow = checked];
+                v986 = arith.constant 4 : u32;
+                v180 = arith.mod v178, v986 : u32;
+                hir.assertz v180 #[code = 250];
+                v181 = hir.int_to_ptr v178 : ptr<byte, i32>;
+                hir.store v181, v137;
+                v984 = arith.constant 0 : i32;
+                v985 = arith.constant 0 : i32;
+                v183 = arith.eq v127, v985 : i1;
+                v184 = arith.zext v183 : u32;
+                v185 = hir.bitcast v184 : i32;
+                v187 = arith.neq v185, v984 : i1;
+                v926 = scf.if v187 : u32 {
                 ^block127:
-                    v990 = arith.constant 0 : u32;
-                    scf.yield v990;
+                    v983 = arith.constant 0 : u32;
+                    scf.yield v983;
                 } else {
                 ^block32:
-                    v185 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/GOT.data.internal.__memory_base : ptr<byte, u8>
-                    v186 = hir.bitcast v185 : ptr<byte, i32>;
-                    v187 = hir.load v186 : i32;
                     v189 = arith.constant 12 : u32;
-                    v188 = hir.bitcast v154 : u32;
+                    v188 = hir.bitcast v157 : u32;
                     v190 = arith.add v188, v189 : u32 #[overflow = checked];
-                    v989 = arith.constant 4 : u32;
-                    v192 = arith.mod v190, v989 : u32;
+                    v982 = arith.constant 4 : u32;
+                    v192 = arith.mod v190, v982 : u32;
                     hir.assertz v192 #[code = 250];
                     v193 = hir.int_to_ptr v190 : ptr<byte, felt>;
                     v194 = hir.load v193 : felt;
                     v196 = arith.constant 8 : u32;
-                    v195 = hir.bitcast v154 : u32;
+                    v195 = hir.bitcast v157 : u32;
                     v197 = arith.add v195, v196 : u32 #[overflow = checked];
-                    v988 = arith.constant 4 : u32;
-                    v199 = arith.mod v197, v988 : u32;
+                    v981 = arith.constant 4 : u32;
+                    v199 = arith.mod v197, v981 : u32;
                     hir.assertz v199 #[code = 250];
                     v200 = hir.int_to_ptr v197 : ptr<byte, felt>;
                     v201 = hir.load v200 : felt;
-                    v987 = arith.constant 4 : u32;
-                    v202 = hir.bitcast v154 : u32;
-                    v204 = arith.add v202, v987 : u32 #[overflow = checked];
-                    v986 = arith.constant 4 : u32;
-                    v206 = arith.mod v204, v986 : u32;
+                    v980 = arith.constant 4 : u32;
+                    v202 = hir.bitcast v157 : u32;
+                    v204 = arith.add v202, v980 : u32 #[overflow = checked];
+                    v979 = arith.constant 4 : u32;
+                    v206 = arith.mod v204, v979 : u32;
                     hir.assertz v206 #[code = 250];
                     v207 = hir.int_to_ptr v204 : ptr<byte, felt>;
                     v208 = hir.load v207 : felt;
-                    v209 = hir.bitcast v154 : u32;
-                    v985 = arith.constant 4 : u32;
-                    v211 = arith.mod v209, v985 : u32;
+                    v209 = hir.bitcast v157 : u32;
+                    v978 = arith.constant 4 : u32;
+                    v211 = arith.mod v209, v978 : u32;
                     hir.assertz v211 #[code = 250];
                     v212 = hir.int_to_ptr v209 : ptr<byte, felt>;
                     v213 = hir.load v212 : felt;
-                    v220 = arith.constant 1048656 : i32;
-                    v221 = arith.add v187, v220 : i32 #[overflow = wrapping];
-                    v983 = arith.constant 8 : i32;
-                    v984 = arith.constant 4 : i32;
+                    v976 = arith.constant 8 : i32;
+                    v977 = arith.constant 4 : i32;
                     v216 = arith.constant 20 : i32;
-                    v217 = arith.add v101, v216 : i32 #[overflow = wrapping];
+                    v217 = arith.add v104, v216 : i32 #[overflow = wrapping];
                     v214 = arith.constant 8 : i32;
-                    v215 = arith.add v101, v214 : i32 #[overflow = wrapping];
-                    hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index(v215, v217, v984, v983, v221)
-                    v982 = arith.constant 12 : u32;
-                    v222 = hir.bitcast v101 : u32;
-                    v224 = arith.add v222, v982 : u32 #[overflow = checked];
-                    v981 = arith.constant 4 : u32;
-                    v226 = arith.mod v224, v981 : u32;
-                    hir.assertz v226 #[code = 250];
-                    v227 = hir.int_to_ptr v224 : ptr<byte, i32>;
-                    v228 = hir.load v227 : i32;
-                    v979 = arith.constant 0 : i32;
-                    v980 = arith.constant 4 : i32;
-                    v230 = arith.neq v228, v980 : i1;
-                    v231 = arith.zext v230 : u32;
-                    v232 = hir.bitcast v231 : i32;
-                    v234 = arith.neq v232, v979 : i1;
-                    v935 = scf.if v234 : u32 {
+                    v215 = arith.add v104, v214 : i32 #[overflow = wrapping];
+                    hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index(v215, v217, v977, v976)
+                    v975 = arith.constant 12 : u32;
+                    v220 = hir.bitcast v104 : u32;
+                    v222 = arith.add v220, v975 : u32 #[overflow = checked];
+                    v974 = arith.constant 4 : u32;
+                    v224 = arith.mod v222, v974 : u32;
+                    hir.assertz v224 #[code = 250];
+                    v225 = hir.int_to_ptr v222 : ptr<byte, i32>;
+                    v226 = hir.load v225 : i32;
+                    v972 = arith.constant 0 : i32;
+                    v973 = arith.constant 4 : i32;
+                    v228 = arith.neq v226, v973 : i1;
+                    v229 = arith.zext v228 : u32;
+                    v230 = hir.bitcast v229 : i32;
+                    v232 = arith.neq v230, v972 : i1;
+                    v928 = scf.if v232 : u32 {
                     ^block126:
-                        v978 = arith.constant 0 : u32;
-                        scf.yield v978;
+                        v971 = arith.constant 0 : u32;
+                        scf.yield v971;
                     } else {
                     ^block33:
-                        v977 = arith.constant 8 : u32;
-                        v235 = hir.bitcast v101 : u32;
-                        v237 = arith.add v235, v977 : u32 #[overflow = checked];
-                        v976 = arith.constant 4 : u32;
-                        v239 = arith.mod v237, v976 : u32;
-                        hir.assertz v239 #[code = 250];
-                        v240 = hir.int_to_ptr v237 : ptr<byte, i32>;
-                        v241 = hir.load v240 : i32;
-                        v242 = hir.bitcast v241 : u32;
-                        v975 = arith.constant 4 : u32;
-                        v244 = arith.mod v242, v975 : u32;
-                        hir.assertz v244 #[code = 250];
-                        v245 = hir.int_to_ptr v242 : ptr<byte, i64>;
-                        v246 = hir.load v245 : i64;
-                        v974 = arith.constant 8 : i32;
-                        v252 = arith.add v241, v974 : i32 #[overflow = wrapping];
-                        v253 = hir.bitcast v252 : u32;
-                        v973 = arith.constant 4 : u32;
-                        v255 = arith.mod v253, v973 : u32;
-                        hir.assertz v255 #[code = 250];
-                        v256 = hir.int_to_ptr v253 : ptr<byte, i64>;
-                        v257 = hir.load v256 : i64;
-                        v972 = arith.constant 8 : i32;
-                        v247 = arith.constant 32 : i32;
-                        v248 = arith.add v101, v247 : i32 #[overflow = wrapping];
-                        v250 = arith.add v248, v972 : i32 #[overflow = wrapping];
-                        v258 = hir.bitcast v250 : u32;
-                        v971 = arith.constant 8 : u32;
-                        v260 = arith.mod v258, v971 : u32;
-                        hir.assertz v260 #[code = 250];
-                        v261 = hir.int_to_ptr v258 : ptr<byte, i64>;
-                        hir.store v261, v257;
-                        v263 = arith.constant 32 : u32;
-                        v262 = hir.bitcast v101 : u32;
-                        v264 = arith.add v262, v263 : u32 #[overflow = checked];
                         v970 = arith.constant 8 : u32;
-                        v266 = arith.mod v264, v970 : u32;
-                        hir.assertz v266 #[code = 250];
-                        v267 = hir.int_to_ptr v264 : ptr<byte, i64>;
-                        hir.store v267, v246;
-                        v268 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/GOT.data.internal.__memory_base : ptr<byte, u8>
-                        v269 = hir.bitcast v268 : ptr<byte, i32>;
-                        v270 = hir.load v269 : i32;
-                        v968 = arith.constant 32 : i32;
-                        v274 = arith.add v101, v968 : i32 #[overflow = wrapping];
-                        v969 = arith.constant 64 : i32;
-                        v272 = arith.add v101, v969 : i32 #[overflow = wrapping];
-                        hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<miden_base_sys::bindings::types::Asset as core::convert::From<[miden_stdlib_sys::intrinsics::felt::Felt; 4]>>::from(v272, v274)
-                        v967 = arith.constant 64 : i32;
-                        v276 = arith.add v101, v967 : i32 #[overflow = wrapping];
-                        v277 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/miden_base_sys::bindings::output_note::create(v213, v208, v201, v194, v276) : felt
-                        v282 = arith.constant 1048672 : i32;
-                        v283 = arith.add v270, v282 : i32 #[overflow = wrapping];
-                        v281 = arith.constant 12 : i32;
+                        v233 = hir.bitcast v104 : u32;
+                        v235 = arith.add v233, v970 : u32 #[overflow = checked];
+                        v969 = arith.constant 4 : u32;
+                        v237 = arith.mod v235, v969 : u32;
+                        hir.assertz v237 #[code = 250];
+                        v238 = hir.int_to_ptr v235 : ptr<byte, i32>;
+                        v239 = hir.load v238 : i32;
+                        v240 = hir.bitcast v239 : u32;
+                        v968 = arith.constant 4 : u32;
+                        v242 = arith.mod v240, v968 : u32;
+                        hir.assertz v242 #[code = 250];
+                        v243 = hir.int_to_ptr v240 : ptr<byte, i64>;
+                        v244 = hir.load v243 : i64;
+                        v967 = arith.constant 8 : i32;
+                        v250 = arith.add v239, v967 : i32 #[overflow = wrapping];
+                        v251 = hir.bitcast v250 : u32;
+                        v966 = arith.constant 4 : u32;
+                        v253 = arith.mod v251, v966 : u32;
+                        hir.assertz v253 #[code = 250];
+                        v254 = hir.int_to_ptr v251 : ptr<byte, i64>;
+                        v255 = hir.load v254 : i64;
                         v965 = arith.constant 8 : i32;
-                        v966 = arith.constant 20 : i32;
-                        v279 = arith.add v101, v966 : i32 #[overflow = wrapping];
-                        hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index(v101, v279, v965, v281, v283)
-                        v964 = arith.constant 4 : u32;
-                        v284 = hir.bitcast v101 : u32;
-                        v286 = arith.add v284, v964 : u32 #[overflow = checked];
-                        v963 = arith.constant 4 : u32;
-                        v288 = arith.mod v286, v963 : u32;
-                        hir.assertz v288 #[code = 250];
-                        v289 = hir.int_to_ptr v286 : ptr<byte, i32>;
-                        v290 = hir.load v289 : i32;
-                        v961 = arith.constant 0 : i32;
-                        v962 = arith.constant 4 : i32;
-                        v292 = arith.neq v290, v962 : i1;
-                        v293 = arith.zext v292 : u32;
-                        v294 = hir.bitcast v293 : i32;
-                        v296 = arith.neq v294, v961 : i1;
-                        scf.if v296{
+                        v245 = arith.constant 32 : i32;
+                        v246 = arith.add v104, v245 : i32 #[overflow = wrapping];
+                        v248 = arith.add v246, v965 : i32 #[overflow = wrapping];
+                        v256 = hir.bitcast v248 : u32;
+                        v964 = arith.constant 8 : u32;
+                        v258 = arith.mod v256, v964 : u32;
+                        hir.assertz v258 #[code = 250];
+                        v259 = hir.int_to_ptr v256 : ptr<byte, i64>;
+                        hir.store v259, v255;
+                        v261 = arith.constant 32 : u32;
+                        v260 = hir.bitcast v104 : u32;
+                        v262 = arith.add v260, v261 : u32 #[overflow = checked];
+                        v963 = arith.constant 8 : u32;
+                        v264 = arith.mod v262, v963 : u32;
+                        hir.assertz v264 #[code = 250];
+                        v265 = hir.int_to_ptr v262 : ptr<byte, i64>;
+                        hir.store v265, v244;
+                        v961 = arith.constant 32 : i32;
+                        v269 = arith.add v104, v961 : i32 #[overflow = wrapping];
+                        v962 = arith.constant 64 : i32;
+                        v267 = arith.add v104, v962 : i32 #[overflow = wrapping];
+                        hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<miden_base_sys::bindings::types::Asset as core::convert::From<[miden_stdlib_sys::intrinsics::felt::Felt; 4]>>::from(v267, v269)
+                        v960 = arith.constant 64 : i32;
+                        v271 = arith.add v104, v960 : i32 #[overflow = wrapping];
+                        v272 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/miden_base_sys::bindings::output_note::create(v213, v208, v201, v194, v271) : felt
+                        v276 = arith.constant 12 : i32;
+                        v958 = arith.constant 8 : i32;
+                        v959 = arith.constant 20 : i32;
+                        v274 = arith.add v104, v959 : i32 #[overflow = wrapping];
+                        hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index(v104, v274, v958, v276)
+                        v957 = arith.constant 4 : u32;
+                        v277 = hir.bitcast v104 : u32;
+                        v279 = arith.add v277, v957 : u32 #[overflow = checked];
+                        v956 = arith.constant 4 : u32;
+                        v281 = arith.mod v279, v956 : u32;
+                        hir.assertz v281 #[code = 250];
+                        v282 = hir.int_to_ptr v279 : ptr<byte, i32>;
+                        v283 = hir.load v282 : i32;
+                        v954 = arith.constant 0 : i32;
+                        v955 = arith.constant 4 : i32;
+                        v285 = arith.neq v283, v955 : i1;
+                        v286 = arith.zext v285 : u32;
+                        v287 = hir.bitcast v286 : i32;
+                        v289 = arith.neq v287, v954 : i1;
+                        scf.if v289{
                         ^block125:
                             scf.yield ;
                         } else {
                         ^block34:
-                            v297 = hir.bitcast v101 : u32;
-                            v960 = arith.constant 4 : u32;
-                            v299 = arith.mod v297, v960 : u32;
-                            hir.assertz v299 #[code = 250];
-                            v300 = hir.int_to_ptr v297 : ptr<byte, i32>;
-                            v301 = hir.load v300 : i32;
-                            v302 = hir.bitcast v301 : u32;
-                            v959 = arith.constant 4 : u32;
-                            v304 = arith.mod v302, v959 : u32;
-                            hir.assertz v304 #[code = 250];
-                            v305 = hir.int_to_ptr v302 : ptr<byte, i64>;
-                            v306 = hir.load v305 : i64;
-                            v958 = arith.constant 8 : i32;
-                            v312 = arith.add v301, v958 : i32 #[overflow = wrapping];
-                            v313 = hir.bitcast v312 : u32;
-                            v957 = arith.constant 4 : u32;
-                            v315 = arith.mod v313, v957 : u32;
-                            hir.assertz v315 #[code = 250];
-                            v316 = hir.int_to_ptr v313 : ptr<byte, i64>;
-                            v317 = hir.load v316 : i64;
-                            v956 = arith.constant 8 : i32;
-                            v307 = arith.constant 48 : i32;
-                            v308 = arith.add v101, v307 : i32 #[overflow = wrapping];
-                            v310 = arith.add v308, v956 : i32 #[overflow = wrapping];
-                            v318 = hir.bitcast v310 : u32;
-                            v955 = arith.constant 8 : u32;
-                            v320 = arith.mod v318, v955 : u32;
-                            hir.assertz v320 #[code = 250];
-                            v321 = hir.int_to_ptr v318 : ptr<byte, i64>;
-                            hir.store v321, v317;
-                            v323 = arith.constant 48 : u32;
-                            v322 = hir.bitcast v101 : u32;
-                            v324 = arith.add v322, v323 : u32 #[overflow = checked];
-                            v954 = arith.constant 8 : u32;
-                            v326 = arith.mod v324, v954 : u32;
-                            hir.assertz v326 #[code = 250];
-                            v327 = hir.int_to_ptr v324 : ptr<byte, i64>;
-                            hir.store v327, v306;
-                            v952 = arith.constant 48 : i32;
-                            v331 = arith.add v101, v952 : i32 #[overflow = wrapping];
-                            v953 = arith.constant 64 : i32;
-                            v329 = arith.add v101, v953 : i32 #[overflow = wrapping];
-                            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<miden_base_sys::bindings::types::Asset as core::convert::From<[miden_stdlib_sys::intrinsics::felt::Felt; 4]>>::from(v329, v331)
-                            v951 = arith.constant 64 : u32;
-                            v332 = hir.bitcast v101 : u32;
-                            v334 = arith.add v332, v951 : u32 #[overflow = checked];
+                            v290 = hir.bitcast v104 : u32;
+                            v953 = arith.constant 4 : u32;
+                            v292 = arith.mod v290, v953 : u32;
+                            hir.assertz v292 #[code = 250];
+                            v293 = hir.int_to_ptr v290 : ptr<byte, i32>;
+                            v294 = hir.load v293 : i32;
+                            v295 = hir.bitcast v294 : u32;
+                            v952 = arith.constant 4 : u32;
+                            v297 = arith.mod v295, v952 : u32;
+                            hir.assertz v297 #[code = 250];
+                            v298 = hir.int_to_ptr v295 : ptr<byte, i64>;
+                            v299 = hir.load v298 : i64;
+                            v951 = arith.constant 8 : i32;
+                            v305 = arith.add v294, v951 : i32 #[overflow = wrapping];
+                            v306 = hir.bitcast v305 : u32;
                             v950 = arith.constant 4 : u32;
-                            v336 = arith.mod v334, v950 : u32;
+                            v308 = arith.mod v306, v950 : u32;
+                            hir.assertz v308 #[code = 250];
+                            v309 = hir.int_to_ptr v306 : ptr<byte, i64>;
+                            v310 = hir.load v309 : i64;
+                            v949 = arith.constant 8 : i32;
+                            v300 = arith.constant 48 : i32;
+                            v301 = arith.add v104, v300 : i32 #[overflow = wrapping];
+                            v303 = arith.add v301, v949 : i32 #[overflow = wrapping];
+                            v311 = hir.bitcast v303 : u32;
+                            v948 = arith.constant 8 : u32;
+                            v313 = arith.mod v311, v948 : u32;
+                            hir.assertz v313 #[code = 250];
+                            v314 = hir.int_to_ptr v311 : ptr<byte, i64>;
+                            hir.store v314, v310;
+                            v316 = arith.constant 48 : u32;
+                            v315 = hir.bitcast v104 : u32;
+                            v317 = arith.add v315, v316 : u32 #[overflow = checked];
+                            v947 = arith.constant 8 : u32;
+                            v319 = arith.mod v317, v947 : u32;
+                            hir.assertz v319 #[code = 250];
+                            v320 = hir.int_to_ptr v317 : ptr<byte, i64>;
+                            hir.store v320, v299;
+                            v945 = arith.constant 48 : i32;
+                            v324 = arith.add v104, v945 : i32 #[overflow = wrapping];
+                            v946 = arith.constant 64 : i32;
+                            v322 = arith.add v104, v946 : i32 #[overflow = wrapping];
+                            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<miden_base_sys::bindings::types::Asset as core::convert::From<[miden_stdlib_sys::intrinsics::felt::Felt; 4]>>::from(v322, v324)
+                            v944 = arith.constant 64 : u32;
+                            v325 = hir.bitcast v104 : u32;
+                            v327 = arith.add v325, v944 : u32 #[overflow = checked];
+                            v943 = arith.constant 4 : u32;
+                            v329 = arith.mod v327, v943 : u32;
+                            hir.assertz v329 #[code = 250];
+                            v330 = hir.int_to_ptr v327 : ptr<byte, felt>;
+                            v331 = hir.load v330 : felt;
+                            v942 = arith.constant 68 : u32;
+                            v332 = hir.bitcast v104 : u32;
+                            v334 = arith.add v332, v942 : u32 #[overflow = checked];
+                            v941 = arith.constant 4 : u32;
+                            v336 = arith.mod v334, v941 : u32;
                             hir.assertz v336 #[code = 250];
                             v337 = hir.int_to_ptr v334 : ptr<byte, felt>;
                             v338 = hir.load v337 : felt;
-                            v949 = arith.constant 68 : u32;
-                            v339 = hir.bitcast v101 : u32;
-                            v341 = arith.add v339, v949 : u32 #[overflow = checked];
-                            v948 = arith.constant 4 : u32;
-                            v343 = arith.mod v341, v948 : u32;
+                            v940 = arith.constant 72 : u32;
+                            v339 = hir.bitcast v104 : u32;
+                            v341 = arith.add v339, v940 : u32 #[overflow = checked];
+                            v939 = arith.constant 4 : u32;
+                            v343 = arith.mod v341, v939 : u32;
                             hir.assertz v343 #[code = 250];
                             v344 = hir.int_to_ptr v341 : ptr<byte, felt>;
                             v345 = hir.load v344 : felt;
-                            v947 = arith.constant 72 : u32;
-                            v346 = hir.bitcast v101 : u32;
-                            v348 = arith.add v346, v947 : u32 #[overflow = checked];
-                            v946 = arith.constant 4 : u32;
-                            v350 = arith.mod v348, v946 : u32;
+                            v347 = arith.constant 76 : u32;
+                            v346 = hir.bitcast v104 : u32;
+                            v348 = arith.add v346, v347 : u32 #[overflow = checked];
+                            v938 = arith.constant 4 : u32;
+                            v350 = arith.mod v348, v938 : u32;
                             hir.assertz v350 #[code = 250];
                             v351 = hir.int_to_ptr v348 : ptr<byte, felt>;
                             v352 = hir.load v351 : felt;
-                            v354 = arith.constant 76 : u32;
-                            v353 = hir.bitcast v101 : u32;
-                            v355 = arith.add v353, v354 : u32 #[overflow = checked];
-                            v945 = arith.constant 4 : u32;
-                            v357 = arith.mod v355, v945 : u32;
-                            hir.assertz v357 #[code = 250];
-                            v358 = hir.int_to_ptr v355 : ptr<byte, felt>;
-                            v359 = hir.load v358 : felt;
-                            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/basic_wallet_tx_script::bindings::miden::basic_wallet::basic_wallet::move_asset_to_note::wit_import9(v338, v345, v352, v359, v277)
-                            v943 = arith.constant 4 : i32;
-                            v944 = arith.constant 20 : i32;
-                            v361 = arith.add v101, v944 : i32 #[overflow = wrapping];
-                            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/alloc::raw_vec::RawVecInner<A>::deallocate(v361, v943, v943)
-                            v942 = arith.constant 80 : i32;
-                            v365 = arith.add v101, v942 : i32 #[overflow = wrapping];
-                            v366 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
-                            v367 = hir.bitcast v366 : ptr<byte, i32>;
-                            hir.store v367, v365;
+                            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/basic_wallet_tx_script::bindings::miden::basic_wallet::basic_wallet::move_asset_to_note::wit_import9(v331, v338, v345, v352, v272)
+                            v936 = arith.constant 4 : i32;
+                            v937 = arith.constant 20 : i32;
+                            v354 = arith.add v104, v937 : i32 #[overflow = wrapping];
+                            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/alloc::raw_vec::RawVecInner<A>::deallocate(v354, v936, v936)
+                            v935 = arith.constant 80 : i32;
+                            v358 = arith.add v104, v935 : i32 #[overflow = wrapping];
+                            v359 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
+                            v360 = hir.bitcast v359 : ptr<byte, i32>;
+                            hir.store v360, v358;
                             scf.yield ;
                         };
-                        v929 = arith.constant 1 : u32;
-                        v941 = arith.constant 0 : u32;
-                        v939 = cf.select v296, v941, v929 : u32;
-                        scf.yield v939;
+                        v922 = arith.constant 1 : u32;
+                        v934 = arith.constant 0 : u32;
+                        v932 = cf.select v289, v934, v922 : u32;
+                        scf.yield v932;
                     };
-                    scf.yield v935;
+                    scf.yield v928;
                 };
-                scf.yield v933;
+                scf.yield v926;
             };
-            v940 = arith.constant 0 : u32;
-            v938 = arith.eq v931, v940 : i1;
-            cf.cond_br v938 ^block29, ^block129;
+            v933 = arith.constant 0 : u32;
+            v931 = arith.eq v924, v933 : i1;
+            cf.cond_br v931 ^block29, ^block129;
         ^block29:
             ub.unreachable ;
         ^block129:
@@ -508,747 +503,747 @@ builtin.component miden:base/transaction-script@1.0.0 {
 
         private builtin.function @wit_bindgen::rt::run_ctors_once() {
         ^block37:
-            v381 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v382 = hir.bitcast v381 : ptr<byte, i32>;
-            v383 = hir.load v382 : i32;
-            v384 = arith.constant 1048692 : i32;
-            v385 = arith.add v383, v384 : i32 #[overflow = wrapping];
-            v386 = hir.bitcast v385 : u32;
-            v387 = hir.int_to_ptr v386 : ptr<byte, u8>;
-            v388 = hir.load v387 : u8;
-            v380 = arith.constant 0 : i32;
-            v389 = arith.zext v388 : u32;
-            v390 = hir.bitcast v389 : i32;
-            v392 = arith.neq v390, v380 : i1;
-            scf.if v392{
+            v374 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v375 = hir.bitcast v374 : ptr<byte, i32>;
+            v376 = hir.load v375 : i32;
+            v377 = arith.constant 1048620 : i32;
+            v378 = arith.add v376, v377 : i32 #[overflow = wrapping];
+            v379 = hir.bitcast v378 : u32;
+            v380 = hir.int_to_ptr v379 : ptr<byte, u8>;
+            v381 = hir.load v380 : u8;
+            v373 = arith.constant 0 : i32;
+            v382 = arith.zext v381 : u32;
+            v383 = hir.bitcast v382 : i32;
+            v385 = arith.neq v383, v373 : i1;
+            scf.if v385{
             ^block39:
                 scf.yield ;
             } else {
             ^block40:
-                v393 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/GOT.data.internal.__memory_base : ptr<byte, u8>
-                v394 = hir.bitcast v393 : ptr<byte, i32>;
-                v395 = hir.load v394 : i32;
+                v386 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/GOT.data.internal.__memory_base : ptr<byte, u8>
+                v387 = hir.bitcast v386 : ptr<byte, i32>;
+                v388 = hir.load v387 : i32;
                 hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__wasm_call_ctors()
-                v1004 = arith.constant 1 : u8;
-                v1006 = arith.constant 1048692 : i32;
-                v397 = arith.add v395, v1006 : i32 #[overflow = wrapping];
-                v401 = hir.bitcast v397 : u32;
-                v402 = hir.int_to_ptr v401 : ptr<byte, u8>;
-                hir.store v402, v1004;
+                v997 = arith.constant 1 : u8;
+                v999 = arith.constant 1048620 : i32;
+                v390 = arith.add v388, v999 : i32 #[overflow = wrapping];
+                v394 = hir.bitcast v390 : u32;
+                v395 = hir.int_to_ptr v394 : ptr<byte, u8>;
+                hir.store v395, v997;
                 scf.yield ;
             };
             builtin.ret ;
         };
 
-        private builtin.function @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v403: i32, v404: i32, v405: i32) -> i32 {
-        ^block41(v403: i32, v404: i32, v405: i32):
-            v408 = arith.constant 16 : i32;
-            v407 = arith.constant 0 : i32;
-            v1008 = arith.constant 16 : u32;
-            v410 = hir.bitcast v404 : u32;
-            v412 = arith.gt v410, v1008 : i1;
-            v413 = arith.zext v412 : u32;
-            v414 = hir.bitcast v413 : i32;
-            v416 = arith.neq v414, v407 : i1;
-            v417 = cf.select v416, v404, v408 : i32;
-            v1048 = arith.constant 0 : i32;
-            v418 = arith.constant -1 : i32;
-            v419 = arith.add v417, v418 : i32 #[overflow = wrapping];
-            v420 = arith.band v417, v419 : i32;
-            v422 = arith.neq v420, v1048 : i1;
-            v1017, v1018 = scf.if v422 : i32, u32 {
+        private builtin.function @<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v396: i32, v397: i32, v398: i32) -> i32 {
+        ^block41(v396: i32, v397: i32, v398: i32):
+            v401 = arith.constant 16 : i32;
+            v400 = arith.constant 0 : i32;
+            v1001 = arith.constant 16 : u32;
+            v403 = hir.bitcast v397 : u32;
+            v405 = arith.gt v403, v1001 : i1;
+            v406 = arith.zext v405 : u32;
+            v407 = hir.bitcast v406 : i32;
+            v409 = arith.neq v407, v400 : i1;
+            v410 = cf.select v409, v397, v401 : i32;
+            v1041 = arith.constant 0 : i32;
+            v411 = arith.constant -1 : i32;
+            v412 = arith.add v410, v411 : i32 #[overflow = wrapping];
+            v413 = arith.band v410, v412 : i32;
+            v415 = arith.neq v413, v1041 : i1;
+            v1010, v1011 = scf.if v415 : i32, u32 {
             ^block137:
-                v1009 = arith.constant 0 : u32;
-                v1013 = ub.poison i32 : i32;
-                scf.yield v1013, v1009;
+                v1002 = arith.constant 0 : u32;
+                v1006 = ub.poison i32 : i32;
+                scf.yield v1006, v1002;
             } else {
             ^block44:
-                v424 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/core::ptr::alignment::Alignment::max(v404, v417) : i32
-                v1047 = arith.constant 0 : i32;
-                v423 = arith.constant -2147483648 : i32;
-                v425 = arith.sub v423, v424 : i32 #[overflow = wrapping];
-                v427 = hir.bitcast v425 : u32;
-                v426 = hir.bitcast v405 : u32;
-                v428 = arith.gt v426, v427 : i1;
-                v429 = arith.zext v428 : u32;
-                v430 = hir.bitcast v429 : i32;
-                v432 = arith.neq v430, v1047 : i1;
-                v1032 = scf.if v432 : i32 {
+                v417 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/core::ptr::alignment::Alignment::max(v397, v410) : i32
+                v1040 = arith.constant 0 : i32;
+                v416 = arith.constant -2147483648 : i32;
+                v418 = arith.sub v416, v417 : i32 #[overflow = wrapping];
+                v420 = hir.bitcast v418 : u32;
+                v419 = hir.bitcast v398 : u32;
+                v421 = arith.gt v419, v420 : i1;
+                v422 = arith.zext v421 : u32;
+                v423 = hir.bitcast v422 : i32;
+                v425 = arith.neq v423, v1040 : i1;
+                v1025 = scf.if v425 : i32 {
                 ^block136:
-                    v1046 = ub.poison i32 : i32;
-                    scf.yield v1046;
+                    v1039 = ub.poison i32 : i32;
+                    scf.yield v1039;
                 } else {
                 ^block45:
-                    v1044 = arith.constant 0 : i32;
-                    v438 = arith.sub v1044, v424 : i32 #[overflow = wrapping];
-                    v1045 = arith.constant -1 : i32;
-                    v434 = arith.add v405, v424 : i32 #[overflow = wrapping];
-                    v436 = arith.add v434, v1045 : i32 #[overflow = wrapping];
-                    v439 = arith.band v436, v438 : i32;
-                    v440 = hir.bitcast v403 : u32;
-                    v441 = arith.constant 4 : u32;
-                    v442 = arith.mod v440, v441 : u32;
-                    hir.assertz v442 #[code = 250];
-                    v443 = hir.int_to_ptr v440 : ptr<byte, i32>;
-                    v444 = hir.load v443 : i32;
-                    v1043 = arith.constant 0 : i32;
-                    v446 = arith.neq v444, v1043 : i1;
-                    scf.if v446{
+                    v1037 = arith.constant 0 : i32;
+                    v431 = arith.sub v1037, v417 : i32 #[overflow = wrapping];
+                    v1038 = arith.constant -1 : i32;
+                    v427 = arith.add v398, v417 : i32 #[overflow = wrapping];
+                    v429 = arith.add v427, v1038 : i32 #[overflow = wrapping];
+                    v432 = arith.band v429, v431 : i32;
+                    v433 = hir.bitcast v396 : u32;
+                    v434 = arith.constant 4 : u32;
+                    v435 = arith.mod v433, v434 : u32;
+                    hir.assertz v435 #[code = 250];
+                    v436 = hir.int_to_ptr v433 : ptr<byte, i32>;
+                    v437 = hir.load v436 : i32;
+                    v1036 = arith.constant 0 : i32;
+                    v439 = arith.neq v437, v1036 : i1;
+                    scf.if v439{
                     ^block135:
                         scf.yield ;
                     } else {
                     ^block47:
-                        v447 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::mem::heap_base() : i32
-                        v448 = hir.mem_size  : u32;
-                        v454 = hir.bitcast v403 : u32;
-                        v1042 = arith.constant 4 : u32;
-                        v456 = arith.mod v454, v1042 : u32;
-                        hir.assertz v456 #[code = 250];
-                        v1041 = arith.constant 16 : u32;
-                        v449 = hir.bitcast v448 : i32;
-                        v452 = arith.shl v449, v1041 : i32;
-                        v453 = arith.add v447, v452 : i32 #[overflow = wrapping];
-                        v457 = hir.int_to_ptr v454 : ptr<byte, i32>;
-                        hir.store v457, v453;
+                        v440 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/intrinsics::mem::heap_base() : i32
+                        v441 = hir.mem_size  : u32;
+                        v447 = hir.bitcast v396 : u32;
+                        v1035 = arith.constant 4 : u32;
+                        v449 = arith.mod v447, v1035 : u32;
+                        hir.assertz v449 #[code = 250];
+                        v1034 = arith.constant 16 : u32;
+                        v442 = hir.bitcast v441 : i32;
+                        v445 = arith.shl v442, v1034 : i32;
+                        v446 = arith.add v440, v445 : i32 #[overflow = wrapping];
+                        v450 = hir.int_to_ptr v447 : ptr<byte, i32>;
+                        hir.store v450, v446;
                         scf.yield ;
                     };
-                    v460 = hir.bitcast v403 : u32;
-                    v1040 = arith.constant 4 : u32;
-                    v462 = arith.mod v460, v1040 : u32;
-                    hir.assertz v462 #[code = 250];
-                    v463 = hir.int_to_ptr v460 : ptr<byte, i32>;
-                    v464 = hir.load v463 : i32;
-                    v1038 = arith.constant 0 : i32;
-                    v1039 = arith.constant -1 : i32;
-                    v466 = arith.bxor v464, v1039 : i32;
-                    v468 = hir.bitcast v466 : u32;
-                    v467 = hir.bitcast v439 : u32;
-                    v469 = arith.gt v467, v468 : i1;
-                    v470 = arith.zext v469 : u32;
-                    v471 = hir.bitcast v470 : i32;
-                    v473 = arith.neq v471, v1038 : i1;
-                    v1031 = scf.if v473 : i32 {
+                    v453 = hir.bitcast v396 : u32;
+                    v1033 = arith.constant 4 : u32;
+                    v455 = arith.mod v453, v1033 : u32;
+                    hir.assertz v455 #[code = 250];
+                    v456 = hir.int_to_ptr v453 : ptr<byte, i32>;
+                    v457 = hir.load v456 : i32;
+                    v1031 = arith.constant 0 : i32;
+                    v1032 = arith.constant -1 : i32;
+                    v459 = arith.bxor v457, v1032 : i32;
+                    v461 = hir.bitcast v459 : u32;
+                    v460 = hir.bitcast v432 : u32;
+                    v462 = arith.gt v460, v461 : i1;
+                    v463 = arith.zext v462 : u32;
+                    v464 = hir.bitcast v463 : i32;
+                    v466 = arith.neq v464, v1031 : i1;
+                    v1024 = scf.if v466 : i32 {
                     ^block48:
-                        v1037 = arith.constant 0 : i32;
-                        scf.yield v1037;
+                        v1030 = arith.constant 0 : i32;
+                        scf.yield v1030;
                     } else {
                     ^block49:
-                        v475 = hir.bitcast v403 : u32;
-                        v1036 = arith.constant 4 : u32;
-                        v477 = arith.mod v475, v1036 : u32;
-                        hir.assertz v477 #[code = 250];
-                        v474 = arith.add v464, v439 : i32 #[overflow = wrapping];
-                        v478 = hir.int_to_ptr v475 : ptr<byte, i32>;
-                        hir.store v478, v474;
-                        v480 = arith.add v464, v424 : i32 #[overflow = wrapping];
-                        scf.yield v480;
+                        v468 = hir.bitcast v396 : u32;
+                        v1029 = arith.constant 4 : u32;
+                        v470 = arith.mod v468, v1029 : u32;
+                        hir.assertz v470 #[code = 250];
+                        v467 = arith.add v457, v432 : i32 #[overflow = wrapping];
+                        v471 = hir.int_to_ptr v468 : ptr<byte, i32>;
+                        hir.store v471, v467;
+                        v473 = arith.add v457, v417 : i32 #[overflow = wrapping];
+                        scf.yield v473;
                     };
-                    scf.yield v1031;
+                    scf.yield v1024;
                 };
-                v1014 = arith.constant 1 : u32;
-                v1035 = arith.constant 0 : u32;
-                v1033 = cf.select v432, v1035, v1014 : u32;
-                scf.yield v1032, v1033;
+                v1007 = arith.constant 1 : u32;
+                v1028 = arith.constant 0 : u32;
+                v1026 = cf.select v425, v1028, v1007 : u32;
+                scf.yield v1025, v1026;
             };
-            v1034 = arith.constant 0 : u32;
-            v1030 = arith.eq v1018, v1034 : i1;
-            cf.cond_br v1030 ^block43, ^block139(v1017);
+            v1027 = arith.constant 0 : u32;
+            v1023 = arith.eq v1011, v1027 : i1;
+            cf.cond_br v1023 ^block43, ^block139(v1010);
         ^block43:
             ub.unreachable ;
-        ^block139(v1010: i32):
-            builtin.ret v1010;
+        ^block139(v1003: i32):
+            builtin.ret v1003;
         };
 
         private builtin.function @intrinsics::mem::heap_base() -> i32 {
         ^block50:
-            v483 = hir.exec @intrinsics/mem/heap_base() : i32
-            builtin.ret v483;
+            v476 = hir.exec @intrinsics/mem/heap_base() : i32
+            builtin.ret v476;
         };
 
-        private builtin.function @miden_base_sys::bindings::output_note::create(v485: felt, v486: felt, v487: felt, v488: felt, v489: i32) -> felt {
-        ^block54(v485: felt, v486: felt, v487: felt, v488: felt, v489: i32):
-            v492 = arith.constant 12 : u32;
-            v491 = hir.bitcast v489 : u32;
+        private builtin.function @miden_base_sys::bindings::output_note::create(v478: felt, v479: felt, v480: felt, v481: felt, v482: i32) -> felt {
+        ^block54(v478: felt, v479: felt, v480: felt, v481: felt, v482: i32):
+            v485 = arith.constant 12 : u32;
+            v484 = hir.bitcast v482 : u32;
+            v486 = arith.add v484, v485 : u32 #[overflow = checked];
+            v487 = arith.constant 4 : u32;
+            v488 = arith.mod v486, v487 : u32;
+            hir.assertz v488 #[code = 250];
+            v489 = hir.int_to_ptr v486 : ptr<byte, felt>;
+            v490 = hir.load v489 : felt;
+            v492 = arith.constant 8 : u32;
+            v491 = hir.bitcast v482 : u32;
             v493 = arith.add v491, v492 : u32 #[overflow = checked];
-            v494 = arith.constant 4 : u32;
-            v495 = arith.mod v493, v494 : u32;
+            v1045 = arith.constant 4 : u32;
+            v495 = arith.mod v493, v1045 : u32;
             hir.assertz v495 #[code = 250];
             v496 = hir.int_to_ptr v493 : ptr<byte, felt>;
             v497 = hir.load v496 : felt;
-            v499 = arith.constant 8 : u32;
-            v498 = hir.bitcast v489 : u32;
-            v500 = arith.add v498, v499 : u32 #[overflow = checked];
-            v1052 = arith.constant 4 : u32;
-            v502 = arith.mod v500, v1052 : u32;
+            v1044 = arith.constant 4 : u32;
+            v498 = hir.bitcast v482 : u32;
+            v500 = arith.add v498, v1044 : u32 #[overflow = checked];
+            v1043 = arith.constant 4 : u32;
+            v502 = arith.mod v500, v1043 : u32;
             hir.assertz v502 #[code = 250];
             v503 = hir.int_to_ptr v500 : ptr<byte, felt>;
             v504 = hir.load v503 : felt;
-            v1051 = arith.constant 4 : u32;
-            v505 = hir.bitcast v489 : u32;
-            v507 = arith.add v505, v1051 : u32 #[overflow = checked];
-            v1050 = arith.constant 4 : u32;
-            v509 = arith.mod v507, v1050 : u32;
-            hir.assertz v509 #[code = 250];
-            v510 = hir.int_to_ptr v507 : ptr<byte, felt>;
-            v511 = hir.load v510 : felt;
-            v512 = hir.bitcast v489 : u32;
-            v1049 = arith.constant 4 : u32;
-            v514 = arith.mod v512, v1049 : u32;
-            hir.assertz v514 #[code = 250];
-            v515 = hir.int_to_ptr v512 : ptr<byte, felt>;
-            v516 = hir.load v515 : felt;
-            v517 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/miden::output_note::create(v485, v486, v487, v488, v497, v504, v511, v516) : felt
-            builtin.ret v517;
+            v505 = hir.bitcast v482 : u32;
+            v1042 = arith.constant 4 : u32;
+            v507 = arith.mod v505, v1042 : u32;
+            hir.assertz v507 #[code = 250];
+            v508 = hir.int_to_ptr v505 : ptr<byte, felt>;
+            v509 = hir.load v508 : felt;
+            v510 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/miden::output_note::create(v478, v479, v480, v481, v490, v497, v504, v509) : felt
+            builtin.ret v510;
         };
 
-        private builtin.function @<miden_base_sys::bindings::types::Asset as core::convert::From<[miden_stdlib_sys::intrinsics::felt::Felt; 4]>>::from(v518: i32, v519: i32) {
-        ^block56(v518: i32, v519: i32):
-            v521 = arith.constant 8 : u32;
-            v520 = hir.bitcast v519 : u32;
-            v522 = arith.add v520, v521 : u32 #[overflow = checked];
-            v523 = arith.constant 4 : u32;
-            v524 = arith.mod v522, v523 : u32;
+        private builtin.function @<miden_base_sys::bindings::types::Asset as core::convert::From<[miden_stdlib_sys::intrinsics::felt::Felt; 4]>>::from(v511: i32, v512: i32) {
+        ^block56(v511: i32, v512: i32):
+            v514 = arith.constant 8 : u32;
+            v513 = hir.bitcast v512 : u32;
+            v515 = arith.add v513, v514 : u32 #[overflow = checked];
+            v516 = arith.constant 4 : u32;
+            v517 = arith.mod v515, v516 : u32;
+            hir.assertz v517 #[code = 250];
+            v518 = hir.int_to_ptr v515 : ptr<byte, i64>;
+            v519 = hir.load v518 : i64;
+            v1049 = arith.constant 8 : u32;
+            v520 = hir.bitcast v511 : u32;
+            v522 = arith.add v520, v1049 : u32 #[overflow = checked];
+            v1048 = arith.constant 8 : u32;
+            v524 = arith.mod v522, v1048 : u32;
             hir.assertz v524 #[code = 250];
             v525 = hir.int_to_ptr v522 : ptr<byte, i64>;
-            v526 = hir.load v525 : i64;
-            v1056 = arith.constant 8 : u32;
-            v527 = hir.bitcast v518 : u32;
-            v529 = arith.add v527, v1056 : u32 #[overflow = checked];
-            v1055 = arith.constant 8 : u32;
-            v531 = arith.mod v529, v1055 : u32;
-            hir.assertz v531 #[code = 250];
-            v532 = hir.int_to_ptr v529 : ptr<byte, i64>;
-            hir.store v532, v526;
-            v533 = hir.bitcast v519 : u32;
-            v1054 = arith.constant 4 : u32;
-            v535 = arith.mod v533, v1054 : u32;
-            hir.assertz v535 #[code = 250];
-            v536 = hir.int_to_ptr v533 : ptr<byte, i64>;
-            v537 = hir.load v536 : i64;
-            v538 = hir.bitcast v518 : u32;
-            v1053 = arith.constant 8 : u32;
-            v540 = arith.mod v538, v1053 : u32;
-            hir.assertz v540 #[code = 250];
-            v541 = hir.int_to_ptr v538 : ptr<byte, i64>;
-            hir.store v541, v537;
+            hir.store v525, v519;
+            v526 = hir.bitcast v512 : u32;
+            v1047 = arith.constant 4 : u32;
+            v528 = arith.mod v526, v1047 : u32;
+            hir.assertz v528 #[code = 250];
+            v529 = hir.int_to_ptr v526 : ptr<byte, i64>;
+            v530 = hir.load v529 : i64;
+            v531 = hir.bitcast v511 : u32;
+            v1046 = arith.constant 8 : u32;
+            v533 = arith.mod v531, v1046 : u32;
+            hir.assertz v533 #[code = 250];
+            v534 = hir.int_to_ptr v531 : ptr<byte, i64>;
+            hir.store v534, v530;
             builtin.ret ;
         };
 
-        private builtin.function @intrinsics::felt::from_u64_unchecked(v542: i64) -> felt {
-        ^block58(v542: i64):
-            v543 = hir.cast v542 : felt;
-            builtin.ret v543;
+        private builtin.function @intrinsics::felt::from_u64_unchecked(v535: i64) -> felt {
+        ^block58(v535: i64):
+            v536 = hir.cast v535 : felt;
+            builtin.ret v536;
         };
 
-        private builtin.function @intrinsics::felt::from_u32(v545: i32) -> felt {
-        ^block60(v545: i32):
-            v546 = hir.bitcast v545 : felt;
-            builtin.ret v546;
+        private builtin.function @intrinsics::felt::from_u32(v538: i32) -> felt {
+        ^block60(v538: i32):
+            v539 = hir.bitcast v538 : felt;
+            builtin.ret v539;
         };
 
-        private builtin.function @intrinsics::felt::as_u64(v548: felt) -> i64 {
-        ^block62(v548: felt):
-            v549 = hir.cast v548 : i64;
-            builtin.ret v549;
+        private builtin.function @intrinsics::felt::as_u64(v541: felt) -> i64 {
+        ^block62(v541: felt):
+            v542 = hir.cast v541 : i64;
+            builtin.ret v542;
         };
 
-        private builtin.function @intrinsics::felt::assert_eq(v551: felt, v552: felt) {
-        ^block64(v551: felt, v552: felt):
-            hir.assert_eq v551, v552;
+        private builtin.function @intrinsics::felt::assert_eq(v544: felt, v545: felt) {
+        ^block64(v544: felt, v545: felt):
+            hir.assert_eq v544, v545;
             builtin.ret ;
         };
 
-        private builtin.function @intrinsics::advice::adv_push_mapvaln(v553: felt, v554: felt, v555: felt, v556: felt) -> felt {
-        ^block66(v553: felt, v554: felt, v555: felt, v556: felt):
-            v557 = hir.exec @intrinsics/advice/adv_push_mapvaln(v553, v554, v555, v556) : felt
-            builtin.ret v557;
+        private builtin.function @intrinsics::advice::adv_push_mapvaln(v546: felt, v547: felt, v548: felt, v549: felt) -> felt {
+        ^block66(v546: felt, v547: felt, v548: felt, v549: felt):
+            v550 = hir.exec @intrinsics/advice/adv_push_mapvaln(v546, v547, v548, v549) : felt
+            builtin.ret v550;
         };
 
-        private builtin.function @std::mem::pipe_preimage_to_memory(v559: felt, v560: i32, v561: felt, v562: felt, v563: felt, v564: felt) -> i32 {
-        ^block69(v559: felt, v560: i32, v561: felt, v562: felt, v563: felt, v564: felt):
-            v565 = hir.exec @std/mem/pipe_preimage_to_memory(v559, v560, v561, v562, v563, v564) : i32
-            builtin.ret v565;
+        private builtin.function @std::mem::pipe_preimage_to_memory(v552: felt, v553: i32, v554: felt, v555: felt, v556: felt, v557: felt) -> i32 {
+        ^block69(v552: felt, v553: i32, v554: felt, v555: felt, v556: felt, v557: felt):
+            v558 = hir.exec @std/mem/pipe_preimage_to_memory(v552, v553, v554, v555, v556, v557) : i32
+            builtin.ret v558;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v567: i32, v568: i32, v569: i32) {
-        ^block73(v567: i32, v568: i32, v569: i32):
-            v571 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
-            v572 = hir.bitcast v571 : ptr<byte, i32>;
-            v573 = hir.load v572 : i32;
-            v574 = arith.constant 16 : i32;
-            v575 = arith.sub v573, v574 : i32 #[overflow = wrapping];
-            v576 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
-            v577 = hir.bitcast v576 : ptr<byte, i32>;
-            hir.store v577, v575;
-            v578 = arith.constant 4 : i32;
-            v579 = arith.add v575, v578 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/alloc::raw_vec::RawVecInner<A>::current_memory(v579, v567, v568, v569)
-            v581 = arith.constant 8 : u32;
-            v580 = hir.bitcast v575 : u32;
-            v582 = arith.add v580, v581 : u32 #[overflow = checked];
-            v583 = arith.constant 4 : u32;
-            v584 = arith.mod v582, v583 : u32;
-            hir.assertz v584 #[code = 250];
-            v585 = hir.int_to_ptr v582 : ptr<byte, i32>;
-            v586 = hir.load v585 : i32;
-            v1063 = arith.constant 0 : i32;
-            v570 = arith.constant 0 : i32;
-            v588 = arith.eq v586, v570 : i1;
-            v589 = arith.zext v588 : u32;
-            v590 = hir.bitcast v589 : i32;
-            v592 = arith.neq v590, v1063 : i1;
-            scf.if v592{
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v560: i32, v561: i32, v562: i32) {
+        ^block73(v560: i32, v561: i32, v562: i32):
+            v564 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
+            v565 = hir.bitcast v564 : ptr<byte, i32>;
+            v566 = hir.load v565 : i32;
+            v567 = arith.constant 16 : i32;
+            v568 = arith.sub v566, v567 : i32 #[overflow = wrapping];
+            v569 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
+            v570 = hir.bitcast v569 : ptr<byte, i32>;
+            hir.store v570, v568;
+            v571 = arith.constant 4 : i32;
+            v572 = arith.add v568, v571 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/alloc::raw_vec::RawVecInner<A>::current_memory(v572, v560, v561, v562)
+            v574 = arith.constant 8 : u32;
+            v573 = hir.bitcast v568 : u32;
+            v575 = arith.add v573, v574 : u32 #[overflow = checked];
+            v576 = arith.constant 4 : u32;
+            v577 = arith.mod v575, v576 : u32;
+            hir.assertz v577 #[code = 250];
+            v578 = hir.int_to_ptr v575 : ptr<byte, i32>;
+            v579 = hir.load v578 : i32;
+            v1056 = arith.constant 0 : i32;
+            v563 = arith.constant 0 : i32;
+            v581 = arith.eq v579, v563 : i1;
+            v582 = arith.zext v581 : u32;
+            v583 = hir.bitcast v582 : i32;
+            v585 = arith.neq v583, v1056 : i1;
+            scf.if v585{
             ^block143:
                 scf.yield ;
             } else {
             ^block76:
-                v1062 = arith.constant 4 : u32;
-                v593 = hir.bitcast v575 : u32;
-                v595 = arith.add v593, v1062 : u32 #[overflow = checked];
-                v1061 = arith.constant 4 : u32;
-                v597 = arith.mod v595, v1061 : u32;
+                v1055 = arith.constant 4 : u32;
+                v586 = hir.bitcast v568 : u32;
+                v588 = arith.add v586, v1055 : u32 #[overflow = checked];
+                v1054 = arith.constant 4 : u32;
+                v590 = arith.mod v588, v1054 : u32;
+                hir.assertz v590 #[code = 250];
+                v591 = hir.int_to_ptr v588 : ptr<byte, i32>;
+                v592 = hir.load v591 : i32;
+                v594 = arith.constant 12 : u32;
+                v593 = hir.bitcast v568 : u32;
+                v595 = arith.add v593, v594 : u32 #[overflow = checked];
+                v1053 = arith.constant 4 : u32;
+                v597 = arith.mod v595, v1053 : u32;
                 hir.assertz v597 #[code = 250];
                 v598 = hir.int_to_ptr v595 : ptr<byte, i32>;
                 v599 = hir.load v598 : i32;
-                v601 = arith.constant 12 : u32;
-                v600 = hir.bitcast v575 : u32;
-                v602 = arith.add v600, v601 : u32 #[overflow = checked];
-                v1060 = arith.constant 4 : u32;
-                v604 = arith.mod v602, v1060 : u32;
-                hir.assertz v604 #[code = 250];
-                v605 = hir.int_to_ptr v602 : ptr<byte, i32>;
-                v606 = hir.load v605 : i32;
-                hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v599, v586, v606)
+                hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v592, v579, v599)
                 scf.yield ;
             };
-            v1059 = arith.constant 16 : i32;
-            v609 = arith.add v575, v1059 : i32 #[overflow = wrapping];
-            v610 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
-            v611 = hir.bitcast v610 : ptr<byte, i32>;
-            hir.store v611, v609;
+            v1052 = arith.constant 16 : i32;
+            v602 = arith.add v568, v1052 : i32 #[overflow = wrapping];
+            v603 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
+            v604 = hir.bitcast v603 : ptr<byte, i32>;
+            hir.store v604, v602;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v612: i32, v613: i32, v614: i32, v615: i32, v616: i32) {
-        ^block77(v612: i32, v613: i32, v614: i32, v615: i32, v616: i32):
-            v619 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
-            v620 = hir.bitcast v619 : ptr<byte, i32>;
-            v621 = hir.load v620 : i32;
-            v622 = arith.constant 16 : i32;
-            v623 = arith.sub v621, v622 : i32 #[overflow = wrapping];
-            v624 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
-            v625 = hir.bitcast v624 : ptr<byte, i32>;
-            hir.store v625, v623;
-            v635 = hir.bitcast v613 : u32;
-            v636 = arith.zext v635 : u64;
-            v637 = hir.bitcast v636 : i64;
-            v617 = arith.constant 0 : i32;
-            v630 = arith.sub v617, v615 : i32 #[overflow = wrapping];
-            v627 = arith.constant -1 : i32;
-            v626 = arith.add v615, v616 : i32 #[overflow = wrapping];
-            v628 = arith.add v626, v627 : i32 #[overflow = wrapping];
-            v631 = arith.band v628, v630 : i32;
-            v632 = hir.bitcast v631 : u32;
-            v633 = arith.zext v632 : u64;
-            v634 = hir.bitcast v633 : i64;
-            v638 = arith.mul v634, v637 : i64 #[overflow = wrapping];
-            v1167 = arith.constant 0 : i32;
-            v639 = arith.constant 32 : i64;
-            v641 = hir.cast v639 : u32;
-            v640 = hir.bitcast v638 : u64;
-            v642 = arith.shr v640, v641 : u64;
-            v643 = hir.bitcast v642 : i64;
-            v644 = arith.trunc v643 : i32;
-            v646 = arith.neq v644, v1167 : i1;
-            v1079, v1080, v1081, v1082, v1083, v1084 = scf.if v646 : i32, i32, i32, i32, i32, u32 {
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v605: i32, v606: i32, v607: i32, v608: i32, v609: i32) {
+        ^block77(v605: i32, v606: i32, v607: i32, v608: i32, v609: i32):
+            v612 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
+            v613 = hir.bitcast v612 : ptr<byte, i32>;
+            v614 = hir.load v613 : i32;
+            v615 = arith.constant 16 : i32;
+            v616 = arith.sub v614, v615 : i32 #[overflow = wrapping];
+            v617 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
+            v618 = hir.bitcast v617 : ptr<byte, i32>;
+            hir.store v618, v616;
+            v628 = hir.bitcast v606 : u32;
+            v629 = arith.zext v628 : u64;
+            v630 = hir.bitcast v629 : i64;
+            v610 = arith.constant 0 : i32;
+            v623 = arith.sub v610, v608 : i32 #[overflow = wrapping];
+            v620 = arith.constant -1 : i32;
+            v619 = arith.add v608, v609 : i32 #[overflow = wrapping];
+            v621 = arith.add v619, v620 : i32 #[overflow = wrapping];
+            v624 = arith.band v621, v623 : i32;
+            v625 = hir.bitcast v624 : u32;
+            v626 = arith.zext v625 : u64;
+            v627 = hir.bitcast v626 : i64;
+            v631 = arith.mul v627, v630 : i64 #[overflow = wrapping];
+            v1160 = arith.constant 0 : i32;
+            v632 = arith.constant 32 : i64;
+            v634 = hir.cast v632 : u32;
+            v633 = hir.bitcast v631 : u64;
+            v635 = arith.shr v633, v634 : u64;
+            v636 = hir.bitcast v635 : i64;
+            v637 = arith.trunc v636 : i32;
+            v639 = arith.neq v637, v1160 : i1;
+            v1072, v1073, v1074, v1075, v1076, v1077 = scf.if v639 : i32, i32, i32, i32, i32, u32 {
             ^block145:
-                v1064 = arith.constant 0 : u32;
-                v1071 = ub.poison i32 : i32;
-                scf.yield v612, v623, v1071, v1071, v1071, v1064;
+                v1057 = arith.constant 0 : u32;
+                v1064 = ub.poison i32 : i32;
+                scf.yield v605, v616, v1064, v1064, v1064, v1057;
             } else {
             ^block82:
-                v647 = arith.trunc v638 : i32;
-                v1166 = arith.constant 0 : i32;
-                v648 = arith.constant -2147483648 : i32;
-                v649 = arith.sub v648, v615 : i32 #[overflow = wrapping];
-                v651 = hir.bitcast v649 : u32;
-                v650 = hir.bitcast v647 : u32;
-                v652 = arith.lte v650, v651 : i1;
-                v653 = arith.zext v652 : u32;
-                v654 = hir.bitcast v653 : i32;
-                v656 = arith.neq v654, v1166 : i1;
-                v1127 = scf.if v656 : i32 {
+                v640 = arith.trunc v631 : i32;
+                v1159 = arith.constant 0 : i32;
+                v641 = arith.constant -2147483648 : i32;
+                v642 = arith.sub v641, v608 : i32 #[overflow = wrapping];
+                v644 = hir.bitcast v642 : u32;
+                v643 = hir.bitcast v640 : u32;
+                v645 = arith.lte v643, v644 : i1;
+                v646 = arith.zext v645 : u32;
+                v647 = hir.bitcast v646 : i32;
+                v649 = arith.neq v647, v1159 : i1;
+                v1120 = scf.if v649 : i32 {
                 ^block80:
-                    v1165 = arith.constant 0 : i32;
-                    v667 = arith.neq v647, v1165 : i1;
-                    v1126 = scf.if v667 : i32 {
+                    v1158 = arith.constant 0 : i32;
+                    v660 = arith.neq v640, v1158 : i1;
+                    v1119 = scf.if v660 : i32 {
                     ^block84:
-                        v1164 = arith.constant 0 : i32;
-                        v683 = arith.neq v614, v1164 : i1;
-                        v1125 = scf.if v683 : i32 {
+                        v1157 = arith.constant 0 : i32;
+                        v676 = arith.neq v607, v1157 : i1;
+                        v1118 = scf.if v676 : i32 {
                         ^block87:
-                            v665 = arith.constant 1 : i32;
-                            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/alloc::alloc::Global::alloc_impl(v623, v615, v647, v665)
-                            v694 = hir.bitcast v623 : u32;
-                            v739 = arith.constant 4 : u32;
-                            v696 = arith.mod v694, v739 : u32;
-                            hir.assertz v696 #[code = 250];
-                            v697 = hir.int_to_ptr v694 : ptr<byte, i32>;
-                            v698 = hir.load v697 : i32;
-                            scf.yield v698;
+                            v658 = arith.constant 1 : i32;
+                            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/alloc::alloc::Global::alloc_impl(v616, v608, v640, v658)
+                            v687 = hir.bitcast v616 : u32;
+                            v732 = arith.constant 4 : u32;
+                            v689 = arith.mod v687, v732 : u32;
+                            hir.assertz v689 #[code = 250];
+                            v690 = hir.int_to_ptr v687 : ptr<byte, i32>;
+                            v691 = hir.load v690 : i32;
+                            scf.yield v691;
                         } else {
                         ^block88:
-                            v684 = arith.constant 8 : i32;
-                            v685 = arith.add v623, v684 : i32 #[overflow = wrapping];
-                            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<alloc::alloc::Global as core::alloc::Allocator>::allocate(v685, v615, v647)
-                            v669 = arith.constant 8 : u32;
-                            v686 = hir.bitcast v623 : u32;
-                            v688 = arith.add v686, v669 : u32 #[overflow = checked];
-                            v1163 = arith.constant 4 : u32;
-                            v690 = arith.mod v688, v1163 : u32;
-                            hir.assertz v690 #[code = 250];
-                            v691 = hir.int_to_ptr v688 : ptr<byte, i32>;
-                            v692 = hir.load v691 : i32;
-                            scf.yield v692;
+                            v677 = arith.constant 8 : i32;
+                            v678 = arith.add v616, v677 : i32 #[overflow = wrapping];
+                            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/<alloc::alloc::Global as core::alloc::Allocator>::allocate(v678, v608, v640)
+                            v662 = arith.constant 8 : u32;
+                            v679 = hir.bitcast v616 : u32;
+                            v681 = arith.add v679, v662 : u32 #[overflow = checked];
+                            v1156 = arith.constant 4 : u32;
+                            v683 = arith.mod v681, v1156 : u32;
+                            hir.assertz v683 #[code = 250];
+                            v684 = hir.int_to_ptr v681 : ptr<byte, i32>;
+                            v685 = hir.load v684 : i32;
+                            scf.yield v685;
                         };
-                        v1161 = arith.constant 0 : i32;
-                        v1162 = arith.constant 0 : i32;
-                        v701 = arith.eq v1125, v1162 : i1;
-                        v702 = arith.zext v701 : u32;
-                        v703 = hir.bitcast v702 : i32;
-                        v705 = arith.neq v703, v1161 : i1;
-                        scf.if v705{
+                        v1154 = arith.constant 0 : i32;
+                        v1155 = arith.constant 0 : i32;
+                        v694 = arith.eq v1118, v1155 : i1;
+                        v695 = arith.zext v694 : u32;
+                        v696 = hir.bitcast v695 : i32;
+                        v698 = arith.neq v696, v1154 : i1;
+                        scf.if v698{
                         ^block89:
-                            v1160 = arith.constant 8 : u32;
-                            v722 = hir.bitcast v612 : u32;
-                            v724 = arith.add v722, v1160 : u32 #[overflow = checked];
-                            v1159 = arith.constant 4 : u32;
-                            v726 = arith.mod v724, v1159 : u32;
+                            v1153 = arith.constant 8 : u32;
+                            v715 = hir.bitcast v605 : u32;
+                            v717 = arith.add v715, v1153 : u32 #[overflow = checked];
+                            v1152 = arith.constant 4 : u32;
+                            v719 = arith.mod v717, v1152 : u32;
+                            hir.assertz v719 #[code = 250];
+                            v720 = hir.int_to_ptr v717 : ptr<byte, i32>;
+                            hir.store v720, v640;
+                            v1151 = arith.constant 4 : u32;
+                            v722 = hir.bitcast v605 : u32;
+                            v724 = arith.add v722, v1151 : u32 #[overflow = checked];
+                            v1150 = arith.constant 4 : u32;
+                            v726 = arith.mod v724, v1150 : u32;
                             hir.assertz v726 #[code = 250];
                             v727 = hir.int_to_ptr v724 : ptr<byte, i32>;
-                            hir.store v727, v647;
-                            v1158 = arith.constant 4 : u32;
-                            v729 = hir.bitcast v612 : u32;
-                            v731 = arith.add v729, v1158 : u32 #[overflow = checked];
-                            v1157 = arith.constant 4 : u32;
-                            v733 = arith.mod v731, v1157 : u32;
-                            hir.assertz v733 #[code = 250];
-                            v734 = hir.int_to_ptr v731 : ptr<byte, i32>;
-                            hir.store v734, v615;
+                            hir.store v727, v608;
                             scf.yield ;
                         } else {
                         ^block90:
-                            v1156 = arith.constant 8 : u32;
-                            v707 = hir.bitcast v612 : u32;
-                            v709 = arith.add v707, v1156 : u32 #[overflow = checked];
-                            v1155 = arith.constant 4 : u32;
-                            v711 = arith.mod v709, v1155 : u32;
+                            v1149 = arith.constant 8 : u32;
+                            v700 = hir.bitcast v605 : u32;
+                            v702 = arith.add v700, v1149 : u32 #[overflow = checked];
+                            v1148 = arith.constant 4 : u32;
+                            v704 = arith.mod v702, v1148 : u32;
+                            hir.assertz v704 #[code = 250];
+                            v705 = hir.int_to_ptr v702 : ptr<byte, i32>;
+                            hir.store v705, v1118;
+                            v1147 = arith.constant 4 : u32;
+                            v707 = hir.bitcast v605 : u32;
+                            v709 = arith.add v707, v1147 : u32 #[overflow = checked];
+                            v1146 = arith.constant 4 : u32;
+                            v711 = arith.mod v709, v1146 : u32;
                             hir.assertz v711 #[code = 250];
                             v712 = hir.int_to_ptr v709 : ptr<byte, i32>;
-                            hir.store v712, v1125;
-                            v1154 = arith.constant 4 : u32;
-                            v714 = hir.bitcast v612 : u32;
-                            v716 = arith.add v714, v1154 : u32 #[overflow = checked];
-                            v1153 = arith.constant 4 : u32;
-                            v718 = arith.mod v716, v1153 : u32;
-                            hir.assertz v718 #[code = 250];
-                            v719 = hir.int_to_ptr v716 : ptr<byte, i32>;
-                            hir.store v719, v613;
+                            hir.store v712, v606;
                             scf.yield ;
                         };
-                        v1151 = arith.constant 0 : i32;
-                        v1152 = arith.constant 1 : i32;
-                        v1124 = cf.select v705, v1152, v1151 : i32;
-                        scf.yield v1124;
+                        v1144 = arith.constant 0 : i32;
+                        v1145 = arith.constant 1 : i32;
+                        v1117 = cf.select v698, v1145, v1144 : i32;
+                        scf.yield v1117;
                     } else {
                     ^block85:
-                        v1150 = arith.constant 8 : u32;
-                        v668 = hir.bitcast v612 : u32;
-                        v670 = arith.add v668, v1150 : u32 #[overflow = checked];
-                        v1149 = arith.constant 4 : u32;
-                        v672 = arith.mod v670, v1149 : u32;
-                        hir.assertz v672 #[code = 250];
-                        v673 = hir.int_to_ptr v670 : ptr<byte, i32>;
-                        hir.store v673, v615;
-                        v1148 = arith.constant 4 : u32;
-                        v676 = hir.bitcast v612 : u32;
-                        v678 = arith.add v676, v1148 : u32 #[overflow = checked];
-                        v1147 = arith.constant 4 : u32;
-                        v680 = arith.mod v678, v1147 : u32;
-                        hir.assertz v680 #[code = 250];
-                        v1146 = arith.constant 0 : i32;
-                        v681 = hir.int_to_ptr v678 : ptr<byte, i32>;
-                        hir.store v681, v1146;
-                        v1145 = arith.constant 0 : i32;
-                        scf.yield v1145;
+                        v1143 = arith.constant 8 : u32;
+                        v661 = hir.bitcast v605 : u32;
+                        v663 = arith.add v661, v1143 : u32 #[overflow = checked];
+                        v1142 = arith.constant 4 : u32;
+                        v665 = arith.mod v663, v1142 : u32;
+                        hir.assertz v665 #[code = 250];
+                        v666 = hir.int_to_ptr v663 : ptr<byte, i32>;
+                        hir.store v666, v608;
+                        v1141 = arith.constant 4 : u32;
+                        v669 = hir.bitcast v605 : u32;
+                        v671 = arith.add v669, v1141 : u32 #[overflow = checked];
+                        v1140 = arith.constant 4 : u32;
+                        v673 = arith.mod v671, v1140 : u32;
+                        hir.assertz v673 #[code = 250];
+                        v1139 = arith.constant 0 : i32;
+                        v674 = hir.int_to_ptr v671 : ptr<byte, i32>;
+                        hir.store v674, v1139;
+                        v1138 = arith.constant 0 : i32;
+                        scf.yield v1138;
                     };
-                    scf.yield v1126;
+                    scf.yield v1119;
                 } else {
                 ^block83:
-                    v1144 = ub.poison i32 : i32;
-                    scf.yield v1144;
+                    v1137 = ub.poison i32 : i32;
+                    scf.yield v1137;
                 };
-                v1139 = arith.constant 0 : u32;
-                v1072 = arith.constant 1 : u32;
-                v1132 = cf.select v656, v1072, v1139 : u32;
-                v1140 = ub.poison i32 : i32;
-                v1131 = cf.select v656, v623, v1140 : i32;
-                v1141 = ub.poison i32 : i32;
-                v1130 = cf.select v656, v612, v1141 : i32;
-                v1142 = ub.poison i32 : i32;
-                v1129 = cf.select v656, v1142, v623 : i32;
-                v1143 = ub.poison i32 : i32;
-                v1128 = cf.select v656, v1143, v612 : i32;
-                scf.yield v1128, v1129, v1130, v1127, v1131, v1132;
+                v1132 = arith.constant 0 : u32;
+                v1065 = arith.constant 1 : u32;
+                v1125 = cf.select v649, v1065, v1132 : u32;
+                v1133 = ub.poison i32 : i32;
+                v1124 = cf.select v649, v616, v1133 : i32;
+                v1134 = ub.poison i32 : i32;
+                v1123 = cf.select v649, v605, v1134 : i32;
+                v1135 = ub.poison i32 : i32;
+                v1122 = cf.select v649, v1135, v616 : i32;
+                v1136 = ub.poison i32 : i32;
+                v1121 = cf.select v649, v1136, v605 : i32;
+                scf.yield v1121, v1122, v1123, v1120, v1124, v1125;
             };
-            v1085, v1086, v1087 = scf.index_switch v1084 : i32, i32, i32 
+            v1078, v1079, v1080 = scf.index_switch v1077 : i32, i32, i32 
             case 0 {
             ^block81:
-                v1138 = arith.constant 4 : u32;
-                v659 = hir.bitcast v1079 : u32;
-                v661 = arith.add v659, v1138 : u32 #[overflow = checked];
-                v1137 = arith.constant 4 : u32;
-                v663 = arith.mod v661, v1137 : u32;
-                hir.assertz v663 #[code = 250];
-                v1136 = arith.constant 0 : i32;
-                v664 = hir.int_to_ptr v661 : ptr<byte, i32>;
-                hir.store v664, v1136;
-                v1135 = arith.constant 1 : i32;
-                scf.yield v1079, v1135, v1080;
+                v1131 = arith.constant 4 : u32;
+                v652 = hir.bitcast v1072 : u32;
+                v654 = arith.add v652, v1131 : u32 #[overflow = checked];
+                v1130 = arith.constant 4 : u32;
+                v656 = arith.mod v654, v1130 : u32;
+                hir.assertz v656 #[code = 250];
+                v1129 = arith.constant 0 : i32;
+                v657 = hir.int_to_ptr v654 : ptr<byte, i32>;
+                hir.store v657, v1129;
+                v1128 = arith.constant 1 : i32;
+                scf.yield v1072, v1128, v1073;
             }
             default {
             ^block149:
-                scf.yield v1081, v1082, v1083;
+                scf.yield v1074, v1075, v1076;
             };
-            v738 = hir.bitcast v1085 : u32;
-            v1134 = arith.constant 4 : u32;
-            v740 = arith.mod v738, v1134 : u32;
-            hir.assertz v740 #[code = 250];
-            v741 = hir.int_to_ptr v738 : ptr<byte, i32>;
-            hir.store v741, v1086;
-            v1133 = arith.constant 16 : i32;
-            v746 = arith.add v1087, v1133 : i32 #[overflow = wrapping];
-            v747 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
-            v748 = hir.bitcast v747 : ptr<byte, i32>;
-            hir.store v748, v746;
+            v731 = hir.bitcast v1078 : u32;
+            v1127 = arith.constant 4 : u32;
+            v733 = arith.mod v731, v1127 : u32;
+            hir.assertz v733 #[code = 250];
+            v734 = hir.int_to_ptr v731 : ptr<byte, i32>;
+            hir.store v734, v1079;
+            v1126 = arith.constant 16 : i32;
+            v739 = arith.add v1080, v1126 : i32 #[overflow = wrapping];
+            v740 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
+            v741 = hir.bitcast v740 : ptr<byte, i32>;
+            hir.store v741, v739;
             builtin.ret ;
         };
 
-        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v749: i32, v750: i32, v751: i32) {
-        ^block91(v749: i32, v750: i32, v751: i32):
-            v753 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
-            v754 = hir.bitcast v753 : ptr<byte, i32>;
-            v755 = hir.load v754 : i32;
-            v756 = arith.constant 16 : i32;
-            v757 = arith.sub v755, v756 : i32 #[overflow = wrapping];
-            v758 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
-            v759 = hir.bitcast v758 : ptr<byte, i32>;
-            hir.store v759, v757;
-            v752 = arith.constant 0 : i32;
-            v760 = arith.constant 8 : i32;
-            v761 = arith.add v757, v760 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/alloc::alloc::Global::alloc_impl(v761, v750, v751, v752)
-            v764 = arith.constant 12 : u32;
-            v763 = hir.bitcast v757 : u32;
+        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v742: i32, v743: i32, v744: i32) {
+        ^block91(v742: i32, v743: i32, v744: i32):
+            v746 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
+            v747 = hir.bitcast v746 : ptr<byte, i32>;
+            v748 = hir.load v747 : i32;
+            v749 = arith.constant 16 : i32;
+            v750 = arith.sub v748, v749 : i32 #[overflow = wrapping];
+            v751 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
+            v752 = hir.bitcast v751 : ptr<byte, i32>;
+            hir.store v752, v750;
+            v745 = arith.constant 0 : i32;
+            v753 = arith.constant 8 : i32;
+            v754 = arith.add v750, v753 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/alloc::alloc::Global::alloc_impl(v754, v743, v744, v745)
+            v757 = arith.constant 12 : u32;
+            v756 = hir.bitcast v750 : u32;
+            v758 = arith.add v756, v757 : u32 #[overflow = checked];
+            v759 = arith.constant 4 : u32;
+            v760 = arith.mod v758, v759 : u32;
+            hir.assertz v760 #[code = 250];
+            v761 = hir.int_to_ptr v758 : ptr<byte, i32>;
+            v762 = hir.load v761 : i32;
+            v764 = arith.constant 8 : u32;
+            v763 = hir.bitcast v750 : u32;
             v765 = arith.add v763, v764 : u32 #[overflow = checked];
-            v766 = arith.constant 4 : u32;
-            v767 = arith.mod v765, v766 : u32;
+            v1165 = arith.constant 4 : u32;
+            v767 = arith.mod v765, v1165 : u32;
             hir.assertz v767 #[code = 250];
             v768 = hir.int_to_ptr v765 : ptr<byte, i32>;
             v769 = hir.load v768 : i32;
-            v771 = arith.constant 8 : u32;
-            v770 = hir.bitcast v757 : u32;
-            v772 = arith.add v770, v771 : u32 #[overflow = checked];
-            v1172 = arith.constant 4 : u32;
-            v774 = arith.mod v772, v1172 : u32;
-            hir.assertz v774 #[code = 250];
-            v775 = hir.int_to_ptr v772 : ptr<byte, i32>;
-            v776 = hir.load v775 : i32;
-            v777 = hir.bitcast v749 : u32;
-            v1171 = arith.constant 4 : u32;
-            v779 = arith.mod v777, v1171 : u32;
-            hir.assertz v779 #[code = 250];
-            v780 = hir.int_to_ptr v777 : ptr<byte, i32>;
-            hir.store v780, v776;
-            v1170 = arith.constant 4 : u32;
-            v781 = hir.bitcast v749 : u32;
-            v783 = arith.add v781, v1170 : u32 #[overflow = checked];
-            v1169 = arith.constant 4 : u32;
-            v785 = arith.mod v783, v1169 : u32;
-            hir.assertz v785 #[code = 250];
-            v786 = hir.int_to_ptr v783 : ptr<byte, i32>;
-            hir.store v786, v769;
-            v1168 = arith.constant 16 : i32;
-            v788 = arith.add v757, v1168 : i32 #[overflow = wrapping];
-            v789 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
-            v790 = hir.bitcast v789 : ptr<byte, i32>;
-            hir.store v790, v788;
+            v770 = hir.bitcast v742 : u32;
+            v1164 = arith.constant 4 : u32;
+            v772 = arith.mod v770, v1164 : u32;
+            hir.assertz v772 #[code = 250];
+            v773 = hir.int_to_ptr v770 : ptr<byte, i32>;
+            hir.store v773, v769;
+            v1163 = arith.constant 4 : u32;
+            v774 = hir.bitcast v742 : u32;
+            v776 = arith.add v774, v1163 : u32 #[overflow = checked];
+            v1162 = arith.constant 4 : u32;
+            v778 = arith.mod v776, v1162 : u32;
+            hir.assertz v778 #[code = 250];
+            v779 = hir.int_to_ptr v776 : ptr<byte, i32>;
+            hir.store v779, v762;
+            v1161 = arith.constant 16 : i32;
+            v781 = arith.add v750, v1161 : i32 #[overflow = wrapping];
+            v782 = builtin.global_symbol @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__stack_pointer : ptr<byte, u8>
+            v783 = hir.bitcast v782 : ptr<byte, i32>;
+            hir.store v783, v781;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::alloc::Global::alloc_impl(v791: i32, v792: i32, v793: i32, v794: i32) {
-        ^block93(v791: i32, v792: i32, v793: i32, v794: i32):
-            v1188 = arith.constant 0 : i32;
-            v795 = arith.constant 0 : i32;
-            v796 = arith.eq v793, v795 : i1;
-            v797 = arith.zext v796 : u32;
-            v798 = hir.bitcast v797 : i32;
-            v800 = arith.neq v798, v1188 : i1;
-            v1184 = scf.if v800 : i32 {
+        private builtin.function @alloc::alloc::Global::alloc_impl(v784: i32, v785: i32, v786: i32, v787: i32) {
+        ^block93(v784: i32, v785: i32, v786: i32, v787: i32):
+            v1181 = arith.constant 0 : i32;
+            v788 = arith.constant 0 : i32;
+            v789 = arith.eq v786, v788 : i1;
+            v790 = arith.zext v789 : u32;
+            v791 = hir.bitcast v790 : i32;
+            v793 = arith.neq v791, v1181 : i1;
+            v1177 = scf.if v793 : i32 {
             ^block152:
-                scf.yield v792;
+                scf.yield v785;
             } else {
             ^block96:
                 hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__rustc::__rust_no_alloc_shim_is_unstable_v2()
-                v1187 = arith.constant 0 : i32;
-                v802 = arith.neq v794, v1187 : i1;
-                v1183 = scf.if v802 : i32 {
+                v1180 = arith.constant 0 : i32;
+                v795 = arith.neq v787, v1180 : i1;
+                v1176 = scf.if v795 : i32 {
                 ^block97:
-                    v804 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__rustc::__rust_alloc_zeroed(v793, v792) : i32
-                    scf.yield v804;
+                    v797 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__rustc::__rust_alloc_zeroed(v786, v785) : i32
+                    scf.yield v797;
                 } else {
                 ^block98:
-                    v803 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__rustc::__rust_alloc(v793, v792) : i32
-                    scf.yield v803;
+                    v796 = hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__rustc::__rust_alloc(v786, v785) : i32
+                    scf.yield v796;
                 };
-                scf.yield v1183;
+                scf.yield v1176;
             };
-            v808 = arith.constant 4 : u32;
-            v807 = hir.bitcast v791 : u32;
-            v809 = arith.add v807, v808 : u32 #[overflow = checked];
-            v1186 = arith.constant 4 : u32;
-            v811 = arith.mod v809, v1186 : u32;
-            hir.assertz v811 #[code = 250];
-            v812 = hir.int_to_ptr v809 : ptr<byte, i32>;
-            hir.store v812, v793;
-            v814 = hir.bitcast v791 : u32;
-            v1185 = arith.constant 4 : u32;
-            v816 = arith.mod v814, v1185 : u32;
-            hir.assertz v816 #[code = 250];
-            v817 = hir.int_to_ptr v814 : ptr<byte, i32>;
-            hir.store v817, v1184;
+            v801 = arith.constant 4 : u32;
+            v800 = hir.bitcast v784 : u32;
+            v802 = arith.add v800, v801 : u32 #[overflow = checked];
+            v1179 = arith.constant 4 : u32;
+            v804 = arith.mod v802, v1179 : u32;
+            hir.assertz v804 #[code = 250];
+            v805 = hir.int_to_ptr v802 : ptr<byte, i32>;
+            hir.store v805, v786;
+            v807 = hir.bitcast v784 : u32;
+            v1178 = arith.constant 4 : u32;
+            v809 = arith.mod v807, v1178 : u32;
+            hir.assertz v809 #[code = 250];
+            v810 = hir.int_to_ptr v807 : ptr<byte, i32>;
+            hir.store v810, v1177;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v818: i32, v819: i32, v820: i32, v821: i32) {
-        ^block99(v818: i32, v819: i32, v820: i32, v821: i32):
-            v1214 = arith.constant 0 : i32;
-            v822 = arith.constant 0 : i32;
-            v826 = arith.eq v821, v822 : i1;
-            v827 = arith.zext v826 : u32;
-            v828 = hir.bitcast v827 : i32;
-            v830 = arith.neq v828, v1214 : i1;
-            v1201, v1202 = scf.if v830 : i32, i32 {
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v811: i32, v812: i32, v813: i32, v814: i32) {
+        ^block99(v811: i32, v812: i32, v813: i32, v814: i32):
+            v1207 = arith.constant 0 : i32;
+            v815 = arith.constant 0 : i32;
+            v819 = arith.eq v814, v815 : i1;
+            v820 = arith.zext v819 : u32;
+            v821 = hir.bitcast v820 : i32;
+            v823 = arith.neq v821, v1207 : i1;
+            v1194, v1195 = scf.if v823 : i32, i32 {
             ^block156:
-                v1213 = arith.constant 0 : i32;
-                v824 = arith.constant 4 : i32;
-                scf.yield v824, v1213;
+                v1206 = arith.constant 0 : i32;
+                v817 = arith.constant 4 : i32;
+                scf.yield v817, v1206;
             } else {
             ^block102:
-                v831 = hir.bitcast v819 : u32;
-                v866 = arith.constant 4 : u32;
-                v833 = arith.mod v831, v866 : u32;
-                hir.assertz v833 #[code = 250];
-                v834 = hir.int_to_ptr v831 : ptr<byte, i32>;
-                v835 = hir.load v834 : i32;
-                v1211 = arith.constant 0 : i32;
-                v1212 = arith.constant 0 : i32;
-                v837 = arith.eq v835, v1212 : i1;
-                v838 = arith.zext v837 : u32;
-                v839 = hir.bitcast v838 : i32;
-                v841 = arith.neq v839, v1211 : i1;
-                v1199 = scf.if v841 : i32 {
+                v824 = hir.bitcast v812 : u32;
+                v859 = arith.constant 4 : u32;
+                v826 = arith.mod v824, v859 : u32;
+                hir.assertz v826 #[code = 250];
+                v827 = hir.int_to_ptr v824 : ptr<byte, i32>;
+                v828 = hir.load v827 : i32;
+                v1204 = arith.constant 0 : i32;
+                v1205 = arith.constant 0 : i32;
+                v830 = arith.eq v828, v1205 : i1;
+                v831 = arith.zext v830 : u32;
+                v832 = hir.bitcast v831 : i32;
+                v834 = arith.neq v832, v1204 : i1;
+                v1192 = scf.if v834 : i32 {
                 ^block155:
-                    v1210 = arith.constant 0 : i32;
-                    scf.yield v1210;
+                    v1203 = arith.constant 0 : i32;
+                    scf.yield v1203;
                 } else {
                 ^block103:
-                    v1209 = arith.constant 4 : u32;
-                    v842 = hir.bitcast v818 : u32;
-                    v844 = arith.add v842, v1209 : u32 #[overflow = checked];
-                    v1208 = arith.constant 4 : u32;
-                    v846 = arith.mod v844, v1208 : u32;
-                    hir.assertz v846 #[code = 250];
-                    v847 = hir.int_to_ptr v844 : ptr<byte, i32>;
-                    hir.store v847, v820;
-                    v1207 = arith.constant 4 : u32;
-                    v848 = hir.bitcast v819 : u32;
-                    v850 = arith.add v848, v1207 : u32 #[overflow = checked];
-                    v1206 = arith.constant 4 : u32;
-                    v852 = arith.mod v850, v1206 : u32;
-                    hir.assertz v852 #[code = 250];
-                    v853 = hir.int_to_ptr v850 : ptr<byte, i32>;
-                    v854 = hir.load v853 : i32;
-                    v855 = hir.bitcast v818 : u32;
-                    v1205 = arith.constant 4 : u32;
-                    v857 = arith.mod v855, v1205 : u32;
-                    hir.assertz v857 #[code = 250];
-                    v858 = hir.int_to_ptr v855 : ptr<byte, i32>;
-                    hir.store v858, v854;
-                    v859 = arith.mul v835, v821 : i32 #[overflow = wrapping];
-                    scf.yield v859;
+                    v1202 = arith.constant 4 : u32;
+                    v835 = hir.bitcast v811 : u32;
+                    v837 = arith.add v835, v1202 : u32 #[overflow = checked];
+                    v1201 = arith.constant 4 : u32;
+                    v839 = arith.mod v837, v1201 : u32;
+                    hir.assertz v839 #[code = 250];
+                    v840 = hir.int_to_ptr v837 : ptr<byte, i32>;
+                    hir.store v840, v813;
+                    v1200 = arith.constant 4 : u32;
+                    v841 = hir.bitcast v812 : u32;
+                    v843 = arith.add v841, v1200 : u32 #[overflow = checked];
+                    v1199 = arith.constant 4 : u32;
+                    v845 = arith.mod v843, v1199 : u32;
+                    hir.assertz v845 #[code = 250];
+                    v846 = hir.int_to_ptr v843 : ptr<byte, i32>;
+                    v847 = hir.load v846 : i32;
+                    v848 = hir.bitcast v811 : u32;
+                    v1198 = arith.constant 4 : u32;
+                    v850 = arith.mod v848, v1198 : u32;
+                    hir.assertz v850 #[code = 250];
+                    v851 = hir.int_to_ptr v848 : ptr<byte, i32>;
+                    hir.store v851, v847;
+                    v852 = arith.mul v828, v814 : i32 #[overflow = wrapping];
+                    scf.yield v852;
                 };
-                v860 = arith.constant 8 : i32;
-                v1204 = arith.constant 4 : i32;
-                v1200 = cf.select v841, v1204, v860 : i32;
-                scf.yield v1200, v1199;
+                v853 = arith.constant 8 : i32;
+                v1197 = arith.constant 4 : i32;
+                v1193 = cf.select v834, v1197, v853 : i32;
+                scf.yield v1193, v1192;
             };
-            v863 = arith.add v818, v1201 : i32 #[overflow = wrapping];
-            v865 = hir.bitcast v863 : u32;
-            v1203 = arith.constant 4 : u32;
-            v867 = arith.mod v865, v1203 : u32;
-            hir.assertz v867 #[code = 250];
-            v868 = hir.int_to_ptr v865 : ptr<byte, i32>;
-            hir.store v868, v1202;
+            v856 = arith.add v811, v1194 : i32 #[overflow = wrapping];
+            v858 = hir.bitcast v856 : u32;
+            v1196 = arith.constant 4 : u32;
+            v860 = arith.mod v858, v1196 : u32;
+            hir.assertz v860 #[code = 250];
+            v861 = hir.int_to_ptr v858 : ptr<byte, i32>;
+            hir.store v861, v1195;
             builtin.ret ;
         };
 
-        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v869: i32, v870: i32, v871: i32) {
-        ^block104(v869: i32, v870: i32, v871: i32):
-            v1216 = arith.constant 0 : i32;
-            v872 = arith.constant 0 : i32;
-            v873 = arith.eq v871, v872 : i1;
-            v874 = arith.zext v873 : u32;
-            v875 = hir.bitcast v874 : i32;
-            v877 = arith.neq v875, v1216 : i1;
-            scf.if v877{
+        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v862: i32, v863: i32, v864: i32) {
+        ^block104(v862: i32, v863: i32, v864: i32):
+            v1209 = arith.constant 0 : i32;
+            v865 = arith.constant 0 : i32;
+            v866 = arith.eq v864, v865 : i1;
+            v867 = arith.zext v866 : u32;
+            v868 = hir.bitcast v867 : i32;
+            v870 = arith.neq v868, v1209 : i1;
+            scf.if v870{
             ^block106:
                 scf.yield ;
             } else {
             ^block107:
-                hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__rustc::__rust_dealloc(v869, v871, v870)
+                hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/__rustc::__rust_dealloc(v862, v864, v863)
                 scf.yield ;
             };
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::handle_error(v878: i32, v879: i32, v880: i32) {
-        ^block108(v878: i32, v879: i32, v880: i32):
+        private builtin.function @alloc::raw_vec::handle_error(v871: i32, v872: i32, v873: i32) {
+        ^block108(v871: i32, v872: i32, v873: i32):
             ub.unreachable ;
         };
 
-        private builtin.function @core::slice::<impl [T]>::copy_from_slice::len_mismatch_fail::do_panic::runtime(v881: i32, v882: i32, v883: i32) {
-        ^block110(v881: i32, v882: i32, v883: i32):
+        private builtin.function @core::slice::<impl [T]>::copy_from_slice::len_mismatch_fail::do_panic::runtime(v874: i32, v875: i32, v876: i32) {
+        ^block110(v874: i32, v875: i32, v876: i32):
             ub.unreachable ;
         };
 
-        private builtin.function @core::ptr::alignment::Alignment::max(v884: i32, v885: i32) -> i32 {
-        ^block112(v884: i32, v885: i32):
-            v892 = arith.constant 0 : i32;
-            v888 = hir.bitcast v885 : u32;
-            v887 = hir.bitcast v884 : u32;
-            v889 = arith.gt v887, v888 : i1;
-            v890 = arith.zext v889 : u32;
-            v891 = hir.bitcast v890 : i32;
-            v893 = arith.neq v891, v892 : i1;
-            v894 = cf.select v893, v884, v885 : i32;
-            builtin.ret v894;
+        private builtin.function @core::ptr::alignment::Alignment::max(v877: i32, v878: i32) -> i32 {
+        ^block112(v877: i32, v878: i32):
+            v885 = arith.constant 0 : i32;
+            v881 = hir.bitcast v878 : u32;
+            v880 = hir.bitcast v877 : u32;
+            v882 = arith.gt v880, v881 : i1;
+            v883 = arith.zext v882 : u32;
+            v884 = hir.bitcast v883 : i32;
+            v886 = arith.neq v884, v885 : i1;
+            v887 = cf.select v886, v877, v878 : i32;
+            builtin.ret v887;
         };
 
-        private builtin.function @miden::output_note::create(v895: felt, v896: felt, v897: felt, v898: felt, v899: felt, v900: felt, v901: felt, v902: felt) -> felt {
-        ^block114(v895: felt, v896: felt, v897: felt, v898: felt, v899: felt, v900: felt, v901: felt, v902: felt):
-            v903 = hir.exec @miden/output_note/create(v895, v896, v897, v898, v899, v900, v901, v902) : felt
-            builtin.ret v903;
+        private builtin.function @miden::output_note::create(v888: felt, v889: felt, v890: felt, v891: felt, v892: felt, v893: felt, v894: felt, v895: felt) -> felt {
+        ^block114(v888: felt, v889: felt, v890: felt, v891: felt, v892: felt, v893: felt, v894: felt, v895: felt):
+            v896 = hir.exec @miden/output_note/create(v888, v889, v890, v891, v892, v893, v894, v895) : felt
+            builtin.ret v896;
         };
 
         builtin.global_variable private @#__stack_pointer : i32 {
@@ -1259,14 +1254,14 @@ builtin.component miden:base/transaction-script@1.0.0 {
             builtin.ret_imm 0;
         };
 
-        builtin.segment readonly @1048576 = 0x0073722e62696c2f6372730073722e6d656d2f62696c6474732f6372732f312e372e302d7379732d62696c6474732d6e6564696d;
+        builtin.segment readonly @1048576 = 0x003e64657463616465723c;
 
-        builtin.segment @1048628 = 0x00000021000000270000000a0010002900000025000000250000000a0010002900000021000000970000002800100000000000010000000100000001;
+        builtin.segment @1048588 = 0x00000000000000000000000a00100000000000010000000100000001;
     };
 
-    public builtin.function @run(v905: felt, v906: felt, v907: felt, v908: felt) {
-    ^block118(v905: felt, v906: felt, v907: felt, v908: felt):
-        hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/miden:base/transaction-script@1.0.0#run(v905, v906, v907, v908)
+    public builtin.function @run(v898: felt, v899: felt, v900: felt, v901: felt) {
+    ^block118(v898: felt, v899: felt, v900: felt, v901: felt):
+        hir.exec @miden:base/transaction-script@1.0.0/basic_wallet_tx_script/miden:base/transaction-script@1.0.0#run(v898, v899, v900, v901)
         builtin.ret ;
     };
 };

--- a/tests/integration/expected/examples/basic_wallet_tx_script.masm
+++ b/tests/integration/expected/examples/basic_wallet_tx_script.masm
@@ -16,20 +16,20 @@ proc init
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
-    push.[10151340310367592649,1643550100843527730,13897610209430550998,3750372866565455699]
+    push.[3747760794384071571,1766386520481277932,2198275188940187258,538857382178104910]
     adv.push_mapval
     push.262144
-    push.7
+    push.3
     trace.240
     exec.::std::mem::pipe_preimage_to_memory
     trace.252
     drop
     push.1048576
     u32assert
-    mem_store.278560
+    mem_store.278544
     push.0
     u32assert
-    mem_store.278561
+    mem_store.278545
 end
 
 # mod miden:base/transaction-script@1.0.0::basic_wallet_tx_script
@@ -59,9 +59,19 @@ end
 @callconv("C")
 proc core::slice::index::slice_end_index_len_fail(
     i32,
-    i32,
     i32
 )
+    push.1114180
+    u32divmod.4
+    swap.1
+    trace.240
+    nop
+    exec.::intrinsics::mem::load_sw
+    trace.252
+    nop
+    push.1048600
+    u32wrapping_add
+    movdn.2
     trace.240
     nop
     exec.::miden:base/transaction-script@1.0.0::basic_wallet_tx_script::core::slice::<impl [T]>::copy_from_slice::len_mismatch_fail::do_panic::runtime
@@ -73,7 +83,6 @@ end
 
 @callconv("C")
 proc <alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index(
-    i32,
     i32,
     i32,
     i32,
@@ -103,9 +112,6 @@ proc <alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index(
     u32lte
     neq
     if.true
-        movup.5
-        swap.1
-        drop
         drop
         push.4
         dup.1
@@ -184,7 +190,7 @@ end
 
 @callconv("C")
 proc __rustc::__rust_alloc(i32, i32) -> i32
-    push.1114244
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -192,7 +198,7 @@ proc __rustc::__rust_alloc(i32, i32) -> i32
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.1048688
+    push.1048616
     u32wrapping_add
     movup.2
     swap.1
@@ -212,7 +218,7 @@ end
 
 @callconv("C")
 proc __rustc::__rust_alloc_zeroed(i32, i32) -> i32
-    push.1114244
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -220,7 +226,7 @@ proc __rustc::__rust_alloc_zeroed(i32, i32) -> i32
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.1048688
+    push.1048616
     u32wrapping_add
     dup.1
     swap.2
@@ -304,7 +310,7 @@ end
 
 @callconv("C")
 proc miden:base/transaction-script@1.0.0#run(felt, felt, felt, felt)
-    push.1114240
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -314,7 +320,7 @@ proc miden:base/transaction-script@1.0.0#run(felt, felt, felt, felt)
     nop
     push.80
     u32wrapping_sub
-    push.1114240
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -466,7 +472,7 @@ proc miden:base/transaction-script@1.0.0#run(felt, felt, felt, felt)
         drop
         movup.2
         drop
-        push.1114244
+        push.1114180
         u32divmod.4
         swap.1
         trace.240
@@ -491,7 +497,7 @@ proc miden:base/transaction-script@1.0.0#run(felt, felt, felt, felt)
         exec.::intrinsics::mem::load_sw
         trace.252
         nop
-        push.1048640
+        push.1048600
         movup.2
         u32wrapping_add
         swap.2
@@ -608,15 +614,24 @@ proc miden:base/transaction-script@1.0.0#run(felt, felt, felt, felt)
             drop
             push.0
         else
-            push.1114244
+            push.12
+            dup.2
+            add
+            u32assert
+            push.4
+            dup.1
+            swap.1
+            u32mod
+            u32assert
+            assertz
             u32divmod.4
             swap.1
             trace.240
             nop
-            exec.::intrinsics::mem::load_sw
+            exec.::intrinsics::mem::load_felt
             trace.252
             nop
-            push.12
+            push.8
             dup.3
             add
             u32assert
@@ -633,7 +648,7 @@ proc miden:base/transaction-script@1.0.0#run(felt, felt, felt, felt)
             exec.::intrinsics::mem::load_felt
             trace.252
             nop
-            push.8
+            push.4
             dup.4
             add
             u32assert
@@ -650,10 +665,7 @@ proc miden:base/transaction-script@1.0.0#run(felt, felt, felt, felt)
             exec.::intrinsics::mem::load_felt
             trace.252
             nop
-            push.4
-            dup.5
-            add
-            u32assert
+            movup.4
             push.4
             dup.1
             swap.1
@@ -667,30 +679,13 @@ proc miden:base/transaction-script@1.0.0#run(felt, felt, felt, felt)
             exec.::intrinsics::mem::load_felt
             trace.252
             nop
-            movup.5
-            push.4
-            dup.1
-            swap.1
-            u32mod
-            u32assert
-            assertz
-            u32divmod.4
-            swap.1
-            trace.240
-            nop
-            exec.::intrinsics::mem::load_felt
-            trace.252
-            nop
-            push.1048656
-            movup.5
-            u32wrapping_add
             push.8
             push.4
             push.20
-            dup.8
+            dup.7
             u32wrapping_add
             push.8
-            dup.9
+            dup.8
             u32wrapping_add
             trace.240
             nop
@@ -806,19 +801,11 @@ proc miden:base/transaction-script@1.0.0#run(felt, felt, felt, felt)
                 exec.::intrinsics::mem::store_dw
                 trace.252
                 nop
-                push.1114244
-                u32divmod.4
-                swap.1
-                trace.240
-                nop
-                exec.::intrinsics::mem::load_sw
-                trace.252
-                nop
                 push.32
-                dup.6
+                dup.5
                 u32wrapping_add
                 push.64
-                dup.7
+                dup.6
                 u32wrapping_add
                 trace.240
                 nop
@@ -826,24 +813,20 @@ proc miden:base/transaction-script@1.0.0#run(felt, felt, felt, felt)
                 trace.252
                 nop
                 push.64
-                dup.6
+                dup.5
                 u32wrapping_add
-                movdn.5
-                movdn.5
+                movdn.4
                 trace.240
                 nop
                 exec.::miden:base/transaction-script@1.0.0::basic_wallet_tx_script::miden_base_sys::bindings::output_note::create
                 trace.252
                 nop
-                push.1048672
-                movup.2
-                u32wrapping_add
                 push.12
                 push.8
                 push.20
-                dup.5
+                dup.4
                 u32wrapping_add
-                dup.5
+                dup.4
                 trace.240
                 nop
                 exec.::miden:base/transaction-script@1.0.0::basic_wallet_tx_script::<alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index
@@ -1062,7 +1045,7 @@ proc miden:base/transaction-script@1.0.0#run(felt, felt, felt, felt)
                     push.80
                     movup.2
                     u32wrapping_add
-                    push.1114240
+                    push.1114176
                     u32divmod.4
                     swap.1
                     trace.240
@@ -1099,7 +1082,7 @@ end
 proc wit_bindgen::rt::run_ctors_once(
 
 )
-    push.1114244
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -1107,7 +1090,7 @@ proc wit_bindgen::rt::run_ctors_once(
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.1048692
+    push.1048620
     u32wrapping_add
     u32divmod.4
     swap.1
@@ -1128,7 +1111,7 @@ proc wit_bindgen::rt::run_ctors_once(
     if.true
         nop
     else
-        push.1114244
+        push.1114180
         u32divmod.4
         swap.1
         trace.240
@@ -1142,7 +1125,7 @@ proc wit_bindgen::rt::run_ctors_once(
         trace.252
         nop
         push.1
-        push.1048692
+        push.1048620
         movup.2
         u32wrapping_add
         u32divmod.4
@@ -1572,7 +1555,7 @@ proc alloc::raw_vec::RawVecInner<A>::deallocate(
     i32,
     i32
 )
-    push.1114240
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1582,7 +1565,7 @@ proc alloc::raw_vec::RawVecInner<A>::deallocate(
     nop
     push.16
     u32wrapping_sub
-    push.1114240
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -1673,7 +1656,7 @@ proc alloc::raw_vec::RawVecInner<A>::deallocate(
     end
     push.16
     u32wrapping_add
-    push.1114240
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1691,7 +1674,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     i32,
     i32
 )
-    push.1114240
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1701,7 +1684,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     nop
     push.16
     u32wrapping_sub
-    push.1114240
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -2086,7 +2069,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     nop
     push.16
     u32wrapping_add
-    push.1114240
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -2102,7 +2085,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     i32,
     i32
 )
-    push.1114240
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -2112,7 +2095,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     nop
     push.16
     u32wrapping_sub
-    push.1114240
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -2205,7 +2188,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     nop
     push.16
     u32wrapping_add
-    push.1114240
+    push.1114176
     u32divmod.4
     swap.1
     trace.240

--- a/tests/integration/expected/examples/basic_wallet_tx_script.wat
+++ b/tests/integration/expected/examples/basic_wallet_tx_script.wat
@@ -29,21 +29,21 @@
   (core module (;0;)
     (type (;0;) (func (param f32 f32 f32 f32 f32)))
     (type (;1;) (func))
-    (type (;2;) (func (param i32 i32 i32)))
-    (type (;3;) (func (param i32 i32 i32 i32 i32)))
+    (type (;2;) (func (param i32 i32)))
+    (type (;3;) (func (param i32 i32 i32 i32)))
     (type (;4;) (func (param i32 i32) (result i32)))
-    (type (;5;) (func (param f32 f32 f32 f32)))
-    (type (;6;) (func (param i32 i32 i32) (result i32)))
-    (type (;7;) (func (result i32)))
-    (type (;8;) (func (param f32 f32 f32 f32 i32) (result f32)))
-    (type (;9;) (func (param i32 i32)))
+    (type (;5;) (func (param i32 i32 i32)))
+    (type (;6;) (func (param f32 f32 f32 f32)))
+    (type (;7;) (func (param i32 i32 i32) (result i32)))
+    (type (;8;) (func (result i32)))
+    (type (;9;) (func (param f32 f32 f32 f32 i32) (result f32)))
     (type (;10;) (func (param i64) (result f32)))
     (type (;11;) (func (param i32) (result f32)))
     (type (;12;) (func (param f32) (result i64)))
     (type (;13;) (func (param f32 f32)))
     (type (;14;) (func (param f32 f32 f32 f32) (result f32)))
     (type (;15;) (func (param f32 i32 f32 f32 f32 f32) (result i32)))
-    (type (;16;) (func (param i32 i32 i32 i32)))
+    (type (;16;) (func (param i32 i32 i32 i32 i32)))
     (type (;17;) (func (param f32 f32 f32 f32 f32 f32 f32 f32) (result f32)))
     (import "miden:basic-wallet/basic-wallet@0.1.0" "move-asset-to-note" (func $basic_wallet_tx_script::bindings::miden::basic_wallet::basic_wallet::move_asset_to_note::wit_import9 (;0;) (type 0)))
     (table (;0;) 2 2 funcref)
@@ -54,24 +54,25 @@
     (export "miden:base/transaction-script@1.0.0#run" (func $miden:base/transaction-script@1.0.0#run))
     (elem (;0;) (i32.const 1) func $basic_wallet_tx_script::bindings::__link_custom_section_describing_imports)
     (func $__wasm_call_ctors (;1;) (type 1))
-    (func $core::slice::index::slice_end_index_len_fail (;2;) (type 2) (param i32 i32 i32)
+    (func $core::slice::index::slice_end_index_len_fail (;2;) (type 2) (param i32 i32)
       local.get 0
       local.get 1
-      local.get 2
+      global.get $GOT.data.internal.__memory_base
+      i32.const 1048600
+      i32.add
       call $core::slice::<impl [T]>::copy_from_slice::len_mismatch_fail::do_panic::runtime
       unreachable
     )
-    (func $<alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index (;3;) (type 3) (param i32 i32 i32 i32 i32)
+    (func $<alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index (;3;) (type 3) (param i32 i32 i32 i32)
       (local i32)
       block ;; label = @1
         local.get 3
         local.get 1
         i32.load offset=8
-        local.tee 5
+        local.tee 4
         i32.le_u
         br_if 0 (;@1;)
         local.get 3
-        local.get 5
         local.get 4
         call $core::slice::index::slice_end_index_len_fail
         unreachable
@@ -92,17 +93,17 @@
     )
     (func $__rustc::__rust_alloc (;4;) (type 4) (param i32 i32) (result i32)
       global.get $GOT.data.internal.__memory_base
-      i32.const 1048688
+      i32.const 1048616
       i32.add
       local.get 1
       local.get 0
       call $<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc
     )
-    (func $__rustc::__rust_dealloc (;5;) (type 2) (param i32 i32 i32))
+    (func $__rustc::__rust_dealloc (;5;) (type 5) (param i32 i32 i32))
     (func $__rustc::__rust_alloc_zeroed (;6;) (type 4) (param i32 i32) (result i32)
       block ;; label = @1
         global.get $GOT.data.internal.__memory_base
-        i32.const 1048688
+        i32.const 1048616
         i32.add
         local.get 1
         local.get 0
@@ -121,7 +122,7 @@
       local.get 1
     )
     (func $basic_wallet_tx_script::bindings::__link_custom_section_describing_imports (;7;) (type 1))
-    (func $miden:base/transaction-script@1.0.0#run (;8;) (type 5) (param f32 f32 f32 f32)
+    (func $miden:base/transaction-script@1.0.0#run (;8;) (type 6) (param f32 f32 f32 f32)
       (local i32 i64 f32 i32 i32 i32)
       global.get $__stack_pointer
       i32.const 80
@@ -194,8 +195,6 @@
           local.get 7
           i32.eqz
           br_if 1 (;@1;)
-          global.get $GOT.data.internal.__memory_base
-          local.set 7
           local.get 9
           f32.load offset=12
           local.set 0
@@ -216,9 +215,6 @@
           i32.add
           i32.const 4
           i32.const 8
-          local.get 7
-          i32.const 1048656
-          i32.add
           call $<alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index
           local.get 4
           i32.load offset=12
@@ -243,8 +239,6 @@
           local.get 4
           local.get 5
           i64.store offset=32
-          global.get $GOT.data.internal.__memory_base
-          local.set 9
           local.get 4
           i32.const 64
           i32.add
@@ -267,9 +261,6 @@
           i32.add
           i32.const 8
           i32.const 12
-          local.get 9
-          i32.const 1048672
-          i32.add
           call $<alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index
           local.get 4
           i32.load offset=4
@@ -329,7 +320,7 @@
         local.get 4
         i32.load offset=72
         local.get 9
-        i32.const 1048640
+        i32.const 1048600
         i32.add
         call $alloc::raw_vec::handle_error
       end
@@ -342,7 +333,7 @@
       (local i32)
       block ;; label = @1
         global.get $GOT.data.internal.__memory_base
-        i32.const 1048692
+        i32.const 1048620
         i32.add
         i32.load8_u
         br_if 0 (;@1;)
@@ -350,13 +341,13 @@
         local.set 0
         call $__wasm_call_ctors
         local.get 0
-        i32.const 1048692
+        i32.const 1048620
         i32.add
         i32.const 1
         i32.store8
       end
     )
-    (func $<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc (;11;) (type 6) (param i32 i32 i32) (result i32)
+    (func $<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc (;11;) (type 7) (param i32 i32 i32) (result i32)
       (local i32 i32)
       block ;; label = @1
         local.get 1
@@ -428,10 +419,10 @@
       end
       unreachable
     )
-    (func $intrinsics::mem::heap_base (;12;) (type 7) (result i32)
+    (func $intrinsics::mem::heap_base (;12;) (type 8) (result i32)
       unreachable
     )
-    (func $miden_base_sys::bindings::output_note::create (;13;) (type 8) (param f32 f32 f32 f32 i32) (result f32)
+    (func $miden_base_sys::bindings::output_note::create (;13;) (type 9) (param f32 f32 f32 f32 i32) (result f32)
       local.get 0
       local.get 1
       local.get 2
@@ -446,7 +437,7 @@
       f32.load
       call $miden::output_note::create
     )
-    (func $<miden_base_sys::bindings::types::Asset as core::convert::From<[miden_stdlib_sys::intrinsics::felt::Felt; 4]>>::from (;14;) (type 9) (param i32 i32)
+    (func $<miden_base_sys::bindings::types::Asset as core::convert::From<[miden_stdlib_sys::intrinsics::felt::Felt; 4]>>::from (;14;) (type 2) (param i32 i32)
       local.get 0
       local.get 1
       i64.load offset=8 align=4
@@ -474,7 +465,7 @@
     (func $std::mem::pipe_preimage_to_memory (;20;) (type 15) (param f32 i32 f32 f32 f32 f32) (result i32)
       unreachable
     )
-    (func $alloc::raw_vec::RawVecInner<A>::deallocate (;21;) (type 2) (param i32 i32 i32)
+    (func $alloc::raw_vec::RawVecInner<A>::deallocate (;21;) (type 5) (param i32 i32 i32)
       (local i32)
       global.get $__stack_pointer
       i32.const 16
@@ -506,7 +497,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $alloc::raw_vec::RawVecInner<A>::try_allocate_in (;22;) (type 3) (param i32 i32 i32 i32 i32)
+    (func $alloc::raw_vec::RawVecInner<A>::try_allocate_in (;22;) (type 16) (param i32 i32 i32 i32 i32)
       (local i32 i64)
       global.get $__stack_pointer
       i32.const 16
@@ -618,7 +609,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $<alloc::alloc::Global as core::alloc::Allocator>::allocate (;23;) (type 2) (param i32 i32 i32)
+    (func $<alloc::alloc::Global as core::alloc::Allocator>::allocate (;23;) (type 5) (param i32 i32 i32)
       (local i32)
       global.get $__stack_pointer
       i32.const 16
@@ -647,7 +638,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $alloc::alloc::Global::alloc_impl (;24;) (type 16) (param i32 i32 i32 i32)
+    (func $alloc::alloc::Global::alloc_impl (;24;) (type 3) (param i32 i32 i32 i32)
       block ;; label = @1
         local.get 2
         i32.eqz
@@ -674,7 +665,7 @@
       local.get 1
       i32.store
     )
-    (func $alloc::raw_vec::RawVecInner<A>::current_memory (;25;) (type 16) (param i32 i32 i32 i32)
+    (func $alloc::raw_vec::RawVecInner<A>::current_memory (;25;) (type 3) (param i32 i32 i32 i32)
       (local i32 i32 i32)
       i32.const 0
       local.set 4
@@ -709,7 +700,7 @@
       local.get 4
       i32.store
     )
-    (func $<alloc::alloc::Global as core::alloc::Allocator>::deallocate (;26;) (type 2) (param i32 i32 i32)
+    (func $<alloc::alloc::Global as core::alloc::Allocator>::deallocate (;26;) (type 5) (param i32 i32 i32)
       block ;; label = @1
         local.get 2
         i32.eqz
@@ -720,10 +711,10 @@
         call $__rustc::__rust_dealloc
       end
     )
-    (func $alloc::raw_vec::handle_error (;27;) (type 2) (param i32 i32 i32)
+    (func $alloc::raw_vec::handle_error (;27;) (type 5) (param i32 i32 i32)
       unreachable
     )
-    (func $core::slice::<impl [T]>::copy_from_slice::len_mismatch_fail::do_panic::runtime (;28;) (type 2) (param i32 i32 i32)
+    (func $core::slice::<impl [T]>::copy_from_slice::len_mismatch_fail::do_panic::runtime (;28;) (type 5) (param i32 i32 i32)
       unreachable
     )
     (func $core::ptr::alignment::Alignment::max (;29;) (type 4) (param i32 i32) (result i32)
@@ -737,8 +728,8 @@
     (func $miden::output_note::create (;30;) (type 17) (param f32 f32 f32 f32 f32 f32 f32 f32) (result f32)
       unreachable
     )
-    (data $.rodata (;0;) (i32.const 1048576) "miden-stdlib-sys-0.7.1/src/stdlib/mem.rs\00src/lib.rs\00")
-    (data $.data (;1;) (i32.const 1048628) "\01\00\00\00\01\00\00\00\01\00\00\00\00\00\10\00(\00\00\00\97\00\00\00!\00\00\00)\00\10\00\0a\00\00\00%\00\00\00%\00\00\00)\00\10\00\0a\00\00\00'\00\00\00!\00\00\00")
+    (data $.rodata (;0;) (i32.const 1048576) "<redacted>\00")
+    (data $.data (;1;) (i32.const 1048588) "\01\00\00\00\01\00\00\00\01\00\00\00\00\00\10\00\0a\00\00\00\00\00\00\00\00\00\00\00")
   )
   (alias export 0 "word" (type (;4;)))
   (alias export 1 "move-asset-to-note" (func (;0;)))

--- a/tests/integration/expected/examples/p2id.hir
+++ b/tests/integration/expected/examples/p2id.hir
@@ -16,7 +16,7 @@ builtin.component miden:base/note-script@1.0.0 {
             v7 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
             v8 = hir.bitcast v7 : ptr<byte, i32>;
             v9 = hir.load v8 : i32;
-            v10 = arith.constant 1048672 : i32;
+            v10 = arith.constant 1048616 : i32;
             v11 = arith.add v9, v10 : i32 #[overflow = wrapping];
             v12 = hir.exec @miden:base/note-script@1.0.0/p2id/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v11, v5, v4) : i32
             builtin.ret v12;
@@ -32,36 +32,36 @@ builtin.component miden:base/note-script@1.0.0 {
             v19 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
             v20 = hir.bitcast v19 : ptr<byte, i32>;
             v21 = hir.load v20 : i32;
-            v22 = arith.constant 1048672 : i32;
+            v22 = arith.constant 1048616 : i32;
             v23 = arith.add v21, v22 : i32 #[overflow = wrapping];
             v24 = hir.exec @miden:base/note-script@1.0.0/p2id/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v23, v17, v16) : i32
-            v905 = arith.constant 0 : i32;
+            v898 = arith.constant 0 : i32;
             v25 = arith.constant 0 : i32;
             v26 = arith.eq v24, v25 : i1;
             v27 = arith.zext v26 : u32;
             v28 = hir.bitcast v27 : i32;
-            v30 = arith.neq v28, v905 : i1;
+            v30 = arith.neq v28, v898 : i1;
             scf.if v30{
             ^block16:
                 scf.yield ;
             } else {
             ^block17:
-                v903 = arith.constant 0 : i32;
-                v904 = arith.constant 0 : i32;
-                v32 = arith.eq v16, v904 : i1;
+                v896 = arith.constant 0 : i32;
+                v897 = arith.constant 0 : i32;
+                v32 = arith.eq v16, v897 : i1;
                 v33 = arith.zext v32 : u32;
                 v34 = hir.bitcast v33 : i32;
-                v36 = arith.neq v34, v903 : i1;
+                v36 = arith.neq v34, v896 : i1;
                 scf.if v36{
                 ^block114:
                     scf.yield ;
                 } else {
                 ^block18:
-                    v897 = arith.constant 0 : u8;
+                    v890 = arith.constant 0 : u8;
                     v39 = hir.bitcast v16 : u32;
                     v40 = hir.bitcast v24 : u32;
                     v41 = hir.int_to_ptr v40 : ptr<byte, u8>;
-                    hir.mem_set v41, v39, v897;
+                    hir.mem_set v41, v39, v890;
                     scf.yield ;
                 };
                 scf.yield ;
@@ -97,38 +97,38 @@ builtin.component miden:base/note-script@1.0.0 {
             v64 = hir.int_to_ptr v61 : ptr<byte, i32>;
             v65 = hir.load v64 : i32;
             v66 = hir.cast v65 : u32;
-            v963 = scf.index_switch v66 : u32 
+            v956 = scf.index_switch v66 : u32 
             case 0 {
             ^block119:
-                v1007 = arith.constant 1 : u32;
-                scf.yield v1007;
+                v1000 = arith.constant 1 : u32;
+                scf.yield v1000;
             }
             case 1 {
             ^block120:
-                v1006 = arith.constant 1 : u32;
-                scf.yield v1006;
+                v999 = arith.constant 1 : u32;
+                scf.yield v999;
             }
             default {
             ^block24:
                 v68 = arith.constant 20 : u32;
                 v67 = hir.bitcast v54 : u32;
                 v69 = arith.add v67, v68 : u32 #[overflow = checked];
-                v1040 = arith.constant 4 : u32;
-                v71 = arith.mod v69, v1040 : u32;
+                v1033 = arith.constant 4 : u32;
+                v71 = arith.mod v69, v1033 : u32;
                 hir.assertz v71 #[code = 250];
                 v72 = hir.int_to_ptr v69 : ptr<byte, i32>;
                 v73 = hir.load v72 : i32;
-                v1039 = arith.constant 4 : u32;
+                v1032 = arith.constant 4 : u32;
                 v74 = hir.bitcast v73 : u32;
-                v76 = arith.add v74, v1039 : u32 #[overflow = checked];
-                v1038 = arith.constant 4 : u32;
-                v78 = arith.mod v76, v1038 : u32;
+                v76 = arith.add v74, v1032 : u32 #[overflow = checked];
+                v1031 = arith.constant 4 : u32;
+                v78 = arith.mod v76, v1031 : u32;
                 hir.assertz v78 #[code = 250];
                 v79 = hir.int_to_ptr v76 : ptr<byte, felt>;
                 v80 = hir.load v79 : felt;
                 v81 = hir.bitcast v73 : u32;
-                v1037 = arith.constant 4 : u32;
-                v83 = arith.mod v81, v1037 : u32;
+                v1030 = arith.constant 4 : u32;
+                v83 = arith.mod v81, v1030 : u32;
                 hir.assertz v83 #[code = 250];
                 v84 = hir.int_to_ptr v81 : ptr<byte, felt>;
                 v85 = hir.load v84 : felt;
@@ -138,16 +138,16 @@ builtin.component miden:base/note-script@1.0.0 {
                 v89 = arith.constant 12 : u32;
                 v88 = hir.bitcast v54 : u32;
                 v90 = arith.add v88, v89 : u32 #[overflow = checked];
-                v1036 = arith.constant 4 : u32;
-                v92 = arith.mod v90, v1036 : u32;
+                v1029 = arith.constant 4 : u32;
+                v92 = arith.mod v90, v1029 : u32;
                 hir.assertz v92 #[code = 250];
                 v93 = hir.int_to_ptr v90 : ptr<byte, felt>;
                 v94 = hir.load v93 : felt;
                 v96 = arith.constant 8 : u32;
                 v95 = hir.bitcast v54 : u32;
                 v97 = arith.add v95, v96 : u32 #[overflow = checked];
-                v1035 = arith.constant 4 : u32;
-                v99 = arith.mod v97, v1035 : u32;
+                v1028 = arith.constant 4 : u32;
+                v99 = arith.mod v97, v1028 : u32;
                 hir.assertz v99 #[code = 250];
                 v100 = hir.int_to_ptr v97 : ptr<byte, felt>;
                 v101 = hir.load v100 : felt;
@@ -158,19 +158,19 @@ builtin.component miden:base/note-script@1.0.0 {
                 v105 = arith.zext v104 : u32;
                 v106 = hir.bitcast v105 : i32;
                 v108 = arith.neq v106, v47 : i1;
-                v965 = scf.if v108 : u32 {
+                v958 = scf.if v108 : u32 {
                 ^block118:
-                    v915 = arith.constant 1 : u32;
-                    scf.yield v915;
+                    v908 = arith.constant 1 : u32;
+                    scf.yield v908;
                 } else {
                 ^block25:
                     v109 = hir.exec @miden:base/note-script@1.0.0/p2id/intrinsics::felt::eq(v94, v80) : i32
-                    v1033 = arith.constant 0 : i32;
-                    v1034 = arith.constant 1 : i32;
-                    v111 = arith.neq v109, v1034 : i1;
+                    v1026 = arith.constant 0 : i32;
+                    v1027 = arith.constant 1 : i32;
+                    v111 = arith.neq v109, v1027 : i1;
                     v112 = arith.zext v111 : u32;
                     v113 = hir.bitcast v112 : i32;
-                    v115 = arith.neq v113, v1033 : i1;
+                    v115 = arith.neq v113, v1026 : i1;
                     scf.if v115{
                     ^block117:
                         scf.yield ;
@@ -182,136 +182,136 @@ builtin.component miden:base/note-script@1.0.0 {
                         v119 = arith.constant 36 : u32;
                         v118 = hir.bitcast v54 : u32;
                         v120 = arith.add v118, v119 : u32 #[overflow = checked];
-                        v1032 = arith.constant 4 : u32;
-                        v122 = arith.mod v120, v1032 : u32;
+                        v1025 = arith.constant 4 : u32;
+                        v122 = arith.mod v120, v1025 : u32;
                         hir.assertz v122 #[code = 250];
                         v123 = hir.int_to_ptr v120 : ptr<byte, i32>;
                         v124 = hir.load v123 : i32;
                         v129 = arith.constant 28 : u32;
                         v128 = hir.bitcast v54 : u32;
                         v130 = arith.add v128, v129 : u32 #[overflow = checked];
-                        v1031 = arith.constant 4 : u32;
-                        v132 = arith.mod v130, v1031 : u32;
+                        v1024 = arith.constant 4 : u32;
+                        v132 = arith.mod v130, v1024 : u32;
                         hir.assertz v132 #[code = 250];
                         v133 = hir.int_to_ptr v130 : ptr<byte, i32>;
                         v134 = hir.load v133 : i32;
                         v136 = arith.constant 32 : u32;
                         v135 = hir.bitcast v54 : u32;
                         v137 = arith.add v135, v136 : u32 #[overflow = checked];
-                        v1030 = arith.constant 4 : u32;
-                        v139 = arith.mod v137, v1030 : u32;
+                        v1023 = arith.constant 4 : u32;
+                        v139 = arith.mod v137, v1023 : u32;
                         hir.assertz v139 #[code = 250];
                         v140 = hir.int_to_ptr v137 : ptr<byte, i32>;
                         v141 = hir.load v140 : i32;
-                        v1029 = arith.constant 4 : u32;
-                        v127 = arith.shl v124, v1029 : i32;
-                        v983, v984, v985, v986, v987, v988, v989, v990 = scf.while v127, v141, v54, v141, v134 : i32, i32, i32, i32, i32, i32, i32, i32 {
-                        ^block132(v991: i32, v992: i32, v993: i32, v994: i32, v995: i32):
-                            v1027 = arith.constant 0 : i32;
-                            v1028 = arith.constant 0 : i32;
-                            v144 = arith.eq v991, v1028 : i1;
+                        v1022 = arith.constant 4 : u32;
+                        v127 = arith.shl v124, v1022 : i32;
+                        v976, v977, v978, v979, v980, v981, v982, v983 = scf.while v127, v141, v54, v141, v134 : i32, i32, i32, i32, i32, i32, i32, i32 {
+                        ^block132(v984: i32, v985: i32, v986: i32, v987: i32, v988: i32):
+                            v1020 = arith.constant 0 : i32;
+                            v1021 = arith.constant 0 : i32;
+                            v144 = arith.eq v984, v1021 : i1;
                             v145 = arith.zext v144 : u32;
                             v146 = hir.bitcast v145 : i32;
-                            v148 = arith.neq v146, v1027 : i1;
-                            v976, v977 = scf.if v148 : i32, i32 {
+                            v148 = arith.neq v146, v1020 : i1;
+                            v969, v970 = scf.if v148 : i32, i32 {
                             ^block131:
-                                v916 = ub.poison i32 : i32;
-                                scf.yield v916, v916;
+                                v909 = ub.poison i32 : i32;
+                                scf.yield v909, v909;
                             } else {
                             ^block30:
-                                v150 = hir.bitcast v992 : u32;
-                                v1026 = arith.constant 4 : u32;
-                                v152 = arith.mod v150, v1026 : u32;
+                                v150 = hir.bitcast v985 : u32;
+                                v1019 = arith.constant 4 : u32;
+                                v152 = arith.mod v150, v1019 : u32;
                                 hir.assertz v152 #[code = 250];
                                 v153 = hir.int_to_ptr v150 : ptr<byte, felt>;
                                 v154 = hir.load v153 : felt;
-                                v1025 = arith.constant 4 : u32;
-                                v155 = hir.bitcast v992 : u32;
-                                v157 = arith.add v155, v1025 : u32 #[overflow = checked];
-                                v1024 = arith.constant 4 : u32;
-                                v159 = arith.mod v157, v1024 : u32;
+                                v1018 = arith.constant 4 : u32;
+                                v155 = hir.bitcast v985 : u32;
+                                v157 = arith.add v155, v1018 : u32 #[overflow = checked];
+                                v1017 = arith.constant 4 : u32;
+                                v159 = arith.mod v157, v1017 : u32;
                                 hir.assertz v159 #[code = 250];
                                 v160 = hir.int_to_ptr v157 : ptr<byte, felt>;
                                 v161 = hir.load v160 : felt;
-                                v1023 = arith.constant 8 : u32;
-                                v162 = hir.bitcast v992 : u32;
-                                v164 = arith.add v162, v1023 : u32 #[overflow = checked];
-                                v1022 = arith.constant 4 : u32;
-                                v166 = arith.mod v164, v1022 : u32;
+                                v1016 = arith.constant 8 : u32;
+                                v162 = hir.bitcast v985 : u32;
+                                v164 = arith.add v162, v1016 : u32 #[overflow = checked];
+                                v1015 = arith.constant 4 : u32;
+                                v166 = arith.mod v164, v1015 : u32;
                                 hir.assertz v166 #[code = 250];
                                 v167 = hir.int_to_ptr v164 : ptr<byte, felt>;
                                 v168 = hir.load v167 : felt;
-                                v1021 = arith.constant 12 : u32;
-                                v169 = hir.bitcast v992 : u32;
-                                v171 = arith.add v169, v1021 : u32 #[overflow = checked];
-                                v1020 = arith.constant 4 : u32;
-                                v173 = arith.mod v171, v1020 : u32;
+                                v1014 = arith.constant 12 : u32;
+                                v169 = hir.bitcast v985 : u32;
+                                v171 = arith.add v169, v1014 : u32 #[overflow = checked];
+                                v1013 = arith.constant 4 : u32;
+                                v173 = arith.mod v171, v1013 : u32;
                                 hir.assertz v173 #[code = 250];
                                 v174 = hir.int_to_ptr v171 : ptr<byte, felt>;
                                 v175 = hir.load v174 : felt;
                                 hir.exec @miden:base/note-script@1.0.0/p2id/p2id::bindings::miden::basic_wallet::basic_wallet::receive_asset::wit_import7(v154, v161, v168, v175)
-                                v1019 = arith.constant 16 : i32;
-                                v179 = arith.add v992, v1019 : i32 #[overflow = wrapping];
+                                v1012 = arith.constant 16 : i32;
+                                v179 = arith.add v985, v1012 : i32 #[overflow = wrapping];
                                 v176 = arith.constant -16 : i32;
-                                v177 = arith.add v991, v176 : i32 #[overflow = wrapping];
+                                v177 = arith.add v984, v176 : i32 #[overflow = wrapping];
                                 scf.yield v177, v179;
                             };
-                            v1015 = ub.poison i32 : i32;
-                            v980 = cf.select v148, v1015, v995 : i32;
-                            v1016 = ub.poison i32 : i32;
-                            v979 = cf.select v148, v1016, v994 : i32;
-                            v1017 = ub.poison i32 : i32;
-                            v978 = cf.select v148, v1017, v993 : i32;
-                            v1018 = arith.constant 1 : u32;
-                            v907 = arith.constant 0 : u32;
-                            v982 = cf.select v148, v907, v1018 : u32;
-                            v960 = arith.trunc v982 : i1;
-                            scf.condition v960, v976, v977, v978, v979, v980, v993, v994, v995;
+                            v1008 = ub.poison i32 : i32;
+                            v973 = cf.select v148, v1008, v988 : i32;
+                            v1009 = ub.poison i32 : i32;
+                            v972 = cf.select v148, v1009, v987 : i32;
+                            v1010 = ub.poison i32 : i32;
+                            v971 = cf.select v148, v1010, v986 : i32;
+                            v1011 = arith.constant 1 : u32;
+                            v900 = arith.constant 0 : u32;
+                            v975 = cf.select v148, v900, v1011 : u32;
+                            v953 = arith.trunc v975 : i1;
+                            scf.condition v953, v969, v970, v971, v972, v973, v986, v987, v988;
                         } do {
-                        ^block133(v996: i32, v997: i32, v998: i32, v999: i32, v1000: i32, v1001: i32, v1002: i32, v1003: i32):
-                            scf.yield v996, v997, v998, v999, v1000;
+                        ^block133(v989: i32, v990: i32, v991: i32, v992: i32, v993: i32, v994: i32, v995: i32, v996: i32):
+                            scf.yield v989, v990, v991, v992, v993;
                         };
                         v183 = arith.constant 44 : u32;
-                        v182 = hir.bitcast v988 : u32;
+                        v182 = hir.bitcast v981 : u32;
                         v184 = arith.add v182, v183 : u32 #[overflow = checked];
-                        v1014 = arith.constant 4 : u32;
-                        v186 = arith.mod v184, v1014 : u32;
+                        v1007 = arith.constant 4 : u32;
+                        v186 = arith.mod v184, v1007 : u32;
                         hir.assertz v186 #[code = 250];
                         v187 = hir.int_to_ptr v184 : ptr<byte, i32>;
-                        hir.store v187, v989;
+                        hir.store v187, v982;
                         v190 = arith.constant 40 : u32;
-                        v189 = hir.bitcast v988 : u32;
+                        v189 = hir.bitcast v981 : u32;
                         v191 = arith.add v189, v190 : u32 #[overflow = checked];
-                        v1013 = arith.constant 4 : u32;
-                        v193 = arith.mod v191, v1013 : u32;
+                        v1006 = arith.constant 4 : u32;
+                        v193 = arith.mod v191, v1006 : u32;
                         hir.assertz v193 #[code = 250];
                         v194 = hir.int_to_ptr v191 : ptr<byte, i32>;
-                        hir.store v194, v990;
-                        v1012 = arith.constant 16 : i32;
+                        hir.store v194, v983;
+                        v1005 = arith.constant 16 : i32;
                         v195 = arith.constant 40 : i32;
-                        v196 = arith.add v988, v195 : i32 #[overflow = wrapping];
-                        hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::deallocate(v196, v1012, v1012)
+                        v196 = arith.add v981, v195 : i32 #[overflow = wrapping];
+                        hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::deallocate(v196, v1005, v1005)
                         v125 = arith.constant 4 : i32;
-                        v1011 = arith.constant 16 : i32;
-                        v200 = arith.add v988, v1011 : i32 #[overflow = wrapping];
+                        v1004 = arith.constant 16 : i32;
+                        v200 = arith.add v981, v1004 : i32 #[overflow = wrapping];
                         hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::deallocate(v200, v125, v125)
-                        v1010 = arith.constant 48 : i32;
-                        v204 = arith.add v988, v1010 : i32 #[overflow = wrapping];
+                        v1003 = arith.constant 48 : i32;
+                        v204 = arith.add v981, v1003 : i32 #[overflow = wrapping];
                         v205 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
                         v206 = hir.bitcast v205 : ptr<byte, i32>;
                         hir.store v206, v204;
                         scf.yield ;
                     };
-                    v1008 = arith.constant 0 : u32;
-                    v1009 = arith.constant 1 : u32;
-                    v1004 = cf.select v115, v1009, v1008 : u32;
-                    scf.yield v1004;
+                    v1001 = arith.constant 0 : u32;
+                    v1002 = arith.constant 1 : u32;
+                    v997 = cf.select v115, v1002, v1001 : u32;
+                    scf.yield v997;
                 };
-                scf.yield v965;
+                scf.yield v958;
             };
-            v1005 = arith.constant 0 : u32;
-            v975 = arith.eq v963, v1005 : i1;
-            cf.cond_br v975 ^block122, ^block23;
+            v998 = arith.constant 0 : u32;
+            v968 = arith.eq v956, v998 : i1;
+            cf.cond_br v968 ^block122, ^block23;
         ^block23:
             ub.unreachable ;
         ^block122:
@@ -328,7 +328,7 @@ builtin.component miden:base/note-script@1.0.0 {
             v208 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
             v209 = hir.bitcast v208 : ptr<byte, i32>;
             v210 = hir.load v209 : i32;
-            v211 = arith.constant 1048676 : i32;
+            v211 = arith.constant 1048620 : i32;
             v212 = arith.add v210, v211 : i32 #[overflow = wrapping];
             v213 = hir.bitcast v212 : u32;
             v214 = hir.int_to_ptr v213 : ptr<byte, u8>;
@@ -346,12 +346,12 @@ builtin.component miden:base/note-script@1.0.0 {
                 v221 = hir.bitcast v220 : ptr<byte, i32>;
                 v222 = hir.load v221 : i32;
                 hir.exec @miden:base/note-script@1.0.0/p2id/__wasm_call_ctors()
-                v1042 = arith.constant 1 : u8;
-                v1044 = arith.constant 1048676 : i32;
-                v224 = arith.add v222, v1044 : i32 #[overflow = wrapping];
+                v1035 = arith.constant 1 : u8;
+                v1037 = arith.constant 1048620 : i32;
+                v224 = arith.add v222, v1037 : i32 #[overflow = wrapping];
                 v228 = hir.bitcast v224 : u32;
                 v229 = hir.int_to_ptr v228 : ptr<byte, u8>;
-                hir.store v229, v1042;
+                hir.store v229, v1035;
                 scf.yield ;
             };
             builtin.ret ;
@@ -361,27 +361,27 @@ builtin.component miden:base/note-script@1.0.0 {
         ^block37(v230: i32, v231: i32, v232: i32):
             v235 = arith.constant 16 : i32;
             v234 = arith.constant 0 : i32;
-            v1046 = arith.constant 16 : u32;
+            v1039 = arith.constant 16 : u32;
             v237 = hir.bitcast v231 : u32;
-            v239 = arith.gt v237, v1046 : i1;
+            v239 = arith.gt v237, v1039 : i1;
             v240 = arith.zext v239 : u32;
             v241 = hir.bitcast v240 : i32;
             v243 = arith.neq v241, v234 : i1;
             v244 = cf.select v243, v231, v235 : i32;
-            v1086 = arith.constant 0 : i32;
+            v1079 = arith.constant 0 : i32;
             v245 = arith.constant -1 : i32;
             v246 = arith.add v244, v245 : i32 #[overflow = wrapping];
             v247 = arith.band v244, v246 : i32;
-            v249 = arith.neq v247, v1086 : i1;
-            v1055, v1056 = scf.if v249 : i32, u32 {
+            v249 = arith.neq v247, v1079 : i1;
+            v1048, v1049 = scf.if v249 : i32, u32 {
             ^block137:
-                v1047 = arith.constant 0 : u32;
-                v1051 = ub.poison i32 : i32;
-                scf.yield v1051, v1047;
+                v1040 = arith.constant 0 : u32;
+                v1044 = ub.poison i32 : i32;
+                scf.yield v1044, v1040;
             } else {
             ^block40:
                 v251 = hir.exec @miden:base/note-script@1.0.0/p2id/core::ptr::alignment::Alignment::max(v231, v244) : i32
-                v1085 = arith.constant 0 : i32;
+                v1078 = arith.constant 0 : i32;
                 v250 = arith.constant -2147483648 : i32;
                 v252 = arith.sub v250, v251 : i32 #[overflow = wrapping];
                 v254 = hir.bitcast v252 : u32;
@@ -389,18 +389,18 @@ builtin.component miden:base/note-script@1.0.0 {
                 v255 = arith.gt v253, v254 : i1;
                 v256 = arith.zext v255 : u32;
                 v257 = hir.bitcast v256 : i32;
-                v259 = arith.neq v257, v1085 : i1;
-                v1070 = scf.if v259 : i32 {
+                v259 = arith.neq v257, v1078 : i1;
+                v1063 = scf.if v259 : i32 {
                 ^block136:
-                    v1084 = ub.poison i32 : i32;
-                    scf.yield v1084;
+                    v1077 = ub.poison i32 : i32;
+                    scf.yield v1077;
                 } else {
                 ^block41:
-                    v1082 = arith.constant 0 : i32;
-                    v265 = arith.sub v1082, v251 : i32 #[overflow = wrapping];
-                    v1083 = arith.constant -1 : i32;
+                    v1075 = arith.constant 0 : i32;
+                    v265 = arith.sub v1075, v251 : i32 #[overflow = wrapping];
+                    v1076 = arith.constant -1 : i32;
                     v261 = arith.add v232, v251 : i32 #[overflow = wrapping];
-                    v263 = arith.add v261, v1083 : i32 #[overflow = wrapping];
+                    v263 = arith.add v261, v1076 : i32 #[overflow = wrapping];
                     v266 = arith.band v263, v265 : i32;
                     v267 = hir.bitcast v230 : u32;
                     v268 = arith.constant 4 : u32;
@@ -408,8 +408,8 @@ builtin.component miden:base/note-script@1.0.0 {
                     hir.assertz v269 #[code = 250];
                     v270 = hir.int_to_ptr v267 : ptr<byte, i32>;
                     v271 = hir.load v270 : i32;
-                    v1081 = arith.constant 0 : i32;
-                    v273 = arith.neq v271, v1081 : i1;
+                    v1074 = arith.constant 0 : i32;
+                    v273 = arith.neq v271, v1074 : i1;
                     scf.if v273{
                     ^block135:
                         scf.yield ;
@@ -418,41 +418,41 @@ builtin.component miden:base/note-script@1.0.0 {
                         v274 = hir.exec @miden:base/note-script@1.0.0/p2id/intrinsics::mem::heap_base() : i32
                         v275 = hir.mem_size  : u32;
                         v281 = hir.bitcast v230 : u32;
-                        v1080 = arith.constant 4 : u32;
-                        v283 = arith.mod v281, v1080 : u32;
+                        v1073 = arith.constant 4 : u32;
+                        v283 = arith.mod v281, v1073 : u32;
                         hir.assertz v283 #[code = 250];
-                        v1079 = arith.constant 16 : u32;
+                        v1072 = arith.constant 16 : u32;
                         v276 = hir.bitcast v275 : i32;
-                        v279 = arith.shl v276, v1079 : i32;
+                        v279 = arith.shl v276, v1072 : i32;
                         v280 = arith.add v274, v279 : i32 #[overflow = wrapping];
                         v284 = hir.int_to_ptr v281 : ptr<byte, i32>;
                         hir.store v284, v280;
                         scf.yield ;
                     };
                     v287 = hir.bitcast v230 : u32;
-                    v1078 = arith.constant 4 : u32;
-                    v289 = arith.mod v287, v1078 : u32;
+                    v1071 = arith.constant 4 : u32;
+                    v289 = arith.mod v287, v1071 : u32;
                     hir.assertz v289 #[code = 250];
                     v290 = hir.int_to_ptr v287 : ptr<byte, i32>;
                     v291 = hir.load v290 : i32;
-                    v1076 = arith.constant 0 : i32;
-                    v1077 = arith.constant -1 : i32;
-                    v293 = arith.bxor v291, v1077 : i32;
+                    v1069 = arith.constant 0 : i32;
+                    v1070 = arith.constant -1 : i32;
+                    v293 = arith.bxor v291, v1070 : i32;
                     v295 = hir.bitcast v293 : u32;
                     v294 = hir.bitcast v266 : u32;
                     v296 = arith.gt v294, v295 : i1;
                     v297 = arith.zext v296 : u32;
                     v298 = hir.bitcast v297 : i32;
-                    v300 = arith.neq v298, v1076 : i1;
-                    v1069 = scf.if v300 : i32 {
+                    v300 = arith.neq v298, v1069 : i1;
+                    v1062 = scf.if v300 : i32 {
                     ^block44:
-                        v1075 = arith.constant 0 : i32;
-                        scf.yield v1075;
+                        v1068 = arith.constant 0 : i32;
+                        scf.yield v1068;
                     } else {
                     ^block45:
                         v302 = hir.bitcast v230 : u32;
-                        v1074 = arith.constant 4 : u32;
-                        v304 = arith.mod v302, v1074 : u32;
+                        v1067 = arith.constant 4 : u32;
+                        v304 = arith.mod v302, v1067 : u32;
                         hir.assertz v304 #[code = 250];
                         v301 = arith.add v291, v266 : i32 #[overflow = wrapping];
                         v305 = hir.int_to_ptr v302 : ptr<byte, i32>;
@@ -460,20 +460,20 @@ builtin.component miden:base/note-script@1.0.0 {
                         v307 = arith.add v291, v251 : i32 #[overflow = wrapping];
                         scf.yield v307;
                     };
-                    scf.yield v1069;
+                    scf.yield v1062;
                 };
-                v1052 = arith.constant 1 : u32;
-                v1073 = arith.constant 0 : u32;
-                v1071 = cf.select v259, v1073, v1052 : u32;
-                scf.yield v1070, v1071;
+                v1045 = arith.constant 1 : u32;
+                v1066 = arith.constant 0 : u32;
+                v1064 = cf.select v259, v1066, v1045 : u32;
+                scf.yield v1063, v1064;
             };
-            v1072 = arith.constant 0 : u32;
-            v1068 = arith.eq v1056, v1072 : i1;
-            cf.cond_br v1068 ^block39, ^block139(v1055);
+            v1065 = arith.constant 0 : u32;
+            v1061 = arith.eq v1049, v1065 : i1;
+            cf.cond_br v1061 ^block39, ^block139(v1048);
         ^block39:
             ub.unreachable ;
-        ^block139(v1048: i32):
-            builtin.ret v1048;
+        ^block139(v1041: i32):
+            builtin.ret v1041;
         };
 
         private builtin.function @intrinsics::mem::heap_base() -> i32 {
@@ -482,797 +482,792 @@ builtin.component miden:base/note-script@1.0.0 {
             builtin.ret v310;
         };
 
-        private builtin.function @alloc::vec::Vec<T>::with_capacity(v312: i32, v313: i32) {
-        ^block50(v312: i32, v313: i32):
-            v316 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v317 = hir.bitcast v316 : ptr<byte, i32>;
-            v318 = hir.load v317 : i32;
-            v319 = arith.constant 16 : i32;
-            v320 = arith.sub v318, v319 : i32 #[overflow = wrapping];
-            v321 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v322 = hir.bitcast v321 : ptr<byte, i32>;
-            hir.store v322, v320;
-            v1091 = arith.constant 16 : i32;
-            v323 = arith.constant 8 : i32;
-            v324 = arith.add v320, v323 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v324, v1091, v1091, v313)
-            v328 = arith.constant 8 : u32;
-            v327 = hir.bitcast v320 : u32;
-            v329 = arith.add v327, v328 : u32 #[overflow = checked];
-            v1090 = arith.constant 8 : u32;
-            v331 = arith.mod v329, v1090 : u32;
-            hir.assertz v331 #[code = 250];
-            v332 = hir.int_to_ptr v329 : ptr<byte, i64>;
-            v333 = hir.load v332 : i64;
-            v1089 = arith.constant 8 : u32;
-            v335 = hir.bitcast v312 : u32;
-            v337 = arith.add v335, v1089 : u32 #[overflow = checked];
-            v338 = arith.constant 4 : u32;
-            v339 = arith.mod v337, v338 : u32;
-            hir.assertz v339 #[code = 250];
-            v314 = arith.constant 0 : i32;
-            v340 = hir.int_to_ptr v337 : ptr<byte, i32>;
-            hir.store v340, v314;
-            v341 = hir.bitcast v312 : u32;
-            v1088 = arith.constant 4 : u32;
-            v343 = arith.mod v341, v1088 : u32;
-            hir.assertz v343 #[code = 250];
-            v344 = hir.int_to_ptr v341 : ptr<byte, i64>;
-            hir.store v344, v333;
-            v1087 = arith.constant 16 : i32;
-            v346 = arith.add v320, v1087 : i32 #[overflow = wrapping];
-            v347 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v348 = hir.bitcast v347 : ptr<byte, i32>;
-            hir.store v348, v346;
+        private builtin.function @alloc::vec::Vec<T>::with_capacity(v312: i32) {
+        ^block50(v312: i32):
+            v315 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v316 = hir.bitcast v315 : ptr<byte, i32>;
+            v317 = hir.load v316 : i32;
+            v318 = arith.constant 16 : i32;
+            v319 = arith.sub v317, v318 : i32 #[overflow = wrapping];
+            v320 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v321 = hir.bitcast v320 : ptr<byte, i32>;
+            hir.store v321, v319;
+            v1084 = arith.constant 16 : i32;
+            v322 = arith.constant 8 : i32;
+            v323 = arith.add v319, v322 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v323, v1084, v1084)
+            v327 = arith.constant 8 : u32;
+            v326 = hir.bitcast v319 : u32;
+            v328 = arith.add v326, v327 : u32 #[overflow = checked];
+            v1083 = arith.constant 8 : u32;
+            v330 = arith.mod v328, v1083 : u32;
+            hir.assertz v330 #[code = 250];
+            v331 = hir.int_to_ptr v328 : ptr<byte, i64>;
+            v332 = hir.load v331 : i64;
+            v1082 = arith.constant 8 : u32;
+            v334 = hir.bitcast v312 : u32;
+            v336 = arith.add v334, v1082 : u32 #[overflow = checked];
+            v337 = arith.constant 4 : u32;
+            v338 = arith.mod v336, v337 : u32;
+            hir.assertz v338 #[code = 250];
+            v313 = arith.constant 0 : i32;
+            v339 = hir.int_to_ptr v336 : ptr<byte, i32>;
+            hir.store v339, v313;
+            v340 = hir.bitcast v312 : u32;
+            v1081 = arith.constant 4 : u32;
+            v342 = arith.mod v340, v1081 : u32;
+            hir.assertz v342 #[code = 250];
+            v343 = hir.int_to_ptr v340 : ptr<byte, i64>;
+            hir.store v343, v332;
+            v1080 = arith.constant 16 : i32;
+            v345 = arith.add v319, v1080 : i32 #[overflow = wrapping];
+            v346 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v347 = hir.bitcast v346 : ptr<byte, i32>;
+            hir.store v347, v345;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::with_capacity_in(v349: i32, v350: i32, v351: i32, v352: i32) {
-        ^block52(v349: i32, v350: i32, v351: i32, v352: i32):
-            v354 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v355 = hir.bitcast v354 : ptr<byte, i32>;
-            v356 = hir.load v355 : i32;
-            v357 = arith.constant 16 : i32;
-            v358 = arith.sub v356, v357 : i32 #[overflow = wrapping];
-            v359 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v360 = hir.bitcast v359 : ptr<byte, i32>;
-            hir.store v360, v358;
-            v353 = arith.constant 0 : i32;
-            v363 = arith.constant 256 : i32;
-            v361 = arith.constant 4 : i32;
-            v362 = arith.add v358, v361 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::try_allocate_in(v362, v363, v353, v350, v351)
-            v366 = arith.constant 8 : u32;
-            v365 = hir.bitcast v358 : u32;
-            v367 = arith.add v365, v366 : u32 #[overflow = checked];
-            v368 = arith.constant 4 : u32;
-            v369 = arith.mod v367, v368 : u32;
-            hir.assertz v369 #[code = 250];
-            v370 = hir.int_to_ptr v367 : ptr<byte, i32>;
-            v371 = hir.load v370 : i32;
-            v1102 = arith.constant 4 : u32;
-            v372 = hir.bitcast v358 : u32;
-            v374 = arith.add v372, v1102 : u32 #[overflow = checked];
-            v1101 = arith.constant 4 : u32;
-            v376 = arith.mod v374, v1101 : u32;
-            hir.assertz v376 #[code = 250];
-            v377 = hir.int_to_ptr v374 : ptr<byte, i32>;
-            v378 = hir.load v377 : i32;
-            v1100 = arith.constant 0 : i32;
-            v379 = arith.constant 1 : i32;
-            v380 = arith.neq v378, v379 : i1;
-            v381 = arith.zext v380 : u32;
-            v382 = hir.bitcast v381 : i32;
-            v384 = arith.neq v382, v1100 : i1;
-            cf.cond_br v384 ^block54, ^block55;
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::with_capacity_in(v348: i32, v349: i32, v350: i32) {
+        ^block52(v348: i32, v349: i32, v350: i32):
+            v352 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v353 = hir.bitcast v352 : ptr<byte, i32>;
+            v354 = hir.load v353 : i32;
+            v355 = arith.constant 16 : i32;
+            v356 = arith.sub v354, v355 : i32 #[overflow = wrapping];
+            v357 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v358 = hir.bitcast v357 : ptr<byte, i32>;
+            hir.store v358, v356;
+            v351 = arith.constant 0 : i32;
+            v361 = arith.constant 256 : i32;
+            v359 = arith.constant 4 : i32;
+            v360 = arith.add v356, v359 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::try_allocate_in(v360, v361, v351, v349, v350)
+            v364 = arith.constant 8 : u32;
+            v363 = hir.bitcast v356 : u32;
+            v365 = arith.add v363, v364 : u32 #[overflow = checked];
+            v366 = arith.constant 4 : u32;
+            v367 = arith.mod v365, v366 : u32;
+            hir.assertz v367 #[code = 250];
+            v368 = hir.int_to_ptr v365 : ptr<byte, i32>;
+            v369 = hir.load v368 : i32;
+            v1095 = arith.constant 4 : u32;
+            v370 = hir.bitcast v356 : u32;
+            v372 = arith.add v370, v1095 : u32 #[overflow = checked];
+            v1094 = arith.constant 4 : u32;
+            v374 = arith.mod v372, v1094 : u32;
+            hir.assertz v374 #[code = 250];
+            v375 = hir.int_to_ptr v372 : ptr<byte, i32>;
+            v376 = hir.load v375 : i32;
+            v1093 = arith.constant 0 : i32;
+            v377 = arith.constant 1 : i32;
+            v378 = arith.neq v376, v377 : i1;
+            v379 = arith.zext v378 : u32;
+            v380 = hir.bitcast v379 : i32;
+            v382 = arith.neq v380, v1093 : i1;
+            cf.cond_br v382 ^block54, ^block55;
         ^block54:
-            v393 = arith.constant 12 : u32;
-            v392 = hir.bitcast v358 : u32;
-            v394 = arith.add v392, v393 : u32 #[overflow = checked];
-            v1099 = arith.constant 4 : u32;
-            v396 = arith.mod v394, v1099 : u32;
-            hir.assertz v396 #[code = 250];
-            v397 = hir.int_to_ptr v394 : ptr<byte, i32>;
-            v398 = hir.load v397 : i32;
-            v1098 = arith.constant 4 : u32;
-            v399 = hir.bitcast v349 : u32;
-            v401 = arith.add v399, v1098 : u32 #[overflow = checked];
-            v1097 = arith.constant 4 : u32;
-            v403 = arith.mod v401, v1097 : u32;
-            hir.assertz v403 #[code = 250];
-            v404 = hir.int_to_ptr v401 : ptr<byte, i32>;
-            hir.store v404, v398;
-            v405 = hir.bitcast v349 : u32;
-            v1096 = arith.constant 4 : u32;
-            v407 = arith.mod v405, v1096 : u32;
-            hir.assertz v407 #[code = 250];
-            v408 = hir.int_to_ptr v405 : ptr<byte, i32>;
-            hir.store v408, v371;
-            v1095 = arith.constant 16 : i32;
-            v410 = arith.add v358, v1095 : i32 #[overflow = wrapping];
-            v411 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v412 = hir.bitcast v411 : ptr<byte, i32>;
-            hir.store v412, v410;
+            v396 = arith.constant 12 : u32;
+            v395 = hir.bitcast v356 : u32;
+            v397 = arith.add v395, v396 : u32 #[overflow = checked];
+            v1092 = arith.constant 4 : u32;
+            v399 = arith.mod v397, v1092 : u32;
+            hir.assertz v399 #[code = 250];
+            v400 = hir.int_to_ptr v397 : ptr<byte, i32>;
+            v401 = hir.load v400 : i32;
+            v1091 = arith.constant 4 : u32;
+            v402 = hir.bitcast v348 : u32;
+            v404 = arith.add v402, v1091 : u32 #[overflow = checked];
+            v1090 = arith.constant 4 : u32;
+            v406 = arith.mod v404, v1090 : u32;
+            hir.assertz v406 #[code = 250];
+            v407 = hir.int_to_ptr v404 : ptr<byte, i32>;
+            hir.store v407, v401;
+            v408 = hir.bitcast v348 : u32;
+            v1089 = arith.constant 4 : u32;
+            v410 = arith.mod v408, v1089 : u32;
+            hir.assertz v410 #[code = 250];
+            v411 = hir.int_to_ptr v408 : ptr<byte, i32>;
+            hir.store v411, v369;
+            v1088 = arith.constant 16 : i32;
+            v413 = arith.add v356, v1088 : i32 #[overflow = wrapping];
+            v414 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v415 = hir.bitcast v414 : ptr<byte, i32>;
+            hir.store v415, v413;
             builtin.ret ;
         ^block55:
-            v1094 = arith.constant 12 : u32;
-            v385 = hir.bitcast v358 : u32;
-            v387 = arith.add v385, v1094 : u32 #[overflow = checked];
-            v1093 = arith.constant 4 : u32;
-            v389 = arith.mod v387, v1093 : u32;
-            hir.assertz v389 #[code = 250];
-            v390 = hir.int_to_ptr v387 : ptr<byte, i32>;
-            v391 = hir.load v390 : i32;
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::handle_error(v371, v391, v352)
+            v383 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v384 = hir.bitcast v383 : ptr<byte, i32>;
+            v385 = hir.load v384 : i32;
+            v1087 = arith.constant 12 : u32;
+            v386 = hir.bitcast v356 : u32;
+            v388 = arith.add v386, v1087 : u32 #[overflow = checked];
+            v1086 = arith.constant 4 : u32;
+            v390 = arith.mod v388, v1086 : u32;
+            hir.assertz v390 #[code = 250];
+            v391 = hir.int_to_ptr v388 : ptr<byte, i32>;
+            v392 = hir.load v391 : i32;
+            v393 = arith.constant 1048600 : i32;
+            v394 = arith.add v385, v393 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::handle_error(v369, v392, v394)
             ub.unreachable ;
         };
 
-        private builtin.function @miden_base_sys::bindings::active_account::get_id(v413: i32) {
-        ^block56(v413: i32):
-            v415 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v416 = hir.bitcast v415 : ptr<byte, i32>;
-            v417 = hir.load v416 : i32;
-            v418 = arith.constant 16 : i32;
-            v419 = arith.sub v417, v418 : i32 #[overflow = wrapping];
-            v420 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v421 = hir.bitcast v420 : ptr<byte, i32>;
-            hir.store v421, v419;
-            v422 = arith.constant 8 : i32;
-            v423 = arith.add v419, v422 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/miden::active_account::get_id(v423)
-            v425 = arith.constant 8 : u32;
-            v424 = hir.bitcast v419 : u32;
-            v426 = arith.add v424, v425 : u32 #[overflow = checked];
-            v427 = arith.constant 4 : u32;
-            v428 = arith.mod v426, v427 : u32;
-            hir.assertz v428 #[code = 250];
-            v429 = hir.int_to_ptr v426 : ptr<byte, i64>;
-            v430 = hir.load v429 : i64;
-            v431 = hir.bitcast v413 : u32;
+        private builtin.function @miden_base_sys::bindings::active_account::get_id(v416: i32) {
+        ^block56(v416: i32):
+            v418 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v419 = hir.bitcast v418 : ptr<byte, i32>;
+            v420 = hir.load v419 : i32;
+            v421 = arith.constant 16 : i32;
+            v422 = arith.sub v420, v421 : i32 #[overflow = wrapping];
+            v423 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v424 = hir.bitcast v423 : ptr<byte, i32>;
+            hir.store v424, v422;
+            v425 = arith.constant 8 : i32;
+            v426 = arith.add v422, v425 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/miden::active_account::get_id(v426)
+            v428 = arith.constant 8 : u32;
+            v427 = hir.bitcast v422 : u32;
+            v429 = arith.add v427, v428 : u32 #[overflow = checked];
+            v430 = arith.constant 4 : u32;
+            v431 = arith.mod v429, v430 : u32;
+            hir.assertz v431 #[code = 250];
+            v432 = hir.int_to_ptr v429 : ptr<byte, i64>;
+            v433 = hir.load v432 : i64;
+            v434 = hir.bitcast v416 : u32;
+            v1097 = arith.constant 8 : u32;
+            v436 = arith.mod v434, v1097 : u32;
+            hir.assertz v436 #[code = 250];
+            v437 = hir.int_to_ptr v434 : ptr<byte, i64>;
+            hir.store v437, v433;
+            v1096 = arith.constant 16 : i32;
+            v439 = arith.add v422, v1096 : i32 #[overflow = wrapping];
+            v440 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v441 = hir.bitcast v440 : ptr<byte, i32>;
+            hir.store v441, v439;
+            builtin.ret ;
+        };
+
+        private builtin.function @miden_base_sys::bindings::active_note::get_inputs(v442: i32) {
+        ^block58(v442: i32):
+            v444 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v445 = hir.bitcast v444 : ptr<byte, i32>;
+            v446 = hir.load v445 : i32;
+            v447 = arith.constant 16 : i32;
+            v448 = arith.sub v446, v447 : i32 #[overflow = wrapping];
+            v449 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v450 = hir.bitcast v449 : ptr<byte, i32>;
+            hir.store v450, v448;
+            v453 = arith.constant 4 : i32;
+            v451 = arith.constant 8 : i32;
+            v452 = arith.add v448, v451 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v452, v453, v453)
+            v456 = arith.constant 8 : u32;
+            v455 = hir.bitcast v448 : u32;
+            v457 = arith.add v455, v456 : u32 #[overflow = checked];
+            v458 = arith.constant 4 : u32;
+            v459 = arith.mod v457, v458 : u32;
+            hir.assertz v459 #[code = 250];
+            v460 = hir.int_to_ptr v457 : ptr<byte, i32>;
+            v461 = hir.load v460 : i32;
+            v463 = arith.constant 12 : u32;
+            v462 = hir.bitcast v448 : u32;
+            v464 = arith.add v462, v463 : u32 #[overflow = checked];
+            v1105 = arith.constant 4 : u32;
+            v466 = arith.mod v464, v1105 : u32;
+            hir.assertz v466 #[code = 250];
+            v467 = hir.int_to_ptr v464 : ptr<byte, i32>;
+            v468 = hir.load v467 : i32;
+            v1098 = arith.constant 2 : u32;
+            v470 = hir.bitcast v468 : u32;
+            v472 = arith.shr v470, v1098 : u32;
+            v473 = hir.bitcast v472 : i32;
+            v474 = hir.exec @miden:base/note-script@1.0.0/p2id/miden::active_note::get_inputs(v473) : i32
             v1104 = arith.constant 8 : u32;
-            v433 = arith.mod v431, v1104 : u32;
-            hir.assertz v433 #[code = 250];
-            v434 = hir.int_to_ptr v431 : ptr<byte, i64>;
-            hir.store v434, v430;
-            v1103 = arith.constant 16 : i32;
-            v436 = arith.add v419, v1103 : i32 #[overflow = wrapping];
-            v437 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v438 = hir.bitcast v437 : ptr<byte, i32>;
-            hir.store v438, v436;
+            v475 = hir.bitcast v442 : u32;
+            v477 = arith.add v475, v1104 : u32 #[overflow = checked];
+            v1103 = arith.constant 4 : u32;
+            v479 = arith.mod v477, v1103 : u32;
+            hir.assertz v479 #[code = 250];
+            v480 = hir.int_to_ptr v477 : ptr<byte, i32>;
+            hir.store v480, v474;
+            v1102 = arith.constant 4 : u32;
+            v481 = hir.bitcast v442 : u32;
+            v483 = arith.add v481, v1102 : u32 #[overflow = checked];
+            v1101 = arith.constant 4 : u32;
+            v485 = arith.mod v483, v1101 : u32;
+            hir.assertz v485 #[code = 250];
+            v486 = hir.int_to_ptr v483 : ptr<byte, i32>;
+            hir.store v486, v468;
+            v487 = hir.bitcast v442 : u32;
+            v1100 = arith.constant 4 : u32;
+            v489 = arith.mod v487, v1100 : u32;
+            hir.assertz v489 #[code = 250];
+            v490 = hir.int_to_ptr v487 : ptr<byte, i32>;
+            hir.store v490, v461;
+            v1099 = arith.constant 16 : i32;
+            v492 = arith.add v448, v1099 : i32 #[overflow = wrapping];
+            v493 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v494 = hir.bitcast v493 : ptr<byte, i32>;
+            hir.store v494, v492;
             builtin.ret ;
         };
 
-        private builtin.function @miden_base_sys::bindings::active_note::get_inputs(v439: i32) {
-        ^block58(v439: i32):
-            v441 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v442 = hir.bitcast v441 : ptr<byte, i32>;
-            v443 = hir.load v442 : i32;
-            v444 = arith.constant 16 : i32;
-            v445 = arith.sub v443, v444 : i32 #[overflow = wrapping];
-            v446 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v447 = hir.bitcast v446 : ptr<byte, i32>;
-            hir.store v447, v445;
-            v452 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v453 = hir.bitcast v452 : ptr<byte, i32>;
-            v454 = hir.load v453 : i32;
-            v455 = arith.constant 1048640 : i32;
-            v456 = arith.add v454, v455 : i32 #[overflow = wrapping];
-            v450 = arith.constant 4 : i32;
-            v448 = arith.constant 8 : i32;
-            v449 = arith.add v445, v448 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v449, v450, v450, v456)
-            v458 = arith.constant 8 : u32;
-            v457 = hir.bitcast v445 : u32;
-            v459 = arith.add v457, v458 : u32 #[overflow = checked];
-            v460 = arith.constant 4 : u32;
-            v461 = arith.mod v459, v460 : u32;
-            hir.assertz v461 #[code = 250];
-            v462 = hir.int_to_ptr v459 : ptr<byte, i32>;
-            v463 = hir.load v462 : i32;
-            v465 = arith.constant 12 : u32;
-            v464 = hir.bitcast v445 : u32;
-            v466 = arith.add v464, v465 : u32 #[overflow = checked];
-            v1112 = arith.constant 4 : u32;
-            v468 = arith.mod v466, v1112 : u32;
-            hir.assertz v468 #[code = 250];
-            v469 = hir.int_to_ptr v466 : ptr<byte, i32>;
-            v470 = hir.load v469 : i32;
-            v1105 = arith.constant 2 : u32;
-            v472 = hir.bitcast v470 : u32;
-            v474 = arith.shr v472, v1105 : u32;
-            v475 = hir.bitcast v474 : i32;
-            v476 = hir.exec @miden:base/note-script@1.0.0/p2id/miden::active_note::get_inputs(v475) : i32
-            v1111 = arith.constant 8 : u32;
-            v477 = hir.bitcast v439 : u32;
-            v479 = arith.add v477, v1111 : u32 #[overflow = checked];
+        private builtin.function @miden_base_sys::bindings::active_note::get_assets(v495: i32) {
+        ^block60(v495: i32):
+            v497 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v498 = hir.bitcast v497 : ptr<byte, i32>;
+            v499 = hir.load v498 : i32;
+            v500 = arith.constant 16 : i32;
+            v501 = arith.sub v499, v500 : i32 #[overflow = wrapping];
+            v502 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v503 = hir.bitcast v502 : ptr<byte, i32>;
+            hir.store v503, v501;
+            v504 = arith.constant 4 : i32;
+            v505 = arith.add v501, v504 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::vec::Vec<T>::with_capacity(v505)
+            v509 = arith.constant 8 : u32;
+            v508 = hir.bitcast v501 : u32;
+            v510 = arith.add v508, v509 : u32 #[overflow = checked];
+            v511 = arith.constant 4 : u32;
+            v512 = arith.mod v510, v511 : u32;
+            hir.assertz v512 #[code = 250];
+            v513 = hir.int_to_ptr v510 : ptr<byte, i32>;
+            v514 = hir.load v513 : i32;
+            v1106 = arith.constant 2 : u32;
+            v516 = hir.bitcast v514 : u32;
+            v518 = arith.shr v516, v1106 : u32;
+            v519 = hir.bitcast v518 : i32;
+            v520 = hir.exec @miden:base/note-script@1.0.0/p2id/miden::active_note::get_assets(v519) : i32
+            v506 = arith.constant 8 : i32;
+            v507 = arith.add v495, v506 : i32 #[overflow = wrapping];
+            v521 = hir.bitcast v507 : u32;
+            v1111 = arith.constant 4 : u32;
+            v523 = arith.mod v521, v1111 : u32;
+            hir.assertz v523 #[code = 250];
+            v524 = hir.int_to_ptr v521 : ptr<byte, i32>;
+            hir.store v524, v520;
             v1110 = arith.constant 4 : u32;
-            v481 = arith.mod v479, v1110 : u32;
-            hir.assertz v481 #[code = 250];
-            v482 = hir.int_to_ptr v479 : ptr<byte, i32>;
-            hir.store v482, v476;
+            v525 = hir.bitcast v501 : u32;
+            v527 = arith.add v525, v1110 : u32 #[overflow = checked];
             v1109 = arith.constant 4 : u32;
-            v483 = hir.bitcast v439 : u32;
-            v485 = arith.add v483, v1109 : u32 #[overflow = checked];
+            v529 = arith.mod v527, v1109 : u32;
+            hir.assertz v529 #[code = 250];
+            v530 = hir.int_to_ptr v527 : ptr<byte, i64>;
+            v531 = hir.load v530 : i64;
+            v532 = hir.bitcast v495 : u32;
             v1108 = arith.constant 4 : u32;
-            v487 = arith.mod v485, v1108 : u32;
-            hir.assertz v487 #[code = 250];
-            v488 = hir.int_to_ptr v485 : ptr<byte, i32>;
-            hir.store v488, v470;
-            v489 = hir.bitcast v439 : u32;
-            v1107 = arith.constant 4 : u32;
-            v491 = arith.mod v489, v1107 : u32;
-            hir.assertz v491 #[code = 250];
-            v492 = hir.int_to_ptr v489 : ptr<byte, i32>;
-            hir.store v492, v463;
-            v1106 = arith.constant 16 : i32;
-            v494 = arith.add v445, v1106 : i32 #[overflow = wrapping];
-            v495 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v496 = hir.bitcast v495 : ptr<byte, i32>;
-            hir.store v496, v494;
+            v534 = arith.mod v532, v1108 : u32;
+            hir.assertz v534 #[code = 250];
+            v535 = hir.int_to_ptr v532 : ptr<byte, i64>;
+            hir.store v535, v531;
+            v1107 = arith.constant 16 : i32;
+            v537 = arith.add v501, v1107 : i32 #[overflow = wrapping];
+            v538 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v539 = hir.bitcast v538 : ptr<byte, i32>;
+            hir.store v539, v537;
             builtin.ret ;
         };
 
-        private builtin.function @miden_base_sys::bindings::active_note::get_assets(v497: i32) {
-        ^block60(v497: i32):
-            v499 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v500 = hir.bitcast v499 : ptr<byte, i32>;
-            v501 = hir.load v500 : i32;
-            v502 = arith.constant 16 : i32;
-            v503 = arith.sub v501, v502 : i32 #[overflow = wrapping];
-            v504 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v505 = hir.bitcast v504 : ptr<byte, i32>;
-            hir.store v505, v503;
-            v508 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v509 = hir.bitcast v508 : ptr<byte, i32>;
-            v510 = hir.load v509 : i32;
-            v511 = arith.constant 1048656 : i32;
-            v512 = arith.add v510, v511 : i32 #[overflow = wrapping];
-            v506 = arith.constant 4 : i32;
-            v507 = arith.add v503, v506 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::vec::Vec<T>::with_capacity(v507, v512)
-            v516 = arith.constant 8 : u32;
-            v515 = hir.bitcast v503 : u32;
-            v517 = arith.add v515, v516 : u32 #[overflow = checked];
-            v518 = arith.constant 4 : u32;
-            v519 = arith.mod v517, v518 : u32;
-            hir.assertz v519 #[code = 250];
-            v520 = hir.int_to_ptr v517 : ptr<byte, i32>;
-            v521 = hir.load v520 : i32;
-            v1113 = arith.constant 2 : u32;
-            v523 = hir.bitcast v521 : u32;
-            v525 = arith.shr v523, v1113 : u32;
-            v526 = hir.bitcast v525 : i32;
-            v527 = hir.exec @miden:base/note-script@1.0.0/p2id/miden::active_note::get_assets(v526) : i32
-            v513 = arith.constant 8 : i32;
-            v514 = arith.add v497, v513 : i32 #[overflow = wrapping];
-            v528 = hir.bitcast v514 : u32;
-            v1118 = arith.constant 4 : u32;
-            v530 = arith.mod v528, v1118 : u32;
-            hir.assertz v530 #[code = 250];
-            v531 = hir.int_to_ptr v528 : ptr<byte, i32>;
-            hir.store v531, v527;
-            v1117 = arith.constant 4 : u32;
-            v532 = hir.bitcast v503 : u32;
-            v534 = arith.add v532, v1117 : u32 #[overflow = checked];
-            v1116 = arith.constant 4 : u32;
-            v536 = arith.mod v534, v1116 : u32;
-            hir.assertz v536 #[code = 250];
-            v537 = hir.int_to_ptr v534 : ptr<byte, i64>;
-            v538 = hir.load v537 : i64;
-            v539 = hir.bitcast v497 : u32;
-            v1115 = arith.constant 4 : u32;
-            v541 = arith.mod v539, v1115 : u32;
-            hir.assertz v541 #[code = 250];
-            v542 = hir.int_to_ptr v539 : ptr<byte, i64>;
-            hir.store v542, v538;
-            v1114 = arith.constant 16 : i32;
-            v544 = arith.add v503, v1114 : i32 #[overflow = wrapping];
-            v545 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v546 = hir.bitcast v545 : ptr<byte, i32>;
-            hir.store v546, v544;
-            builtin.ret ;
+        private builtin.function @intrinsics::felt::eq(v540: felt, v541: felt) -> i32 {
+        ^block62(v540: felt, v541: felt):
+            v542 = arith.eq v540, v541 : i1;
+            v543 = hir.cast v542 : i32;
+            builtin.ret v543;
         };
 
-        private builtin.function @intrinsics::felt::eq(v547: felt, v548: felt) -> i32 {
-        ^block62(v547: felt, v548: felt):
-            v549 = arith.eq v547, v548 : i1;
-            v550 = hir.cast v549 : i32;
-            builtin.ret v550;
-        };
-
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v552: i32, v553: i32, v554: i32) {
-        ^block64(v552: i32, v553: i32, v554: i32):
-            v556 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v557 = hir.bitcast v556 : ptr<byte, i32>;
-            v558 = hir.load v557 : i32;
-            v559 = arith.constant 16 : i32;
-            v560 = arith.sub v558, v559 : i32 #[overflow = wrapping];
-            v561 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v562 = hir.bitcast v561 : ptr<byte, i32>;
-            hir.store v562, v560;
-            v563 = arith.constant 4 : i32;
-            v564 = arith.add v560, v563 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::current_memory(v564, v552, v553, v554)
-            v566 = arith.constant 8 : u32;
-            v565 = hir.bitcast v560 : u32;
-            v567 = arith.add v565, v566 : u32 #[overflow = checked];
-            v568 = arith.constant 4 : u32;
-            v569 = arith.mod v567, v568 : u32;
-            hir.assertz v569 #[code = 250];
-            v570 = hir.int_to_ptr v567 : ptr<byte, i32>;
-            v571 = hir.load v570 : i32;
-            v1125 = arith.constant 0 : i32;
-            v555 = arith.constant 0 : i32;
-            v573 = arith.eq v571, v555 : i1;
-            v574 = arith.zext v573 : u32;
-            v575 = hir.bitcast v574 : i32;
-            v577 = arith.neq v575, v1125 : i1;
-            scf.if v577{
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v545: i32, v546: i32, v547: i32) {
+        ^block64(v545: i32, v546: i32, v547: i32):
+            v549 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v550 = hir.bitcast v549 : ptr<byte, i32>;
+            v551 = hir.load v550 : i32;
+            v552 = arith.constant 16 : i32;
+            v553 = arith.sub v551, v552 : i32 #[overflow = wrapping];
+            v554 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v555 = hir.bitcast v554 : ptr<byte, i32>;
+            hir.store v555, v553;
+            v556 = arith.constant 4 : i32;
+            v557 = arith.add v553, v556 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::raw_vec::RawVecInner<A>::current_memory(v557, v545, v546, v547)
+            v559 = arith.constant 8 : u32;
+            v558 = hir.bitcast v553 : u32;
+            v560 = arith.add v558, v559 : u32 #[overflow = checked];
+            v561 = arith.constant 4 : u32;
+            v562 = arith.mod v560, v561 : u32;
+            hir.assertz v562 #[code = 250];
+            v563 = hir.int_to_ptr v560 : ptr<byte, i32>;
+            v564 = hir.load v563 : i32;
+            v1118 = arith.constant 0 : i32;
+            v548 = arith.constant 0 : i32;
+            v566 = arith.eq v564, v548 : i1;
+            v567 = arith.zext v566 : u32;
+            v568 = hir.bitcast v567 : i32;
+            v570 = arith.neq v568, v1118 : i1;
+            scf.if v570{
             ^block145:
                 scf.yield ;
             } else {
             ^block67:
-                v1124 = arith.constant 4 : u32;
-                v578 = hir.bitcast v560 : u32;
-                v580 = arith.add v578, v1124 : u32 #[overflow = checked];
-                v1123 = arith.constant 4 : u32;
-                v582 = arith.mod v580, v1123 : u32;
+                v1117 = arith.constant 4 : u32;
+                v571 = hir.bitcast v553 : u32;
+                v573 = arith.add v571, v1117 : u32 #[overflow = checked];
+                v1116 = arith.constant 4 : u32;
+                v575 = arith.mod v573, v1116 : u32;
+                hir.assertz v575 #[code = 250];
+                v576 = hir.int_to_ptr v573 : ptr<byte, i32>;
+                v577 = hir.load v576 : i32;
+                v579 = arith.constant 12 : u32;
+                v578 = hir.bitcast v553 : u32;
+                v580 = arith.add v578, v579 : u32 #[overflow = checked];
+                v1115 = arith.constant 4 : u32;
+                v582 = arith.mod v580, v1115 : u32;
                 hir.assertz v582 #[code = 250];
                 v583 = hir.int_to_ptr v580 : ptr<byte, i32>;
                 v584 = hir.load v583 : i32;
-                v586 = arith.constant 12 : u32;
-                v585 = hir.bitcast v560 : u32;
-                v587 = arith.add v585, v586 : u32 #[overflow = checked];
-                v1122 = arith.constant 4 : u32;
-                v589 = arith.mod v587, v1122 : u32;
-                hir.assertz v589 #[code = 250];
-                v590 = hir.int_to_ptr v587 : ptr<byte, i32>;
-                v591 = hir.load v590 : i32;
-                hir.exec @miden:base/note-script@1.0.0/p2id/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v584, v571, v591)
+                hir.exec @miden:base/note-script@1.0.0/p2id/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v577, v564, v584)
                 scf.yield ;
             };
-            v1121 = arith.constant 16 : i32;
-            v594 = arith.add v560, v1121 : i32 #[overflow = wrapping];
-            v595 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v596 = hir.bitcast v595 : ptr<byte, i32>;
-            hir.store v596, v594;
+            v1114 = arith.constant 16 : i32;
+            v587 = arith.add v553, v1114 : i32 #[overflow = wrapping];
+            v588 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v589 = hir.bitcast v588 : ptr<byte, i32>;
+            hir.store v589, v587;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v597: i32, v598: i32, v599: i32, v600: i32, v601: i32) {
-        ^block68(v597: i32, v598: i32, v599: i32, v600: i32, v601: i32):
-            v604 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v605 = hir.bitcast v604 : ptr<byte, i32>;
-            v606 = hir.load v605 : i32;
-            v607 = arith.constant 16 : i32;
-            v608 = arith.sub v606, v607 : i32 #[overflow = wrapping];
-            v609 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v610 = hir.bitcast v609 : ptr<byte, i32>;
-            hir.store v610, v608;
-            v620 = hir.bitcast v598 : u32;
-            v621 = arith.zext v620 : u64;
-            v622 = hir.bitcast v621 : i64;
-            v602 = arith.constant 0 : i32;
-            v615 = arith.sub v602, v600 : i32 #[overflow = wrapping];
-            v612 = arith.constant -1 : i32;
-            v611 = arith.add v600, v601 : i32 #[overflow = wrapping];
-            v613 = arith.add v611, v612 : i32 #[overflow = wrapping];
-            v616 = arith.band v613, v615 : i32;
-            v617 = hir.bitcast v616 : u32;
-            v618 = arith.zext v617 : u64;
-            v619 = hir.bitcast v618 : i64;
-            v623 = arith.mul v619, v622 : i64 #[overflow = wrapping];
-            v1229 = arith.constant 0 : i32;
-            v624 = arith.constant 32 : i64;
-            v626 = hir.cast v624 : u32;
-            v625 = hir.bitcast v623 : u64;
-            v627 = arith.shr v625, v626 : u64;
-            v628 = hir.bitcast v627 : i64;
-            v629 = arith.trunc v628 : i32;
-            v631 = arith.neq v629, v1229 : i1;
-            v1141, v1142, v1143, v1144, v1145, v1146 = scf.if v631 : i32, i32, i32, i32, i32, u32 {
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v590: i32, v591: i32, v592: i32, v593: i32, v594: i32) {
+        ^block68(v590: i32, v591: i32, v592: i32, v593: i32, v594: i32):
+            v597 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v598 = hir.bitcast v597 : ptr<byte, i32>;
+            v599 = hir.load v598 : i32;
+            v600 = arith.constant 16 : i32;
+            v601 = arith.sub v599, v600 : i32 #[overflow = wrapping];
+            v602 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v603 = hir.bitcast v602 : ptr<byte, i32>;
+            hir.store v603, v601;
+            v613 = hir.bitcast v591 : u32;
+            v614 = arith.zext v613 : u64;
+            v615 = hir.bitcast v614 : i64;
+            v595 = arith.constant 0 : i32;
+            v608 = arith.sub v595, v593 : i32 #[overflow = wrapping];
+            v605 = arith.constant -1 : i32;
+            v604 = arith.add v593, v594 : i32 #[overflow = wrapping];
+            v606 = arith.add v604, v605 : i32 #[overflow = wrapping];
+            v609 = arith.band v606, v608 : i32;
+            v610 = hir.bitcast v609 : u32;
+            v611 = arith.zext v610 : u64;
+            v612 = hir.bitcast v611 : i64;
+            v616 = arith.mul v612, v615 : i64 #[overflow = wrapping];
+            v1222 = arith.constant 0 : i32;
+            v617 = arith.constant 32 : i64;
+            v619 = hir.cast v617 : u32;
+            v618 = hir.bitcast v616 : u64;
+            v620 = arith.shr v618, v619 : u64;
+            v621 = hir.bitcast v620 : i64;
+            v622 = arith.trunc v621 : i32;
+            v624 = arith.neq v622, v1222 : i1;
+            v1134, v1135, v1136, v1137, v1138, v1139 = scf.if v624 : i32, i32, i32, i32, i32, u32 {
             ^block147:
-                v1126 = arith.constant 0 : u32;
-                v1133 = ub.poison i32 : i32;
-                scf.yield v597, v608, v1133, v1133, v1133, v1126;
+                v1119 = arith.constant 0 : u32;
+                v1126 = ub.poison i32 : i32;
+                scf.yield v590, v601, v1126, v1126, v1126, v1119;
             } else {
             ^block73:
-                v632 = arith.trunc v623 : i32;
-                v1228 = arith.constant 0 : i32;
-                v633 = arith.constant -2147483648 : i32;
-                v634 = arith.sub v633, v600 : i32 #[overflow = wrapping];
-                v636 = hir.bitcast v634 : u32;
-                v635 = hir.bitcast v632 : u32;
-                v637 = arith.lte v635, v636 : i1;
-                v638 = arith.zext v637 : u32;
-                v639 = hir.bitcast v638 : i32;
-                v641 = arith.neq v639, v1228 : i1;
-                v1189 = scf.if v641 : i32 {
+                v625 = arith.trunc v616 : i32;
+                v1221 = arith.constant 0 : i32;
+                v626 = arith.constant -2147483648 : i32;
+                v627 = arith.sub v626, v593 : i32 #[overflow = wrapping];
+                v629 = hir.bitcast v627 : u32;
+                v628 = hir.bitcast v625 : u32;
+                v630 = arith.lte v628, v629 : i1;
+                v631 = arith.zext v630 : u32;
+                v632 = hir.bitcast v631 : i32;
+                v634 = arith.neq v632, v1221 : i1;
+                v1182 = scf.if v634 : i32 {
                 ^block71:
-                    v1227 = arith.constant 0 : i32;
-                    v652 = arith.neq v632, v1227 : i1;
-                    v1188 = scf.if v652 : i32 {
+                    v1220 = arith.constant 0 : i32;
+                    v645 = arith.neq v625, v1220 : i1;
+                    v1181 = scf.if v645 : i32 {
                     ^block75:
-                        v1226 = arith.constant 0 : i32;
-                        v668 = arith.neq v599, v1226 : i1;
-                        v1187 = scf.if v668 : i32 {
+                        v1219 = arith.constant 0 : i32;
+                        v661 = arith.neq v592, v1219 : i1;
+                        v1180 = scf.if v661 : i32 {
                         ^block78:
-                            v650 = arith.constant 1 : i32;
-                            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::alloc::Global::alloc_impl(v608, v600, v632, v650)
-                            v679 = hir.bitcast v608 : u32;
-                            v724 = arith.constant 4 : u32;
-                            v681 = arith.mod v679, v724 : u32;
-                            hir.assertz v681 #[code = 250];
-                            v682 = hir.int_to_ptr v679 : ptr<byte, i32>;
-                            v683 = hir.load v682 : i32;
-                            scf.yield v683;
+                            v643 = arith.constant 1 : i32;
+                            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::alloc::Global::alloc_impl(v601, v593, v625, v643)
+                            v672 = hir.bitcast v601 : u32;
+                            v717 = arith.constant 4 : u32;
+                            v674 = arith.mod v672, v717 : u32;
+                            hir.assertz v674 #[code = 250];
+                            v675 = hir.int_to_ptr v672 : ptr<byte, i32>;
+                            v676 = hir.load v675 : i32;
+                            scf.yield v676;
                         } else {
                         ^block79:
-                            v669 = arith.constant 8 : i32;
-                            v670 = arith.add v608, v669 : i32 #[overflow = wrapping];
-                            hir.exec @miden:base/note-script@1.0.0/p2id/<alloc::alloc::Global as core::alloc::Allocator>::allocate(v670, v600, v632)
-                            v654 = arith.constant 8 : u32;
-                            v671 = hir.bitcast v608 : u32;
-                            v673 = arith.add v671, v654 : u32 #[overflow = checked];
-                            v1225 = arith.constant 4 : u32;
-                            v675 = arith.mod v673, v1225 : u32;
-                            hir.assertz v675 #[code = 250];
-                            v676 = hir.int_to_ptr v673 : ptr<byte, i32>;
-                            v677 = hir.load v676 : i32;
-                            scf.yield v677;
+                            v662 = arith.constant 8 : i32;
+                            v663 = arith.add v601, v662 : i32 #[overflow = wrapping];
+                            hir.exec @miden:base/note-script@1.0.0/p2id/<alloc::alloc::Global as core::alloc::Allocator>::allocate(v663, v593, v625)
+                            v647 = arith.constant 8 : u32;
+                            v664 = hir.bitcast v601 : u32;
+                            v666 = arith.add v664, v647 : u32 #[overflow = checked];
+                            v1218 = arith.constant 4 : u32;
+                            v668 = arith.mod v666, v1218 : u32;
+                            hir.assertz v668 #[code = 250];
+                            v669 = hir.int_to_ptr v666 : ptr<byte, i32>;
+                            v670 = hir.load v669 : i32;
+                            scf.yield v670;
                         };
-                        v1223 = arith.constant 0 : i32;
-                        v1224 = arith.constant 0 : i32;
-                        v686 = arith.eq v1187, v1224 : i1;
-                        v687 = arith.zext v686 : u32;
-                        v688 = hir.bitcast v687 : i32;
-                        v690 = arith.neq v688, v1223 : i1;
-                        scf.if v690{
+                        v1216 = arith.constant 0 : i32;
+                        v1217 = arith.constant 0 : i32;
+                        v679 = arith.eq v1180, v1217 : i1;
+                        v680 = arith.zext v679 : u32;
+                        v681 = hir.bitcast v680 : i32;
+                        v683 = arith.neq v681, v1216 : i1;
+                        scf.if v683{
                         ^block80:
-                            v1222 = arith.constant 8 : u32;
-                            v707 = hir.bitcast v597 : u32;
-                            v709 = arith.add v707, v1222 : u32 #[overflow = checked];
-                            v1221 = arith.constant 4 : u32;
-                            v711 = arith.mod v709, v1221 : u32;
+                            v1215 = arith.constant 8 : u32;
+                            v700 = hir.bitcast v590 : u32;
+                            v702 = arith.add v700, v1215 : u32 #[overflow = checked];
+                            v1214 = arith.constant 4 : u32;
+                            v704 = arith.mod v702, v1214 : u32;
+                            hir.assertz v704 #[code = 250];
+                            v705 = hir.int_to_ptr v702 : ptr<byte, i32>;
+                            hir.store v705, v625;
+                            v1213 = arith.constant 4 : u32;
+                            v707 = hir.bitcast v590 : u32;
+                            v709 = arith.add v707, v1213 : u32 #[overflow = checked];
+                            v1212 = arith.constant 4 : u32;
+                            v711 = arith.mod v709, v1212 : u32;
                             hir.assertz v711 #[code = 250];
                             v712 = hir.int_to_ptr v709 : ptr<byte, i32>;
-                            hir.store v712, v632;
-                            v1220 = arith.constant 4 : u32;
-                            v714 = hir.bitcast v597 : u32;
-                            v716 = arith.add v714, v1220 : u32 #[overflow = checked];
-                            v1219 = arith.constant 4 : u32;
-                            v718 = arith.mod v716, v1219 : u32;
-                            hir.assertz v718 #[code = 250];
-                            v719 = hir.int_to_ptr v716 : ptr<byte, i32>;
-                            hir.store v719, v600;
+                            hir.store v712, v593;
                             scf.yield ;
                         } else {
                         ^block81:
-                            v1218 = arith.constant 8 : u32;
-                            v692 = hir.bitcast v597 : u32;
-                            v694 = arith.add v692, v1218 : u32 #[overflow = checked];
-                            v1217 = arith.constant 4 : u32;
-                            v696 = arith.mod v694, v1217 : u32;
+                            v1211 = arith.constant 8 : u32;
+                            v685 = hir.bitcast v590 : u32;
+                            v687 = arith.add v685, v1211 : u32 #[overflow = checked];
+                            v1210 = arith.constant 4 : u32;
+                            v689 = arith.mod v687, v1210 : u32;
+                            hir.assertz v689 #[code = 250];
+                            v690 = hir.int_to_ptr v687 : ptr<byte, i32>;
+                            hir.store v690, v1180;
+                            v1209 = arith.constant 4 : u32;
+                            v692 = hir.bitcast v590 : u32;
+                            v694 = arith.add v692, v1209 : u32 #[overflow = checked];
+                            v1208 = arith.constant 4 : u32;
+                            v696 = arith.mod v694, v1208 : u32;
                             hir.assertz v696 #[code = 250];
                             v697 = hir.int_to_ptr v694 : ptr<byte, i32>;
-                            hir.store v697, v1187;
-                            v1216 = arith.constant 4 : u32;
-                            v699 = hir.bitcast v597 : u32;
-                            v701 = arith.add v699, v1216 : u32 #[overflow = checked];
-                            v1215 = arith.constant 4 : u32;
-                            v703 = arith.mod v701, v1215 : u32;
-                            hir.assertz v703 #[code = 250];
-                            v704 = hir.int_to_ptr v701 : ptr<byte, i32>;
-                            hir.store v704, v598;
+                            hir.store v697, v591;
                             scf.yield ;
                         };
-                        v1213 = arith.constant 0 : i32;
-                        v1214 = arith.constant 1 : i32;
-                        v1186 = cf.select v690, v1214, v1213 : i32;
-                        scf.yield v1186;
+                        v1206 = arith.constant 0 : i32;
+                        v1207 = arith.constant 1 : i32;
+                        v1179 = cf.select v683, v1207, v1206 : i32;
+                        scf.yield v1179;
                     } else {
                     ^block76:
-                        v1212 = arith.constant 8 : u32;
-                        v653 = hir.bitcast v597 : u32;
-                        v655 = arith.add v653, v1212 : u32 #[overflow = checked];
-                        v1211 = arith.constant 4 : u32;
-                        v657 = arith.mod v655, v1211 : u32;
-                        hir.assertz v657 #[code = 250];
-                        v658 = hir.int_to_ptr v655 : ptr<byte, i32>;
-                        hir.store v658, v600;
-                        v1210 = arith.constant 4 : u32;
-                        v661 = hir.bitcast v597 : u32;
-                        v663 = arith.add v661, v1210 : u32 #[overflow = checked];
-                        v1209 = arith.constant 4 : u32;
-                        v665 = arith.mod v663, v1209 : u32;
-                        hir.assertz v665 #[code = 250];
-                        v1208 = arith.constant 0 : i32;
-                        v666 = hir.int_to_ptr v663 : ptr<byte, i32>;
-                        hir.store v666, v1208;
-                        v1207 = arith.constant 0 : i32;
-                        scf.yield v1207;
+                        v1205 = arith.constant 8 : u32;
+                        v646 = hir.bitcast v590 : u32;
+                        v648 = arith.add v646, v1205 : u32 #[overflow = checked];
+                        v1204 = arith.constant 4 : u32;
+                        v650 = arith.mod v648, v1204 : u32;
+                        hir.assertz v650 #[code = 250];
+                        v651 = hir.int_to_ptr v648 : ptr<byte, i32>;
+                        hir.store v651, v593;
+                        v1203 = arith.constant 4 : u32;
+                        v654 = hir.bitcast v590 : u32;
+                        v656 = arith.add v654, v1203 : u32 #[overflow = checked];
+                        v1202 = arith.constant 4 : u32;
+                        v658 = arith.mod v656, v1202 : u32;
+                        hir.assertz v658 #[code = 250];
+                        v1201 = arith.constant 0 : i32;
+                        v659 = hir.int_to_ptr v656 : ptr<byte, i32>;
+                        hir.store v659, v1201;
+                        v1200 = arith.constant 0 : i32;
+                        scf.yield v1200;
                     };
-                    scf.yield v1188;
+                    scf.yield v1181;
                 } else {
                 ^block74:
-                    v1206 = ub.poison i32 : i32;
-                    scf.yield v1206;
+                    v1199 = ub.poison i32 : i32;
+                    scf.yield v1199;
                 };
-                v1201 = arith.constant 0 : u32;
-                v1134 = arith.constant 1 : u32;
-                v1194 = cf.select v641, v1134, v1201 : u32;
-                v1202 = ub.poison i32 : i32;
-                v1193 = cf.select v641, v608, v1202 : i32;
-                v1203 = ub.poison i32 : i32;
-                v1192 = cf.select v641, v597, v1203 : i32;
-                v1204 = ub.poison i32 : i32;
-                v1191 = cf.select v641, v1204, v608 : i32;
-                v1205 = ub.poison i32 : i32;
-                v1190 = cf.select v641, v1205, v597 : i32;
-                scf.yield v1190, v1191, v1192, v1189, v1193, v1194;
+                v1194 = arith.constant 0 : u32;
+                v1127 = arith.constant 1 : u32;
+                v1187 = cf.select v634, v1127, v1194 : u32;
+                v1195 = ub.poison i32 : i32;
+                v1186 = cf.select v634, v601, v1195 : i32;
+                v1196 = ub.poison i32 : i32;
+                v1185 = cf.select v634, v590, v1196 : i32;
+                v1197 = ub.poison i32 : i32;
+                v1184 = cf.select v634, v1197, v601 : i32;
+                v1198 = ub.poison i32 : i32;
+                v1183 = cf.select v634, v1198, v590 : i32;
+                scf.yield v1183, v1184, v1185, v1182, v1186, v1187;
             };
-            v1147, v1148, v1149 = scf.index_switch v1146 : i32, i32, i32 
+            v1140, v1141, v1142 = scf.index_switch v1139 : i32, i32, i32 
             case 0 {
             ^block72:
-                v1200 = arith.constant 4 : u32;
-                v644 = hir.bitcast v1141 : u32;
-                v646 = arith.add v644, v1200 : u32 #[overflow = checked];
-                v1199 = arith.constant 4 : u32;
-                v648 = arith.mod v646, v1199 : u32;
-                hir.assertz v648 #[code = 250];
-                v1198 = arith.constant 0 : i32;
-                v649 = hir.int_to_ptr v646 : ptr<byte, i32>;
-                hir.store v649, v1198;
-                v1197 = arith.constant 1 : i32;
-                scf.yield v1141, v1197, v1142;
+                v1193 = arith.constant 4 : u32;
+                v637 = hir.bitcast v1134 : u32;
+                v639 = arith.add v637, v1193 : u32 #[overflow = checked];
+                v1192 = arith.constant 4 : u32;
+                v641 = arith.mod v639, v1192 : u32;
+                hir.assertz v641 #[code = 250];
+                v1191 = arith.constant 0 : i32;
+                v642 = hir.int_to_ptr v639 : ptr<byte, i32>;
+                hir.store v642, v1191;
+                v1190 = arith.constant 1 : i32;
+                scf.yield v1134, v1190, v1135;
             }
             default {
             ^block151:
-                scf.yield v1143, v1144, v1145;
+                scf.yield v1136, v1137, v1138;
             };
-            v723 = hir.bitcast v1147 : u32;
-            v1196 = arith.constant 4 : u32;
-            v725 = arith.mod v723, v1196 : u32;
-            hir.assertz v725 #[code = 250];
-            v726 = hir.int_to_ptr v723 : ptr<byte, i32>;
-            hir.store v726, v1148;
-            v1195 = arith.constant 16 : i32;
-            v731 = arith.add v1149, v1195 : i32 #[overflow = wrapping];
-            v732 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v733 = hir.bitcast v732 : ptr<byte, i32>;
-            hir.store v733, v731;
+            v716 = hir.bitcast v1140 : u32;
+            v1189 = arith.constant 4 : u32;
+            v718 = arith.mod v716, v1189 : u32;
+            hir.assertz v718 #[code = 250];
+            v719 = hir.int_to_ptr v716 : ptr<byte, i32>;
+            hir.store v719, v1141;
+            v1188 = arith.constant 16 : i32;
+            v724 = arith.add v1142, v1188 : i32 #[overflow = wrapping];
+            v725 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v726 = hir.bitcast v725 : ptr<byte, i32>;
+            hir.store v726, v724;
             builtin.ret ;
         };
 
-        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v734: i32, v735: i32, v736: i32) {
-        ^block82(v734: i32, v735: i32, v736: i32):
-            v738 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v739 = hir.bitcast v738 : ptr<byte, i32>;
-            v740 = hir.load v739 : i32;
-            v741 = arith.constant 16 : i32;
-            v742 = arith.sub v740, v741 : i32 #[overflow = wrapping];
-            v743 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v744 = hir.bitcast v743 : ptr<byte, i32>;
-            hir.store v744, v742;
-            v737 = arith.constant 0 : i32;
-            v745 = arith.constant 8 : i32;
-            v746 = arith.add v742, v745 : i32 #[overflow = wrapping];
-            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::alloc::Global::alloc_impl(v746, v735, v736, v737)
-            v749 = arith.constant 12 : u32;
-            v748 = hir.bitcast v742 : u32;
+        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v727: i32, v728: i32, v729: i32) {
+        ^block82(v727: i32, v728: i32, v729: i32):
+            v731 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v732 = hir.bitcast v731 : ptr<byte, i32>;
+            v733 = hir.load v732 : i32;
+            v734 = arith.constant 16 : i32;
+            v735 = arith.sub v733, v734 : i32 #[overflow = wrapping];
+            v736 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v737 = hir.bitcast v736 : ptr<byte, i32>;
+            hir.store v737, v735;
+            v730 = arith.constant 0 : i32;
+            v738 = arith.constant 8 : i32;
+            v739 = arith.add v735, v738 : i32 #[overflow = wrapping];
+            hir.exec @miden:base/note-script@1.0.0/p2id/alloc::alloc::Global::alloc_impl(v739, v728, v729, v730)
+            v742 = arith.constant 12 : u32;
+            v741 = hir.bitcast v735 : u32;
+            v743 = arith.add v741, v742 : u32 #[overflow = checked];
+            v744 = arith.constant 4 : u32;
+            v745 = arith.mod v743, v744 : u32;
+            hir.assertz v745 #[code = 250];
+            v746 = hir.int_to_ptr v743 : ptr<byte, i32>;
+            v747 = hir.load v746 : i32;
+            v749 = arith.constant 8 : u32;
+            v748 = hir.bitcast v735 : u32;
             v750 = arith.add v748, v749 : u32 #[overflow = checked];
-            v751 = arith.constant 4 : u32;
-            v752 = arith.mod v750, v751 : u32;
+            v1227 = arith.constant 4 : u32;
+            v752 = arith.mod v750, v1227 : u32;
             hir.assertz v752 #[code = 250];
             v753 = hir.int_to_ptr v750 : ptr<byte, i32>;
             v754 = hir.load v753 : i32;
-            v756 = arith.constant 8 : u32;
-            v755 = hir.bitcast v742 : u32;
-            v757 = arith.add v755, v756 : u32 #[overflow = checked];
-            v1234 = arith.constant 4 : u32;
-            v759 = arith.mod v757, v1234 : u32;
-            hir.assertz v759 #[code = 250];
-            v760 = hir.int_to_ptr v757 : ptr<byte, i32>;
-            v761 = hir.load v760 : i32;
-            v762 = hir.bitcast v734 : u32;
-            v1233 = arith.constant 4 : u32;
-            v764 = arith.mod v762, v1233 : u32;
-            hir.assertz v764 #[code = 250];
-            v765 = hir.int_to_ptr v762 : ptr<byte, i32>;
-            hir.store v765, v761;
-            v1232 = arith.constant 4 : u32;
-            v766 = hir.bitcast v734 : u32;
-            v768 = arith.add v766, v1232 : u32 #[overflow = checked];
-            v1231 = arith.constant 4 : u32;
-            v770 = arith.mod v768, v1231 : u32;
-            hir.assertz v770 #[code = 250];
-            v771 = hir.int_to_ptr v768 : ptr<byte, i32>;
-            hir.store v771, v754;
-            v1230 = arith.constant 16 : i32;
-            v773 = arith.add v742, v1230 : i32 #[overflow = wrapping];
-            v774 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
-            v775 = hir.bitcast v774 : ptr<byte, i32>;
-            hir.store v775, v773;
+            v755 = hir.bitcast v727 : u32;
+            v1226 = arith.constant 4 : u32;
+            v757 = arith.mod v755, v1226 : u32;
+            hir.assertz v757 #[code = 250];
+            v758 = hir.int_to_ptr v755 : ptr<byte, i32>;
+            hir.store v758, v754;
+            v1225 = arith.constant 4 : u32;
+            v759 = hir.bitcast v727 : u32;
+            v761 = arith.add v759, v1225 : u32 #[overflow = checked];
+            v1224 = arith.constant 4 : u32;
+            v763 = arith.mod v761, v1224 : u32;
+            hir.assertz v763 #[code = 250];
+            v764 = hir.int_to_ptr v761 : ptr<byte, i32>;
+            hir.store v764, v747;
+            v1223 = arith.constant 16 : i32;
+            v766 = arith.add v735, v1223 : i32 #[overflow = wrapping];
+            v767 = builtin.global_symbol @miden:base/note-script@1.0.0/p2id/__stack_pointer : ptr<byte, u8>
+            v768 = hir.bitcast v767 : ptr<byte, i32>;
+            hir.store v768, v766;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::alloc::Global::alloc_impl(v776: i32, v777: i32, v778: i32, v779: i32) {
-        ^block84(v776: i32, v777: i32, v778: i32, v779: i32):
-            v1250 = arith.constant 0 : i32;
-            v780 = arith.constant 0 : i32;
-            v781 = arith.eq v778, v780 : i1;
-            v782 = arith.zext v781 : u32;
-            v783 = hir.bitcast v782 : i32;
-            v785 = arith.neq v783, v1250 : i1;
-            v1246 = scf.if v785 : i32 {
+        private builtin.function @alloc::alloc::Global::alloc_impl(v769: i32, v770: i32, v771: i32, v772: i32) {
+        ^block84(v769: i32, v770: i32, v771: i32, v772: i32):
+            v1243 = arith.constant 0 : i32;
+            v773 = arith.constant 0 : i32;
+            v774 = arith.eq v771, v773 : i1;
+            v775 = arith.zext v774 : u32;
+            v776 = hir.bitcast v775 : i32;
+            v778 = arith.neq v776, v1243 : i1;
+            v1239 = scf.if v778 : i32 {
             ^block154:
-                scf.yield v777;
+                scf.yield v770;
             } else {
             ^block87:
                 hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_no_alloc_shim_is_unstable_v2()
-                v1249 = arith.constant 0 : i32;
-                v787 = arith.neq v779, v1249 : i1;
-                v1245 = scf.if v787 : i32 {
+                v1242 = arith.constant 0 : i32;
+                v780 = arith.neq v772, v1242 : i1;
+                v1238 = scf.if v780 : i32 {
                 ^block88:
-                    v789 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc_zeroed(v778, v777) : i32
-                    scf.yield v789;
+                    v782 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc_zeroed(v771, v770) : i32
+                    scf.yield v782;
                 } else {
                 ^block89:
-                    v788 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc(v778, v777) : i32
-                    scf.yield v788;
+                    v781 = hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_alloc(v771, v770) : i32
+                    scf.yield v781;
                 };
-                scf.yield v1245;
+                scf.yield v1238;
             };
-            v793 = arith.constant 4 : u32;
-            v792 = hir.bitcast v776 : u32;
-            v794 = arith.add v792, v793 : u32 #[overflow = checked];
-            v1248 = arith.constant 4 : u32;
-            v796 = arith.mod v794, v1248 : u32;
-            hir.assertz v796 #[code = 250];
-            v797 = hir.int_to_ptr v794 : ptr<byte, i32>;
-            hir.store v797, v778;
-            v799 = hir.bitcast v776 : u32;
-            v1247 = arith.constant 4 : u32;
-            v801 = arith.mod v799, v1247 : u32;
-            hir.assertz v801 #[code = 250];
-            v802 = hir.int_to_ptr v799 : ptr<byte, i32>;
-            hir.store v802, v1246;
+            v786 = arith.constant 4 : u32;
+            v785 = hir.bitcast v769 : u32;
+            v787 = arith.add v785, v786 : u32 #[overflow = checked];
+            v1241 = arith.constant 4 : u32;
+            v789 = arith.mod v787, v1241 : u32;
+            hir.assertz v789 #[code = 250];
+            v790 = hir.int_to_ptr v787 : ptr<byte, i32>;
+            hir.store v790, v771;
+            v792 = hir.bitcast v769 : u32;
+            v1240 = arith.constant 4 : u32;
+            v794 = arith.mod v792, v1240 : u32;
+            hir.assertz v794 #[code = 250];
+            v795 = hir.int_to_ptr v792 : ptr<byte, i32>;
+            hir.store v795, v1239;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v803: i32, v804: i32, v805: i32, v806: i32) {
-        ^block90(v803: i32, v804: i32, v805: i32, v806: i32):
-            v1276 = arith.constant 0 : i32;
-            v807 = arith.constant 0 : i32;
-            v811 = arith.eq v806, v807 : i1;
-            v812 = arith.zext v811 : u32;
-            v813 = hir.bitcast v812 : i32;
-            v815 = arith.neq v813, v1276 : i1;
-            v1263, v1264 = scf.if v815 : i32, i32 {
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v796: i32, v797: i32, v798: i32, v799: i32) {
+        ^block90(v796: i32, v797: i32, v798: i32, v799: i32):
+            v1269 = arith.constant 0 : i32;
+            v800 = arith.constant 0 : i32;
+            v804 = arith.eq v799, v800 : i1;
+            v805 = arith.zext v804 : u32;
+            v806 = hir.bitcast v805 : i32;
+            v808 = arith.neq v806, v1269 : i1;
+            v1256, v1257 = scf.if v808 : i32, i32 {
             ^block158:
-                v1275 = arith.constant 0 : i32;
-                v809 = arith.constant 4 : i32;
-                scf.yield v809, v1275;
+                v1268 = arith.constant 0 : i32;
+                v802 = arith.constant 4 : i32;
+                scf.yield v802, v1268;
             } else {
             ^block93:
-                v816 = hir.bitcast v804 : u32;
-                v851 = arith.constant 4 : u32;
-                v818 = arith.mod v816, v851 : u32;
-                hir.assertz v818 #[code = 250];
-                v819 = hir.int_to_ptr v816 : ptr<byte, i32>;
-                v820 = hir.load v819 : i32;
-                v1273 = arith.constant 0 : i32;
-                v1274 = arith.constant 0 : i32;
-                v822 = arith.eq v820, v1274 : i1;
-                v823 = arith.zext v822 : u32;
-                v824 = hir.bitcast v823 : i32;
-                v826 = arith.neq v824, v1273 : i1;
-                v1261 = scf.if v826 : i32 {
+                v809 = hir.bitcast v797 : u32;
+                v844 = arith.constant 4 : u32;
+                v811 = arith.mod v809, v844 : u32;
+                hir.assertz v811 #[code = 250];
+                v812 = hir.int_to_ptr v809 : ptr<byte, i32>;
+                v813 = hir.load v812 : i32;
+                v1266 = arith.constant 0 : i32;
+                v1267 = arith.constant 0 : i32;
+                v815 = arith.eq v813, v1267 : i1;
+                v816 = arith.zext v815 : u32;
+                v817 = hir.bitcast v816 : i32;
+                v819 = arith.neq v817, v1266 : i1;
+                v1254 = scf.if v819 : i32 {
                 ^block157:
-                    v1272 = arith.constant 0 : i32;
-                    scf.yield v1272;
+                    v1265 = arith.constant 0 : i32;
+                    scf.yield v1265;
                 } else {
                 ^block94:
-                    v1271 = arith.constant 4 : u32;
-                    v827 = hir.bitcast v803 : u32;
-                    v829 = arith.add v827, v1271 : u32 #[overflow = checked];
-                    v1270 = arith.constant 4 : u32;
-                    v831 = arith.mod v829, v1270 : u32;
-                    hir.assertz v831 #[code = 250];
-                    v832 = hir.int_to_ptr v829 : ptr<byte, i32>;
-                    hir.store v832, v805;
-                    v1269 = arith.constant 4 : u32;
-                    v833 = hir.bitcast v804 : u32;
-                    v835 = arith.add v833, v1269 : u32 #[overflow = checked];
-                    v1268 = arith.constant 4 : u32;
-                    v837 = arith.mod v835, v1268 : u32;
-                    hir.assertz v837 #[code = 250];
-                    v838 = hir.int_to_ptr v835 : ptr<byte, i32>;
-                    v839 = hir.load v838 : i32;
-                    v840 = hir.bitcast v803 : u32;
-                    v1267 = arith.constant 4 : u32;
-                    v842 = arith.mod v840, v1267 : u32;
-                    hir.assertz v842 #[code = 250];
-                    v843 = hir.int_to_ptr v840 : ptr<byte, i32>;
-                    hir.store v843, v839;
-                    v844 = arith.mul v820, v806 : i32 #[overflow = wrapping];
-                    scf.yield v844;
+                    v1264 = arith.constant 4 : u32;
+                    v820 = hir.bitcast v796 : u32;
+                    v822 = arith.add v820, v1264 : u32 #[overflow = checked];
+                    v1263 = arith.constant 4 : u32;
+                    v824 = arith.mod v822, v1263 : u32;
+                    hir.assertz v824 #[code = 250];
+                    v825 = hir.int_to_ptr v822 : ptr<byte, i32>;
+                    hir.store v825, v798;
+                    v1262 = arith.constant 4 : u32;
+                    v826 = hir.bitcast v797 : u32;
+                    v828 = arith.add v826, v1262 : u32 #[overflow = checked];
+                    v1261 = arith.constant 4 : u32;
+                    v830 = arith.mod v828, v1261 : u32;
+                    hir.assertz v830 #[code = 250];
+                    v831 = hir.int_to_ptr v828 : ptr<byte, i32>;
+                    v832 = hir.load v831 : i32;
+                    v833 = hir.bitcast v796 : u32;
+                    v1260 = arith.constant 4 : u32;
+                    v835 = arith.mod v833, v1260 : u32;
+                    hir.assertz v835 #[code = 250];
+                    v836 = hir.int_to_ptr v833 : ptr<byte, i32>;
+                    hir.store v836, v832;
+                    v837 = arith.mul v813, v799 : i32 #[overflow = wrapping];
+                    scf.yield v837;
                 };
-                v845 = arith.constant 8 : i32;
-                v1266 = arith.constant 4 : i32;
-                v1262 = cf.select v826, v1266, v845 : i32;
-                scf.yield v1262, v1261;
+                v838 = arith.constant 8 : i32;
+                v1259 = arith.constant 4 : i32;
+                v1255 = cf.select v819, v1259, v838 : i32;
+                scf.yield v1255, v1254;
             };
-            v848 = arith.add v803, v1263 : i32 #[overflow = wrapping];
-            v850 = hir.bitcast v848 : u32;
-            v1265 = arith.constant 4 : u32;
-            v852 = arith.mod v850, v1265 : u32;
-            hir.assertz v852 #[code = 250];
-            v853 = hir.int_to_ptr v850 : ptr<byte, i32>;
-            hir.store v853, v1264;
+            v841 = arith.add v796, v1256 : i32 #[overflow = wrapping];
+            v843 = hir.bitcast v841 : u32;
+            v1258 = arith.constant 4 : u32;
+            v845 = arith.mod v843, v1258 : u32;
+            hir.assertz v845 #[code = 250];
+            v846 = hir.int_to_ptr v843 : ptr<byte, i32>;
+            hir.store v846, v1257;
             builtin.ret ;
         };
 
-        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v854: i32, v855: i32, v856: i32) {
-        ^block95(v854: i32, v855: i32, v856: i32):
-            v1278 = arith.constant 0 : i32;
-            v857 = arith.constant 0 : i32;
-            v858 = arith.eq v856, v857 : i1;
-            v859 = arith.zext v858 : u32;
-            v860 = hir.bitcast v859 : i32;
-            v862 = arith.neq v860, v1278 : i1;
-            scf.if v862{
+        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v847: i32, v848: i32, v849: i32) {
+        ^block95(v847: i32, v848: i32, v849: i32):
+            v1271 = arith.constant 0 : i32;
+            v850 = arith.constant 0 : i32;
+            v851 = arith.eq v849, v850 : i1;
+            v852 = arith.zext v851 : u32;
+            v853 = hir.bitcast v852 : i32;
+            v855 = arith.neq v853, v1271 : i1;
+            scf.if v855{
             ^block97:
                 scf.yield ;
             } else {
             ^block98:
-                hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_dealloc(v854, v856, v855)
+                hir.exec @miden:base/note-script@1.0.0/p2id/__rustc::__rust_dealloc(v847, v849, v848)
                 scf.yield ;
             };
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::handle_error(v863: i32, v864: i32, v865: i32) {
-        ^block99(v863: i32, v864: i32, v865: i32):
+        private builtin.function @alloc::raw_vec::handle_error(v856: i32, v857: i32, v858: i32) {
+        ^block99(v856: i32, v857: i32, v858: i32):
             ub.unreachable ;
         };
 
-        private builtin.function @core::ptr::alignment::Alignment::max(v866: i32, v867: i32) -> i32 {
-        ^block101(v866: i32, v867: i32):
-            v874 = arith.constant 0 : i32;
-            v870 = hir.bitcast v867 : u32;
-            v869 = hir.bitcast v866 : u32;
-            v871 = arith.gt v869, v870 : i1;
-            v872 = arith.zext v871 : u32;
-            v873 = hir.bitcast v872 : i32;
-            v875 = arith.neq v873, v874 : i1;
-            v876 = cf.select v875, v866, v867 : i32;
-            builtin.ret v876;
+        private builtin.function @core::ptr::alignment::Alignment::max(v859: i32, v860: i32) -> i32 {
+        ^block101(v859: i32, v860: i32):
+            v867 = arith.constant 0 : i32;
+            v863 = hir.bitcast v860 : u32;
+            v862 = hir.bitcast v859 : u32;
+            v864 = arith.gt v862, v863 : i1;
+            v865 = arith.zext v864 : u32;
+            v866 = hir.bitcast v865 : i32;
+            v868 = arith.neq v866, v867 : i1;
+            v869 = cf.select v868, v859, v860 : i32;
+            builtin.ret v869;
         };
 
-        private builtin.function @miden::active_account::get_id(v877: i32) {
-        ^block103(v877: i32):
-            v878, v879 = hir.exec @miden/active_account/get_id() : felt, felt
-            v880 = hir.bitcast v877 : u32;
-            v881 = hir.int_to_ptr v880 : ptr<byte, felt>;
-            hir.store v881, v878;
-            v882 = arith.constant 4 : u32;
-            v883 = arith.add v880, v882 : u32 #[overflow = checked];
-            v884 = hir.int_to_ptr v883 : ptr<byte, felt>;
-            hir.store v884, v879;
+        private builtin.function @miden::active_account::get_id(v870: i32) {
+        ^block103(v870: i32):
+            v871, v872 = hir.exec @miden/active_account/get_id() : felt, felt
+            v873 = hir.bitcast v870 : u32;
+            v874 = hir.int_to_ptr v873 : ptr<byte, felt>;
+            hir.store v874, v871;
+            v875 = arith.constant 4 : u32;
+            v876 = arith.add v873, v875 : u32 #[overflow = checked];
+            v877 = hir.int_to_ptr v876 : ptr<byte, felt>;
+            hir.store v877, v872;
             builtin.ret ;
         };
 
-        private builtin.function @miden::active_note::get_inputs(v885: i32) -> i32 {
-        ^block107(v885: i32):
-            v886, v887 = hir.exec @miden/active_note/get_inputs(v885) : i32, i32
-            builtin.ret v886;
+        private builtin.function @miden::active_note::get_inputs(v878: i32) -> i32 {
+        ^block107(v878: i32):
+            v879, v880 = hir.exec @miden/active_note/get_inputs(v878) : i32, i32
+            builtin.ret v879;
         };
 
-        private builtin.function @miden::active_note::get_assets(v889: i32) -> i32 {
-        ^block110(v889: i32):
-            v890, v891 = hir.exec @miden/active_note/get_assets(v889) : i32, i32
-            builtin.ret v890;
+        private builtin.function @miden::active_note::get_assets(v882: i32) -> i32 {
+        ^block110(v882: i32):
+            v883, v884 = hir.exec @miden/active_note/get_assets(v882) : i32, i32
+            builtin.ret v883;
         };
 
         builtin.global_variable private @#__stack_pointer : i32 {
@@ -1283,14 +1278,14 @@ builtin.component miden:base/note-script@1.0.0 {
             builtin.ret_imm 0;
         };
 
-        builtin.segment readonly @1048576 = 0x0073722e65746f6e5f6576697463612f73676e69646e69622f6372732f302e382e302d7379732d657361622d6e6564696d;
+        builtin.segment readonly @1048576 = 0x003e64657463616465723c;
 
-        builtin.segment @1048628 = 0x000000220000003d0000003000100000000000210000001f0000003000100000000000010000000100000001;
+        builtin.segment @1048588 = 0x00000000000000000000000a00100000000000010000000100000001;
     };
 
-    public builtin.function @run(v893: felt, v894: felt, v895: felt, v896: felt) {
-    ^block112(v893: felt, v894: felt, v895: felt, v896: felt):
-        hir.exec @miden:base/note-script@1.0.0/p2id/miden:base/note-script@1.0.0#run(v893, v894, v895, v896)
+    public builtin.function @run(v886: felt, v887: felt, v888: felt, v889: felt) {
+    ^block112(v886: felt, v887: felt, v888: felt, v889: felt):
+        hir.exec @miden:base/note-script@1.0.0/p2id/miden:base/note-script@1.0.0#run(v886, v887, v888, v889)
         builtin.ret ;
     };
 };

--- a/tests/integration/expected/examples/p2id.masm
+++ b/tests/integration/expected/examples/p2id.masm
@@ -16,20 +16,20 @@ proc init
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
-    push.[9678401178389669350,4413180703889426351,1344973330089033162,11194032919842094804]
+    push.[3747760794384071571,1766386520481277932,2198275188940187258,538857382178104910]
     adv.push_mapval
     push.262144
-    push.6
+    push.3
     trace.240
     exec.::std::mem::pipe_preimage_to_memory
     trace.252
     drop
     push.1048576
     u32assert
-    mem_store.278552
+    mem_store.278544
     push.0
     u32assert
-    mem_store.278553
+    mem_store.278545
 end
 
 # mod miden:base/note-script@1.0.0::p2id
@@ -57,7 +57,7 @@ end
 
 @callconv("C")
 proc __rustc::__rust_alloc(i32, i32) -> i32
-    push.1114212
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -65,7 +65,7 @@ proc __rustc::__rust_alloc(i32, i32) -> i32
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.1048672
+    push.1048616
     u32wrapping_add
     movup.2
     swap.1
@@ -85,7 +85,7 @@ end
 
 @callconv("C")
 proc __rustc::__rust_alloc_zeroed(i32, i32) -> i32
-    push.1114212
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -93,7 +93,7 @@ proc __rustc::__rust_alloc_zeroed(i32, i32) -> i32
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.1048672
+    push.1048616
     u32wrapping_add
     dup.1
     swap.2
@@ -181,7 +181,7 @@ proc miden:base/note-script@1.0.0#run(felt, felt, felt, felt)
     drop
     drop
     drop
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -191,7 +191,7 @@ proc miden:base/note-script@1.0.0#run(felt, felt, felt, felt)
     nop
     push.48
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -646,7 +646,7 @@ proc miden:base/note-script@1.0.0#run(felt, felt, felt, felt)
                 nop
                 push.48
                 u32wrapping_add
-                push.1114208
+                push.1114176
                 u32divmod.4
                 swap.1
                 trace.240
@@ -682,7 +682,7 @@ end
 proc wit_bindgen::rt::run_ctors_once(
 
 )
-    push.1114212
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -690,7 +690,7 @@ proc wit_bindgen::rt::run_ctors_once(
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.1048676
+    push.1048620
     u32wrapping_add
     u32divmod.4
     swap.1
@@ -711,7 +711,7 @@ proc wit_bindgen::rt::run_ctors_once(
     if.true
         nop
     else
-        push.1114212
+        push.1114180
         u32divmod.4
         swap.1
         trace.240
@@ -725,7 +725,7 @@ proc wit_bindgen::rt::run_ctors_once(
         trace.252
         nop
         push.1
-        push.1048676
+        push.1048620
         movup.2
         u32wrapping_add
         u32divmod.4
@@ -944,8 +944,8 @@ proc intrinsics::mem::heap_base(
 end
 
 @callconv("C")
-proc alloc::vec::Vec<T>::with_capacity(i32, i32)
-    push.1114208
+proc alloc::vec::Vec<T>::with_capacity(i32)
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -955,7 +955,7 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -970,9 +970,6 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     dup.2
     u32wrapping_add
     dup.1
-    movup.3
-    swap.5
-    movdn.3
     swap.2
     swap.1
     trace.240
@@ -981,7 +978,7 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     trace.252
     nop
     push.8
-    dup.2
+    dup.1
     add
     u32assert
     push.8
@@ -998,7 +995,7 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     trace.252
     nop
     push.8
-    dup.3
+    dup.4
     add
     u32assert
     push.4
@@ -1016,7 +1013,7 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     exec.::intrinsics::mem::store_sw
     trace.252
     nop
-    movup.2
+    movup.3
     push.4
     dup.1
     swap.1
@@ -1032,7 +1029,7 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1046,10 +1043,9 @@ end
 proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
     i32,
     i32,
-    i32,
     i32
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1059,7 +1055,7 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -1125,8 +1121,6 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
     neq
     neq
     if.true
-        movup.3
-        drop
         push.12
         dup.2
         add
@@ -1177,7 +1171,7 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
         nop
         push.16
         u32wrapping_add
-        push.1114208
+        push.1114176
         u32divmod.4
         swap.1
         trace.240
@@ -1188,8 +1182,16 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
     else
         movup.2
         drop
+        push.1114180
+        u32divmod.4
+        swap.1
+        trace.240
+        nop
+        exec.::intrinsics::mem::load_sw
+        trace.252
+        nop
         push.12
-        movup.2
+        movup.3
         add
         u32assert
         push.4
@@ -1205,7 +1207,10 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
         exec.::intrinsics::mem::load_sw
         trace.252
         nop
-        swap.1
+        push.1048600
+        movup.2
+        u32wrapping_add
+        swap.2
         trace.240
         nop
         exec.::miden:base/note-script@1.0.0::p2id::alloc::raw_vec::handle_error
@@ -1220,7 +1225,7 @@ end
 proc miden_base_sys::bindings::active_account::get_id(
     i32
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1230,7 +1235,7 @@ proc miden_base_sys::bindings::active_account::get_id(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -1281,7 +1286,7 @@ proc miden_base_sys::bindings::active_account::get_id(
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1295,7 +1300,7 @@ end
 proc miden_base_sys::bindings::active_note::get_inputs(
     i32
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1305,7 +1310,7 @@ proc miden_base_sys::bindings::active_note::get_inputs(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -1315,19 +1320,9 @@ proc miden_base_sys::bindings::active_note::get_inputs(
     exec.::intrinsics::mem::store_sw
     trace.252
     nop
-    push.1114212
-    u32divmod.4
-    swap.1
-    trace.240
-    nop
-    exec.::intrinsics::mem::load_sw
-    trace.252
-    nop
-    push.1048640
-    u32wrapping_add
     push.4
     push.8
-    dup.3
+    dup.2
     u32wrapping_add
     dup.1
     swap.2
@@ -1430,7 +1425,7 @@ proc miden_base_sys::bindings::active_note::get_inputs(
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1444,7 +1439,7 @@ end
 proc miden_base_sys::bindings::active_note::get_assets(
     i32
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1454,7 +1449,7 @@ proc miden_base_sys::bindings::active_note::get_assets(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -1464,18 +1459,8 @@ proc miden_base_sys::bindings::active_note::get_assets(
     exec.::intrinsics::mem::store_sw
     trace.252
     nop
-    push.1114212
-    u32divmod.4
-    swap.1
-    trace.240
-    nop
-    exec.::intrinsics::mem::load_sw
-    trace.252
-    nop
-    push.1048656
-    u32wrapping_add
     push.4
-    dup.2
+    dup.1
     u32wrapping_add
     trace.240
     nop
@@ -1557,7 +1542,7 @@ proc miden_base_sys::bindings::active_note::get_assets(
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1578,7 +1563,7 @@ proc alloc::raw_vec::RawVecInner<A>::deallocate(
     i32,
     i32
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1588,7 +1573,7 @@ proc alloc::raw_vec::RawVecInner<A>::deallocate(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -1679,7 +1664,7 @@ proc alloc::raw_vec::RawVecInner<A>::deallocate(
     end
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1697,7 +1682,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     i32,
     i32
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1707,7 +1692,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -2092,7 +2077,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -2108,7 +2093,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     i32,
     i32
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -2118,7 +2103,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -2211,7 +2196,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240

--- a/tests/integration/expected/examples/p2id.wat
+++ b/tests/integration/expected/examples/p2id.wat
@@ -28,12 +28,11 @@
     (type (;3;) (func (param i32 i32 i32)))
     (type (;4;) (func (param i32 i32 i32) (result i32)))
     (type (;5;) (func (result i32)))
-    (type (;6;) (func (param i32 i32)))
-    (type (;7;) (func (param i32 i32 i32 i32)))
-    (type (;8;) (func (param i32)))
-    (type (;9;) (func (param f32 f32) (result i32)))
-    (type (;10;) (func (param i32 i32 i32 i32 i32)))
-    (type (;11;) (func (param i32) (result i32)))
+    (type (;6;) (func (param i32)))
+    (type (;7;) (func (param f32 f32) (result i32)))
+    (type (;8;) (func (param i32 i32 i32 i32 i32)))
+    (type (;9;) (func (param i32 i32 i32 i32)))
+    (type (;10;) (func (param i32) (result i32)))
     (import "miden:basic-wallet/basic-wallet@0.1.0" "receive-asset" (func $p2id::bindings::miden::basic_wallet::basic_wallet::receive_asset::wit_import7 (;0;) (type 0)))
     (table (;0;) 2 2 funcref)
     (memory (;0;) 17)
@@ -45,7 +44,7 @@
     (func $__wasm_call_ctors (;1;) (type 1))
     (func $__rustc::__rust_alloc (;2;) (type 2) (param i32 i32) (result i32)
       global.get $GOT.data.internal.__memory_base
-      i32.const 1048672
+      i32.const 1048616
       i32.add
       local.get 1
       local.get 0
@@ -55,7 +54,7 @@
     (func $__rustc::__rust_alloc_zeroed (;4;) (type 2) (param i32 i32) (result i32)
       block ;; label = @1
         global.get $GOT.data.internal.__memory_base
-        i32.const 1048672
+        i32.const 1048616
         i32.add
         local.get 1
         local.get 0
@@ -194,7 +193,7 @@
       (local i32)
       block ;; label = @1
         global.get $GOT.data.internal.__memory_base
-        i32.const 1048676
+        i32.const 1048620
         i32.add
         i32.load8_u
         br_if 0 (;@1;)
@@ -202,7 +201,7 @@
         local.set 0
         call $__wasm_call_ctors
         local.get 0
-        i32.const 1048676
+        i32.const 1048620
         i32.add
         i32.const 1
         i32.store8
@@ -283,42 +282,41 @@
     (func $intrinsics::mem::heap_base (;10;) (type 5) (result i32)
       unreachable
     )
-    (func $alloc::vec::Vec<T>::with_capacity (;11;) (type 6) (param i32 i32)
+    (func $alloc::vec::Vec<T>::with_capacity (;11;) (type 6) (param i32)
       (local i32 i64)
       global.get $__stack_pointer
       i32.const 16
       i32.sub
-      local.tee 2
+      local.tee 1
       global.set $__stack_pointer
-      local.get 2
+      local.get 1
       i32.const 8
       i32.add
       i32.const 16
       i32.const 16
-      local.get 1
       call $alloc::raw_vec::RawVecInner<A>::with_capacity_in
-      local.get 2
+      local.get 1
       i64.load offset=8
-      local.set 3
+      local.set 2
       local.get 0
       i32.const 0
       i32.store offset=8
       local.get 0
-      local.get 3
-      i64.store align=4
       local.get 2
+      i64.store align=4
+      local.get 1
       i32.const 16
       i32.add
       global.set $__stack_pointer
     )
-    (func $alloc::raw_vec::RawVecInner<A>::with_capacity_in (;12;) (type 7) (param i32 i32 i32 i32)
+    (func $alloc::raw_vec::RawVecInner<A>::with_capacity_in (;12;) (type 3) (param i32 i32 i32)
       (local i32)
       global.get $__stack_pointer
       i32.const 16
       i32.sub
-      local.tee 4
+      local.tee 3
       global.set $__stack_pointer
-      local.get 4
+      local.get 3
       i32.const 4
       i32.add
       i32.const 256
@@ -326,35 +324,39 @@
       local.get 1
       local.get 2
       call $alloc::raw_vec::RawVecInner<A>::try_allocate_in
-      local.get 4
+      local.get 3
       i32.load offset=8
       local.set 2
       block ;; label = @1
-        local.get 4
+        local.get 3
         i32.load offset=4
         i32.const 1
         i32.ne
         br_if 0 (;@1;)
+        global.get $GOT.data.internal.__memory_base
+        local.set 0
         local.get 2
-        local.get 4
-        i32.load offset=12
         local.get 3
+        i32.load offset=12
+        local.get 0
+        i32.const 1048600
+        i32.add
         call $alloc::raw_vec::handle_error
         unreachable
       end
       local.get 0
-      local.get 4
+      local.get 3
       i32.load offset=12
       i32.store offset=4
       local.get 0
       local.get 2
       i32.store
-      local.get 4
+      local.get 3
       i32.const 16
       i32.add
       global.set $__stack_pointer
     )
-    (func $miden_base_sys::bindings::active_account::get_id (;13;) (type 8) (param i32)
+    (func $miden_base_sys::bindings::active_account::get_id (;13;) (type 6) (param i32)
       (local i32)
       global.get $__stack_pointer
       i32.const 16
@@ -374,7 +376,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $miden_base_sys::bindings::active_note::get_inputs (;14;) (type 8) (param i32)
+    (func $miden_base_sys::bindings::active_note::get_inputs (;14;) (type 6) (param i32)
       (local i32 i32 i32)
       global.get $__stack_pointer
       i32.const 16
@@ -386,9 +388,6 @@
       i32.add
       i32.const 4
       i32.const 4
-      global.get $GOT.data.internal.__memory_base
-      i32.const 1048640
-      i32.add
       call $alloc::raw_vec::RawVecInner<A>::with_capacity_in
       local.get 1
       i32.load offset=8
@@ -412,7 +411,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $miden_base_sys::bindings::active_note::get_assets (;15;) (type 8) (param i32)
+    (func $miden_base_sys::bindings::active_note::get_assets (;15;) (type 6) (param i32)
       (local i32)
       global.get $__stack_pointer
       i32.const 16
@@ -421,9 +420,6 @@
       global.set $__stack_pointer
       local.get 1
       i32.const 4
-      i32.add
-      global.get $GOT.data.internal.__memory_base
-      i32.const 1048656
       i32.add
       call $alloc::vec::Vec<T>::with_capacity
       local.get 0
@@ -444,7 +440,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $intrinsics::felt::eq (;16;) (type 9) (param f32 f32) (result i32)
+    (func $intrinsics::felt::eq (;16;) (type 7) (param f32 f32) (result i32)
       unreachable
     )
     (func $alloc::raw_vec::RawVecInner<A>::deallocate (;17;) (type 3) (param i32 i32 i32)
@@ -479,7 +475,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $alloc::raw_vec::RawVecInner<A>::try_allocate_in (;18;) (type 10) (param i32 i32 i32 i32 i32)
+    (func $alloc::raw_vec::RawVecInner<A>::try_allocate_in (;18;) (type 8) (param i32 i32 i32 i32 i32)
       (local i32 i64)
       global.get $__stack_pointer
       i32.const 16
@@ -620,7 +616,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $alloc::alloc::Global::alloc_impl (;20;) (type 7) (param i32 i32 i32 i32)
+    (func $alloc::alloc::Global::alloc_impl (;20;) (type 9) (param i32 i32 i32 i32)
       block ;; label = @1
         local.get 2
         i32.eqz
@@ -647,7 +643,7 @@
       local.get 1
       i32.store
     )
-    (func $alloc::raw_vec::RawVecInner<A>::current_memory (;21;) (type 7) (param i32 i32 i32 i32)
+    (func $alloc::raw_vec::RawVecInner<A>::current_memory (;21;) (type 9) (param i32 i32 i32 i32)
       (local i32 i32 i32)
       i32.const 0
       local.set 4
@@ -704,17 +700,17 @@
       i32.gt_u
       select
     )
-    (func $miden::active_account::get_id (;25;) (type 8) (param i32)
+    (func $miden::active_account::get_id (;25;) (type 6) (param i32)
       unreachable
     )
-    (func $miden::active_note::get_inputs (;26;) (type 11) (param i32) (result i32)
+    (func $miden::active_note::get_inputs (;26;) (type 10) (param i32) (result i32)
       unreachable
     )
-    (func $miden::active_note::get_assets (;27;) (type 11) (param i32) (result i32)
+    (func $miden::active_note::get_assets (;27;) (type 10) (param i32) (result i32)
       unreachable
     )
-    (data $.rodata (;0;) (i32.const 1048576) "miden-base-sys-0.8.0/src/bindings/active_note.rs\00")
-    (data $.data (;1;) (i32.const 1048628) "\01\00\00\00\01\00\00\00\01\00\00\00\00\00\10\000\00\00\00\1f\00\00\00!\00\00\00\00\00\10\000\00\00\00=\00\00\00\22\00\00\00")
+    (data $.rodata (;0;) (i32.const 1048576) "<redacted>\00")
+    (data $.data (;1;) (i32.const 1048588) "\01\00\00\00\01\00\00\00\01\00\00\00\00\00\10\00\0a\00\00\00\00\00\00\00\00\00\00\00")
   )
   (alias export 0 "word" (type (;3;)))
   (alias export 1 "receive-asset" (func (;0;)))

--- a/tests/integration/expected/rust_sdk/rust_sdk_input_note_get_assets_binding.hir
+++ b/tests/integration/expected/rust_sdk/rust_sdk_input_note_get_assets_binding.hir
@@ -10,7 +10,7 @@ builtin.component miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-no
             v3 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/GOT.data.internal.__memory_base : ptr<byte, u8>
             v4 = hir.bitcast v3 : ptr<byte, i32>;
             v5 = hir.load v4 : i32;
-            v6 = arith.constant 1048648 : i32;
+            v6 = arith.constant 1048612 : i32;
             v7 = arith.add v5, v6 : i32 #[overflow = wrapping];
             v8 = hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v7, v1, v0) : i32
             builtin.ret v8;
@@ -26,36 +26,36 @@ builtin.component miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-no
             v15 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/GOT.data.internal.__memory_base : ptr<byte, u8>
             v16 = hir.bitcast v15 : ptr<byte, i32>;
             v17 = hir.load v16 : i32;
-            v18 = arith.constant 1048648 : i32;
+            v18 = arith.constant 1048612 : i32;
             v19 = arith.add v17, v18 : i32 #[overflow = wrapping];
             v20 = hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v19, v13, v12) : i32
-            v668 = arith.constant 0 : i32;
+            v666 = arith.constant 0 : i32;
             v21 = arith.constant 0 : i32;
             v22 = arith.eq v20, v21 : i1;
             v23 = arith.zext v22 : u32;
             v24 = hir.bitcast v23 : i32;
-            v26 = arith.neq v24, v668 : i1;
+            v26 = arith.neq v24, v666 : i1;
             scf.if v26{
             ^block13:
                 scf.yield ;
             } else {
             ^block14:
-                v666 = arith.constant 0 : i32;
-                v667 = arith.constant 0 : i32;
-                v28 = arith.eq v12, v667 : i1;
+                v664 = arith.constant 0 : i32;
+                v665 = arith.constant 0 : i32;
+                v28 = arith.eq v12, v665 : i1;
                 v29 = arith.zext v28 : u32;
                 v30 = hir.bitcast v29 : i32;
-                v32 = arith.neq v30, v666 : i1;
+                v32 = arith.neq v30, v664 : i1;
                 scf.if v32{
                 ^block94:
                     scf.yield ;
                 } else {
                 ^block15:
-                    v660 = arith.constant 0 : u8;
+                    v658 = arith.constant 0 : u8;
                     v35 = hir.bitcast v12 : u32;
                     v36 = hir.bitcast v20 : u32;
                     v37 = hir.int_to_ptr v36 : ptr<byte, u8>;
-                    hir.mem_set v37, v35, v660;
+                    hir.mem_set v37, v35, v658;
                     scf.yield ;
                 };
                 scf.yield ;
@@ -93,12 +93,12 @@ builtin.component miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-no
             v58 = hir.int_to_ptr v55 : ptr<byte, i32>;
             v59 = hir.load v58 : i32;
             v60 = hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/intrinsics::felt::from_u32(v59) : felt
-            v670 = arith.constant 16 : i32;
-            v671 = arith.constant 4 : i32;
-            v62 = arith.add v46, v671 : i32 #[overflow = wrapping];
-            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::deallocate(v62, v670, v670)
-            v669 = arith.constant 16 : i32;
-            v66 = arith.add v46, v669 : i32 #[overflow = wrapping];
+            v668 = arith.constant 16 : i32;
+            v669 = arith.constant 4 : i32;
+            v62 = arith.add v46, v669 : i32 #[overflow = wrapping];
+            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::deallocate(v62, v668, v668)
+            v667 = arith.constant 16 : i32;
+            v66 = arith.add v46, v667 : i32 #[overflow = wrapping];
             v67 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
             v68 = hir.bitcast v67 : ptr<byte, i32>;
             hir.store v68, v66;
@@ -115,7 +115,7 @@ builtin.component miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-no
             v70 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/GOT.data.internal.__memory_base : ptr<byte, u8>
             v71 = hir.bitcast v70 : ptr<byte, i32>;
             v72 = hir.load v71 : i32;
-            v73 = arith.constant 1048652 : i32;
+            v73 = arith.constant 1048616 : i32;
             v74 = arith.add v72, v73 : i32 #[overflow = wrapping];
             v75 = hir.bitcast v74 : u32;
             v76 = hir.int_to_ptr v75 : ptr<byte, u8>;
@@ -133,12 +133,12 @@ builtin.component miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-no
                 v83 = hir.bitcast v82 : ptr<byte, i32>;
                 v84 = hir.load v83 : i32;
                 hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__wasm_call_ctors()
-                v673 = arith.constant 1 : u8;
-                v675 = arith.constant 1048652 : i32;
-                v86 = arith.add v84, v675 : i32 #[overflow = wrapping];
+                v671 = arith.constant 1 : u8;
+                v673 = arith.constant 1048616 : i32;
+                v86 = arith.add v84, v673 : i32 #[overflow = wrapping];
                 v90 = hir.bitcast v86 : u32;
                 v91 = hir.int_to_ptr v90 : ptr<byte, u8>;
-                hir.store v91, v673;
+                hir.store v91, v671;
                 scf.yield ;
             };
             builtin.ret ;
@@ -148,27 +148,27 @@ builtin.component miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-no
         ^block26(v92: i32, v93: i32, v94: i32):
             v97 = arith.constant 16 : i32;
             v96 = arith.constant 0 : i32;
-            v677 = arith.constant 16 : u32;
+            v675 = arith.constant 16 : u32;
             v99 = hir.bitcast v93 : u32;
-            v101 = arith.gt v99, v677 : i1;
+            v101 = arith.gt v99, v675 : i1;
             v102 = arith.zext v101 : u32;
             v103 = hir.bitcast v102 : i32;
             v105 = arith.neq v103, v96 : i1;
             v106 = cf.select v105, v93, v97 : i32;
-            v717 = arith.constant 0 : i32;
+            v715 = arith.constant 0 : i32;
             v107 = arith.constant -1 : i32;
             v108 = arith.add v106, v107 : i32 #[overflow = wrapping];
             v109 = arith.band v106, v108 : i32;
-            v111 = arith.neq v109, v717 : i1;
-            v686, v687 = scf.if v111 : i32, u32 {
+            v111 = arith.neq v109, v715 : i1;
+            v684, v685 = scf.if v111 : i32, u32 {
             ^block100:
-                v678 = arith.constant 0 : u32;
-                v682 = ub.poison i32 : i32;
-                scf.yield v682, v678;
+                v676 = arith.constant 0 : u32;
+                v680 = ub.poison i32 : i32;
+                scf.yield v680, v676;
             } else {
             ^block29:
                 v113 = hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/core::ptr::alignment::Alignment::max(v93, v106) : i32
-                v716 = arith.constant 0 : i32;
+                v714 = arith.constant 0 : i32;
                 v112 = arith.constant -2147483648 : i32;
                 v114 = arith.sub v112, v113 : i32 #[overflow = wrapping];
                 v116 = hir.bitcast v114 : u32;
@@ -176,18 +176,18 @@ builtin.component miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-no
                 v117 = arith.gt v115, v116 : i1;
                 v118 = arith.zext v117 : u32;
                 v119 = hir.bitcast v118 : i32;
-                v121 = arith.neq v119, v716 : i1;
-                v701 = scf.if v121 : i32 {
+                v121 = arith.neq v119, v714 : i1;
+                v699 = scf.if v121 : i32 {
                 ^block99:
-                    v715 = ub.poison i32 : i32;
-                    scf.yield v715;
+                    v713 = ub.poison i32 : i32;
+                    scf.yield v713;
                 } else {
                 ^block30:
-                    v713 = arith.constant 0 : i32;
-                    v127 = arith.sub v713, v113 : i32 #[overflow = wrapping];
-                    v714 = arith.constant -1 : i32;
+                    v711 = arith.constant 0 : i32;
+                    v127 = arith.sub v711, v113 : i32 #[overflow = wrapping];
+                    v712 = arith.constant -1 : i32;
                     v123 = arith.add v94, v113 : i32 #[overflow = wrapping];
-                    v125 = arith.add v123, v714 : i32 #[overflow = wrapping];
+                    v125 = arith.add v123, v712 : i32 #[overflow = wrapping];
                     v128 = arith.band v125, v127 : i32;
                     v129 = hir.bitcast v92 : u32;
                     v130 = arith.constant 4 : u32;
@@ -195,8 +195,8 @@ builtin.component miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-no
                     hir.assertz v131 #[code = 250];
                     v132 = hir.int_to_ptr v129 : ptr<byte, i32>;
                     v133 = hir.load v132 : i32;
-                    v712 = arith.constant 0 : i32;
-                    v135 = arith.neq v133, v712 : i1;
+                    v710 = arith.constant 0 : i32;
+                    v135 = arith.neq v133, v710 : i1;
                     scf.if v135{
                     ^block98:
                         scf.yield ;
@@ -205,41 +205,41 @@ builtin.component miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-no
                         v136 = hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/intrinsics::mem::heap_base() : i32
                         v137 = hir.mem_size  : u32;
                         v143 = hir.bitcast v92 : u32;
-                        v711 = arith.constant 4 : u32;
-                        v145 = arith.mod v143, v711 : u32;
+                        v709 = arith.constant 4 : u32;
+                        v145 = arith.mod v143, v709 : u32;
                         hir.assertz v145 #[code = 250];
-                        v710 = arith.constant 16 : u32;
+                        v708 = arith.constant 16 : u32;
                         v138 = hir.bitcast v137 : i32;
-                        v141 = arith.shl v138, v710 : i32;
+                        v141 = arith.shl v138, v708 : i32;
                         v142 = arith.add v136, v141 : i32 #[overflow = wrapping];
                         v146 = hir.int_to_ptr v143 : ptr<byte, i32>;
                         hir.store v146, v142;
                         scf.yield ;
                     };
                     v149 = hir.bitcast v92 : u32;
-                    v709 = arith.constant 4 : u32;
-                    v151 = arith.mod v149, v709 : u32;
+                    v707 = arith.constant 4 : u32;
+                    v151 = arith.mod v149, v707 : u32;
                     hir.assertz v151 #[code = 250];
                     v152 = hir.int_to_ptr v149 : ptr<byte, i32>;
                     v153 = hir.load v152 : i32;
-                    v707 = arith.constant 0 : i32;
-                    v708 = arith.constant -1 : i32;
-                    v155 = arith.bxor v153, v708 : i32;
+                    v705 = arith.constant 0 : i32;
+                    v706 = arith.constant -1 : i32;
+                    v155 = arith.bxor v153, v706 : i32;
                     v157 = hir.bitcast v155 : u32;
                     v156 = hir.bitcast v128 : u32;
                     v158 = arith.gt v156, v157 : i1;
                     v159 = arith.zext v158 : u32;
                     v160 = hir.bitcast v159 : i32;
-                    v162 = arith.neq v160, v707 : i1;
-                    v700 = scf.if v162 : i32 {
+                    v162 = arith.neq v160, v705 : i1;
+                    v698 = scf.if v162 : i32 {
                     ^block33:
-                        v706 = arith.constant 0 : i32;
-                        scf.yield v706;
+                        v704 = arith.constant 0 : i32;
+                        scf.yield v704;
                     } else {
                     ^block34:
                         v164 = hir.bitcast v92 : u32;
-                        v705 = arith.constant 4 : u32;
-                        v166 = arith.mod v164, v705 : u32;
+                        v703 = arith.constant 4 : u32;
+                        v166 = arith.mod v164, v703 : u32;
                         hir.assertz v166 #[code = 250];
                         v163 = arith.add v153, v128 : i32 #[overflow = wrapping];
                         v167 = hir.int_to_ptr v164 : ptr<byte, i32>;
@@ -247,20 +247,20 @@ builtin.component miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-no
                         v169 = arith.add v153, v113 : i32 #[overflow = wrapping];
                         scf.yield v169;
                     };
-                    scf.yield v700;
+                    scf.yield v698;
                 };
-                v683 = arith.constant 1 : u32;
-                v704 = arith.constant 0 : u32;
-                v702 = cf.select v121, v704, v683 : u32;
-                scf.yield v701, v702;
+                v681 = arith.constant 1 : u32;
+                v702 = arith.constant 0 : u32;
+                v700 = cf.select v121, v702, v681 : u32;
+                scf.yield v699, v700;
             };
-            v703 = arith.constant 0 : u32;
-            v699 = arith.eq v687, v703 : i1;
-            cf.cond_br v699 ^block28, ^block102(v686);
+            v701 = arith.constant 0 : u32;
+            v697 = arith.eq v685, v701 : i1;
+            cf.cond_br v697 ^block28, ^block102(v684);
         ^block28:
             ub.unreachable ;
-        ^block102(v679: i32):
-            builtin.ret v679;
+        ^block102(v677: i32):
+            builtin.ret v677;
         };
 
         private builtin.function @intrinsics::mem::heap_base() -> i32 {
@@ -269,672 +269,672 @@ builtin.component miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-no
             builtin.ret v172;
         };
 
-        private builtin.function @alloc::vec::Vec<T>::with_capacity(v174: i32, v175: i32) {
-        ^block39(v174: i32, v175: i32):
-            v178 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v179 = hir.bitcast v178 : ptr<byte, i32>;
-            v180 = hir.load v179 : i32;
-            v181 = arith.constant 16 : i32;
-            v182 = arith.sub v180, v181 : i32 #[overflow = wrapping];
-            v183 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v184 = hir.bitcast v183 : ptr<byte, i32>;
-            hir.store v184, v182;
-            v722 = arith.constant 16 : i32;
-            v185 = arith.constant 8 : i32;
-            v186 = arith.add v182, v185 : i32 #[overflow = wrapping];
-            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v186, v722, v722, v175)
-            v190 = arith.constant 8 : u32;
-            v189 = hir.bitcast v182 : u32;
-            v191 = arith.add v189, v190 : u32 #[overflow = checked];
-            v721 = arith.constant 8 : u32;
-            v193 = arith.mod v191, v721 : u32;
-            hir.assertz v193 #[code = 250];
-            v194 = hir.int_to_ptr v191 : ptr<byte, i64>;
-            v195 = hir.load v194 : i64;
-            v720 = arith.constant 8 : u32;
-            v197 = hir.bitcast v174 : u32;
-            v199 = arith.add v197, v720 : u32 #[overflow = checked];
-            v200 = arith.constant 4 : u32;
-            v201 = arith.mod v199, v200 : u32;
-            hir.assertz v201 #[code = 250];
-            v176 = arith.constant 0 : i32;
-            v202 = hir.int_to_ptr v199 : ptr<byte, i32>;
-            hir.store v202, v176;
-            v203 = hir.bitcast v174 : u32;
-            v719 = arith.constant 4 : u32;
-            v205 = arith.mod v203, v719 : u32;
-            hir.assertz v205 #[code = 250];
-            v206 = hir.int_to_ptr v203 : ptr<byte, i64>;
-            hir.store v206, v195;
-            v718 = arith.constant 16 : i32;
-            v208 = arith.add v182, v718 : i32 #[overflow = wrapping];
-            v209 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v210 = hir.bitcast v209 : ptr<byte, i32>;
-            hir.store v210, v208;
+        private builtin.function @alloc::vec::Vec<T>::with_capacity(v174: i32) {
+        ^block39(v174: i32):
+            v177 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v178 = hir.bitcast v177 : ptr<byte, i32>;
+            v179 = hir.load v178 : i32;
+            v180 = arith.constant 16 : i32;
+            v181 = arith.sub v179, v180 : i32 #[overflow = wrapping];
+            v182 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v183 = hir.bitcast v182 : ptr<byte, i32>;
+            hir.store v183, v181;
+            v720 = arith.constant 16 : i32;
+            v184 = arith.constant 8 : i32;
+            v185 = arith.add v181, v184 : i32 #[overflow = wrapping];
+            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v185, v720, v720)
+            v189 = arith.constant 8 : u32;
+            v188 = hir.bitcast v181 : u32;
+            v190 = arith.add v188, v189 : u32 #[overflow = checked];
+            v719 = arith.constant 8 : u32;
+            v192 = arith.mod v190, v719 : u32;
+            hir.assertz v192 #[code = 250];
+            v193 = hir.int_to_ptr v190 : ptr<byte, i64>;
+            v194 = hir.load v193 : i64;
+            v718 = arith.constant 8 : u32;
+            v196 = hir.bitcast v174 : u32;
+            v198 = arith.add v196, v718 : u32 #[overflow = checked];
+            v199 = arith.constant 4 : u32;
+            v200 = arith.mod v198, v199 : u32;
+            hir.assertz v200 #[code = 250];
+            v175 = arith.constant 0 : i32;
+            v201 = hir.int_to_ptr v198 : ptr<byte, i32>;
+            hir.store v201, v175;
+            v202 = hir.bitcast v174 : u32;
+            v717 = arith.constant 4 : u32;
+            v204 = arith.mod v202, v717 : u32;
+            hir.assertz v204 #[code = 250];
+            v205 = hir.int_to_ptr v202 : ptr<byte, i64>;
+            hir.store v205, v194;
+            v716 = arith.constant 16 : i32;
+            v207 = arith.add v181, v716 : i32 #[overflow = wrapping];
+            v208 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v209 = hir.bitcast v208 : ptr<byte, i32>;
+            hir.store v209, v207;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::with_capacity_in(v211: i32, v212: i32, v213: i32, v214: i32) {
-        ^block41(v211: i32, v212: i32, v213: i32, v214: i32):
-            v216 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v217 = hir.bitcast v216 : ptr<byte, i32>;
-            v218 = hir.load v217 : i32;
-            v219 = arith.constant 16 : i32;
-            v220 = arith.sub v218, v219 : i32 #[overflow = wrapping];
-            v221 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v222 = hir.bitcast v221 : ptr<byte, i32>;
-            hir.store v222, v220;
-            v215 = arith.constant 0 : i32;
-            v225 = arith.constant 256 : i32;
-            v223 = arith.constant 4 : i32;
-            v224 = arith.add v220, v223 : i32 #[overflow = wrapping];
-            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::try_allocate_in(v224, v225, v215, v212, v213)
-            v228 = arith.constant 8 : u32;
-            v227 = hir.bitcast v220 : u32;
-            v229 = arith.add v227, v228 : u32 #[overflow = checked];
-            v230 = arith.constant 4 : u32;
-            v231 = arith.mod v229, v230 : u32;
-            hir.assertz v231 #[code = 250];
-            v232 = hir.int_to_ptr v229 : ptr<byte, i32>;
-            v233 = hir.load v232 : i32;
-            v733 = arith.constant 4 : u32;
-            v234 = hir.bitcast v220 : u32;
-            v236 = arith.add v234, v733 : u32 #[overflow = checked];
-            v732 = arith.constant 4 : u32;
-            v238 = arith.mod v236, v732 : u32;
-            hir.assertz v238 #[code = 250];
-            v239 = hir.int_to_ptr v236 : ptr<byte, i32>;
-            v240 = hir.load v239 : i32;
-            v731 = arith.constant 0 : i32;
-            v241 = arith.constant 1 : i32;
-            v242 = arith.neq v240, v241 : i1;
-            v243 = arith.zext v242 : u32;
-            v244 = hir.bitcast v243 : i32;
-            v246 = arith.neq v244, v731 : i1;
-            cf.cond_br v246 ^block43, ^block44;
-        ^block43:
-            v255 = arith.constant 12 : u32;
-            v254 = hir.bitcast v220 : u32;
-            v256 = arith.add v254, v255 : u32 #[overflow = checked];
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::with_capacity_in(v210: i32, v211: i32, v212: i32) {
+        ^block41(v210: i32, v211: i32, v212: i32):
+            v214 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v215 = hir.bitcast v214 : ptr<byte, i32>;
+            v216 = hir.load v215 : i32;
+            v217 = arith.constant 16 : i32;
+            v218 = arith.sub v216, v217 : i32 #[overflow = wrapping];
+            v219 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v220 = hir.bitcast v219 : ptr<byte, i32>;
+            hir.store v220, v218;
+            v213 = arith.constant 0 : i32;
+            v223 = arith.constant 256 : i32;
+            v221 = arith.constant 4 : i32;
+            v222 = arith.add v218, v221 : i32 #[overflow = wrapping];
+            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::try_allocate_in(v222, v223, v213, v211, v212)
+            v226 = arith.constant 8 : u32;
+            v225 = hir.bitcast v218 : u32;
+            v227 = arith.add v225, v226 : u32 #[overflow = checked];
+            v228 = arith.constant 4 : u32;
+            v229 = arith.mod v227, v228 : u32;
+            hir.assertz v229 #[code = 250];
+            v230 = hir.int_to_ptr v227 : ptr<byte, i32>;
+            v231 = hir.load v230 : i32;
+            v731 = arith.constant 4 : u32;
+            v232 = hir.bitcast v218 : u32;
+            v234 = arith.add v232, v731 : u32 #[overflow = checked];
             v730 = arith.constant 4 : u32;
-            v258 = arith.mod v256, v730 : u32;
-            hir.assertz v258 #[code = 250];
-            v259 = hir.int_to_ptr v256 : ptr<byte, i32>;
-            v260 = hir.load v259 : i32;
-            v729 = arith.constant 4 : u32;
-            v261 = hir.bitcast v211 : u32;
-            v263 = arith.add v261, v729 : u32 #[overflow = checked];
+            v236 = arith.mod v234, v730 : u32;
+            hir.assertz v236 #[code = 250];
+            v237 = hir.int_to_ptr v234 : ptr<byte, i32>;
+            v238 = hir.load v237 : i32;
+            v729 = arith.constant 0 : i32;
+            v239 = arith.constant 1 : i32;
+            v240 = arith.neq v238, v239 : i1;
+            v241 = arith.zext v240 : u32;
+            v242 = hir.bitcast v241 : i32;
+            v244 = arith.neq v242, v729 : i1;
+            cf.cond_br v244 ^block43, ^block44;
+        ^block43:
+            v258 = arith.constant 12 : u32;
+            v257 = hir.bitcast v218 : u32;
+            v259 = arith.add v257, v258 : u32 #[overflow = checked];
             v728 = arith.constant 4 : u32;
-            v265 = arith.mod v263, v728 : u32;
-            hir.assertz v265 #[code = 250];
-            v266 = hir.int_to_ptr v263 : ptr<byte, i32>;
-            hir.store v266, v260;
-            v267 = hir.bitcast v211 : u32;
+            v261 = arith.mod v259, v728 : u32;
+            hir.assertz v261 #[code = 250];
+            v262 = hir.int_to_ptr v259 : ptr<byte, i32>;
+            v263 = hir.load v262 : i32;
             v727 = arith.constant 4 : u32;
-            v269 = arith.mod v267, v727 : u32;
-            hir.assertz v269 #[code = 250];
-            v270 = hir.int_to_ptr v267 : ptr<byte, i32>;
-            hir.store v270, v233;
-            v726 = arith.constant 16 : i32;
-            v272 = arith.add v220, v726 : i32 #[overflow = wrapping];
-            v273 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v274 = hir.bitcast v273 : ptr<byte, i32>;
-            hir.store v274, v272;
+            v264 = hir.bitcast v210 : u32;
+            v266 = arith.add v264, v727 : u32 #[overflow = checked];
+            v726 = arith.constant 4 : u32;
+            v268 = arith.mod v266, v726 : u32;
+            hir.assertz v268 #[code = 250];
+            v269 = hir.int_to_ptr v266 : ptr<byte, i32>;
+            hir.store v269, v263;
+            v270 = hir.bitcast v210 : u32;
+            v725 = arith.constant 4 : u32;
+            v272 = arith.mod v270, v725 : u32;
+            hir.assertz v272 #[code = 250];
+            v273 = hir.int_to_ptr v270 : ptr<byte, i32>;
+            hir.store v273, v231;
+            v724 = arith.constant 16 : i32;
+            v275 = arith.add v218, v724 : i32 #[overflow = wrapping];
+            v276 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v277 = hir.bitcast v276 : ptr<byte, i32>;
+            hir.store v277, v275;
             builtin.ret ;
         ^block44:
-            v725 = arith.constant 12 : u32;
-            v247 = hir.bitcast v220 : u32;
-            v249 = arith.add v247, v725 : u32 #[overflow = checked];
-            v724 = arith.constant 4 : u32;
-            v251 = arith.mod v249, v724 : u32;
-            hir.assertz v251 #[code = 250];
-            v252 = hir.int_to_ptr v249 : ptr<byte, i32>;
-            v253 = hir.load v252 : i32;
-            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::raw_vec::handle_error(v233, v253, v214)
+            v245 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v246 = hir.bitcast v245 : ptr<byte, i32>;
+            v247 = hir.load v246 : i32;
+            v723 = arith.constant 12 : u32;
+            v248 = hir.bitcast v218 : u32;
+            v250 = arith.add v248, v723 : u32 #[overflow = checked];
+            v722 = arith.constant 4 : u32;
+            v252 = arith.mod v250, v722 : u32;
+            hir.assertz v252 #[code = 250];
+            v253 = hir.int_to_ptr v250 : ptr<byte, i32>;
+            v254 = hir.load v253 : i32;
+            v255 = arith.constant 1048596 : i32;
+            v256 = arith.add v247, v255 : i32 #[overflow = wrapping];
+            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::raw_vec::handle_error(v231, v254, v256)
             ub.unreachable ;
         };
 
-        private builtin.function @miden_base_sys::bindings::input_note::get_assets(v275: i32, v276: felt) {
-        ^block45(v275: i32, v276: felt):
-            v278 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v279 = hir.bitcast v278 : ptr<byte, i32>;
-            v280 = hir.load v279 : i32;
-            v281 = arith.constant 16 : i32;
-            v282 = arith.sub v280, v281 : i32 #[overflow = wrapping];
-            v283 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v284 = hir.bitcast v283 : ptr<byte, i32>;
-            hir.store v284, v282;
-            v287 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v288 = hir.bitcast v287 : ptr<byte, i32>;
-            v289 = hir.load v288 : i32;
-            v290 = arith.constant 1048632 : i32;
-            v291 = arith.add v289, v290 : i32 #[overflow = wrapping];
-            v285 = arith.constant 4 : i32;
-            v286 = arith.add v282, v285 : i32 #[overflow = wrapping];
-            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::vec::Vec<T>::with_capacity(v286, v291)
-            v295 = arith.constant 8 : u32;
-            v294 = hir.bitcast v282 : u32;
-            v296 = arith.add v294, v295 : u32 #[overflow = checked];
-            v297 = arith.constant 4 : u32;
-            v298 = arith.mod v296, v297 : u32;
-            hir.assertz v298 #[code = 250];
-            v299 = hir.int_to_ptr v296 : ptr<byte, i32>;
-            v300 = hir.load v299 : i32;
-            v734 = arith.constant 2 : u32;
-            v302 = hir.bitcast v300 : u32;
-            v304 = arith.shr v302, v734 : u32;
-            v305 = hir.bitcast v304 : i32;
-            v306 = hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/miden::input_note::get_assets(v305, v276) : i32
-            v292 = arith.constant 8 : i32;
-            v293 = arith.add v275, v292 : i32 #[overflow = wrapping];
-            v307 = hir.bitcast v293 : u32;
-            v739 = arith.constant 4 : u32;
-            v309 = arith.mod v307, v739 : u32;
-            hir.assertz v309 #[code = 250];
-            v310 = hir.int_to_ptr v307 : ptr<byte, i32>;
-            hir.store v310, v306;
-            v738 = arith.constant 4 : u32;
-            v311 = hir.bitcast v282 : u32;
-            v313 = arith.add v311, v738 : u32 #[overflow = checked];
+        private builtin.function @miden_base_sys::bindings::input_note::get_assets(v278: i32, v279: felt) {
+        ^block45(v278: i32, v279: felt):
+            v281 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v282 = hir.bitcast v281 : ptr<byte, i32>;
+            v283 = hir.load v282 : i32;
+            v284 = arith.constant 16 : i32;
+            v285 = arith.sub v283, v284 : i32 #[overflow = wrapping];
+            v286 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v287 = hir.bitcast v286 : ptr<byte, i32>;
+            hir.store v287, v285;
+            v288 = arith.constant 4 : i32;
+            v289 = arith.add v285, v288 : i32 #[overflow = wrapping];
+            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::vec::Vec<T>::with_capacity(v289)
+            v293 = arith.constant 8 : u32;
+            v292 = hir.bitcast v285 : u32;
+            v294 = arith.add v292, v293 : u32 #[overflow = checked];
+            v295 = arith.constant 4 : u32;
+            v296 = arith.mod v294, v295 : u32;
+            hir.assertz v296 #[code = 250];
+            v297 = hir.int_to_ptr v294 : ptr<byte, i32>;
+            v298 = hir.load v297 : i32;
+            v732 = arith.constant 2 : u32;
+            v300 = hir.bitcast v298 : u32;
+            v302 = arith.shr v300, v732 : u32;
+            v303 = hir.bitcast v302 : i32;
+            v304 = hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/miden::input_note::get_assets(v303, v279) : i32
+            v290 = arith.constant 8 : i32;
+            v291 = arith.add v278, v290 : i32 #[overflow = wrapping];
+            v305 = hir.bitcast v291 : u32;
             v737 = arith.constant 4 : u32;
-            v315 = arith.mod v313, v737 : u32;
-            hir.assertz v315 #[code = 250];
-            v316 = hir.int_to_ptr v313 : ptr<byte, i64>;
-            v317 = hir.load v316 : i64;
-            v318 = hir.bitcast v275 : u32;
+            v307 = arith.mod v305, v737 : u32;
+            hir.assertz v307 #[code = 250];
+            v308 = hir.int_to_ptr v305 : ptr<byte, i32>;
+            hir.store v308, v304;
             v736 = arith.constant 4 : u32;
-            v320 = arith.mod v318, v736 : u32;
-            hir.assertz v320 #[code = 250];
-            v321 = hir.int_to_ptr v318 : ptr<byte, i64>;
-            hir.store v321, v317;
-            v735 = arith.constant 16 : i32;
-            v323 = arith.add v282, v735 : i32 #[overflow = wrapping];
-            v324 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v325 = hir.bitcast v324 : ptr<byte, i32>;
-            hir.store v325, v323;
+            v309 = hir.bitcast v285 : u32;
+            v311 = arith.add v309, v736 : u32 #[overflow = checked];
+            v735 = arith.constant 4 : u32;
+            v313 = arith.mod v311, v735 : u32;
+            hir.assertz v313 #[code = 250];
+            v314 = hir.int_to_ptr v311 : ptr<byte, i64>;
+            v315 = hir.load v314 : i64;
+            v316 = hir.bitcast v278 : u32;
+            v734 = arith.constant 4 : u32;
+            v318 = arith.mod v316, v734 : u32;
+            hir.assertz v318 #[code = 250];
+            v319 = hir.int_to_ptr v316 : ptr<byte, i64>;
+            hir.store v319, v315;
+            v733 = arith.constant 16 : i32;
+            v321 = arith.add v285, v733 : i32 #[overflow = wrapping];
+            v322 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v323 = hir.bitcast v322 : ptr<byte, i32>;
+            hir.store v323, v321;
             builtin.ret ;
         };
 
-        private builtin.function @intrinsics::felt::from_u32(v326: i32) -> felt {
-        ^block47(v326: i32):
-            v327 = hir.bitcast v326 : felt;
-            builtin.ret v327;
+        private builtin.function @intrinsics::felt::from_u32(v324: i32) -> felt {
+        ^block47(v324: i32):
+            v325 = hir.bitcast v324 : felt;
+            builtin.ret v325;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v329: i32, v330: i32, v331: i32) {
-        ^block49(v329: i32, v330: i32, v331: i32):
-            v333 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v334 = hir.bitcast v333 : ptr<byte, i32>;
-            v335 = hir.load v334 : i32;
-            v336 = arith.constant 16 : i32;
-            v337 = arith.sub v335, v336 : i32 #[overflow = wrapping];
-            v338 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v339 = hir.bitcast v338 : ptr<byte, i32>;
-            hir.store v339, v337;
-            v340 = arith.constant 4 : i32;
-            v341 = arith.add v337, v340 : i32 #[overflow = wrapping];
-            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::current_memory(v341, v329, v330, v331)
-            v343 = arith.constant 8 : u32;
-            v342 = hir.bitcast v337 : u32;
-            v344 = arith.add v342, v343 : u32 #[overflow = checked];
-            v345 = arith.constant 4 : u32;
-            v346 = arith.mod v344, v345 : u32;
-            hir.assertz v346 #[code = 250];
-            v347 = hir.int_to_ptr v344 : ptr<byte, i32>;
-            v348 = hir.load v347 : i32;
-            v746 = arith.constant 0 : i32;
-            v332 = arith.constant 0 : i32;
-            v350 = arith.eq v348, v332 : i1;
-            v351 = arith.zext v350 : u32;
-            v352 = hir.bitcast v351 : i32;
-            v354 = arith.neq v352, v746 : i1;
-            scf.if v354{
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v327: i32, v328: i32, v329: i32) {
+        ^block49(v327: i32, v328: i32, v329: i32):
+            v331 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v332 = hir.bitcast v331 : ptr<byte, i32>;
+            v333 = hir.load v332 : i32;
+            v334 = arith.constant 16 : i32;
+            v335 = arith.sub v333, v334 : i32 #[overflow = wrapping];
+            v336 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v337 = hir.bitcast v336 : ptr<byte, i32>;
+            hir.store v337, v335;
+            v338 = arith.constant 4 : i32;
+            v339 = arith.add v335, v338 : i32 #[overflow = wrapping];
+            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::current_memory(v339, v327, v328, v329)
+            v341 = arith.constant 8 : u32;
+            v340 = hir.bitcast v335 : u32;
+            v342 = arith.add v340, v341 : u32 #[overflow = checked];
+            v343 = arith.constant 4 : u32;
+            v344 = arith.mod v342, v343 : u32;
+            hir.assertz v344 #[code = 250];
+            v345 = hir.int_to_ptr v342 : ptr<byte, i32>;
+            v346 = hir.load v345 : i32;
+            v744 = arith.constant 0 : i32;
+            v330 = arith.constant 0 : i32;
+            v348 = arith.eq v346, v330 : i1;
+            v349 = arith.zext v348 : u32;
+            v350 = hir.bitcast v349 : i32;
+            v352 = arith.neq v350, v744 : i1;
+            scf.if v352{
             ^block108:
                 scf.yield ;
             } else {
             ^block52:
-                v745 = arith.constant 4 : u32;
-                v355 = hir.bitcast v337 : u32;
-                v357 = arith.add v355, v745 : u32 #[overflow = checked];
-                v744 = arith.constant 4 : u32;
-                v359 = arith.mod v357, v744 : u32;
-                hir.assertz v359 #[code = 250];
-                v360 = hir.int_to_ptr v357 : ptr<byte, i32>;
-                v361 = hir.load v360 : i32;
-                v363 = arith.constant 12 : u32;
-                v362 = hir.bitcast v337 : u32;
-                v364 = arith.add v362, v363 : u32 #[overflow = checked];
                 v743 = arith.constant 4 : u32;
-                v366 = arith.mod v364, v743 : u32;
-                hir.assertz v366 #[code = 250];
-                v367 = hir.int_to_ptr v364 : ptr<byte, i32>;
-                v368 = hir.load v367 : i32;
-                hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v361, v348, v368)
+                v353 = hir.bitcast v335 : u32;
+                v355 = arith.add v353, v743 : u32 #[overflow = checked];
+                v742 = arith.constant 4 : u32;
+                v357 = arith.mod v355, v742 : u32;
+                hir.assertz v357 #[code = 250];
+                v358 = hir.int_to_ptr v355 : ptr<byte, i32>;
+                v359 = hir.load v358 : i32;
+                v361 = arith.constant 12 : u32;
+                v360 = hir.bitcast v335 : u32;
+                v362 = arith.add v360, v361 : u32 #[overflow = checked];
+                v741 = arith.constant 4 : u32;
+                v364 = arith.mod v362, v741 : u32;
+                hir.assertz v364 #[code = 250];
+                v365 = hir.int_to_ptr v362 : ptr<byte, i32>;
+                v366 = hir.load v365 : i32;
+                hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v359, v346, v366)
                 scf.yield ;
             };
-            v742 = arith.constant 16 : i32;
-            v371 = arith.add v337, v742 : i32 #[overflow = wrapping];
-            v372 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v373 = hir.bitcast v372 : ptr<byte, i32>;
-            hir.store v373, v371;
+            v740 = arith.constant 16 : i32;
+            v369 = arith.add v335, v740 : i32 #[overflow = wrapping];
+            v370 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v371 = hir.bitcast v370 : ptr<byte, i32>;
+            hir.store v371, v369;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v374: i32, v375: i32, v376: i32, v377: i32, v378: i32) {
-        ^block53(v374: i32, v375: i32, v376: i32, v377: i32, v378: i32):
-            v381 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v382 = hir.bitcast v381 : ptr<byte, i32>;
-            v383 = hir.load v382 : i32;
-            v384 = arith.constant 16 : i32;
-            v385 = arith.sub v383, v384 : i32 #[overflow = wrapping];
-            v386 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v387 = hir.bitcast v386 : ptr<byte, i32>;
-            hir.store v387, v385;
-            v397 = hir.bitcast v375 : u32;
-            v398 = arith.zext v397 : u64;
-            v399 = hir.bitcast v398 : i64;
-            v379 = arith.constant 0 : i32;
-            v392 = arith.sub v379, v377 : i32 #[overflow = wrapping];
-            v389 = arith.constant -1 : i32;
-            v388 = arith.add v377, v378 : i32 #[overflow = wrapping];
-            v390 = arith.add v388, v389 : i32 #[overflow = wrapping];
-            v393 = arith.band v390, v392 : i32;
-            v394 = hir.bitcast v393 : u32;
-            v395 = arith.zext v394 : u64;
-            v396 = hir.bitcast v395 : i64;
-            v400 = arith.mul v396, v399 : i64 #[overflow = wrapping];
-            v850 = arith.constant 0 : i32;
-            v401 = arith.constant 32 : i64;
-            v403 = hir.cast v401 : u32;
-            v402 = hir.bitcast v400 : u64;
-            v404 = arith.shr v402, v403 : u64;
-            v405 = hir.bitcast v404 : i64;
-            v406 = arith.trunc v405 : i32;
-            v408 = arith.neq v406, v850 : i1;
-            v762, v763, v764, v765, v766, v767 = scf.if v408 : i32, i32, i32, i32, i32, u32 {
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v372: i32, v373: i32, v374: i32, v375: i32, v376: i32) {
+        ^block53(v372: i32, v373: i32, v374: i32, v375: i32, v376: i32):
+            v379 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v380 = hir.bitcast v379 : ptr<byte, i32>;
+            v381 = hir.load v380 : i32;
+            v382 = arith.constant 16 : i32;
+            v383 = arith.sub v381, v382 : i32 #[overflow = wrapping];
+            v384 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v385 = hir.bitcast v384 : ptr<byte, i32>;
+            hir.store v385, v383;
+            v395 = hir.bitcast v373 : u32;
+            v396 = arith.zext v395 : u64;
+            v397 = hir.bitcast v396 : i64;
+            v377 = arith.constant 0 : i32;
+            v390 = arith.sub v377, v375 : i32 #[overflow = wrapping];
+            v387 = arith.constant -1 : i32;
+            v386 = arith.add v375, v376 : i32 #[overflow = wrapping];
+            v388 = arith.add v386, v387 : i32 #[overflow = wrapping];
+            v391 = arith.band v388, v390 : i32;
+            v392 = hir.bitcast v391 : u32;
+            v393 = arith.zext v392 : u64;
+            v394 = hir.bitcast v393 : i64;
+            v398 = arith.mul v394, v397 : i64 #[overflow = wrapping];
+            v848 = arith.constant 0 : i32;
+            v399 = arith.constant 32 : i64;
+            v401 = hir.cast v399 : u32;
+            v400 = hir.bitcast v398 : u64;
+            v402 = arith.shr v400, v401 : u64;
+            v403 = hir.bitcast v402 : i64;
+            v404 = arith.trunc v403 : i32;
+            v406 = arith.neq v404, v848 : i1;
+            v760, v761, v762, v763, v764, v765 = scf.if v406 : i32, i32, i32, i32, i32, u32 {
             ^block110:
-                v747 = arith.constant 0 : u32;
-                v754 = ub.poison i32 : i32;
-                scf.yield v374, v385, v754, v754, v754, v747;
+                v745 = arith.constant 0 : u32;
+                v752 = ub.poison i32 : i32;
+                scf.yield v372, v383, v752, v752, v752, v745;
             } else {
             ^block58:
-                v409 = arith.trunc v400 : i32;
-                v849 = arith.constant 0 : i32;
-                v410 = arith.constant -2147483648 : i32;
-                v411 = arith.sub v410, v377 : i32 #[overflow = wrapping];
-                v413 = hir.bitcast v411 : u32;
-                v412 = hir.bitcast v409 : u32;
-                v414 = arith.lte v412, v413 : i1;
-                v415 = arith.zext v414 : u32;
-                v416 = hir.bitcast v415 : i32;
-                v418 = arith.neq v416, v849 : i1;
-                v810 = scf.if v418 : i32 {
+                v407 = arith.trunc v398 : i32;
+                v847 = arith.constant 0 : i32;
+                v408 = arith.constant -2147483648 : i32;
+                v409 = arith.sub v408, v375 : i32 #[overflow = wrapping];
+                v411 = hir.bitcast v409 : u32;
+                v410 = hir.bitcast v407 : u32;
+                v412 = arith.lte v410, v411 : i1;
+                v413 = arith.zext v412 : u32;
+                v414 = hir.bitcast v413 : i32;
+                v416 = arith.neq v414, v847 : i1;
+                v808 = scf.if v416 : i32 {
                 ^block56:
-                    v848 = arith.constant 0 : i32;
-                    v429 = arith.neq v409, v848 : i1;
-                    v809 = scf.if v429 : i32 {
+                    v846 = arith.constant 0 : i32;
+                    v427 = arith.neq v407, v846 : i1;
+                    v807 = scf.if v427 : i32 {
                     ^block60:
-                        v847 = arith.constant 0 : i32;
-                        v445 = arith.neq v376, v847 : i1;
-                        v808 = scf.if v445 : i32 {
+                        v845 = arith.constant 0 : i32;
+                        v443 = arith.neq v374, v845 : i1;
+                        v806 = scf.if v443 : i32 {
                         ^block63:
-                            v427 = arith.constant 1 : i32;
-                            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::alloc::Global::alloc_impl(v385, v377, v409, v427)
-                            v456 = hir.bitcast v385 : u32;
-                            v501 = arith.constant 4 : u32;
-                            v458 = arith.mod v456, v501 : u32;
-                            hir.assertz v458 #[code = 250];
-                            v459 = hir.int_to_ptr v456 : ptr<byte, i32>;
-                            v460 = hir.load v459 : i32;
-                            scf.yield v460;
+                            v425 = arith.constant 1 : i32;
+                            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::alloc::Global::alloc_impl(v383, v375, v407, v425)
+                            v454 = hir.bitcast v383 : u32;
+                            v499 = arith.constant 4 : u32;
+                            v456 = arith.mod v454, v499 : u32;
+                            hir.assertz v456 #[code = 250];
+                            v457 = hir.int_to_ptr v454 : ptr<byte, i32>;
+                            v458 = hir.load v457 : i32;
+                            scf.yield v458;
                         } else {
                         ^block64:
-                            v446 = arith.constant 8 : i32;
-                            v447 = arith.add v385, v446 : i32 #[overflow = wrapping];
-                            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/<alloc::alloc::Global as core::alloc::Allocator>::allocate(v447, v377, v409)
-                            v431 = arith.constant 8 : u32;
-                            v448 = hir.bitcast v385 : u32;
-                            v450 = arith.add v448, v431 : u32 #[overflow = checked];
-                            v846 = arith.constant 4 : u32;
-                            v452 = arith.mod v450, v846 : u32;
-                            hir.assertz v452 #[code = 250];
-                            v453 = hir.int_to_ptr v450 : ptr<byte, i32>;
-                            v454 = hir.load v453 : i32;
-                            scf.yield v454;
+                            v444 = arith.constant 8 : i32;
+                            v445 = arith.add v383, v444 : i32 #[overflow = wrapping];
+                            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/<alloc::alloc::Global as core::alloc::Allocator>::allocate(v445, v375, v407)
+                            v429 = arith.constant 8 : u32;
+                            v446 = hir.bitcast v383 : u32;
+                            v448 = arith.add v446, v429 : u32 #[overflow = checked];
+                            v844 = arith.constant 4 : u32;
+                            v450 = arith.mod v448, v844 : u32;
+                            hir.assertz v450 #[code = 250];
+                            v451 = hir.int_to_ptr v448 : ptr<byte, i32>;
+                            v452 = hir.load v451 : i32;
+                            scf.yield v452;
                         };
-                        v844 = arith.constant 0 : i32;
-                        v845 = arith.constant 0 : i32;
-                        v463 = arith.eq v808, v845 : i1;
-                        v464 = arith.zext v463 : u32;
-                        v465 = hir.bitcast v464 : i32;
-                        v467 = arith.neq v465, v844 : i1;
-                        scf.if v467{
+                        v842 = arith.constant 0 : i32;
+                        v843 = arith.constant 0 : i32;
+                        v461 = arith.eq v806, v843 : i1;
+                        v462 = arith.zext v461 : u32;
+                        v463 = hir.bitcast v462 : i32;
+                        v465 = arith.neq v463, v842 : i1;
+                        scf.if v465{
                         ^block65:
-                            v843 = arith.constant 8 : u32;
-                            v484 = hir.bitcast v374 : u32;
-                            v486 = arith.add v484, v843 : u32 #[overflow = checked];
-                            v842 = arith.constant 4 : u32;
-                            v488 = arith.mod v486, v842 : u32;
-                            hir.assertz v488 #[code = 250];
-                            v489 = hir.int_to_ptr v486 : ptr<byte, i32>;
-                            hir.store v489, v409;
-                            v841 = arith.constant 4 : u32;
-                            v491 = hir.bitcast v374 : u32;
-                            v493 = arith.add v491, v841 : u32 #[overflow = checked];
+                            v841 = arith.constant 8 : u32;
+                            v482 = hir.bitcast v372 : u32;
+                            v484 = arith.add v482, v841 : u32 #[overflow = checked];
                             v840 = arith.constant 4 : u32;
-                            v495 = arith.mod v493, v840 : u32;
-                            hir.assertz v495 #[code = 250];
-                            v496 = hir.int_to_ptr v493 : ptr<byte, i32>;
-                            hir.store v496, v377;
+                            v486 = arith.mod v484, v840 : u32;
+                            hir.assertz v486 #[code = 250];
+                            v487 = hir.int_to_ptr v484 : ptr<byte, i32>;
+                            hir.store v487, v407;
+                            v839 = arith.constant 4 : u32;
+                            v489 = hir.bitcast v372 : u32;
+                            v491 = arith.add v489, v839 : u32 #[overflow = checked];
+                            v838 = arith.constant 4 : u32;
+                            v493 = arith.mod v491, v838 : u32;
+                            hir.assertz v493 #[code = 250];
+                            v494 = hir.int_to_ptr v491 : ptr<byte, i32>;
+                            hir.store v494, v375;
                             scf.yield ;
                         } else {
                         ^block66:
-                            v839 = arith.constant 8 : u32;
-                            v469 = hir.bitcast v374 : u32;
-                            v471 = arith.add v469, v839 : u32 #[overflow = checked];
-                            v838 = arith.constant 4 : u32;
-                            v473 = arith.mod v471, v838 : u32;
-                            hir.assertz v473 #[code = 250];
-                            v474 = hir.int_to_ptr v471 : ptr<byte, i32>;
-                            hir.store v474, v808;
-                            v837 = arith.constant 4 : u32;
-                            v476 = hir.bitcast v374 : u32;
-                            v478 = arith.add v476, v837 : u32 #[overflow = checked];
+                            v837 = arith.constant 8 : u32;
+                            v467 = hir.bitcast v372 : u32;
+                            v469 = arith.add v467, v837 : u32 #[overflow = checked];
                             v836 = arith.constant 4 : u32;
-                            v480 = arith.mod v478, v836 : u32;
-                            hir.assertz v480 #[code = 250];
-                            v481 = hir.int_to_ptr v478 : ptr<byte, i32>;
-                            hir.store v481, v375;
+                            v471 = arith.mod v469, v836 : u32;
+                            hir.assertz v471 #[code = 250];
+                            v472 = hir.int_to_ptr v469 : ptr<byte, i32>;
+                            hir.store v472, v806;
+                            v835 = arith.constant 4 : u32;
+                            v474 = hir.bitcast v372 : u32;
+                            v476 = arith.add v474, v835 : u32 #[overflow = checked];
+                            v834 = arith.constant 4 : u32;
+                            v478 = arith.mod v476, v834 : u32;
+                            hir.assertz v478 #[code = 250];
+                            v479 = hir.int_to_ptr v476 : ptr<byte, i32>;
+                            hir.store v479, v373;
                             scf.yield ;
                         };
-                        v834 = arith.constant 0 : i32;
-                        v835 = arith.constant 1 : i32;
-                        v807 = cf.select v467, v835, v834 : i32;
-                        scf.yield v807;
+                        v832 = arith.constant 0 : i32;
+                        v833 = arith.constant 1 : i32;
+                        v805 = cf.select v465, v833, v832 : i32;
+                        scf.yield v805;
                     } else {
                     ^block61:
-                        v833 = arith.constant 8 : u32;
-                        v430 = hir.bitcast v374 : u32;
-                        v432 = arith.add v430, v833 : u32 #[overflow = checked];
-                        v832 = arith.constant 4 : u32;
-                        v434 = arith.mod v432, v832 : u32;
-                        hir.assertz v434 #[code = 250];
-                        v435 = hir.int_to_ptr v432 : ptr<byte, i32>;
-                        hir.store v435, v377;
-                        v831 = arith.constant 4 : u32;
-                        v438 = hir.bitcast v374 : u32;
-                        v440 = arith.add v438, v831 : u32 #[overflow = checked];
+                        v831 = arith.constant 8 : u32;
+                        v428 = hir.bitcast v372 : u32;
+                        v430 = arith.add v428, v831 : u32 #[overflow = checked];
                         v830 = arith.constant 4 : u32;
-                        v442 = arith.mod v440, v830 : u32;
-                        hir.assertz v442 #[code = 250];
-                        v829 = arith.constant 0 : i32;
-                        v443 = hir.int_to_ptr v440 : ptr<byte, i32>;
-                        hir.store v443, v829;
-                        v828 = arith.constant 0 : i32;
-                        scf.yield v828;
+                        v432 = arith.mod v430, v830 : u32;
+                        hir.assertz v432 #[code = 250];
+                        v433 = hir.int_to_ptr v430 : ptr<byte, i32>;
+                        hir.store v433, v375;
+                        v829 = arith.constant 4 : u32;
+                        v436 = hir.bitcast v372 : u32;
+                        v438 = arith.add v436, v829 : u32 #[overflow = checked];
+                        v828 = arith.constant 4 : u32;
+                        v440 = arith.mod v438, v828 : u32;
+                        hir.assertz v440 #[code = 250];
+                        v827 = arith.constant 0 : i32;
+                        v441 = hir.int_to_ptr v438 : ptr<byte, i32>;
+                        hir.store v441, v827;
+                        v826 = arith.constant 0 : i32;
+                        scf.yield v826;
                     };
-                    scf.yield v809;
+                    scf.yield v807;
                 } else {
                 ^block59:
-                    v827 = ub.poison i32 : i32;
-                    scf.yield v827;
+                    v825 = ub.poison i32 : i32;
+                    scf.yield v825;
                 };
-                v822 = arith.constant 0 : u32;
-                v755 = arith.constant 1 : u32;
-                v815 = cf.select v418, v755, v822 : u32;
+                v820 = arith.constant 0 : u32;
+                v753 = arith.constant 1 : u32;
+                v813 = cf.select v416, v753, v820 : u32;
+                v821 = ub.poison i32 : i32;
+                v812 = cf.select v416, v383, v821 : i32;
+                v822 = ub.poison i32 : i32;
+                v811 = cf.select v416, v372, v822 : i32;
                 v823 = ub.poison i32 : i32;
-                v814 = cf.select v418, v385, v823 : i32;
+                v810 = cf.select v416, v823, v383 : i32;
                 v824 = ub.poison i32 : i32;
-                v813 = cf.select v418, v374, v824 : i32;
-                v825 = ub.poison i32 : i32;
-                v812 = cf.select v418, v825, v385 : i32;
-                v826 = ub.poison i32 : i32;
-                v811 = cf.select v418, v826, v374 : i32;
-                scf.yield v811, v812, v813, v810, v814, v815;
+                v809 = cf.select v416, v824, v372 : i32;
+                scf.yield v809, v810, v811, v808, v812, v813;
             };
-            v768, v769, v770 = scf.index_switch v767 : i32, i32, i32 
+            v766, v767, v768 = scf.index_switch v765 : i32, i32, i32 
             case 0 {
             ^block57:
-                v821 = arith.constant 4 : u32;
-                v421 = hir.bitcast v762 : u32;
-                v423 = arith.add v421, v821 : u32 #[overflow = checked];
-                v820 = arith.constant 4 : u32;
-                v425 = arith.mod v423, v820 : u32;
-                hir.assertz v425 #[code = 250];
-                v819 = arith.constant 0 : i32;
-                v426 = hir.int_to_ptr v423 : ptr<byte, i32>;
-                hir.store v426, v819;
-                v818 = arith.constant 1 : i32;
-                scf.yield v762, v818, v763;
+                v819 = arith.constant 4 : u32;
+                v419 = hir.bitcast v760 : u32;
+                v421 = arith.add v419, v819 : u32 #[overflow = checked];
+                v818 = arith.constant 4 : u32;
+                v423 = arith.mod v421, v818 : u32;
+                hir.assertz v423 #[code = 250];
+                v817 = arith.constant 0 : i32;
+                v424 = hir.int_to_ptr v421 : ptr<byte, i32>;
+                hir.store v424, v817;
+                v816 = arith.constant 1 : i32;
+                scf.yield v760, v816, v761;
             }
             default {
             ^block114:
-                scf.yield v764, v765, v766;
+                scf.yield v762, v763, v764;
             };
-            v500 = hir.bitcast v768 : u32;
-            v817 = arith.constant 4 : u32;
-            v502 = arith.mod v500, v817 : u32;
-            hir.assertz v502 #[code = 250];
-            v503 = hir.int_to_ptr v500 : ptr<byte, i32>;
-            hir.store v503, v769;
-            v816 = arith.constant 16 : i32;
-            v508 = arith.add v770, v816 : i32 #[overflow = wrapping];
-            v509 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v510 = hir.bitcast v509 : ptr<byte, i32>;
-            hir.store v510, v508;
+            v498 = hir.bitcast v766 : u32;
+            v815 = arith.constant 4 : u32;
+            v500 = arith.mod v498, v815 : u32;
+            hir.assertz v500 #[code = 250];
+            v501 = hir.int_to_ptr v498 : ptr<byte, i32>;
+            hir.store v501, v767;
+            v814 = arith.constant 16 : i32;
+            v506 = arith.add v768, v814 : i32 #[overflow = wrapping];
+            v507 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v508 = hir.bitcast v507 : ptr<byte, i32>;
+            hir.store v508, v506;
             builtin.ret ;
         };
 
-        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v511: i32, v512: i32, v513: i32) {
-        ^block67(v511: i32, v512: i32, v513: i32):
-            v515 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v516 = hir.bitcast v515 : ptr<byte, i32>;
-            v517 = hir.load v516 : i32;
-            v518 = arith.constant 16 : i32;
-            v519 = arith.sub v517, v518 : i32 #[overflow = wrapping];
-            v520 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v521 = hir.bitcast v520 : ptr<byte, i32>;
-            hir.store v521, v519;
-            v514 = arith.constant 0 : i32;
-            v522 = arith.constant 8 : i32;
-            v523 = arith.add v519, v522 : i32 #[overflow = wrapping];
-            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::alloc::Global::alloc_impl(v523, v512, v513, v514)
-            v526 = arith.constant 12 : u32;
-            v525 = hir.bitcast v519 : u32;
-            v527 = arith.add v525, v526 : u32 #[overflow = checked];
-            v528 = arith.constant 4 : u32;
-            v529 = arith.mod v527, v528 : u32;
-            hir.assertz v529 #[code = 250];
-            v530 = hir.int_to_ptr v527 : ptr<byte, i32>;
-            v531 = hir.load v530 : i32;
-            v533 = arith.constant 8 : u32;
-            v532 = hir.bitcast v519 : u32;
-            v534 = arith.add v532, v533 : u32 #[overflow = checked];
-            v855 = arith.constant 4 : u32;
-            v536 = arith.mod v534, v855 : u32;
-            hir.assertz v536 #[code = 250];
-            v537 = hir.int_to_ptr v534 : ptr<byte, i32>;
-            v538 = hir.load v537 : i32;
-            v539 = hir.bitcast v511 : u32;
-            v854 = arith.constant 4 : u32;
-            v541 = arith.mod v539, v854 : u32;
-            hir.assertz v541 #[code = 250];
-            v542 = hir.int_to_ptr v539 : ptr<byte, i32>;
-            hir.store v542, v538;
+        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v509: i32, v510: i32, v511: i32) {
+        ^block67(v509: i32, v510: i32, v511: i32):
+            v513 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v514 = hir.bitcast v513 : ptr<byte, i32>;
+            v515 = hir.load v514 : i32;
+            v516 = arith.constant 16 : i32;
+            v517 = arith.sub v515, v516 : i32 #[overflow = wrapping];
+            v518 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v519 = hir.bitcast v518 : ptr<byte, i32>;
+            hir.store v519, v517;
+            v512 = arith.constant 0 : i32;
+            v520 = arith.constant 8 : i32;
+            v521 = arith.add v517, v520 : i32 #[overflow = wrapping];
+            hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/alloc::alloc::Global::alloc_impl(v521, v510, v511, v512)
+            v524 = arith.constant 12 : u32;
+            v523 = hir.bitcast v517 : u32;
+            v525 = arith.add v523, v524 : u32 #[overflow = checked];
+            v526 = arith.constant 4 : u32;
+            v527 = arith.mod v525, v526 : u32;
+            hir.assertz v527 #[code = 250];
+            v528 = hir.int_to_ptr v525 : ptr<byte, i32>;
+            v529 = hir.load v528 : i32;
+            v531 = arith.constant 8 : u32;
+            v530 = hir.bitcast v517 : u32;
+            v532 = arith.add v530, v531 : u32 #[overflow = checked];
             v853 = arith.constant 4 : u32;
-            v543 = hir.bitcast v511 : u32;
-            v545 = arith.add v543, v853 : u32 #[overflow = checked];
+            v534 = arith.mod v532, v853 : u32;
+            hir.assertz v534 #[code = 250];
+            v535 = hir.int_to_ptr v532 : ptr<byte, i32>;
+            v536 = hir.load v535 : i32;
+            v537 = hir.bitcast v509 : u32;
             v852 = arith.constant 4 : u32;
-            v547 = arith.mod v545, v852 : u32;
-            hir.assertz v547 #[code = 250];
-            v548 = hir.int_to_ptr v545 : ptr<byte, i32>;
-            hir.store v548, v531;
-            v851 = arith.constant 16 : i32;
-            v550 = arith.add v519, v851 : i32 #[overflow = wrapping];
-            v551 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v552 = hir.bitcast v551 : ptr<byte, i32>;
-            hir.store v552, v550;
+            v539 = arith.mod v537, v852 : u32;
+            hir.assertz v539 #[code = 250];
+            v540 = hir.int_to_ptr v537 : ptr<byte, i32>;
+            hir.store v540, v536;
+            v851 = arith.constant 4 : u32;
+            v541 = hir.bitcast v509 : u32;
+            v543 = arith.add v541, v851 : u32 #[overflow = checked];
+            v850 = arith.constant 4 : u32;
+            v545 = arith.mod v543, v850 : u32;
+            hir.assertz v545 #[code = 250];
+            v546 = hir.int_to_ptr v543 : ptr<byte, i32>;
+            hir.store v546, v529;
+            v849 = arith.constant 16 : i32;
+            v548 = arith.add v517, v849 : i32 #[overflow = wrapping];
+            v549 = builtin.global_symbol @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v550 = hir.bitcast v549 : ptr<byte, i32>;
+            hir.store v550, v548;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::alloc::Global::alloc_impl(v553: i32, v554: i32, v555: i32, v556: i32) {
-        ^block69(v553: i32, v554: i32, v555: i32, v556: i32):
-            v871 = arith.constant 0 : i32;
-            v557 = arith.constant 0 : i32;
-            v558 = arith.eq v555, v557 : i1;
-            v559 = arith.zext v558 : u32;
-            v560 = hir.bitcast v559 : i32;
-            v562 = arith.neq v560, v871 : i1;
-            v867 = scf.if v562 : i32 {
+        private builtin.function @alloc::alloc::Global::alloc_impl(v551: i32, v552: i32, v553: i32, v554: i32) {
+        ^block69(v551: i32, v552: i32, v553: i32, v554: i32):
+            v869 = arith.constant 0 : i32;
+            v555 = arith.constant 0 : i32;
+            v556 = arith.eq v553, v555 : i1;
+            v557 = arith.zext v556 : u32;
+            v558 = hir.bitcast v557 : i32;
+            v560 = arith.neq v558, v869 : i1;
+            v865 = scf.if v560 : i32 {
             ^block117:
-                scf.yield v554;
+                scf.yield v552;
             } else {
             ^block72:
                 hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__rustc::__rust_no_alloc_shim_is_unstable_v2()
-                v870 = arith.constant 0 : i32;
-                v564 = arith.neq v556, v870 : i1;
-                v866 = scf.if v564 : i32 {
+                v868 = arith.constant 0 : i32;
+                v562 = arith.neq v554, v868 : i1;
+                v864 = scf.if v562 : i32 {
                 ^block73:
-                    v566 = hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__rustc::__rust_alloc_zeroed(v555, v554) : i32
-                    scf.yield v566;
+                    v564 = hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__rustc::__rust_alloc_zeroed(v553, v552) : i32
+                    scf.yield v564;
                 } else {
                 ^block74:
-                    v565 = hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__rustc::__rust_alloc(v555, v554) : i32
-                    scf.yield v565;
+                    v563 = hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__rustc::__rust_alloc(v553, v552) : i32
+                    scf.yield v563;
                 };
-                scf.yield v866;
+                scf.yield v864;
             };
-            v570 = arith.constant 4 : u32;
-            v569 = hir.bitcast v553 : u32;
-            v571 = arith.add v569, v570 : u32 #[overflow = checked];
-            v869 = arith.constant 4 : u32;
-            v573 = arith.mod v571, v869 : u32;
-            hir.assertz v573 #[code = 250];
-            v574 = hir.int_to_ptr v571 : ptr<byte, i32>;
-            hir.store v574, v555;
-            v576 = hir.bitcast v553 : u32;
-            v868 = arith.constant 4 : u32;
-            v578 = arith.mod v576, v868 : u32;
-            hir.assertz v578 #[code = 250];
-            v579 = hir.int_to_ptr v576 : ptr<byte, i32>;
-            hir.store v579, v867;
+            v568 = arith.constant 4 : u32;
+            v567 = hir.bitcast v551 : u32;
+            v569 = arith.add v567, v568 : u32 #[overflow = checked];
+            v867 = arith.constant 4 : u32;
+            v571 = arith.mod v569, v867 : u32;
+            hir.assertz v571 #[code = 250];
+            v572 = hir.int_to_ptr v569 : ptr<byte, i32>;
+            hir.store v572, v553;
+            v574 = hir.bitcast v551 : u32;
+            v866 = arith.constant 4 : u32;
+            v576 = arith.mod v574, v866 : u32;
+            hir.assertz v576 #[code = 250];
+            v577 = hir.int_to_ptr v574 : ptr<byte, i32>;
+            hir.store v577, v865;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v580: i32, v581: i32, v582: i32, v583: i32) {
-        ^block75(v580: i32, v581: i32, v582: i32, v583: i32):
-            v897 = arith.constant 0 : i32;
-            v584 = arith.constant 0 : i32;
-            v588 = arith.eq v583, v584 : i1;
-            v589 = arith.zext v588 : u32;
-            v590 = hir.bitcast v589 : i32;
-            v592 = arith.neq v590, v897 : i1;
-            v884, v885 = scf.if v592 : i32, i32 {
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v578: i32, v579: i32, v580: i32, v581: i32) {
+        ^block75(v578: i32, v579: i32, v580: i32, v581: i32):
+            v895 = arith.constant 0 : i32;
+            v582 = arith.constant 0 : i32;
+            v586 = arith.eq v581, v582 : i1;
+            v587 = arith.zext v586 : u32;
+            v588 = hir.bitcast v587 : i32;
+            v590 = arith.neq v588, v895 : i1;
+            v882, v883 = scf.if v590 : i32, i32 {
             ^block121:
-                v896 = arith.constant 0 : i32;
-                v586 = arith.constant 4 : i32;
-                scf.yield v586, v896;
+                v894 = arith.constant 0 : i32;
+                v584 = arith.constant 4 : i32;
+                scf.yield v584, v894;
             } else {
             ^block78:
-                v593 = hir.bitcast v581 : u32;
-                v628 = arith.constant 4 : u32;
-                v595 = arith.mod v593, v628 : u32;
-                hir.assertz v595 #[code = 250];
-                v596 = hir.int_to_ptr v593 : ptr<byte, i32>;
-                v597 = hir.load v596 : i32;
-                v894 = arith.constant 0 : i32;
-                v895 = arith.constant 0 : i32;
-                v599 = arith.eq v597, v895 : i1;
-                v600 = arith.zext v599 : u32;
-                v601 = hir.bitcast v600 : i32;
-                v603 = arith.neq v601, v894 : i1;
-                v882 = scf.if v603 : i32 {
+                v591 = hir.bitcast v579 : u32;
+                v626 = arith.constant 4 : u32;
+                v593 = arith.mod v591, v626 : u32;
+                hir.assertz v593 #[code = 250];
+                v594 = hir.int_to_ptr v591 : ptr<byte, i32>;
+                v595 = hir.load v594 : i32;
+                v892 = arith.constant 0 : i32;
+                v893 = arith.constant 0 : i32;
+                v597 = arith.eq v595, v893 : i1;
+                v598 = arith.zext v597 : u32;
+                v599 = hir.bitcast v598 : i32;
+                v601 = arith.neq v599, v892 : i1;
+                v880 = scf.if v601 : i32 {
                 ^block120:
-                    v893 = arith.constant 0 : i32;
-                    scf.yield v893;
+                    v891 = arith.constant 0 : i32;
+                    scf.yield v891;
                 } else {
                 ^block79:
-                    v892 = arith.constant 4 : u32;
-                    v604 = hir.bitcast v580 : u32;
-                    v606 = arith.add v604, v892 : u32 #[overflow = checked];
-                    v891 = arith.constant 4 : u32;
-                    v608 = arith.mod v606, v891 : u32;
-                    hir.assertz v608 #[code = 250];
-                    v609 = hir.int_to_ptr v606 : ptr<byte, i32>;
-                    hir.store v609, v582;
                     v890 = arith.constant 4 : u32;
-                    v610 = hir.bitcast v581 : u32;
-                    v612 = arith.add v610, v890 : u32 #[overflow = checked];
+                    v602 = hir.bitcast v578 : u32;
+                    v604 = arith.add v602, v890 : u32 #[overflow = checked];
                     v889 = arith.constant 4 : u32;
-                    v614 = arith.mod v612, v889 : u32;
-                    hir.assertz v614 #[code = 250];
-                    v615 = hir.int_to_ptr v612 : ptr<byte, i32>;
-                    v616 = hir.load v615 : i32;
-                    v617 = hir.bitcast v580 : u32;
+                    v606 = arith.mod v604, v889 : u32;
+                    hir.assertz v606 #[code = 250];
+                    v607 = hir.int_to_ptr v604 : ptr<byte, i32>;
+                    hir.store v607, v580;
                     v888 = arith.constant 4 : u32;
-                    v619 = arith.mod v617, v888 : u32;
-                    hir.assertz v619 #[code = 250];
-                    v620 = hir.int_to_ptr v617 : ptr<byte, i32>;
-                    hir.store v620, v616;
-                    v621 = arith.mul v597, v583 : i32 #[overflow = wrapping];
-                    scf.yield v621;
+                    v608 = hir.bitcast v579 : u32;
+                    v610 = arith.add v608, v888 : u32 #[overflow = checked];
+                    v887 = arith.constant 4 : u32;
+                    v612 = arith.mod v610, v887 : u32;
+                    hir.assertz v612 #[code = 250];
+                    v613 = hir.int_to_ptr v610 : ptr<byte, i32>;
+                    v614 = hir.load v613 : i32;
+                    v615 = hir.bitcast v578 : u32;
+                    v886 = arith.constant 4 : u32;
+                    v617 = arith.mod v615, v886 : u32;
+                    hir.assertz v617 #[code = 250];
+                    v618 = hir.int_to_ptr v615 : ptr<byte, i32>;
+                    hir.store v618, v614;
+                    v619 = arith.mul v595, v581 : i32 #[overflow = wrapping];
+                    scf.yield v619;
                 };
-                v622 = arith.constant 8 : i32;
-                v887 = arith.constant 4 : i32;
-                v883 = cf.select v603, v887, v622 : i32;
-                scf.yield v883, v882;
+                v620 = arith.constant 8 : i32;
+                v885 = arith.constant 4 : i32;
+                v881 = cf.select v601, v885, v620 : i32;
+                scf.yield v881, v880;
             };
-            v625 = arith.add v580, v884 : i32 #[overflow = wrapping];
-            v627 = hir.bitcast v625 : u32;
-            v886 = arith.constant 4 : u32;
-            v629 = arith.mod v627, v886 : u32;
-            hir.assertz v629 #[code = 250];
-            v630 = hir.int_to_ptr v627 : ptr<byte, i32>;
-            hir.store v630, v885;
+            v623 = arith.add v578, v882 : i32 #[overflow = wrapping];
+            v625 = hir.bitcast v623 : u32;
+            v884 = arith.constant 4 : u32;
+            v627 = arith.mod v625, v884 : u32;
+            hir.assertz v627 #[code = 250];
+            v628 = hir.int_to_ptr v625 : ptr<byte, i32>;
+            hir.store v628, v883;
             builtin.ret ;
         };
 
-        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v631: i32, v632: i32, v633: i32) {
-        ^block80(v631: i32, v632: i32, v633: i32):
-            v899 = arith.constant 0 : i32;
-            v634 = arith.constant 0 : i32;
-            v635 = arith.eq v633, v634 : i1;
-            v636 = arith.zext v635 : u32;
-            v637 = hir.bitcast v636 : i32;
-            v639 = arith.neq v637, v899 : i1;
-            scf.if v639{
+        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v629: i32, v630: i32, v631: i32) {
+        ^block80(v629: i32, v630: i32, v631: i32):
+            v897 = arith.constant 0 : i32;
+            v632 = arith.constant 0 : i32;
+            v633 = arith.eq v631, v632 : i1;
+            v634 = arith.zext v633 : u32;
+            v635 = hir.bitcast v634 : i32;
+            v637 = arith.neq v635, v897 : i1;
+            scf.if v637{
             ^block82:
                 scf.yield ;
             } else {
             ^block83:
-                hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__rustc::__rust_dealloc(v631, v633, v632)
+                hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/__rustc::__rust_dealloc(v629, v631, v630)
                 scf.yield ;
             };
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::handle_error(v640: i32, v641: i32, v642: i32) {
-        ^block84(v640: i32, v641: i32, v642: i32):
+        private builtin.function @alloc::raw_vec::handle_error(v638: i32, v639: i32, v640: i32) {
+        ^block84(v638: i32, v639: i32, v640: i32):
             ub.unreachable ;
         };
 
-        private builtin.function @core::ptr::alignment::Alignment::max(v643: i32, v644: i32) -> i32 {
-        ^block86(v643: i32, v644: i32):
-            v651 = arith.constant 0 : i32;
-            v647 = hir.bitcast v644 : u32;
-            v646 = hir.bitcast v643 : u32;
-            v648 = arith.gt v646, v647 : i1;
-            v649 = arith.zext v648 : u32;
-            v650 = hir.bitcast v649 : i32;
-            v652 = arith.neq v650, v651 : i1;
-            v653 = cf.select v652, v643, v644 : i32;
-            builtin.ret v653;
+        private builtin.function @core::ptr::alignment::Alignment::max(v641: i32, v642: i32) -> i32 {
+        ^block86(v641: i32, v642: i32):
+            v649 = arith.constant 0 : i32;
+            v645 = hir.bitcast v642 : u32;
+            v644 = hir.bitcast v641 : u32;
+            v646 = arith.gt v644, v645 : i1;
+            v647 = arith.zext v646 : u32;
+            v648 = hir.bitcast v647 : i32;
+            v650 = arith.neq v648, v649 : i1;
+            v651 = cf.select v650, v641, v642 : i32;
+            builtin.ret v651;
         };
 
-        private builtin.function @miden::input_note::get_assets(v654: i32, v655: felt) -> i32 {
-        ^block88(v654: i32, v655: felt):
-            v656, v657 = hir.exec @miden/input_note/get_assets(v654, v655) : i32, i32
-            builtin.ret v656;
+        private builtin.function @miden::input_note::get_assets(v652: i32, v653: felt) -> i32 {
+        ^block88(v652: i32, v653: felt):
+            v654, v655 = hir.exec @miden/input_note/get_assets(v652, v653) : i32, i32
+            builtin.ret v654;
         };
 
         builtin.global_variable private @#__stack_pointer : i32 {
@@ -945,14 +945,14 @@ builtin.component miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-no
             builtin.ret_imm 0;
         };
 
-        builtin.segment readonly @1048576 = 0x0073722e65746f6e5f7475706e692f73676e69646e69622f6372732f302e382e302d7379732d657361622d6e6564696d;
+        builtin.segment readonly @1048576 = 0x003e64657463616465723c;
 
-        builtin.segment @1048624 = 0x000000220000003f0000002f001000000000000100000001;
+        builtin.segment @1048588 = 0x00000000000000000000000a001000000000000100000001;
     };
 
     public builtin.function @binding() -> felt {
     ^block92:
-        v659 = hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1#binding() : felt
-        builtin.ret v659;
+        v657 = hir.exec @miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1/rust_sdk_input_note_get_assets_binding/miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1#binding() : felt
+        builtin.ret v657;
     };
 };

--- a/tests/integration/expected/rust_sdk/rust_sdk_input_note_get_assets_binding.masm
+++ b/tests/integration/expected/rust_sdk/rust_sdk_input_note_get_assets_binding.masm
@@ -18,20 +18,20 @@ proc init
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
-    push.[3782401883760717684,9295017189735772129,18169115864861297568,15636957763524619456]
+    push.[11433644200372730325,11349691924608542755,2482790568805339584,12018669310975905431]
     adv.push_mapval
     push.262144
-    push.5
+    push.3
     trace.240
     exec.::std::mem::pipe_preimage_to_memory
     trace.252
     drop
     push.1048576
     u32assert
-    mem_store.278552
+    mem_store.278544
     push.0
     u32assert
-    mem_store.278553
+    mem_store.278545
 end
 
 # mod miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1::rust_sdk_input_note_get_assets_binding
@@ -45,7 +45,7 @@ end
 
 @callconv("C")
 proc __rustc::__rust_alloc(i32, i32) -> i32
-    push.1114212
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -53,7 +53,7 @@ proc __rustc::__rust_alloc(i32, i32) -> i32
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.1048648
+    push.1048612
     u32wrapping_add
     movup.2
     swap.1
@@ -73,7 +73,7 @@ end
 
 @callconv("C")
 proc __rustc::__rust_alloc_zeroed(i32, i32) -> i32
-    push.1114212
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -81,7 +81,7 @@ proc __rustc::__rust_alloc_zeroed(i32, i32) -> i32
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.1048648
+    push.1048612
     u32wrapping_add
     dup.1
     swap.2
@@ -167,7 +167,7 @@ end
 proc miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1#binding(
 
 ) -> felt
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -177,7 +177,7 @@ proc miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -243,7 +243,7 @@ proc miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets
     push.16
     movup.2
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -264,7 +264,7 @@ end
 proc wit_bindgen::rt::run_ctors_once(
 
 )
-    push.1114212
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -272,7 +272,7 @@ proc wit_bindgen::rt::run_ctors_once(
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.1048652
+    push.1048616
     u32wrapping_add
     u32divmod.4
     swap.1
@@ -293,7 +293,7 @@ proc wit_bindgen::rt::run_ctors_once(
     if.true
         nop
     else
-        push.1114212
+        push.1114180
         u32divmod.4
         swap.1
         trace.240
@@ -307,7 +307,7 @@ proc wit_bindgen::rt::run_ctors_once(
         trace.252
         nop
         push.1
-        push.1048652
+        push.1048616
         movup.2
         u32wrapping_add
         u32divmod.4
@@ -526,8 +526,8 @@ proc intrinsics::mem::heap_base(
 end
 
 @callconv("C")
-proc alloc::vec::Vec<T>::with_capacity(i32, i32)
-    push.1114208
+proc alloc::vec::Vec<T>::with_capacity(i32)
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -537,7 +537,7 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -552,9 +552,6 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     dup.2
     u32wrapping_add
     dup.1
-    movup.3
-    swap.5
-    movdn.3
     swap.2
     swap.1
     trace.240
@@ -563,7 +560,7 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     trace.252
     nop
     push.8
-    dup.2
+    dup.1
     add
     u32assert
     push.8
@@ -580,7 +577,7 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     trace.252
     nop
     push.8
-    dup.3
+    dup.4
     add
     u32assert
     push.4
@@ -598,7 +595,7 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     exec.::intrinsics::mem::store_sw
     trace.252
     nop
-    movup.2
+    movup.3
     push.4
     dup.1
     swap.1
@@ -614,7 +611,7 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -628,10 +625,9 @@ end
 proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
     i32,
     i32,
-    i32,
     i32
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -641,7 +637,7 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -707,8 +703,6 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
     neq
     neq
     if.true
-        movup.3
-        drop
         push.12
         dup.2
         add
@@ -759,7 +753,7 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
         nop
         push.16
         u32wrapping_add
-        push.1114208
+        push.1114176
         u32divmod.4
         swap.1
         trace.240
@@ -770,8 +764,16 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
     else
         movup.2
         drop
+        push.1114180
+        u32divmod.4
+        swap.1
+        trace.240
+        nop
+        exec.::intrinsics::mem::load_sw
+        trace.252
+        nop
         push.12
-        movup.2
+        movup.3
         add
         u32assert
         push.4
@@ -787,7 +789,10 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
         exec.::intrinsics::mem::load_sw
         trace.252
         nop
-        swap.1
+        push.1048596
+        movup.2
+        u32wrapping_add
+        swap.2
         trace.240
         nop
         exec.::miden:rust-sdk-input-note-get-assets-binding/rust-sdk-input-note-get-assets-binding@0.0.1::rust_sdk_input_note_get_assets_binding::alloc::raw_vec::handle_error
@@ -803,7 +808,7 @@ proc miden_base_sys::bindings::input_note::get_assets(
     i32,
     felt
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -813,7 +818,7 @@ proc miden_base_sys::bindings::input_note::get_assets(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -823,18 +828,8 @@ proc miden_base_sys::bindings::input_note::get_assets(
     exec.::intrinsics::mem::store_sw
     trace.252
     nop
-    push.1114212
-    u32divmod.4
-    swap.1
-    trace.240
-    nop
-    exec.::intrinsics::mem::load_sw
-    trace.252
-    nop
-    push.1048632
-    u32wrapping_add
     push.4
-    dup.2
+    dup.1
     u32wrapping_add
     trace.240
     nop
@@ -918,7 +913,7 @@ proc miden_base_sys::bindings::input_note::get_assets(
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -939,7 +934,7 @@ proc alloc::raw_vec::RawVecInner<A>::deallocate(
     i32,
     i32
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -949,7 +944,7 @@ proc alloc::raw_vec::RawVecInner<A>::deallocate(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -1040,7 +1035,7 @@ proc alloc::raw_vec::RawVecInner<A>::deallocate(
     end
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1058,7 +1053,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     i32,
     i32
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1068,7 +1063,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -1453,7 +1448,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1469,7 +1464,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     i32,
     i32
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1479,7 +1474,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -1572,7 +1567,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240

--- a/tests/integration/expected/rust_sdk/rust_sdk_input_note_get_assets_binding.wat
+++ b/tests/integration/expected/rust_sdk/rust_sdk_input_note_get_assets_binding.wat
@@ -13,11 +13,11 @@
     (type (;3;) (func (result f32)))
     (type (;4;) (func (param i32 i32 i32) (result i32)))
     (type (;5;) (func (result i32)))
-    (type (;6;) (func (param i32 i32)))
-    (type (;7;) (func (param i32 i32 i32 i32)))
-    (type (;8;) (func (param i32 f32)))
-    (type (;9;) (func (param i32) (result f32)))
-    (type (;10;) (func (param i32 i32 i32 i32 i32)))
+    (type (;6;) (func (param i32)))
+    (type (;7;) (func (param i32 f32)))
+    (type (;8;) (func (param i32) (result f32)))
+    (type (;9;) (func (param i32 i32 i32 i32 i32)))
+    (type (;10;) (func (param i32 i32 i32 i32)))
     (type (;11;) (func (param i32 f32) (result i32)))
     (table (;0;) 2 2 funcref)
     (memory (;0;) 17)
@@ -29,7 +29,7 @@
     (func $__wasm_call_ctors (;0;) (type 0))
     (func $__rustc::__rust_alloc (;1;) (type 1) (param i32 i32) (result i32)
       global.get $GOT.data.internal.__memory_base
-      i32.const 1048648
+      i32.const 1048612
       i32.add
       local.get 1
       local.get 0
@@ -39,7 +39,7 @@
     (func $__rustc::__rust_alloc_zeroed (;3;) (type 1) (param i32 i32) (result i32)
       block ;; label = @1
         global.get $GOT.data.internal.__memory_base
-        i32.const 1048648
+        i32.const 1048612
         i32.add
         local.get 1
         local.get 0
@@ -95,7 +95,7 @@
       (local i32)
       block ;; label = @1
         global.get $GOT.data.internal.__memory_base
-        i32.const 1048652
+        i32.const 1048616
         i32.add
         i32.load8_u
         br_if 0 (;@1;)
@@ -103,7 +103,7 @@
         local.set 0
         call $__wasm_call_ctors
         local.get 0
-        i32.const 1048652
+        i32.const 1048616
         i32.add
         i32.const 1
         i32.store8
@@ -184,42 +184,41 @@
     (func $intrinsics::mem::heap_base (;9;) (type 5) (result i32)
       unreachable
     )
-    (func $alloc::vec::Vec<T>::with_capacity (;10;) (type 6) (param i32 i32)
+    (func $alloc::vec::Vec<T>::with_capacity (;10;) (type 6) (param i32)
       (local i32 i64)
       global.get $__stack_pointer
       i32.const 16
       i32.sub
-      local.tee 2
+      local.tee 1
       global.set $__stack_pointer
-      local.get 2
+      local.get 1
       i32.const 8
       i32.add
       i32.const 16
       i32.const 16
-      local.get 1
       call $alloc::raw_vec::RawVecInner<A>::with_capacity_in
-      local.get 2
+      local.get 1
       i64.load offset=8
-      local.set 3
+      local.set 2
       local.get 0
       i32.const 0
       i32.store offset=8
       local.get 0
-      local.get 3
-      i64.store align=4
       local.get 2
+      i64.store align=4
+      local.get 1
       i32.const 16
       i32.add
       global.set $__stack_pointer
     )
-    (func $alloc::raw_vec::RawVecInner<A>::with_capacity_in (;11;) (type 7) (param i32 i32 i32 i32)
+    (func $alloc::raw_vec::RawVecInner<A>::with_capacity_in (;11;) (type 2) (param i32 i32 i32)
       (local i32)
       global.get $__stack_pointer
       i32.const 16
       i32.sub
-      local.tee 4
+      local.tee 3
       global.set $__stack_pointer
-      local.get 4
+      local.get 3
       i32.const 4
       i32.add
       i32.const 256
@@ -227,35 +226,39 @@
       local.get 1
       local.get 2
       call $alloc::raw_vec::RawVecInner<A>::try_allocate_in
-      local.get 4
+      local.get 3
       i32.load offset=8
       local.set 2
       block ;; label = @1
-        local.get 4
+        local.get 3
         i32.load offset=4
         i32.const 1
         i32.ne
         br_if 0 (;@1;)
+        global.get $GOT.data.internal.__memory_base
+        local.set 0
         local.get 2
-        local.get 4
-        i32.load offset=12
         local.get 3
+        i32.load offset=12
+        local.get 0
+        i32.const 1048596
+        i32.add
         call $alloc::raw_vec::handle_error
         unreachable
       end
       local.get 0
-      local.get 4
+      local.get 3
       i32.load offset=12
       i32.store offset=4
       local.get 0
       local.get 2
       i32.store
-      local.get 4
+      local.get 3
       i32.const 16
       i32.add
       global.set $__stack_pointer
     )
-    (func $miden_base_sys::bindings::input_note::get_assets (;12;) (type 8) (param i32 f32)
+    (func $miden_base_sys::bindings::input_note::get_assets (;12;) (type 7) (param i32 f32)
       (local i32)
       global.get $__stack_pointer
       i32.const 16
@@ -264,9 +267,6 @@
       global.set $__stack_pointer
       local.get 2
       i32.const 4
-      i32.add
-      global.get $GOT.data.internal.__memory_base
-      i32.const 1048632
       i32.add
       call $alloc::vec::Vec<T>::with_capacity
       local.get 0
@@ -288,7 +288,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $intrinsics::felt::from_u32 (;13;) (type 9) (param i32) (result f32)
+    (func $intrinsics::felt::from_u32 (;13;) (type 8) (param i32) (result f32)
       unreachable
     )
     (func $alloc::raw_vec::RawVecInner<A>::deallocate (;14;) (type 2) (param i32 i32 i32)
@@ -323,7 +323,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $alloc::raw_vec::RawVecInner<A>::try_allocate_in (;15;) (type 10) (param i32 i32 i32 i32 i32)
+    (func $alloc::raw_vec::RawVecInner<A>::try_allocate_in (;15;) (type 9) (param i32 i32 i32 i32 i32)
       (local i32 i64)
       global.get $__stack_pointer
       i32.const 16
@@ -464,7 +464,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $alloc::alloc::Global::alloc_impl (;17;) (type 7) (param i32 i32 i32 i32)
+    (func $alloc::alloc::Global::alloc_impl (;17;) (type 10) (param i32 i32 i32 i32)
       block ;; label = @1
         local.get 2
         i32.eqz
@@ -491,7 +491,7 @@
       local.get 1
       i32.store
     )
-    (func $alloc::raw_vec::RawVecInner<A>::current_memory (;18;) (type 7) (param i32 i32 i32 i32)
+    (func $alloc::raw_vec::RawVecInner<A>::current_memory (;18;) (type 10) (param i32 i32 i32 i32)
       (local i32 i32 i32)
       i32.const 0
       local.set 4
@@ -551,8 +551,8 @@
     (func $miden::input_note::get_assets (;22;) (type 11) (param i32 f32) (result i32)
       unreachable
     )
-    (data $.rodata (;0;) (i32.const 1048576) "miden-base-sys-0.8.0/src/bindings/input_note.rs\00")
-    (data $.data (;1;) (i32.const 1048624) "\01\00\00\00\01\00\00\00\00\00\10\00/\00\00\00?\00\00\00\22\00\00\00")
+    (data $.rodata (;0;) (i32.const 1048576) "<redacted>\00")
+    (data $.data (;1;) (i32.const 1048588) "\01\00\00\00\01\00\00\00\00\00\10\00\0a\00\00\00\00\00\00\00\00\00\00\00")
     (@custom "rodata,miden_account" (after data) "Mrust_sdk_input_note_get_assets_binding\01\0b0.0.1\03\01\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
   )
   (alias export 0 "felt" (type (;1;)))

--- a/tests/integration/expected/rust_sdk/rust_sdk_output_note_get_assets_binding.hir
+++ b/tests/integration/expected/rust_sdk/rust_sdk_output_note_get_assets_binding.hir
@@ -10,7 +10,7 @@ builtin.component miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-
             v3 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/GOT.data.internal.__memory_base : ptr<byte, u8>
             v4 = hir.bitcast v3 : ptr<byte, i32>;
             v5 = hir.load v4 : i32;
-            v6 = arith.constant 1048652 : i32;
+            v6 = arith.constant 1048612 : i32;
             v7 = arith.add v5, v6 : i32 #[overflow = wrapping];
             v8 = hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v7, v1, v0) : i32
             builtin.ret v8;
@@ -26,36 +26,36 @@ builtin.component miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-
             v15 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/GOT.data.internal.__memory_base : ptr<byte, u8>
             v16 = hir.bitcast v15 : ptr<byte, i32>;
             v17 = hir.load v16 : i32;
-            v18 = arith.constant 1048652 : i32;
+            v18 = arith.constant 1048612 : i32;
             v19 = arith.add v17, v18 : i32 #[overflow = wrapping];
             v20 = hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/<miden_sdk_alloc::BumpAlloc as core::alloc::global::GlobalAlloc>::alloc(v19, v13, v12) : i32
-            v668 = arith.constant 0 : i32;
+            v666 = arith.constant 0 : i32;
             v21 = arith.constant 0 : i32;
             v22 = arith.eq v20, v21 : i1;
             v23 = arith.zext v22 : u32;
             v24 = hir.bitcast v23 : i32;
-            v26 = arith.neq v24, v668 : i1;
+            v26 = arith.neq v24, v666 : i1;
             scf.if v26{
             ^block13:
                 scf.yield ;
             } else {
             ^block14:
-                v666 = arith.constant 0 : i32;
-                v667 = arith.constant 0 : i32;
-                v28 = arith.eq v12, v667 : i1;
+                v664 = arith.constant 0 : i32;
+                v665 = arith.constant 0 : i32;
+                v28 = arith.eq v12, v665 : i1;
                 v29 = arith.zext v28 : u32;
                 v30 = hir.bitcast v29 : i32;
-                v32 = arith.neq v30, v666 : i1;
+                v32 = arith.neq v30, v664 : i1;
                 scf.if v32{
                 ^block94:
                     scf.yield ;
                 } else {
                 ^block15:
-                    v660 = arith.constant 0 : u8;
+                    v658 = arith.constant 0 : u8;
                     v35 = hir.bitcast v12 : u32;
                     v36 = hir.bitcast v20 : u32;
                     v37 = hir.int_to_ptr v36 : ptr<byte, u8>;
-                    hir.mem_set v37, v35, v660;
+                    hir.mem_set v37, v35, v658;
                     scf.yield ;
                 };
                 scf.yield ;
@@ -93,12 +93,12 @@ builtin.component miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-
             v58 = hir.int_to_ptr v55 : ptr<byte, i32>;
             v59 = hir.load v58 : i32;
             v60 = hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/intrinsics::felt::from_u32(v59) : felt
-            v670 = arith.constant 16 : i32;
-            v671 = arith.constant 4 : i32;
-            v62 = arith.add v46, v671 : i32 #[overflow = wrapping];
-            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::deallocate(v62, v670, v670)
-            v669 = arith.constant 16 : i32;
-            v66 = arith.add v46, v669 : i32 #[overflow = wrapping];
+            v668 = arith.constant 16 : i32;
+            v669 = arith.constant 4 : i32;
+            v62 = arith.add v46, v669 : i32 #[overflow = wrapping];
+            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::deallocate(v62, v668, v668)
+            v667 = arith.constant 16 : i32;
+            v66 = arith.add v46, v667 : i32 #[overflow = wrapping];
             v67 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
             v68 = hir.bitcast v67 : ptr<byte, i32>;
             hir.store v68, v66;
@@ -115,7 +115,7 @@ builtin.component miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-
             v70 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/GOT.data.internal.__memory_base : ptr<byte, u8>
             v71 = hir.bitcast v70 : ptr<byte, i32>;
             v72 = hir.load v71 : i32;
-            v73 = arith.constant 1048656 : i32;
+            v73 = arith.constant 1048616 : i32;
             v74 = arith.add v72, v73 : i32 #[overflow = wrapping];
             v75 = hir.bitcast v74 : u32;
             v76 = hir.int_to_ptr v75 : ptr<byte, u8>;
@@ -133,12 +133,12 @@ builtin.component miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-
                 v83 = hir.bitcast v82 : ptr<byte, i32>;
                 v84 = hir.load v83 : i32;
                 hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__wasm_call_ctors()
-                v673 = arith.constant 1 : u8;
-                v675 = arith.constant 1048656 : i32;
-                v86 = arith.add v84, v675 : i32 #[overflow = wrapping];
+                v671 = arith.constant 1 : u8;
+                v673 = arith.constant 1048616 : i32;
+                v86 = arith.add v84, v673 : i32 #[overflow = wrapping];
                 v90 = hir.bitcast v86 : u32;
                 v91 = hir.int_to_ptr v90 : ptr<byte, u8>;
-                hir.store v91, v673;
+                hir.store v91, v671;
                 scf.yield ;
             };
             builtin.ret ;
@@ -148,27 +148,27 @@ builtin.component miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-
         ^block26(v92: i32, v93: i32, v94: i32):
             v97 = arith.constant 16 : i32;
             v96 = arith.constant 0 : i32;
-            v677 = arith.constant 16 : u32;
+            v675 = arith.constant 16 : u32;
             v99 = hir.bitcast v93 : u32;
-            v101 = arith.gt v99, v677 : i1;
+            v101 = arith.gt v99, v675 : i1;
             v102 = arith.zext v101 : u32;
             v103 = hir.bitcast v102 : i32;
             v105 = arith.neq v103, v96 : i1;
             v106 = cf.select v105, v93, v97 : i32;
-            v717 = arith.constant 0 : i32;
+            v715 = arith.constant 0 : i32;
             v107 = arith.constant -1 : i32;
             v108 = arith.add v106, v107 : i32 #[overflow = wrapping];
             v109 = arith.band v106, v108 : i32;
-            v111 = arith.neq v109, v717 : i1;
-            v686, v687 = scf.if v111 : i32, u32 {
+            v111 = arith.neq v109, v715 : i1;
+            v684, v685 = scf.if v111 : i32, u32 {
             ^block100:
-                v678 = arith.constant 0 : u32;
-                v682 = ub.poison i32 : i32;
-                scf.yield v682, v678;
+                v676 = arith.constant 0 : u32;
+                v680 = ub.poison i32 : i32;
+                scf.yield v680, v676;
             } else {
             ^block29:
                 v113 = hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/core::ptr::alignment::Alignment::max(v93, v106) : i32
-                v716 = arith.constant 0 : i32;
+                v714 = arith.constant 0 : i32;
                 v112 = arith.constant -2147483648 : i32;
                 v114 = arith.sub v112, v113 : i32 #[overflow = wrapping];
                 v116 = hir.bitcast v114 : u32;
@@ -176,18 +176,18 @@ builtin.component miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-
                 v117 = arith.gt v115, v116 : i1;
                 v118 = arith.zext v117 : u32;
                 v119 = hir.bitcast v118 : i32;
-                v121 = arith.neq v119, v716 : i1;
-                v701 = scf.if v121 : i32 {
+                v121 = arith.neq v119, v714 : i1;
+                v699 = scf.if v121 : i32 {
                 ^block99:
-                    v715 = ub.poison i32 : i32;
-                    scf.yield v715;
+                    v713 = ub.poison i32 : i32;
+                    scf.yield v713;
                 } else {
                 ^block30:
-                    v713 = arith.constant 0 : i32;
-                    v127 = arith.sub v713, v113 : i32 #[overflow = wrapping];
-                    v714 = arith.constant -1 : i32;
+                    v711 = arith.constant 0 : i32;
+                    v127 = arith.sub v711, v113 : i32 #[overflow = wrapping];
+                    v712 = arith.constant -1 : i32;
                     v123 = arith.add v94, v113 : i32 #[overflow = wrapping];
-                    v125 = arith.add v123, v714 : i32 #[overflow = wrapping];
+                    v125 = arith.add v123, v712 : i32 #[overflow = wrapping];
                     v128 = arith.band v125, v127 : i32;
                     v129 = hir.bitcast v92 : u32;
                     v130 = arith.constant 4 : u32;
@@ -195,8 +195,8 @@ builtin.component miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-
                     hir.assertz v131 #[code = 250];
                     v132 = hir.int_to_ptr v129 : ptr<byte, i32>;
                     v133 = hir.load v132 : i32;
-                    v712 = arith.constant 0 : i32;
-                    v135 = arith.neq v133, v712 : i1;
+                    v710 = arith.constant 0 : i32;
+                    v135 = arith.neq v133, v710 : i1;
                     scf.if v135{
                     ^block98:
                         scf.yield ;
@@ -205,41 +205,41 @@ builtin.component miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-
                         v136 = hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/intrinsics::mem::heap_base() : i32
                         v137 = hir.mem_size  : u32;
                         v143 = hir.bitcast v92 : u32;
-                        v711 = arith.constant 4 : u32;
-                        v145 = arith.mod v143, v711 : u32;
+                        v709 = arith.constant 4 : u32;
+                        v145 = arith.mod v143, v709 : u32;
                         hir.assertz v145 #[code = 250];
-                        v710 = arith.constant 16 : u32;
+                        v708 = arith.constant 16 : u32;
                         v138 = hir.bitcast v137 : i32;
-                        v141 = arith.shl v138, v710 : i32;
+                        v141 = arith.shl v138, v708 : i32;
                         v142 = arith.add v136, v141 : i32 #[overflow = wrapping];
                         v146 = hir.int_to_ptr v143 : ptr<byte, i32>;
                         hir.store v146, v142;
                         scf.yield ;
                     };
                     v149 = hir.bitcast v92 : u32;
-                    v709 = arith.constant 4 : u32;
-                    v151 = arith.mod v149, v709 : u32;
+                    v707 = arith.constant 4 : u32;
+                    v151 = arith.mod v149, v707 : u32;
                     hir.assertz v151 #[code = 250];
                     v152 = hir.int_to_ptr v149 : ptr<byte, i32>;
                     v153 = hir.load v152 : i32;
-                    v707 = arith.constant 0 : i32;
-                    v708 = arith.constant -1 : i32;
-                    v155 = arith.bxor v153, v708 : i32;
+                    v705 = arith.constant 0 : i32;
+                    v706 = arith.constant -1 : i32;
+                    v155 = arith.bxor v153, v706 : i32;
                     v157 = hir.bitcast v155 : u32;
                     v156 = hir.bitcast v128 : u32;
                     v158 = arith.gt v156, v157 : i1;
                     v159 = arith.zext v158 : u32;
                     v160 = hir.bitcast v159 : i32;
-                    v162 = arith.neq v160, v707 : i1;
-                    v700 = scf.if v162 : i32 {
+                    v162 = arith.neq v160, v705 : i1;
+                    v698 = scf.if v162 : i32 {
                     ^block33:
-                        v706 = arith.constant 0 : i32;
-                        scf.yield v706;
+                        v704 = arith.constant 0 : i32;
+                        scf.yield v704;
                     } else {
                     ^block34:
                         v164 = hir.bitcast v92 : u32;
-                        v705 = arith.constant 4 : u32;
-                        v166 = arith.mod v164, v705 : u32;
+                        v703 = arith.constant 4 : u32;
+                        v166 = arith.mod v164, v703 : u32;
                         hir.assertz v166 #[code = 250];
                         v163 = arith.add v153, v128 : i32 #[overflow = wrapping];
                         v167 = hir.int_to_ptr v164 : ptr<byte, i32>;
@@ -247,20 +247,20 @@ builtin.component miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-
                         v169 = arith.add v153, v113 : i32 #[overflow = wrapping];
                         scf.yield v169;
                     };
-                    scf.yield v700;
+                    scf.yield v698;
                 };
-                v683 = arith.constant 1 : u32;
-                v704 = arith.constant 0 : u32;
-                v702 = cf.select v121, v704, v683 : u32;
-                scf.yield v701, v702;
+                v681 = arith.constant 1 : u32;
+                v702 = arith.constant 0 : u32;
+                v700 = cf.select v121, v702, v681 : u32;
+                scf.yield v699, v700;
             };
-            v703 = arith.constant 0 : u32;
-            v699 = arith.eq v687, v703 : i1;
-            cf.cond_br v699 ^block28, ^block102(v686);
+            v701 = arith.constant 0 : u32;
+            v697 = arith.eq v685, v701 : i1;
+            cf.cond_br v697 ^block28, ^block102(v684);
         ^block28:
             ub.unreachable ;
-        ^block102(v679: i32):
-            builtin.ret v679;
+        ^block102(v677: i32):
+            builtin.ret v677;
         };
 
         private builtin.function @intrinsics::mem::heap_base() -> i32 {
@@ -269,672 +269,672 @@ builtin.component miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-
             builtin.ret v172;
         };
 
-        private builtin.function @alloc::vec::Vec<T>::with_capacity(v174: i32, v175: i32) {
-        ^block39(v174: i32, v175: i32):
-            v178 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v179 = hir.bitcast v178 : ptr<byte, i32>;
-            v180 = hir.load v179 : i32;
-            v181 = arith.constant 16 : i32;
-            v182 = arith.sub v180, v181 : i32 #[overflow = wrapping];
-            v183 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v184 = hir.bitcast v183 : ptr<byte, i32>;
-            hir.store v184, v182;
-            v722 = arith.constant 16 : i32;
-            v185 = arith.constant 8 : i32;
-            v186 = arith.add v182, v185 : i32 #[overflow = wrapping];
-            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v186, v722, v722, v175)
-            v190 = arith.constant 8 : u32;
-            v189 = hir.bitcast v182 : u32;
-            v191 = arith.add v189, v190 : u32 #[overflow = checked];
-            v721 = arith.constant 8 : u32;
-            v193 = arith.mod v191, v721 : u32;
-            hir.assertz v193 #[code = 250];
-            v194 = hir.int_to_ptr v191 : ptr<byte, i64>;
-            v195 = hir.load v194 : i64;
-            v720 = arith.constant 8 : u32;
-            v197 = hir.bitcast v174 : u32;
-            v199 = arith.add v197, v720 : u32 #[overflow = checked];
-            v200 = arith.constant 4 : u32;
-            v201 = arith.mod v199, v200 : u32;
-            hir.assertz v201 #[code = 250];
-            v176 = arith.constant 0 : i32;
-            v202 = hir.int_to_ptr v199 : ptr<byte, i32>;
-            hir.store v202, v176;
-            v203 = hir.bitcast v174 : u32;
-            v719 = arith.constant 4 : u32;
-            v205 = arith.mod v203, v719 : u32;
-            hir.assertz v205 #[code = 250];
-            v206 = hir.int_to_ptr v203 : ptr<byte, i64>;
-            hir.store v206, v195;
-            v718 = arith.constant 16 : i32;
-            v208 = arith.add v182, v718 : i32 #[overflow = wrapping];
-            v209 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v210 = hir.bitcast v209 : ptr<byte, i32>;
-            hir.store v210, v208;
+        private builtin.function @alloc::vec::Vec<T>::with_capacity(v174: i32) {
+        ^block39(v174: i32):
+            v177 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v178 = hir.bitcast v177 : ptr<byte, i32>;
+            v179 = hir.load v178 : i32;
+            v180 = arith.constant 16 : i32;
+            v181 = arith.sub v179, v180 : i32 #[overflow = wrapping];
+            v182 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v183 = hir.bitcast v182 : ptr<byte, i32>;
+            hir.store v183, v181;
+            v720 = arith.constant 16 : i32;
+            v184 = arith.constant 8 : i32;
+            v185 = arith.add v181, v184 : i32 #[overflow = wrapping];
+            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::with_capacity_in(v185, v720, v720)
+            v189 = arith.constant 8 : u32;
+            v188 = hir.bitcast v181 : u32;
+            v190 = arith.add v188, v189 : u32 #[overflow = checked];
+            v719 = arith.constant 8 : u32;
+            v192 = arith.mod v190, v719 : u32;
+            hir.assertz v192 #[code = 250];
+            v193 = hir.int_to_ptr v190 : ptr<byte, i64>;
+            v194 = hir.load v193 : i64;
+            v718 = arith.constant 8 : u32;
+            v196 = hir.bitcast v174 : u32;
+            v198 = arith.add v196, v718 : u32 #[overflow = checked];
+            v199 = arith.constant 4 : u32;
+            v200 = arith.mod v198, v199 : u32;
+            hir.assertz v200 #[code = 250];
+            v175 = arith.constant 0 : i32;
+            v201 = hir.int_to_ptr v198 : ptr<byte, i32>;
+            hir.store v201, v175;
+            v202 = hir.bitcast v174 : u32;
+            v717 = arith.constant 4 : u32;
+            v204 = arith.mod v202, v717 : u32;
+            hir.assertz v204 #[code = 250];
+            v205 = hir.int_to_ptr v202 : ptr<byte, i64>;
+            hir.store v205, v194;
+            v716 = arith.constant 16 : i32;
+            v207 = arith.add v181, v716 : i32 #[overflow = wrapping];
+            v208 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v209 = hir.bitcast v208 : ptr<byte, i32>;
+            hir.store v209, v207;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::with_capacity_in(v211: i32, v212: i32, v213: i32, v214: i32) {
-        ^block41(v211: i32, v212: i32, v213: i32, v214: i32):
-            v216 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v217 = hir.bitcast v216 : ptr<byte, i32>;
-            v218 = hir.load v217 : i32;
-            v219 = arith.constant 16 : i32;
-            v220 = arith.sub v218, v219 : i32 #[overflow = wrapping];
-            v221 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v222 = hir.bitcast v221 : ptr<byte, i32>;
-            hir.store v222, v220;
-            v215 = arith.constant 0 : i32;
-            v225 = arith.constant 256 : i32;
-            v223 = arith.constant 4 : i32;
-            v224 = arith.add v220, v223 : i32 #[overflow = wrapping];
-            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::try_allocate_in(v224, v225, v215, v212, v213)
-            v228 = arith.constant 8 : u32;
-            v227 = hir.bitcast v220 : u32;
-            v229 = arith.add v227, v228 : u32 #[overflow = checked];
-            v230 = arith.constant 4 : u32;
-            v231 = arith.mod v229, v230 : u32;
-            hir.assertz v231 #[code = 250];
-            v232 = hir.int_to_ptr v229 : ptr<byte, i32>;
-            v233 = hir.load v232 : i32;
-            v733 = arith.constant 4 : u32;
-            v234 = hir.bitcast v220 : u32;
-            v236 = arith.add v234, v733 : u32 #[overflow = checked];
-            v732 = arith.constant 4 : u32;
-            v238 = arith.mod v236, v732 : u32;
-            hir.assertz v238 #[code = 250];
-            v239 = hir.int_to_ptr v236 : ptr<byte, i32>;
-            v240 = hir.load v239 : i32;
-            v731 = arith.constant 0 : i32;
-            v241 = arith.constant 1 : i32;
-            v242 = arith.neq v240, v241 : i1;
-            v243 = arith.zext v242 : u32;
-            v244 = hir.bitcast v243 : i32;
-            v246 = arith.neq v244, v731 : i1;
-            cf.cond_br v246 ^block43, ^block44;
-        ^block43:
-            v255 = arith.constant 12 : u32;
-            v254 = hir.bitcast v220 : u32;
-            v256 = arith.add v254, v255 : u32 #[overflow = checked];
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::with_capacity_in(v210: i32, v211: i32, v212: i32) {
+        ^block41(v210: i32, v211: i32, v212: i32):
+            v214 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v215 = hir.bitcast v214 : ptr<byte, i32>;
+            v216 = hir.load v215 : i32;
+            v217 = arith.constant 16 : i32;
+            v218 = arith.sub v216, v217 : i32 #[overflow = wrapping];
+            v219 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v220 = hir.bitcast v219 : ptr<byte, i32>;
+            hir.store v220, v218;
+            v213 = arith.constant 0 : i32;
+            v223 = arith.constant 256 : i32;
+            v221 = arith.constant 4 : i32;
+            v222 = arith.add v218, v221 : i32 #[overflow = wrapping];
+            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::try_allocate_in(v222, v223, v213, v211, v212)
+            v226 = arith.constant 8 : u32;
+            v225 = hir.bitcast v218 : u32;
+            v227 = arith.add v225, v226 : u32 #[overflow = checked];
+            v228 = arith.constant 4 : u32;
+            v229 = arith.mod v227, v228 : u32;
+            hir.assertz v229 #[code = 250];
+            v230 = hir.int_to_ptr v227 : ptr<byte, i32>;
+            v231 = hir.load v230 : i32;
+            v731 = arith.constant 4 : u32;
+            v232 = hir.bitcast v218 : u32;
+            v234 = arith.add v232, v731 : u32 #[overflow = checked];
             v730 = arith.constant 4 : u32;
-            v258 = arith.mod v256, v730 : u32;
-            hir.assertz v258 #[code = 250];
-            v259 = hir.int_to_ptr v256 : ptr<byte, i32>;
-            v260 = hir.load v259 : i32;
-            v729 = arith.constant 4 : u32;
-            v261 = hir.bitcast v211 : u32;
-            v263 = arith.add v261, v729 : u32 #[overflow = checked];
+            v236 = arith.mod v234, v730 : u32;
+            hir.assertz v236 #[code = 250];
+            v237 = hir.int_to_ptr v234 : ptr<byte, i32>;
+            v238 = hir.load v237 : i32;
+            v729 = arith.constant 0 : i32;
+            v239 = arith.constant 1 : i32;
+            v240 = arith.neq v238, v239 : i1;
+            v241 = arith.zext v240 : u32;
+            v242 = hir.bitcast v241 : i32;
+            v244 = arith.neq v242, v729 : i1;
+            cf.cond_br v244 ^block43, ^block44;
+        ^block43:
+            v258 = arith.constant 12 : u32;
+            v257 = hir.bitcast v218 : u32;
+            v259 = arith.add v257, v258 : u32 #[overflow = checked];
             v728 = arith.constant 4 : u32;
-            v265 = arith.mod v263, v728 : u32;
-            hir.assertz v265 #[code = 250];
-            v266 = hir.int_to_ptr v263 : ptr<byte, i32>;
-            hir.store v266, v260;
-            v267 = hir.bitcast v211 : u32;
+            v261 = arith.mod v259, v728 : u32;
+            hir.assertz v261 #[code = 250];
+            v262 = hir.int_to_ptr v259 : ptr<byte, i32>;
+            v263 = hir.load v262 : i32;
             v727 = arith.constant 4 : u32;
-            v269 = arith.mod v267, v727 : u32;
-            hir.assertz v269 #[code = 250];
-            v270 = hir.int_to_ptr v267 : ptr<byte, i32>;
-            hir.store v270, v233;
-            v726 = arith.constant 16 : i32;
-            v272 = arith.add v220, v726 : i32 #[overflow = wrapping];
-            v273 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v274 = hir.bitcast v273 : ptr<byte, i32>;
-            hir.store v274, v272;
+            v264 = hir.bitcast v210 : u32;
+            v266 = arith.add v264, v727 : u32 #[overflow = checked];
+            v726 = arith.constant 4 : u32;
+            v268 = arith.mod v266, v726 : u32;
+            hir.assertz v268 #[code = 250];
+            v269 = hir.int_to_ptr v266 : ptr<byte, i32>;
+            hir.store v269, v263;
+            v270 = hir.bitcast v210 : u32;
+            v725 = arith.constant 4 : u32;
+            v272 = arith.mod v270, v725 : u32;
+            hir.assertz v272 #[code = 250];
+            v273 = hir.int_to_ptr v270 : ptr<byte, i32>;
+            hir.store v273, v231;
+            v724 = arith.constant 16 : i32;
+            v275 = arith.add v218, v724 : i32 #[overflow = wrapping];
+            v276 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v277 = hir.bitcast v276 : ptr<byte, i32>;
+            hir.store v277, v275;
             builtin.ret ;
         ^block44:
-            v725 = arith.constant 12 : u32;
-            v247 = hir.bitcast v220 : u32;
-            v249 = arith.add v247, v725 : u32 #[overflow = checked];
-            v724 = arith.constant 4 : u32;
-            v251 = arith.mod v249, v724 : u32;
-            hir.assertz v251 #[code = 250];
-            v252 = hir.int_to_ptr v249 : ptr<byte, i32>;
-            v253 = hir.load v252 : i32;
-            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::raw_vec::handle_error(v233, v253, v214)
+            v245 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/GOT.data.internal.__memory_base : ptr<byte, u8>
+            v246 = hir.bitcast v245 : ptr<byte, i32>;
+            v247 = hir.load v246 : i32;
+            v723 = arith.constant 12 : u32;
+            v248 = hir.bitcast v218 : u32;
+            v250 = arith.add v248, v723 : u32 #[overflow = checked];
+            v722 = arith.constant 4 : u32;
+            v252 = arith.mod v250, v722 : u32;
+            hir.assertz v252 #[code = 250];
+            v253 = hir.int_to_ptr v250 : ptr<byte, i32>;
+            v254 = hir.load v253 : i32;
+            v255 = arith.constant 1048596 : i32;
+            v256 = arith.add v247, v255 : i32 #[overflow = wrapping];
+            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::raw_vec::handle_error(v231, v254, v256)
             ub.unreachable ;
         };
 
-        private builtin.function @miden_base_sys::bindings::output_note::get_assets(v275: i32, v276: felt) {
-        ^block45(v275: i32, v276: felt):
-            v278 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v279 = hir.bitcast v278 : ptr<byte, i32>;
-            v280 = hir.load v279 : i32;
-            v281 = arith.constant 16 : i32;
-            v282 = arith.sub v280, v281 : i32 #[overflow = wrapping];
-            v283 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v284 = hir.bitcast v283 : ptr<byte, i32>;
-            hir.store v284, v282;
-            v287 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/GOT.data.internal.__memory_base : ptr<byte, u8>
-            v288 = hir.bitcast v287 : ptr<byte, i32>;
-            v289 = hir.load v288 : i32;
-            v290 = arith.constant 1048636 : i32;
-            v291 = arith.add v289, v290 : i32 #[overflow = wrapping];
-            v285 = arith.constant 4 : i32;
-            v286 = arith.add v282, v285 : i32 #[overflow = wrapping];
-            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::vec::Vec<T>::with_capacity(v286, v291)
-            v295 = arith.constant 8 : u32;
-            v294 = hir.bitcast v282 : u32;
-            v296 = arith.add v294, v295 : u32 #[overflow = checked];
-            v297 = arith.constant 4 : u32;
-            v298 = arith.mod v296, v297 : u32;
-            hir.assertz v298 #[code = 250];
-            v299 = hir.int_to_ptr v296 : ptr<byte, i32>;
-            v300 = hir.load v299 : i32;
-            v734 = arith.constant 2 : u32;
-            v302 = hir.bitcast v300 : u32;
-            v304 = arith.shr v302, v734 : u32;
-            v305 = hir.bitcast v304 : i32;
-            v306 = hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/miden::output_note::get_assets(v305, v276) : i32
-            v292 = arith.constant 8 : i32;
-            v293 = arith.add v275, v292 : i32 #[overflow = wrapping];
-            v307 = hir.bitcast v293 : u32;
-            v739 = arith.constant 4 : u32;
-            v309 = arith.mod v307, v739 : u32;
-            hir.assertz v309 #[code = 250];
-            v310 = hir.int_to_ptr v307 : ptr<byte, i32>;
-            hir.store v310, v306;
-            v738 = arith.constant 4 : u32;
-            v311 = hir.bitcast v282 : u32;
-            v313 = arith.add v311, v738 : u32 #[overflow = checked];
+        private builtin.function @miden_base_sys::bindings::output_note::get_assets(v278: i32, v279: felt) {
+        ^block45(v278: i32, v279: felt):
+            v281 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v282 = hir.bitcast v281 : ptr<byte, i32>;
+            v283 = hir.load v282 : i32;
+            v284 = arith.constant 16 : i32;
+            v285 = arith.sub v283, v284 : i32 #[overflow = wrapping];
+            v286 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v287 = hir.bitcast v286 : ptr<byte, i32>;
+            hir.store v287, v285;
+            v288 = arith.constant 4 : i32;
+            v289 = arith.add v285, v288 : i32 #[overflow = wrapping];
+            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::vec::Vec<T>::with_capacity(v289)
+            v293 = arith.constant 8 : u32;
+            v292 = hir.bitcast v285 : u32;
+            v294 = arith.add v292, v293 : u32 #[overflow = checked];
+            v295 = arith.constant 4 : u32;
+            v296 = arith.mod v294, v295 : u32;
+            hir.assertz v296 #[code = 250];
+            v297 = hir.int_to_ptr v294 : ptr<byte, i32>;
+            v298 = hir.load v297 : i32;
+            v732 = arith.constant 2 : u32;
+            v300 = hir.bitcast v298 : u32;
+            v302 = arith.shr v300, v732 : u32;
+            v303 = hir.bitcast v302 : i32;
+            v304 = hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/miden::output_note::get_assets(v303, v279) : i32
+            v290 = arith.constant 8 : i32;
+            v291 = arith.add v278, v290 : i32 #[overflow = wrapping];
+            v305 = hir.bitcast v291 : u32;
             v737 = arith.constant 4 : u32;
-            v315 = arith.mod v313, v737 : u32;
-            hir.assertz v315 #[code = 250];
-            v316 = hir.int_to_ptr v313 : ptr<byte, i64>;
-            v317 = hir.load v316 : i64;
-            v318 = hir.bitcast v275 : u32;
+            v307 = arith.mod v305, v737 : u32;
+            hir.assertz v307 #[code = 250];
+            v308 = hir.int_to_ptr v305 : ptr<byte, i32>;
+            hir.store v308, v304;
             v736 = arith.constant 4 : u32;
-            v320 = arith.mod v318, v736 : u32;
-            hir.assertz v320 #[code = 250];
-            v321 = hir.int_to_ptr v318 : ptr<byte, i64>;
-            hir.store v321, v317;
-            v735 = arith.constant 16 : i32;
-            v323 = arith.add v282, v735 : i32 #[overflow = wrapping];
-            v324 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v325 = hir.bitcast v324 : ptr<byte, i32>;
-            hir.store v325, v323;
+            v309 = hir.bitcast v285 : u32;
+            v311 = arith.add v309, v736 : u32 #[overflow = checked];
+            v735 = arith.constant 4 : u32;
+            v313 = arith.mod v311, v735 : u32;
+            hir.assertz v313 #[code = 250];
+            v314 = hir.int_to_ptr v311 : ptr<byte, i64>;
+            v315 = hir.load v314 : i64;
+            v316 = hir.bitcast v278 : u32;
+            v734 = arith.constant 4 : u32;
+            v318 = arith.mod v316, v734 : u32;
+            hir.assertz v318 #[code = 250];
+            v319 = hir.int_to_ptr v316 : ptr<byte, i64>;
+            hir.store v319, v315;
+            v733 = arith.constant 16 : i32;
+            v321 = arith.add v285, v733 : i32 #[overflow = wrapping];
+            v322 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v323 = hir.bitcast v322 : ptr<byte, i32>;
+            hir.store v323, v321;
             builtin.ret ;
         };
 
-        private builtin.function @intrinsics::felt::from_u32(v326: i32) -> felt {
-        ^block47(v326: i32):
-            v327 = hir.bitcast v326 : felt;
-            builtin.ret v327;
+        private builtin.function @intrinsics::felt::from_u32(v324: i32) -> felt {
+        ^block47(v324: i32):
+            v325 = hir.bitcast v324 : felt;
+            builtin.ret v325;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v329: i32, v330: i32, v331: i32) {
-        ^block49(v329: i32, v330: i32, v331: i32):
-            v333 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v334 = hir.bitcast v333 : ptr<byte, i32>;
-            v335 = hir.load v334 : i32;
-            v336 = arith.constant 16 : i32;
-            v337 = arith.sub v335, v336 : i32 #[overflow = wrapping];
-            v338 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v339 = hir.bitcast v338 : ptr<byte, i32>;
-            hir.store v339, v337;
-            v340 = arith.constant 4 : i32;
-            v341 = arith.add v337, v340 : i32 #[overflow = wrapping];
-            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::current_memory(v341, v329, v330, v331)
-            v343 = arith.constant 8 : u32;
-            v342 = hir.bitcast v337 : u32;
-            v344 = arith.add v342, v343 : u32 #[overflow = checked];
-            v345 = arith.constant 4 : u32;
-            v346 = arith.mod v344, v345 : u32;
-            hir.assertz v346 #[code = 250];
-            v347 = hir.int_to_ptr v344 : ptr<byte, i32>;
-            v348 = hir.load v347 : i32;
-            v746 = arith.constant 0 : i32;
-            v332 = arith.constant 0 : i32;
-            v350 = arith.eq v348, v332 : i1;
-            v351 = arith.zext v350 : u32;
-            v352 = hir.bitcast v351 : i32;
-            v354 = arith.neq v352, v746 : i1;
-            scf.if v354{
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::deallocate(v327: i32, v328: i32, v329: i32) {
+        ^block49(v327: i32, v328: i32, v329: i32):
+            v331 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v332 = hir.bitcast v331 : ptr<byte, i32>;
+            v333 = hir.load v332 : i32;
+            v334 = arith.constant 16 : i32;
+            v335 = arith.sub v333, v334 : i32 #[overflow = wrapping];
+            v336 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v337 = hir.bitcast v336 : ptr<byte, i32>;
+            hir.store v337, v335;
+            v338 = arith.constant 4 : i32;
+            v339 = arith.add v335, v338 : i32 #[overflow = wrapping];
+            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::raw_vec::RawVecInner<A>::current_memory(v339, v327, v328, v329)
+            v341 = arith.constant 8 : u32;
+            v340 = hir.bitcast v335 : u32;
+            v342 = arith.add v340, v341 : u32 #[overflow = checked];
+            v343 = arith.constant 4 : u32;
+            v344 = arith.mod v342, v343 : u32;
+            hir.assertz v344 #[code = 250];
+            v345 = hir.int_to_ptr v342 : ptr<byte, i32>;
+            v346 = hir.load v345 : i32;
+            v744 = arith.constant 0 : i32;
+            v330 = arith.constant 0 : i32;
+            v348 = arith.eq v346, v330 : i1;
+            v349 = arith.zext v348 : u32;
+            v350 = hir.bitcast v349 : i32;
+            v352 = arith.neq v350, v744 : i1;
+            scf.if v352{
             ^block108:
                 scf.yield ;
             } else {
             ^block52:
-                v745 = arith.constant 4 : u32;
-                v355 = hir.bitcast v337 : u32;
-                v357 = arith.add v355, v745 : u32 #[overflow = checked];
-                v744 = arith.constant 4 : u32;
-                v359 = arith.mod v357, v744 : u32;
-                hir.assertz v359 #[code = 250];
-                v360 = hir.int_to_ptr v357 : ptr<byte, i32>;
-                v361 = hir.load v360 : i32;
-                v363 = arith.constant 12 : u32;
-                v362 = hir.bitcast v337 : u32;
-                v364 = arith.add v362, v363 : u32 #[overflow = checked];
                 v743 = arith.constant 4 : u32;
-                v366 = arith.mod v364, v743 : u32;
-                hir.assertz v366 #[code = 250];
-                v367 = hir.int_to_ptr v364 : ptr<byte, i32>;
-                v368 = hir.load v367 : i32;
-                hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v361, v348, v368)
+                v353 = hir.bitcast v335 : u32;
+                v355 = arith.add v353, v743 : u32 #[overflow = checked];
+                v742 = arith.constant 4 : u32;
+                v357 = arith.mod v355, v742 : u32;
+                hir.assertz v357 #[code = 250];
+                v358 = hir.int_to_ptr v355 : ptr<byte, i32>;
+                v359 = hir.load v358 : i32;
+                v361 = arith.constant 12 : u32;
+                v360 = hir.bitcast v335 : u32;
+                v362 = arith.add v360, v361 : u32 #[overflow = checked];
+                v741 = arith.constant 4 : u32;
+                v364 = arith.mod v362, v741 : u32;
+                hir.assertz v364 #[code = 250];
+                v365 = hir.int_to_ptr v362 : ptr<byte, i32>;
+                v366 = hir.load v365 : i32;
+                hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v359, v346, v366)
                 scf.yield ;
             };
-            v742 = arith.constant 16 : i32;
-            v371 = arith.add v337, v742 : i32 #[overflow = wrapping];
-            v372 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v373 = hir.bitcast v372 : ptr<byte, i32>;
-            hir.store v373, v371;
+            v740 = arith.constant 16 : i32;
+            v369 = arith.add v335, v740 : i32 #[overflow = wrapping];
+            v370 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v371 = hir.bitcast v370 : ptr<byte, i32>;
+            hir.store v371, v369;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v374: i32, v375: i32, v376: i32, v377: i32, v378: i32) {
-        ^block53(v374: i32, v375: i32, v376: i32, v377: i32, v378: i32):
-            v381 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v382 = hir.bitcast v381 : ptr<byte, i32>;
-            v383 = hir.load v382 : i32;
-            v384 = arith.constant 16 : i32;
-            v385 = arith.sub v383, v384 : i32 #[overflow = wrapping];
-            v386 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v387 = hir.bitcast v386 : ptr<byte, i32>;
-            hir.store v387, v385;
-            v397 = hir.bitcast v375 : u32;
-            v398 = arith.zext v397 : u64;
-            v399 = hir.bitcast v398 : i64;
-            v379 = arith.constant 0 : i32;
-            v392 = arith.sub v379, v377 : i32 #[overflow = wrapping];
-            v389 = arith.constant -1 : i32;
-            v388 = arith.add v377, v378 : i32 #[overflow = wrapping];
-            v390 = arith.add v388, v389 : i32 #[overflow = wrapping];
-            v393 = arith.band v390, v392 : i32;
-            v394 = hir.bitcast v393 : u32;
-            v395 = arith.zext v394 : u64;
-            v396 = hir.bitcast v395 : i64;
-            v400 = arith.mul v396, v399 : i64 #[overflow = wrapping];
-            v850 = arith.constant 0 : i32;
-            v401 = arith.constant 32 : i64;
-            v403 = hir.cast v401 : u32;
-            v402 = hir.bitcast v400 : u64;
-            v404 = arith.shr v402, v403 : u64;
-            v405 = hir.bitcast v404 : i64;
-            v406 = arith.trunc v405 : i32;
-            v408 = arith.neq v406, v850 : i1;
-            v762, v763, v764, v765, v766, v767 = scf.if v408 : i32, i32, i32, i32, i32, u32 {
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::try_allocate_in(v372: i32, v373: i32, v374: i32, v375: i32, v376: i32) {
+        ^block53(v372: i32, v373: i32, v374: i32, v375: i32, v376: i32):
+            v379 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v380 = hir.bitcast v379 : ptr<byte, i32>;
+            v381 = hir.load v380 : i32;
+            v382 = arith.constant 16 : i32;
+            v383 = arith.sub v381, v382 : i32 #[overflow = wrapping];
+            v384 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v385 = hir.bitcast v384 : ptr<byte, i32>;
+            hir.store v385, v383;
+            v395 = hir.bitcast v373 : u32;
+            v396 = arith.zext v395 : u64;
+            v397 = hir.bitcast v396 : i64;
+            v377 = arith.constant 0 : i32;
+            v390 = arith.sub v377, v375 : i32 #[overflow = wrapping];
+            v387 = arith.constant -1 : i32;
+            v386 = arith.add v375, v376 : i32 #[overflow = wrapping];
+            v388 = arith.add v386, v387 : i32 #[overflow = wrapping];
+            v391 = arith.band v388, v390 : i32;
+            v392 = hir.bitcast v391 : u32;
+            v393 = arith.zext v392 : u64;
+            v394 = hir.bitcast v393 : i64;
+            v398 = arith.mul v394, v397 : i64 #[overflow = wrapping];
+            v848 = arith.constant 0 : i32;
+            v399 = arith.constant 32 : i64;
+            v401 = hir.cast v399 : u32;
+            v400 = hir.bitcast v398 : u64;
+            v402 = arith.shr v400, v401 : u64;
+            v403 = hir.bitcast v402 : i64;
+            v404 = arith.trunc v403 : i32;
+            v406 = arith.neq v404, v848 : i1;
+            v760, v761, v762, v763, v764, v765 = scf.if v406 : i32, i32, i32, i32, i32, u32 {
             ^block110:
-                v747 = arith.constant 0 : u32;
-                v754 = ub.poison i32 : i32;
-                scf.yield v374, v385, v754, v754, v754, v747;
+                v745 = arith.constant 0 : u32;
+                v752 = ub.poison i32 : i32;
+                scf.yield v372, v383, v752, v752, v752, v745;
             } else {
             ^block58:
-                v409 = arith.trunc v400 : i32;
-                v849 = arith.constant 0 : i32;
-                v410 = arith.constant -2147483648 : i32;
-                v411 = arith.sub v410, v377 : i32 #[overflow = wrapping];
-                v413 = hir.bitcast v411 : u32;
-                v412 = hir.bitcast v409 : u32;
-                v414 = arith.lte v412, v413 : i1;
-                v415 = arith.zext v414 : u32;
-                v416 = hir.bitcast v415 : i32;
-                v418 = arith.neq v416, v849 : i1;
-                v810 = scf.if v418 : i32 {
+                v407 = arith.trunc v398 : i32;
+                v847 = arith.constant 0 : i32;
+                v408 = arith.constant -2147483648 : i32;
+                v409 = arith.sub v408, v375 : i32 #[overflow = wrapping];
+                v411 = hir.bitcast v409 : u32;
+                v410 = hir.bitcast v407 : u32;
+                v412 = arith.lte v410, v411 : i1;
+                v413 = arith.zext v412 : u32;
+                v414 = hir.bitcast v413 : i32;
+                v416 = arith.neq v414, v847 : i1;
+                v808 = scf.if v416 : i32 {
                 ^block56:
-                    v848 = arith.constant 0 : i32;
-                    v429 = arith.neq v409, v848 : i1;
-                    v809 = scf.if v429 : i32 {
+                    v846 = arith.constant 0 : i32;
+                    v427 = arith.neq v407, v846 : i1;
+                    v807 = scf.if v427 : i32 {
                     ^block60:
-                        v847 = arith.constant 0 : i32;
-                        v445 = arith.neq v376, v847 : i1;
-                        v808 = scf.if v445 : i32 {
+                        v845 = arith.constant 0 : i32;
+                        v443 = arith.neq v374, v845 : i1;
+                        v806 = scf.if v443 : i32 {
                         ^block63:
-                            v427 = arith.constant 1 : i32;
-                            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::alloc::Global::alloc_impl(v385, v377, v409, v427)
-                            v456 = hir.bitcast v385 : u32;
-                            v501 = arith.constant 4 : u32;
-                            v458 = arith.mod v456, v501 : u32;
-                            hir.assertz v458 #[code = 250];
-                            v459 = hir.int_to_ptr v456 : ptr<byte, i32>;
-                            v460 = hir.load v459 : i32;
-                            scf.yield v460;
+                            v425 = arith.constant 1 : i32;
+                            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::alloc::Global::alloc_impl(v383, v375, v407, v425)
+                            v454 = hir.bitcast v383 : u32;
+                            v499 = arith.constant 4 : u32;
+                            v456 = arith.mod v454, v499 : u32;
+                            hir.assertz v456 #[code = 250];
+                            v457 = hir.int_to_ptr v454 : ptr<byte, i32>;
+                            v458 = hir.load v457 : i32;
+                            scf.yield v458;
                         } else {
                         ^block64:
-                            v446 = arith.constant 8 : i32;
-                            v447 = arith.add v385, v446 : i32 #[overflow = wrapping];
-                            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/<alloc::alloc::Global as core::alloc::Allocator>::allocate(v447, v377, v409)
-                            v431 = arith.constant 8 : u32;
-                            v448 = hir.bitcast v385 : u32;
-                            v450 = arith.add v448, v431 : u32 #[overflow = checked];
-                            v846 = arith.constant 4 : u32;
-                            v452 = arith.mod v450, v846 : u32;
-                            hir.assertz v452 #[code = 250];
-                            v453 = hir.int_to_ptr v450 : ptr<byte, i32>;
-                            v454 = hir.load v453 : i32;
-                            scf.yield v454;
+                            v444 = arith.constant 8 : i32;
+                            v445 = arith.add v383, v444 : i32 #[overflow = wrapping];
+                            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/<alloc::alloc::Global as core::alloc::Allocator>::allocate(v445, v375, v407)
+                            v429 = arith.constant 8 : u32;
+                            v446 = hir.bitcast v383 : u32;
+                            v448 = arith.add v446, v429 : u32 #[overflow = checked];
+                            v844 = arith.constant 4 : u32;
+                            v450 = arith.mod v448, v844 : u32;
+                            hir.assertz v450 #[code = 250];
+                            v451 = hir.int_to_ptr v448 : ptr<byte, i32>;
+                            v452 = hir.load v451 : i32;
+                            scf.yield v452;
                         };
-                        v844 = arith.constant 0 : i32;
-                        v845 = arith.constant 0 : i32;
-                        v463 = arith.eq v808, v845 : i1;
-                        v464 = arith.zext v463 : u32;
-                        v465 = hir.bitcast v464 : i32;
-                        v467 = arith.neq v465, v844 : i1;
-                        scf.if v467{
+                        v842 = arith.constant 0 : i32;
+                        v843 = arith.constant 0 : i32;
+                        v461 = arith.eq v806, v843 : i1;
+                        v462 = arith.zext v461 : u32;
+                        v463 = hir.bitcast v462 : i32;
+                        v465 = arith.neq v463, v842 : i1;
+                        scf.if v465{
                         ^block65:
-                            v843 = arith.constant 8 : u32;
-                            v484 = hir.bitcast v374 : u32;
-                            v486 = arith.add v484, v843 : u32 #[overflow = checked];
-                            v842 = arith.constant 4 : u32;
-                            v488 = arith.mod v486, v842 : u32;
-                            hir.assertz v488 #[code = 250];
-                            v489 = hir.int_to_ptr v486 : ptr<byte, i32>;
-                            hir.store v489, v409;
-                            v841 = arith.constant 4 : u32;
-                            v491 = hir.bitcast v374 : u32;
-                            v493 = arith.add v491, v841 : u32 #[overflow = checked];
+                            v841 = arith.constant 8 : u32;
+                            v482 = hir.bitcast v372 : u32;
+                            v484 = arith.add v482, v841 : u32 #[overflow = checked];
                             v840 = arith.constant 4 : u32;
-                            v495 = arith.mod v493, v840 : u32;
-                            hir.assertz v495 #[code = 250];
-                            v496 = hir.int_to_ptr v493 : ptr<byte, i32>;
-                            hir.store v496, v377;
+                            v486 = arith.mod v484, v840 : u32;
+                            hir.assertz v486 #[code = 250];
+                            v487 = hir.int_to_ptr v484 : ptr<byte, i32>;
+                            hir.store v487, v407;
+                            v839 = arith.constant 4 : u32;
+                            v489 = hir.bitcast v372 : u32;
+                            v491 = arith.add v489, v839 : u32 #[overflow = checked];
+                            v838 = arith.constant 4 : u32;
+                            v493 = arith.mod v491, v838 : u32;
+                            hir.assertz v493 #[code = 250];
+                            v494 = hir.int_to_ptr v491 : ptr<byte, i32>;
+                            hir.store v494, v375;
                             scf.yield ;
                         } else {
                         ^block66:
-                            v839 = arith.constant 8 : u32;
-                            v469 = hir.bitcast v374 : u32;
-                            v471 = arith.add v469, v839 : u32 #[overflow = checked];
-                            v838 = arith.constant 4 : u32;
-                            v473 = arith.mod v471, v838 : u32;
-                            hir.assertz v473 #[code = 250];
-                            v474 = hir.int_to_ptr v471 : ptr<byte, i32>;
-                            hir.store v474, v808;
-                            v837 = arith.constant 4 : u32;
-                            v476 = hir.bitcast v374 : u32;
-                            v478 = arith.add v476, v837 : u32 #[overflow = checked];
+                            v837 = arith.constant 8 : u32;
+                            v467 = hir.bitcast v372 : u32;
+                            v469 = arith.add v467, v837 : u32 #[overflow = checked];
                             v836 = arith.constant 4 : u32;
-                            v480 = arith.mod v478, v836 : u32;
-                            hir.assertz v480 #[code = 250];
-                            v481 = hir.int_to_ptr v478 : ptr<byte, i32>;
-                            hir.store v481, v375;
+                            v471 = arith.mod v469, v836 : u32;
+                            hir.assertz v471 #[code = 250];
+                            v472 = hir.int_to_ptr v469 : ptr<byte, i32>;
+                            hir.store v472, v806;
+                            v835 = arith.constant 4 : u32;
+                            v474 = hir.bitcast v372 : u32;
+                            v476 = arith.add v474, v835 : u32 #[overflow = checked];
+                            v834 = arith.constant 4 : u32;
+                            v478 = arith.mod v476, v834 : u32;
+                            hir.assertz v478 #[code = 250];
+                            v479 = hir.int_to_ptr v476 : ptr<byte, i32>;
+                            hir.store v479, v373;
                             scf.yield ;
                         };
-                        v834 = arith.constant 0 : i32;
-                        v835 = arith.constant 1 : i32;
-                        v807 = cf.select v467, v835, v834 : i32;
-                        scf.yield v807;
+                        v832 = arith.constant 0 : i32;
+                        v833 = arith.constant 1 : i32;
+                        v805 = cf.select v465, v833, v832 : i32;
+                        scf.yield v805;
                     } else {
                     ^block61:
-                        v833 = arith.constant 8 : u32;
-                        v430 = hir.bitcast v374 : u32;
-                        v432 = arith.add v430, v833 : u32 #[overflow = checked];
-                        v832 = arith.constant 4 : u32;
-                        v434 = arith.mod v432, v832 : u32;
-                        hir.assertz v434 #[code = 250];
-                        v435 = hir.int_to_ptr v432 : ptr<byte, i32>;
-                        hir.store v435, v377;
-                        v831 = arith.constant 4 : u32;
-                        v438 = hir.bitcast v374 : u32;
-                        v440 = arith.add v438, v831 : u32 #[overflow = checked];
+                        v831 = arith.constant 8 : u32;
+                        v428 = hir.bitcast v372 : u32;
+                        v430 = arith.add v428, v831 : u32 #[overflow = checked];
                         v830 = arith.constant 4 : u32;
-                        v442 = arith.mod v440, v830 : u32;
-                        hir.assertz v442 #[code = 250];
-                        v829 = arith.constant 0 : i32;
-                        v443 = hir.int_to_ptr v440 : ptr<byte, i32>;
-                        hir.store v443, v829;
-                        v828 = arith.constant 0 : i32;
-                        scf.yield v828;
+                        v432 = arith.mod v430, v830 : u32;
+                        hir.assertz v432 #[code = 250];
+                        v433 = hir.int_to_ptr v430 : ptr<byte, i32>;
+                        hir.store v433, v375;
+                        v829 = arith.constant 4 : u32;
+                        v436 = hir.bitcast v372 : u32;
+                        v438 = arith.add v436, v829 : u32 #[overflow = checked];
+                        v828 = arith.constant 4 : u32;
+                        v440 = arith.mod v438, v828 : u32;
+                        hir.assertz v440 #[code = 250];
+                        v827 = arith.constant 0 : i32;
+                        v441 = hir.int_to_ptr v438 : ptr<byte, i32>;
+                        hir.store v441, v827;
+                        v826 = arith.constant 0 : i32;
+                        scf.yield v826;
                     };
-                    scf.yield v809;
+                    scf.yield v807;
                 } else {
                 ^block59:
-                    v827 = ub.poison i32 : i32;
-                    scf.yield v827;
+                    v825 = ub.poison i32 : i32;
+                    scf.yield v825;
                 };
-                v822 = arith.constant 0 : u32;
-                v755 = arith.constant 1 : u32;
-                v815 = cf.select v418, v755, v822 : u32;
+                v820 = arith.constant 0 : u32;
+                v753 = arith.constant 1 : u32;
+                v813 = cf.select v416, v753, v820 : u32;
+                v821 = ub.poison i32 : i32;
+                v812 = cf.select v416, v383, v821 : i32;
+                v822 = ub.poison i32 : i32;
+                v811 = cf.select v416, v372, v822 : i32;
                 v823 = ub.poison i32 : i32;
-                v814 = cf.select v418, v385, v823 : i32;
+                v810 = cf.select v416, v823, v383 : i32;
                 v824 = ub.poison i32 : i32;
-                v813 = cf.select v418, v374, v824 : i32;
-                v825 = ub.poison i32 : i32;
-                v812 = cf.select v418, v825, v385 : i32;
-                v826 = ub.poison i32 : i32;
-                v811 = cf.select v418, v826, v374 : i32;
-                scf.yield v811, v812, v813, v810, v814, v815;
+                v809 = cf.select v416, v824, v372 : i32;
+                scf.yield v809, v810, v811, v808, v812, v813;
             };
-            v768, v769, v770 = scf.index_switch v767 : i32, i32, i32 
+            v766, v767, v768 = scf.index_switch v765 : i32, i32, i32 
             case 0 {
             ^block57:
-                v821 = arith.constant 4 : u32;
-                v421 = hir.bitcast v762 : u32;
-                v423 = arith.add v421, v821 : u32 #[overflow = checked];
-                v820 = arith.constant 4 : u32;
-                v425 = arith.mod v423, v820 : u32;
-                hir.assertz v425 #[code = 250];
-                v819 = arith.constant 0 : i32;
-                v426 = hir.int_to_ptr v423 : ptr<byte, i32>;
-                hir.store v426, v819;
-                v818 = arith.constant 1 : i32;
-                scf.yield v762, v818, v763;
+                v819 = arith.constant 4 : u32;
+                v419 = hir.bitcast v760 : u32;
+                v421 = arith.add v419, v819 : u32 #[overflow = checked];
+                v818 = arith.constant 4 : u32;
+                v423 = arith.mod v421, v818 : u32;
+                hir.assertz v423 #[code = 250];
+                v817 = arith.constant 0 : i32;
+                v424 = hir.int_to_ptr v421 : ptr<byte, i32>;
+                hir.store v424, v817;
+                v816 = arith.constant 1 : i32;
+                scf.yield v760, v816, v761;
             }
             default {
             ^block114:
-                scf.yield v764, v765, v766;
+                scf.yield v762, v763, v764;
             };
-            v500 = hir.bitcast v768 : u32;
-            v817 = arith.constant 4 : u32;
-            v502 = arith.mod v500, v817 : u32;
-            hir.assertz v502 #[code = 250];
-            v503 = hir.int_to_ptr v500 : ptr<byte, i32>;
-            hir.store v503, v769;
-            v816 = arith.constant 16 : i32;
-            v508 = arith.add v770, v816 : i32 #[overflow = wrapping];
-            v509 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v510 = hir.bitcast v509 : ptr<byte, i32>;
-            hir.store v510, v508;
+            v498 = hir.bitcast v766 : u32;
+            v815 = arith.constant 4 : u32;
+            v500 = arith.mod v498, v815 : u32;
+            hir.assertz v500 #[code = 250];
+            v501 = hir.int_to_ptr v498 : ptr<byte, i32>;
+            hir.store v501, v767;
+            v814 = arith.constant 16 : i32;
+            v506 = arith.add v768, v814 : i32 #[overflow = wrapping];
+            v507 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v508 = hir.bitcast v507 : ptr<byte, i32>;
+            hir.store v508, v506;
             builtin.ret ;
         };
 
-        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v511: i32, v512: i32, v513: i32) {
-        ^block67(v511: i32, v512: i32, v513: i32):
-            v515 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v516 = hir.bitcast v515 : ptr<byte, i32>;
-            v517 = hir.load v516 : i32;
-            v518 = arith.constant 16 : i32;
-            v519 = arith.sub v517, v518 : i32 #[overflow = wrapping];
-            v520 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v521 = hir.bitcast v520 : ptr<byte, i32>;
-            hir.store v521, v519;
-            v514 = arith.constant 0 : i32;
-            v522 = arith.constant 8 : i32;
-            v523 = arith.add v519, v522 : i32 #[overflow = wrapping];
-            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::alloc::Global::alloc_impl(v523, v512, v513, v514)
-            v526 = arith.constant 12 : u32;
-            v525 = hir.bitcast v519 : u32;
-            v527 = arith.add v525, v526 : u32 #[overflow = checked];
-            v528 = arith.constant 4 : u32;
-            v529 = arith.mod v527, v528 : u32;
-            hir.assertz v529 #[code = 250];
-            v530 = hir.int_to_ptr v527 : ptr<byte, i32>;
-            v531 = hir.load v530 : i32;
-            v533 = arith.constant 8 : u32;
-            v532 = hir.bitcast v519 : u32;
-            v534 = arith.add v532, v533 : u32 #[overflow = checked];
-            v855 = arith.constant 4 : u32;
-            v536 = arith.mod v534, v855 : u32;
-            hir.assertz v536 #[code = 250];
-            v537 = hir.int_to_ptr v534 : ptr<byte, i32>;
-            v538 = hir.load v537 : i32;
-            v539 = hir.bitcast v511 : u32;
-            v854 = arith.constant 4 : u32;
-            v541 = arith.mod v539, v854 : u32;
-            hir.assertz v541 #[code = 250];
-            v542 = hir.int_to_ptr v539 : ptr<byte, i32>;
-            hir.store v542, v538;
+        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::allocate(v509: i32, v510: i32, v511: i32) {
+        ^block67(v509: i32, v510: i32, v511: i32):
+            v513 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v514 = hir.bitcast v513 : ptr<byte, i32>;
+            v515 = hir.load v514 : i32;
+            v516 = arith.constant 16 : i32;
+            v517 = arith.sub v515, v516 : i32 #[overflow = wrapping];
+            v518 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v519 = hir.bitcast v518 : ptr<byte, i32>;
+            hir.store v519, v517;
+            v512 = arith.constant 0 : i32;
+            v520 = arith.constant 8 : i32;
+            v521 = arith.add v517, v520 : i32 #[overflow = wrapping];
+            hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/alloc::alloc::Global::alloc_impl(v521, v510, v511, v512)
+            v524 = arith.constant 12 : u32;
+            v523 = hir.bitcast v517 : u32;
+            v525 = arith.add v523, v524 : u32 #[overflow = checked];
+            v526 = arith.constant 4 : u32;
+            v527 = arith.mod v525, v526 : u32;
+            hir.assertz v527 #[code = 250];
+            v528 = hir.int_to_ptr v525 : ptr<byte, i32>;
+            v529 = hir.load v528 : i32;
+            v531 = arith.constant 8 : u32;
+            v530 = hir.bitcast v517 : u32;
+            v532 = arith.add v530, v531 : u32 #[overflow = checked];
             v853 = arith.constant 4 : u32;
-            v543 = hir.bitcast v511 : u32;
-            v545 = arith.add v543, v853 : u32 #[overflow = checked];
+            v534 = arith.mod v532, v853 : u32;
+            hir.assertz v534 #[code = 250];
+            v535 = hir.int_to_ptr v532 : ptr<byte, i32>;
+            v536 = hir.load v535 : i32;
+            v537 = hir.bitcast v509 : u32;
             v852 = arith.constant 4 : u32;
-            v547 = arith.mod v545, v852 : u32;
-            hir.assertz v547 #[code = 250];
-            v548 = hir.int_to_ptr v545 : ptr<byte, i32>;
-            hir.store v548, v531;
-            v851 = arith.constant 16 : i32;
-            v550 = arith.add v519, v851 : i32 #[overflow = wrapping];
-            v551 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
-            v552 = hir.bitcast v551 : ptr<byte, i32>;
-            hir.store v552, v550;
+            v539 = arith.mod v537, v852 : u32;
+            hir.assertz v539 #[code = 250];
+            v540 = hir.int_to_ptr v537 : ptr<byte, i32>;
+            hir.store v540, v536;
+            v851 = arith.constant 4 : u32;
+            v541 = hir.bitcast v509 : u32;
+            v543 = arith.add v541, v851 : u32 #[overflow = checked];
+            v850 = arith.constant 4 : u32;
+            v545 = arith.mod v543, v850 : u32;
+            hir.assertz v545 #[code = 250];
+            v546 = hir.int_to_ptr v543 : ptr<byte, i32>;
+            hir.store v546, v529;
+            v849 = arith.constant 16 : i32;
+            v548 = arith.add v517, v849 : i32 #[overflow = wrapping];
+            v549 = builtin.global_symbol @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__stack_pointer : ptr<byte, u8>
+            v550 = hir.bitcast v549 : ptr<byte, i32>;
+            hir.store v550, v548;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::alloc::Global::alloc_impl(v553: i32, v554: i32, v555: i32, v556: i32) {
-        ^block69(v553: i32, v554: i32, v555: i32, v556: i32):
-            v871 = arith.constant 0 : i32;
-            v557 = arith.constant 0 : i32;
-            v558 = arith.eq v555, v557 : i1;
-            v559 = arith.zext v558 : u32;
-            v560 = hir.bitcast v559 : i32;
-            v562 = arith.neq v560, v871 : i1;
-            v867 = scf.if v562 : i32 {
+        private builtin.function @alloc::alloc::Global::alloc_impl(v551: i32, v552: i32, v553: i32, v554: i32) {
+        ^block69(v551: i32, v552: i32, v553: i32, v554: i32):
+            v869 = arith.constant 0 : i32;
+            v555 = arith.constant 0 : i32;
+            v556 = arith.eq v553, v555 : i1;
+            v557 = arith.zext v556 : u32;
+            v558 = hir.bitcast v557 : i32;
+            v560 = arith.neq v558, v869 : i1;
+            v865 = scf.if v560 : i32 {
             ^block117:
-                scf.yield v554;
+                scf.yield v552;
             } else {
             ^block72:
                 hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__rustc::__rust_no_alloc_shim_is_unstable_v2()
-                v870 = arith.constant 0 : i32;
-                v564 = arith.neq v556, v870 : i1;
-                v866 = scf.if v564 : i32 {
+                v868 = arith.constant 0 : i32;
+                v562 = arith.neq v554, v868 : i1;
+                v864 = scf.if v562 : i32 {
                 ^block73:
-                    v566 = hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__rustc::__rust_alloc_zeroed(v555, v554) : i32
-                    scf.yield v566;
+                    v564 = hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__rustc::__rust_alloc_zeroed(v553, v552) : i32
+                    scf.yield v564;
                 } else {
                 ^block74:
-                    v565 = hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__rustc::__rust_alloc(v555, v554) : i32
-                    scf.yield v565;
+                    v563 = hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__rustc::__rust_alloc(v553, v552) : i32
+                    scf.yield v563;
                 };
-                scf.yield v866;
+                scf.yield v864;
             };
-            v570 = arith.constant 4 : u32;
-            v569 = hir.bitcast v553 : u32;
-            v571 = arith.add v569, v570 : u32 #[overflow = checked];
-            v869 = arith.constant 4 : u32;
-            v573 = arith.mod v571, v869 : u32;
-            hir.assertz v573 #[code = 250];
-            v574 = hir.int_to_ptr v571 : ptr<byte, i32>;
-            hir.store v574, v555;
-            v576 = hir.bitcast v553 : u32;
-            v868 = arith.constant 4 : u32;
-            v578 = arith.mod v576, v868 : u32;
-            hir.assertz v578 #[code = 250];
-            v579 = hir.int_to_ptr v576 : ptr<byte, i32>;
-            hir.store v579, v867;
+            v568 = arith.constant 4 : u32;
+            v567 = hir.bitcast v551 : u32;
+            v569 = arith.add v567, v568 : u32 #[overflow = checked];
+            v867 = arith.constant 4 : u32;
+            v571 = arith.mod v569, v867 : u32;
+            hir.assertz v571 #[code = 250];
+            v572 = hir.int_to_ptr v569 : ptr<byte, i32>;
+            hir.store v572, v553;
+            v574 = hir.bitcast v551 : u32;
+            v866 = arith.constant 4 : u32;
+            v576 = arith.mod v574, v866 : u32;
+            hir.assertz v576 #[code = 250];
+            v577 = hir.int_to_ptr v574 : ptr<byte, i32>;
+            hir.store v577, v865;
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v580: i32, v581: i32, v582: i32, v583: i32) {
-        ^block75(v580: i32, v581: i32, v582: i32, v583: i32):
-            v897 = arith.constant 0 : i32;
-            v584 = arith.constant 0 : i32;
-            v588 = arith.eq v583, v584 : i1;
-            v589 = arith.zext v588 : u32;
-            v590 = hir.bitcast v589 : i32;
-            v592 = arith.neq v590, v897 : i1;
-            v884, v885 = scf.if v592 : i32, i32 {
+        private builtin.function @alloc::raw_vec::RawVecInner<A>::current_memory(v578: i32, v579: i32, v580: i32, v581: i32) {
+        ^block75(v578: i32, v579: i32, v580: i32, v581: i32):
+            v895 = arith.constant 0 : i32;
+            v582 = arith.constant 0 : i32;
+            v586 = arith.eq v581, v582 : i1;
+            v587 = arith.zext v586 : u32;
+            v588 = hir.bitcast v587 : i32;
+            v590 = arith.neq v588, v895 : i1;
+            v882, v883 = scf.if v590 : i32, i32 {
             ^block121:
-                v896 = arith.constant 0 : i32;
-                v586 = arith.constant 4 : i32;
-                scf.yield v586, v896;
+                v894 = arith.constant 0 : i32;
+                v584 = arith.constant 4 : i32;
+                scf.yield v584, v894;
             } else {
             ^block78:
-                v593 = hir.bitcast v581 : u32;
-                v628 = arith.constant 4 : u32;
-                v595 = arith.mod v593, v628 : u32;
-                hir.assertz v595 #[code = 250];
-                v596 = hir.int_to_ptr v593 : ptr<byte, i32>;
-                v597 = hir.load v596 : i32;
-                v894 = arith.constant 0 : i32;
-                v895 = arith.constant 0 : i32;
-                v599 = arith.eq v597, v895 : i1;
-                v600 = arith.zext v599 : u32;
-                v601 = hir.bitcast v600 : i32;
-                v603 = arith.neq v601, v894 : i1;
-                v882 = scf.if v603 : i32 {
+                v591 = hir.bitcast v579 : u32;
+                v626 = arith.constant 4 : u32;
+                v593 = arith.mod v591, v626 : u32;
+                hir.assertz v593 #[code = 250];
+                v594 = hir.int_to_ptr v591 : ptr<byte, i32>;
+                v595 = hir.load v594 : i32;
+                v892 = arith.constant 0 : i32;
+                v893 = arith.constant 0 : i32;
+                v597 = arith.eq v595, v893 : i1;
+                v598 = arith.zext v597 : u32;
+                v599 = hir.bitcast v598 : i32;
+                v601 = arith.neq v599, v892 : i1;
+                v880 = scf.if v601 : i32 {
                 ^block120:
-                    v893 = arith.constant 0 : i32;
-                    scf.yield v893;
+                    v891 = arith.constant 0 : i32;
+                    scf.yield v891;
                 } else {
                 ^block79:
-                    v892 = arith.constant 4 : u32;
-                    v604 = hir.bitcast v580 : u32;
-                    v606 = arith.add v604, v892 : u32 #[overflow = checked];
-                    v891 = arith.constant 4 : u32;
-                    v608 = arith.mod v606, v891 : u32;
-                    hir.assertz v608 #[code = 250];
-                    v609 = hir.int_to_ptr v606 : ptr<byte, i32>;
-                    hir.store v609, v582;
                     v890 = arith.constant 4 : u32;
-                    v610 = hir.bitcast v581 : u32;
-                    v612 = arith.add v610, v890 : u32 #[overflow = checked];
+                    v602 = hir.bitcast v578 : u32;
+                    v604 = arith.add v602, v890 : u32 #[overflow = checked];
                     v889 = arith.constant 4 : u32;
-                    v614 = arith.mod v612, v889 : u32;
-                    hir.assertz v614 #[code = 250];
-                    v615 = hir.int_to_ptr v612 : ptr<byte, i32>;
-                    v616 = hir.load v615 : i32;
-                    v617 = hir.bitcast v580 : u32;
+                    v606 = arith.mod v604, v889 : u32;
+                    hir.assertz v606 #[code = 250];
+                    v607 = hir.int_to_ptr v604 : ptr<byte, i32>;
+                    hir.store v607, v580;
                     v888 = arith.constant 4 : u32;
-                    v619 = arith.mod v617, v888 : u32;
-                    hir.assertz v619 #[code = 250];
-                    v620 = hir.int_to_ptr v617 : ptr<byte, i32>;
-                    hir.store v620, v616;
-                    v621 = arith.mul v597, v583 : i32 #[overflow = wrapping];
-                    scf.yield v621;
+                    v608 = hir.bitcast v579 : u32;
+                    v610 = arith.add v608, v888 : u32 #[overflow = checked];
+                    v887 = arith.constant 4 : u32;
+                    v612 = arith.mod v610, v887 : u32;
+                    hir.assertz v612 #[code = 250];
+                    v613 = hir.int_to_ptr v610 : ptr<byte, i32>;
+                    v614 = hir.load v613 : i32;
+                    v615 = hir.bitcast v578 : u32;
+                    v886 = arith.constant 4 : u32;
+                    v617 = arith.mod v615, v886 : u32;
+                    hir.assertz v617 #[code = 250];
+                    v618 = hir.int_to_ptr v615 : ptr<byte, i32>;
+                    hir.store v618, v614;
+                    v619 = arith.mul v595, v581 : i32 #[overflow = wrapping];
+                    scf.yield v619;
                 };
-                v622 = arith.constant 8 : i32;
-                v887 = arith.constant 4 : i32;
-                v883 = cf.select v603, v887, v622 : i32;
-                scf.yield v883, v882;
+                v620 = arith.constant 8 : i32;
+                v885 = arith.constant 4 : i32;
+                v881 = cf.select v601, v885, v620 : i32;
+                scf.yield v881, v880;
             };
-            v625 = arith.add v580, v884 : i32 #[overflow = wrapping];
-            v627 = hir.bitcast v625 : u32;
-            v886 = arith.constant 4 : u32;
-            v629 = arith.mod v627, v886 : u32;
-            hir.assertz v629 #[code = 250];
-            v630 = hir.int_to_ptr v627 : ptr<byte, i32>;
-            hir.store v630, v885;
+            v623 = arith.add v578, v882 : i32 #[overflow = wrapping];
+            v625 = hir.bitcast v623 : u32;
+            v884 = arith.constant 4 : u32;
+            v627 = arith.mod v625, v884 : u32;
+            hir.assertz v627 #[code = 250];
+            v628 = hir.int_to_ptr v625 : ptr<byte, i32>;
+            hir.store v628, v883;
             builtin.ret ;
         };
 
-        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v631: i32, v632: i32, v633: i32) {
-        ^block80(v631: i32, v632: i32, v633: i32):
-            v899 = arith.constant 0 : i32;
-            v634 = arith.constant 0 : i32;
-            v635 = arith.eq v633, v634 : i1;
-            v636 = arith.zext v635 : u32;
-            v637 = hir.bitcast v636 : i32;
-            v639 = arith.neq v637, v899 : i1;
-            scf.if v639{
+        private builtin.function @<alloc::alloc::Global as core::alloc::Allocator>::deallocate(v629: i32, v630: i32, v631: i32) {
+        ^block80(v629: i32, v630: i32, v631: i32):
+            v897 = arith.constant 0 : i32;
+            v632 = arith.constant 0 : i32;
+            v633 = arith.eq v631, v632 : i1;
+            v634 = arith.zext v633 : u32;
+            v635 = hir.bitcast v634 : i32;
+            v637 = arith.neq v635, v897 : i1;
+            scf.if v637{
             ^block82:
                 scf.yield ;
             } else {
             ^block83:
-                hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__rustc::__rust_dealloc(v631, v633, v632)
+                hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/__rustc::__rust_dealloc(v629, v631, v630)
                 scf.yield ;
             };
             builtin.ret ;
         };
 
-        private builtin.function @alloc::raw_vec::handle_error(v640: i32, v641: i32, v642: i32) {
-        ^block84(v640: i32, v641: i32, v642: i32):
+        private builtin.function @alloc::raw_vec::handle_error(v638: i32, v639: i32, v640: i32) {
+        ^block84(v638: i32, v639: i32, v640: i32):
             ub.unreachable ;
         };
 
-        private builtin.function @core::ptr::alignment::Alignment::max(v643: i32, v644: i32) -> i32 {
-        ^block86(v643: i32, v644: i32):
-            v651 = arith.constant 0 : i32;
-            v647 = hir.bitcast v644 : u32;
-            v646 = hir.bitcast v643 : u32;
-            v648 = arith.gt v646, v647 : i1;
-            v649 = arith.zext v648 : u32;
-            v650 = hir.bitcast v649 : i32;
-            v652 = arith.neq v650, v651 : i1;
-            v653 = cf.select v652, v643, v644 : i32;
-            builtin.ret v653;
+        private builtin.function @core::ptr::alignment::Alignment::max(v641: i32, v642: i32) -> i32 {
+        ^block86(v641: i32, v642: i32):
+            v649 = arith.constant 0 : i32;
+            v645 = hir.bitcast v642 : u32;
+            v644 = hir.bitcast v641 : u32;
+            v646 = arith.gt v644, v645 : i1;
+            v647 = arith.zext v646 : u32;
+            v648 = hir.bitcast v647 : i32;
+            v650 = arith.neq v648, v649 : i1;
+            v651 = cf.select v650, v641, v642 : i32;
+            builtin.ret v651;
         };
 
-        private builtin.function @miden::output_note::get_assets(v654: i32, v655: felt) -> i32 {
-        ^block88(v654: i32, v655: felt):
-            v656, v657 = hir.exec @miden/output_note/get_assets(v654, v655) : i32, i32
-            builtin.ret v656;
+        private builtin.function @miden::output_note::get_assets(v652: i32, v653: felt) -> i32 {
+        ^block88(v652: i32, v653: felt):
+            v654, v655 = hir.exec @miden/output_note/get_assets(v652, v653) : i32, i32
+            builtin.ret v654;
         };
 
         builtin.global_variable private @#__stack_pointer : i32 {
@@ -945,14 +945,14 @@ builtin.component miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-
             builtin.ret_imm 0;
         };
 
-        builtin.segment readonly @1048576 = 0x0073722e65746f6e5f74757074756f2f73676e69646e69622f6372732f302e382e302d7379732d657361622d6e6564696d;
+        builtin.segment readonly @1048576 = 0x003e64657463616465723c;
 
-        builtin.segment @1048628 = 0x000000220000006500000030001000000000000100000001;
+        builtin.segment @1048588 = 0x00000000000000000000000a001000000000000100000001;
     };
 
     public builtin.function @binding() -> felt {
     ^block92:
-        v659 = hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1#binding() : felt
-        builtin.ret v659;
+        v657 = hir.exec @miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1/rust_sdk_output_note_get_assets_binding/miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1#binding() : felt
+        builtin.ret v657;
     };
 };

--- a/tests/integration/expected/rust_sdk/rust_sdk_output_note_get_assets_binding.masm
+++ b/tests/integration/expected/rust_sdk/rust_sdk_output_note_get_assets_binding.masm
@@ -18,20 +18,20 @@ proc init
     trace.240
     exec.::intrinsics::mem::heap_init
     trace.252
-    push.[1299769949614318155,17537286569450742772,6595043140619191035,14014199975760862929]
+    push.[11433644200372730325,11349691924608542755,2482790568805339584,12018669310975905431]
     adv.push_mapval
     push.262144
-    push.5
+    push.3
     trace.240
     exec.::std::mem::pipe_preimage_to_memory
     trace.252
     drop
     push.1048576
     u32assert
-    mem_store.278552
+    mem_store.278544
     push.0
     u32assert
-    mem_store.278553
+    mem_store.278545
 end
 
 # mod miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1::rust_sdk_output_note_get_assets_binding
@@ -45,7 +45,7 @@ end
 
 @callconv("C")
 proc __rustc::__rust_alloc(i32, i32) -> i32
-    push.1114212
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -53,7 +53,7 @@ proc __rustc::__rust_alloc(i32, i32) -> i32
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.1048652
+    push.1048612
     u32wrapping_add
     movup.2
     swap.1
@@ -73,7 +73,7 @@ end
 
 @callconv("C")
 proc __rustc::__rust_alloc_zeroed(i32, i32) -> i32
-    push.1114212
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -81,7 +81,7 @@ proc __rustc::__rust_alloc_zeroed(i32, i32) -> i32
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.1048652
+    push.1048612
     u32wrapping_add
     dup.1
     swap.2
@@ -167,7 +167,7 @@ end
 proc miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1#binding(
 
 ) -> felt
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -177,7 +177,7 @@ proc miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-asse
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -243,7 +243,7 @@ proc miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-asse
     push.16
     movup.2
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -264,7 +264,7 @@ end
 proc wit_bindgen::rt::run_ctors_once(
 
 )
-    push.1114212
+    push.1114180
     u32divmod.4
     swap.1
     trace.240
@@ -272,7 +272,7 @@ proc wit_bindgen::rt::run_ctors_once(
     exec.::intrinsics::mem::load_sw
     trace.252
     nop
-    push.1048656
+    push.1048616
     u32wrapping_add
     u32divmod.4
     swap.1
@@ -293,7 +293,7 @@ proc wit_bindgen::rt::run_ctors_once(
     if.true
         nop
     else
-        push.1114212
+        push.1114180
         u32divmod.4
         swap.1
         trace.240
@@ -307,7 +307,7 @@ proc wit_bindgen::rt::run_ctors_once(
         trace.252
         nop
         push.1
-        push.1048656
+        push.1048616
         movup.2
         u32wrapping_add
         u32divmod.4
@@ -526,8 +526,8 @@ proc intrinsics::mem::heap_base(
 end
 
 @callconv("C")
-proc alloc::vec::Vec<T>::with_capacity(i32, i32)
-    push.1114208
+proc alloc::vec::Vec<T>::with_capacity(i32)
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -537,7 +537,7 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -552,9 +552,6 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     dup.2
     u32wrapping_add
     dup.1
-    movup.3
-    swap.5
-    movdn.3
     swap.2
     swap.1
     trace.240
@@ -563,7 +560,7 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     trace.252
     nop
     push.8
-    dup.2
+    dup.1
     add
     u32assert
     push.8
@@ -580,7 +577,7 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     trace.252
     nop
     push.8
-    dup.3
+    dup.4
     add
     u32assert
     push.4
@@ -598,7 +595,7 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     exec.::intrinsics::mem::store_sw
     trace.252
     nop
-    movup.2
+    movup.3
     push.4
     dup.1
     swap.1
@@ -614,7 +611,7 @@ proc alloc::vec::Vec<T>::with_capacity(i32, i32)
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -628,10 +625,9 @@ end
 proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
     i32,
     i32,
-    i32,
     i32
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -641,7 +637,7 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -707,8 +703,6 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
     neq
     neq
     if.true
-        movup.3
-        drop
         push.12
         dup.2
         add
@@ -759,7 +753,7 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
         nop
         push.16
         u32wrapping_add
-        push.1114208
+        push.1114176
         u32divmod.4
         swap.1
         trace.240
@@ -770,8 +764,16 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
     else
         movup.2
         drop
+        push.1114180
+        u32divmod.4
+        swap.1
+        trace.240
+        nop
+        exec.::intrinsics::mem::load_sw
+        trace.252
+        nop
         push.12
-        movup.2
+        movup.3
         add
         u32assert
         push.4
@@ -787,7 +789,10 @@ proc alloc::raw_vec::RawVecInner<A>::with_capacity_in(
         exec.::intrinsics::mem::load_sw
         trace.252
         nop
-        swap.1
+        push.1048596
+        movup.2
+        u32wrapping_add
+        swap.2
         trace.240
         nop
         exec.::miden:rust-sdk-output-note-get-assets-binding/rust-sdk-output-note-get-assets-binding@0.0.1::rust_sdk_output_note_get_assets_binding::alloc::raw_vec::handle_error
@@ -803,7 +808,7 @@ proc miden_base_sys::bindings::output_note::get_assets(
     i32,
     felt
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -813,7 +818,7 @@ proc miden_base_sys::bindings::output_note::get_assets(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -823,18 +828,8 @@ proc miden_base_sys::bindings::output_note::get_assets(
     exec.::intrinsics::mem::store_sw
     trace.252
     nop
-    push.1114212
-    u32divmod.4
-    swap.1
-    trace.240
-    nop
-    exec.::intrinsics::mem::load_sw
-    trace.252
-    nop
-    push.1048636
-    u32wrapping_add
     push.4
-    dup.2
+    dup.1
     u32wrapping_add
     trace.240
     nop
@@ -918,7 +913,7 @@ proc miden_base_sys::bindings::output_note::get_assets(
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -939,7 +934,7 @@ proc alloc::raw_vec::RawVecInner<A>::deallocate(
     i32,
     i32
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -949,7 +944,7 @@ proc alloc::raw_vec::RawVecInner<A>::deallocate(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -1040,7 +1035,7 @@ proc alloc::raw_vec::RawVecInner<A>::deallocate(
     end
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1058,7 +1053,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     i32,
     i32
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1068,7 +1063,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -1453,7 +1448,7 @@ proc alloc::raw_vec::RawVecInner<A>::try_allocate_in(
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1469,7 +1464,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     i32,
     i32
 )
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240
@@ -1479,7 +1474,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     nop
     push.16
     u32wrapping_sub
-    push.1114208
+    push.1114176
     dup.1
     swap.1
     u32divmod.4
@@ -1572,7 +1567,7 @@ proc <alloc::alloc::Global as core::alloc::Allocator>::allocate(
     nop
     push.16
     u32wrapping_add
-    push.1114208
+    push.1114176
     u32divmod.4
     swap.1
     trace.240

--- a/tests/integration/expected/rust_sdk/rust_sdk_output_note_get_assets_binding.wat
+++ b/tests/integration/expected/rust_sdk/rust_sdk_output_note_get_assets_binding.wat
@@ -13,11 +13,11 @@
     (type (;3;) (func (result f32)))
     (type (;4;) (func (param i32 i32 i32) (result i32)))
     (type (;5;) (func (result i32)))
-    (type (;6;) (func (param i32 i32)))
-    (type (;7;) (func (param i32 i32 i32 i32)))
-    (type (;8;) (func (param i32 f32)))
-    (type (;9;) (func (param i32) (result f32)))
-    (type (;10;) (func (param i32 i32 i32 i32 i32)))
+    (type (;6;) (func (param i32)))
+    (type (;7;) (func (param i32 f32)))
+    (type (;8;) (func (param i32) (result f32)))
+    (type (;9;) (func (param i32 i32 i32 i32 i32)))
+    (type (;10;) (func (param i32 i32 i32 i32)))
     (type (;11;) (func (param i32 f32) (result i32)))
     (table (;0;) 2 2 funcref)
     (memory (;0;) 17)
@@ -29,7 +29,7 @@
     (func $__wasm_call_ctors (;0;) (type 0))
     (func $__rustc::__rust_alloc (;1;) (type 1) (param i32 i32) (result i32)
       global.get $GOT.data.internal.__memory_base
-      i32.const 1048652
+      i32.const 1048612
       i32.add
       local.get 1
       local.get 0
@@ -39,7 +39,7 @@
     (func $__rustc::__rust_alloc_zeroed (;3;) (type 1) (param i32 i32) (result i32)
       block ;; label = @1
         global.get $GOT.data.internal.__memory_base
-        i32.const 1048652
+        i32.const 1048612
         i32.add
         local.get 1
         local.get 0
@@ -95,7 +95,7 @@
       (local i32)
       block ;; label = @1
         global.get $GOT.data.internal.__memory_base
-        i32.const 1048656
+        i32.const 1048616
         i32.add
         i32.load8_u
         br_if 0 (;@1;)
@@ -103,7 +103,7 @@
         local.set 0
         call $__wasm_call_ctors
         local.get 0
-        i32.const 1048656
+        i32.const 1048616
         i32.add
         i32.const 1
         i32.store8
@@ -184,42 +184,41 @@
     (func $intrinsics::mem::heap_base (;9;) (type 5) (result i32)
       unreachable
     )
-    (func $alloc::vec::Vec<T>::with_capacity (;10;) (type 6) (param i32 i32)
+    (func $alloc::vec::Vec<T>::with_capacity (;10;) (type 6) (param i32)
       (local i32 i64)
       global.get $__stack_pointer
       i32.const 16
       i32.sub
-      local.tee 2
+      local.tee 1
       global.set $__stack_pointer
-      local.get 2
+      local.get 1
       i32.const 8
       i32.add
       i32.const 16
       i32.const 16
-      local.get 1
       call $alloc::raw_vec::RawVecInner<A>::with_capacity_in
-      local.get 2
+      local.get 1
       i64.load offset=8
-      local.set 3
+      local.set 2
       local.get 0
       i32.const 0
       i32.store offset=8
       local.get 0
-      local.get 3
-      i64.store align=4
       local.get 2
+      i64.store align=4
+      local.get 1
       i32.const 16
       i32.add
       global.set $__stack_pointer
     )
-    (func $alloc::raw_vec::RawVecInner<A>::with_capacity_in (;11;) (type 7) (param i32 i32 i32 i32)
+    (func $alloc::raw_vec::RawVecInner<A>::with_capacity_in (;11;) (type 2) (param i32 i32 i32)
       (local i32)
       global.get $__stack_pointer
       i32.const 16
       i32.sub
-      local.tee 4
+      local.tee 3
       global.set $__stack_pointer
-      local.get 4
+      local.get 3
       i32.const 4
       i32.add
       i32.const 256
@@ -227,35 +226,39 @@
       local.get 1
       local.get 2
       call $alloc::raw_vec::RawVecInner<A>::try_allocate_in
-      local.get 4
+      local.get 3
       i32.load offset=8
       local.set 2
       block ;; label = @1
-        local.get 4
+        local.get 3
         i32.load offset=4
         i32.const 1
         i32.ne
         br_if 0 (;@1;)
+        global.get $GOT.data.internal.__memory_base
+        local.set 0
         local.get 2
-        local.get 4
-        i32.load offset=12
         local.get 3
+        i32.load offset=12
+        local.get 0
+        i32.const 1048596
+        i32.add
         call $alloc::raw_vec::handle_error
         unreachable
       end
       local.get 0
-      local.get 4
+      local.get 3
       i32.load offset=12
       i32.store offset=4
       local.get 0
       local.get 2
       i32.store
-      local.get 4
+      local.get 3
       i32.const 16
       i32.add
       global.set $__stack_pointer
     )
-    (func $miden_base_sys::bindings::output_note::get_assets (;12;) (type 8) (param i32 f32)
+    (func $miden_base_sys::bindings::output_note::get_assets (;12;) (type 7) (param i32 f32)
       (local i32)
       global.get $__stack_pointer
       i32.const 16
@@ -264,9 +267,6 @@
       global.set $__stack_pointer
       local.get 2
       i32.const 4
-      i32.add
-      global.get $GOT.data.internal.__memory_base
-      i32.const 1048636
       i32.add
       call $alloc::vec::Vec<T>::with_capacity
       local.get 0
@@ -288,7 +288,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $intrinsics::felt::from_u32 (;13;) (type 9) (param i32) (result f32)
+    (func $intrinsics::felt::from_u32 (;13;) (type 8) (param i32) (result f32)
       unreachable
     )
     (func $alloc::raw_vec::RawVecInner<A>::deallocate (;14;) (type 2) (param i32 i32 i32)
@@ -323,7 +323,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $alloc::raw_vec::RawVecInner<A>::try_allocate_in (;15;) (type 10) (param i32 i32 i32 i32 i32)
+    (func $alloc::raw_vec::RawVecInner<A>::try_allocate_in (;15;) (type 9) (param i32 i32 i32 i32 i32)
       (local i32 i64)
       global.get $__stack_pointer
       i32.const 16
@@ -464,7 +464,7 @@
       i32.add
       global.set $__stack_pointer
     )
-    (func $alloc::alloc::Global::alloc_impl (;17;) (type 7) (param i32 i32 i32 i32)
+    (func $alloc::alloc::Global::alloc_impl (;17;) (type 10) (param i32 i32 i32 i32)
       block ;; label = @1
         local.get 2
         i32.eqz
@@ -491,7 +491,7 @@
       local.get 1
       i32.store
     )
-    (func $alloc::raw_vec::RawVecInner<A>::current_memory (;18;) (type 7) (param i32 i32 i32 i32)
+    (func $alloc::raw_vec::RawVecInner<A>::current_memory (;18;) (type 10) (param i32 i32 i32 i32)
       (local i32 i32 i32)
       i32.const 0
       local.set 4
@@ -551,8 +551,8 @@
     (func $miden::output_note::get_assets (;22;) (type 11) (param i32 f32) (result i32)
       unreachable
     )
-    (data $.rodata (;0;) (i32.const 1048576) "miden-base-sys-0.8.0/src/bindings/output_note.rs\00")
-    (data $.data (;1;) (i32.const 1048628) "\01\00\00\00\01\00\00\00\00\00\10\000\00\00\00e\00\00\00\22\00\00\00")
+    (data $.rodata (;0;) (i32.const 1048576) "<redacted>\00")
+    (data $.data (;1;) (i32.const 1048588) "\01\00\00\00\01\00\00\00\00\00\10\00\0a\00\00\00\00\00\00\00\00\00\00\00")
     (@custom "rodata,miden_account" (after data) "Orust_sdk_output_note_get_assets_binding\01\0b0.0.1\03\01\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
   )
   (alias export 0 "felt" (type (;1;)))

--- a/tools/cargo-miden/src/commands/build.rs
+++ b/tools/cargo-miden/src/commands/build.rs
@@ -87,9 +87,13 @@ impl BuildCommand {
             spawn_args.push(format!("{key}={value}"));
         }
 
-        let extra_rust_flags = String::from(
-            "-C target-feature=+bulk-memory,+wide-arithmetic -C link-args=--fatal-warnings",
-        );
+        // Enable memcopy and 128-bit arithmetic ops
+        let mut extra_rust_flags = String::from("-C target-feature=+bulk-memory,+wide-arithmetic");
+        // Enable errors on missing stub functions
+        extra_rust_flags.push_str(" -C link-args=--fatal-warnings");
+        // Remove the source file paths in the data segment for panics
+        // https://doc.rust-lang.org/beta/unstable-book/compiler-flags/location-detail.html
+        extra_rust_flags.push_str(" -Zlocation-detail=none");
         let maybe_old_rustflags = match std::env::var("RUSTFLAGS") {
             Ok(current) if !current.is_empty() => {
                 std::env::set_var("RUSTFLAGS", format!("{current} {extra_rust_flags}"));


### PR DESCRIPTION
Close #778 

**This PR is stacked on #791 and should be merged after it.**

This PR removes panic source file location info in the data segment. See https://doc.rust-lang.org/beta/unstable-book/compiler-flags/location-detail.html