### PR TITLE
chore: fix node integration tests failing with HTTP 500 error 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,9 +314,7 @@ jobs:
           fi
       - name: Test
         run: |
-          # Run sequentially as a workaround until
-          # https://github.com/0xMiden/compiler/issues/766 is resolved
-          cargo make test -E 'package(miden-integration-node-tests)' --test-threads 1
+          cargo make test -E 'package(miden-integration-node-tests)'
 
   cargo_publish_dry_run:
     name: cargo publish dry run


### PR DESCRIPTION
Close #766 

**This PR is stacked on #797 and should be merged after it.** 

The error "grpc-status header missing mapped from HTTP status code 500" errors. The root cause was that the node process was started with `Stdio::piped()` for stdout/stderr, and when the pipe buffers filled up during heavy logging, the node would block on I/O writes, causing gRPC requests to fail.
The fix changes the node process to use `Stdio::null()` instead, which prevents blocking. For debugging, users can run the node manually with `RUST_LOG=debug`.