### PR TITLE
chore: remove unused tools in the GA runner image to free up disc space

### DIFF
--- a/.github/actions/cleanup-runner/action.yml
+++ b/.github/actions/cleanup-runner/action.yml
@@ -1,0 +1,12 @@
+name: 'Cleanup Runner'
+description: 'Remove unused tools in the runner image to free disk space'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Remove unused tools in the runner image
+      shell: bash
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        sudo docker image prune --all --force || true
+        sudo docker builder prune -a --force || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Remove unused tools in the runner image
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-          sudo docker builder prune -a --force || true
+      - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
@@ -64,11 +60,7 @@ jobs:
     if: ${{ always() }}
     steps:
       - uses: actions/checkout@v5
-      - name: Remove unused tools in the runner image
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-          sudo docker builder prune -a --force || true
+      - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
@@ -95,11 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Remove unused tools in the runner image
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-          sudo docker builder prune -a --force || true
+      - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
@@ -132,11 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Remove unused tools in the runner image
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-          sudo docker builder prune -a --force || true
+      - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
@@ -172,11 +156,7 @@ jobs:
     needs: [unit_tests]
     steps:
       - uses: actions/checkout@v5
-      - name: Remove unused tools in the runner image
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-          sudo docker builder prune -a --force || true
+      - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
@@ -207,11 +187,7 @@ jobs:
     needs: [unit_tests]
     steps:
       - uses: actions/checkout@v5
-      - name: Remove unused tools in the runner image
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-          sudo docker builder prune -a --force || true
+      - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
@@ -241,11 +217,7 @@ jobs:
     needs: [unit_tests]
     steps:
       - uses: actions/checkout@v5
-      - name: Remove unused tools in the runner image
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-          sudo docker builder prune -a --force || true
+      - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
@@ -275,11 +247,7 @@ jobs:
     needs: [unit_tests]
     steps:
       - uses: actions/checkout@v5
-      - name: Remove unused tools in the runner image
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-          sudo docker builder prune -a --force || true
+      - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
@@ -308,11 +276,7 @@ jobs:
     needs: [unit_tests]
     steps:
       - uses: actions/checkout@v5
-      - name: Remove unused tools in the runner image
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-          sudo docker builder prune -a --force || true
+      - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
@@ -341,11 +305,7 @@ jobs:
     needs: [unit_tests]
     steps:
       - uses: actions/checkout@v5
-      - name: Remove unused tools in the runner image
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-          sudo docker builder prune -a --force || true
+      - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
@@ -372,11 +332,7 @@ jobs:
     needs: [unit_tests]
     steps:
       - uses: actions/checkout@v5
-      - name: Remove unused tools in the runner image
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
-          sudo docker builder prune -a --force || true
+      - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update


### PR DESCRIPTION
Stolen from https://github.com/0xMiden/miden-vm/pull/2391