### PR TITLE
Add synthetic source locations

### DIFF
--- a/frontend/wasm/src/component/parser.rs
+++ b/frontend/wasm/src/component/parser.rs
@@ -365,7 +365,6 @@ impl<'a, 'data> ComponentParser<'a, 'data> {
         // but reference the embedded module's code. We need to:
         // 1. Copy the DWARF data to the module's debuginfo
         // 2. Store the module's base offset for address translation
-        // TODO: Add test for this!!
         if let Some(first_module) = self.static_modules.values_mut().next() {
             // Only inject if DWARF was actually parsed
             if !self.component_debuginfo.dwarf.debug_info.reader().is_empty() {
@@ -938,7 +937,6 @@ impl<'a, 'data> ComponentParser<'a, 'data> {
     /// Parses a DWARF debug section from the component.
     /// These sections are stored at the component level but contain debug info
     /// for the embedded modules.
-    /// TODO: Add tests for this!!!
     fn dwarf_section(&mut self, section: &wasmparser::CustomSectionReader<'data>) {
         let name = section.name();
         if !self.config.generate_native_debuginfo && !self.config.parse_wasm_debuginfo {
@@ -985,6 +983,45 @@ impl<'a, 'data> ComponentParser<'a, 'data> {
 
         dwarf.ranges = gimli::RangeLists::new(info.debug_ranges, info.debug_rnglists);
         dwarf.locations = gimli::LocationLists::new(info.debug_loc, info.debug_loclists);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use midenc_hir::Context;
+    use wasmparser::Validator;
+
+    use super::*;
+    use crate::supported_component_model_features;
+
+    #[test]
+    fn injects_component_level_dwarf_into_first_module() {
+        let component = wat::parse_str(
+            r#"
+            (component
+                (@custom ".debug_info" "\01\02\03")
+                (core module
+                    (func (export "f"))
+                )
+            )
+            "#,
+        )
+        .expect("component wat should compile");
+        let context = Context::default();
+        let config = WasmTranslationConfig::default();
+        let mut validator = Validator::new_with_features(supported_component_model_features());
+        let mut types = ComponentTypesBuilder::default();
+        let parser = ComponentParser::new(&config, context.session(), &mut validator, &mut types);
+
+        let parsed = parser.parse(&component).expect("component should parse");
+        let first_module = parsed
+            .static_modules
+            .values()
+            .next()
+            .expect("component should contain a core module");
+
+        assert_eq!(first_module.debuginfo.dwarf.debug_info.reader().len(), 3);
+        assert!(first_module.wasm_file.module_base_offset > 0);
     }
 }
 

--- a/frontend/wasm/src/component/parser.rs
+++ b/frontend/wasm/src/component/parser.rs
@@ -3,9 +3,11 @@
 
 // Based on wasmtime v16.0 Wasm component translation
 
+use alloc::sync::Arc;
 use std::mem;
 
 use cranelift_entity::PrimaryMap;
+use gimli::Section;
 use indexmap::IndexMap;
 use midenc_hir::{FxBuildHasher, FxHashMap};
 use midenc_session::{Session, diagnostics::IntoDiagnostic};
@@ -22,7 +24,7 @@ use crate::{
     component::*,
     error::WasmResult,
     module::{
-        module_env::{ModuleEnvironment, ParsedModule},
+        module_env::{DebugInfoData, Dwarf, ModuleEnvironment, ParsedModule},
         types::{
             EntityIndex, FuncIndex, GlobalIndex, MemoryIndex, TableIndex, WasmType,
             convert_func_type, convert_valtype,
@@ -76,6 +78,14 @@ pub struct ComponentParser<'a, 'data> {
     /// As frames are popped from `lexical_scopes` their completed component
     /// will be pushed onto this list.
     pub static_components: PrimaryMap<StaticComponentIndex, ParsedComponent<'data>>,
+
+    /// DWARF debug info parsed from component-level custom sections.
+    /// This will be injected into the parsed modules after component parsing completes.
+    component_debuginfo: DebugInfoData<'data>,
+
+    /// The byte offset where the first module starts within the component.
+    /// Used to adjust DWARF addresses when looking up source locations.
+    first_module_base_offset: Option<usize>,
 }
 
 pub struct ParsedRootComponent<'data> {
@@ -324,6 +334,8 @@ impl<'a, 'data> ComponentParser<'a, 'data> {
             lexical_scopes: Vec::new(),
             static_components: Default::default(),
             static_modules: Default::default(),
+            component_debuginfo: Default::default(),
+            first_module_base_offset: None,
         }
     }
 
@@ -347,6 +359,23 @@ impl<'a, 'data> ComponentParser<'a, 'data> {
         }
         assert!(remaining.is_empty());
         assert!(self.lexical_scopes.is_empty());
+
+        // Inject component-level DWARF debug info into the first module.
+        // In wasm components, DWARF sections are stored at the component level
+        // but reference the embedded module's code. We need to:
+        // 1. Copy the DWARF data to the module's debuginfo
+        // 2. Store the module's base offset for address translation
+        // TODO: Add test for this!!
+        if let Some(first_module) = self.static_modules.values_mut().next() {
+            // Only inject if DWARF was actually parsed
+            if !self.component_debuginfo.dwarf.debug_info.reader().is_empty() {
+                first_module.debuginfo = self.component_debuginfo;
+                // Store the module's base offset for DWARF address translation
+                if let Some(base_offset) = self.first_module_base_offset {
+                    first_module.wasm_file.module_base_offset = base_offset as u64;
+                }
+            }
+        }
 
         Ok(ParsedRootComponent {
             root_component: self.result,
@@ -426,8 +455,9 @@ impl<'a, 'data> ComponentParser<'a, 'data> {
                 );
             }
             Payload::ComponentAliasSection(s) => self.component_alias_section(s)?,
-            // All custom sections are ignored at this time.
-            // and parse a `name` section here.
+            // Parse DWARF debug sections at component level.
+            // Other custom sections are ignored.
+            Payload::CustomSection(s) if s.name().starts_with(".debug_") => self.dwarf_section(&s),
             Payload::CustomSection { .. } => {}
             // Anything else is either not reachable since we never enable the
             // feature or we do enable it and it's a bug we don't
@@ -624,6 +654,13 @@ impl<'a, 'data> ComponentParser<'a, 'data> {
         // module and actual function translation is deferred until this
         // entire process has completed.
         self.validator.module_section(&range).into_diagnostic()?;
+
+        // Track the first module's base offset for DWARF address translation.
+        // DWARF addresses in components reference the module's position within the component.
+        if self.first_module_base_offset.is_none() {
+            self.first_module_base_offset = Some(range.start);
+        }
+
         let module_environment = ModuleEnvironment::new(
             self.config,
             self.validator,
@@ -896,6 +933,58 @@ impl<'a, 'data> ComponentParser<'a, 'data> {
         let ty = types[id].unwrap_func();
         let ty = convert_func_type(ty);
         self.types.module_types_builder_mut().wasm_func_type(id, ty)
+    }
+
+    /// Parses a DWARF debug section from the component.
+    /// These sections are stored at the component level but contain debug info
+    /// for the embedded modules.
+    /// TODO: Add tests for this!!!
+    fn dwarf_section(&mut self, section: &wasmparser::CustomSectionReader<'data>) {
+        let name = section.name();
+        if !self.config.generate_native_debuginfo && !self.config.parse_wasm_debuginfo {
+            return;
+        }
+        let info = &mut self.component_debuginfo;
+        let dwarf = &mut info.dwarf;
+        let endian = gimli::LittleEndian;
+        let data = section.data();
+        let slice = gimli::EndianSlice::new(data, endian);
+
+        match name {
+            // `gimli::Dwarf` fields.
+            ".debug_abbrev" => dwarf.debug_abbrev = gimli::DebugAbbrev::new(data, endian),
+            ".debug_addr" => dwarf.debug_addr = gimli::DebugAddr::from(slice),
+            ".debug_info" => dwarf.debug_info = gimli::DebugInfo::new(data, endian),
+            ".debug_line" => dwarf.debug_line = gimli::DebugLine::new(data, endian),
+            ".debug_line_str" => dwarf.debug_line_str = gimli::DebugLineStr::from(slice),
+            ".debug_str" => dwarf.debug_str = gimli::DebugStr::new(data, endian),
+            ".debug_str_offsets" => dwarf.debug_str_offsets = gimli::DebugStrOffsets::from(slice),
+            ".debug_str_sup" => {
+                let dwarf_sup: Dwarf<'data> = Dwarf {
+                    debug_str: gimli::DebugStr::from(slice),
+                    ..Default::default()
+                };
+                dwarf.sup = Some(Arc::new(dwarf_sup));
+            }
+            ".debug_types" => dwarf.debug_types = gimli::DebugTypes::from(slice),
+
+            // Additional fields.
+            ".debug_loc" => info.debug_loc = gimli::DebugLoc::from(slice),
+            ".debug_loclists" => info.debug_loclists = gimli::DebugLocLists::from(slice),
+            ".debug_ranges" => info.debug_ranges = gimli::DebugRanges::new(data, endian),
+            ".debug_rnglists" => info.debug_rnglists = gimli::DebugRngLists::new(data, endian),
+
+            // We don't use these at the moment.
+            ".debug_aranges" | ".debug_pubnames" | ".debug_pubtypes" => return,
+
+            other => {
+                log::warn!(target: "component-parser", "unknown debug section `{other}`");
+                return;
+            }
+        }
+
+        dwarf.ranges = gimli::RangeLists::new(info.debug_ranges, info.debug_rnglists);
+        dwarf.locations = gimli::LocationLists::new(info.debug_loc, info.debug_loclists);
     }
 }
 

--- a/frontend/wasm/src/miden_abi/transform.rs
+++ b/frontend/wasm/src/miden_abi/transform.rs
@@ -8,16 +8,6 @@ use midenc_hir::{
 use super::{stdlib, tx_kernel};
 use crate::module::function_builder_ext::FunctionBuilderExt;
 
-/// Returns a synthetic SourceSpan for compiler-generated code.
-///
-/// This uses SourceSpan::SYNTHETIC from miden-debug-types which is identified
-/// by having an unknown source_id and both start and end set to u32::MAX.
-/// This differentiates it from UNKNOWN spans (which have start and end at 0)
-/// and indicates the code doesn't correspond to any specific user source location.
-fn synthetic_span() -> SourceSpan {
-    SourceSpan::SYNTHETIC
-}
-
 /// The strategy to use for transforming a function call
 enum TransformStrategy {
     /// The Miden ABI function returns a length and a pointer and we only want the length
@@ -340,7 +330,7 @@ pub fn return_via_pointer<B: ?Sized + Builder>(
     // Use synthetic span for all compiler-generated ABI transformation operations
     // These operations are part of the return-via-pointer calling convention
     // and don't correspond to any specific user source code
-    let span = synthetic_span();
+    let span = SourceSpan::SYNTHETIC;
     let ptr_u32 = builder.bitcast(ptr_arg, Type::U32, span).expect("failed bitcast to U32");
 
     let result_ty = midenc_hir::StructType::new(results.iter().map(|v| (*v).borrow().ty().clone()));

--- a/frontend/wasm/src/miden_abi/transform.rs
+++ b/frontend/wasm/src/miden_abi/transform.rs
@@ -1,12 +1,22 @@
 use midenc_dialect_arith::ArithOpBuilder;
 use midenc_dialect_hir::HirOpBuilder;
 use midenc_hir::{
-    Builder, Immediate, Op, PointerType, SymbolNameComponent, SymbolPath, Type, ValueRef,
-    dialects::builtin::FunctionRef, interner::symbols,
+    Builder, Immediate, Op, PointerType, SourceSpan, SymbolNameComponent, SymbolPath, Type,
+    ValueRef, dialects::builtin::FunctionRef, interner::symbols,
 };
 
 use super::{stdlib, tx_kernel};
 use crate::module::function_builder_ext::FunctionBuilderExt;
+
+/// Returns a synthetic SourceSpan for compiler-generated code.
+///
+/// This uses SourceSpan::SYNTHETIC from miden-debug-types which is identified
+/// by having an unknown source_id and both start and end set to u32::MAX.
+/// This differentiates it from UNKNOWN spans (which have start and end at 0)
+/// and indicates the code doesn't correspond to any specific user source location.
+fn synthetic_span() -> SourceSpan {
+    SourceSpan::SYNTHETIC
+}
 
 /// The strategy to use for transforming a function call
 enum TransformStrategy {
@@ -311,12 +321,12 @@ pub fn return_via_pointer<B: ?Sized + Builder>(
     args: &[ValueRef],
     builder: &mut FunctionBuilderExt<'_, B>,
 ) -> Vec<ValueRef> {
-    let span = import_func_ref.borrow().name().span;
+    let exec_span = import_func_ref.borrow().name().span;
     // Omit the last argument (pointer)
     let args_wo_pointer = &args[0..args.len() - 1];
     let signature = import_func_ref.borrow().get_signature().clone();
     let exec = builder
-        .exec(import_func_ref, signature, args_wo_pointer.to_vec(), span)
+        .exec(import_func_ref, signature, args_wo_pointer.to_vec(), exec_span)
         .expect("failed to build an exec op in return_via_pointer strategy");
 
     let borrow = exec.borrow();
@@ -327,6 +337,10 @@ pub fn return_via_pointer<B: ?Sized + Builder>(
     let ptr_arg = *args.last().expect("empty args");
     let ptr_arg_ty = ptr_arg.borrow().ty().clone();
     assert_eq!(ptr_arg_ty, Type::I32);
+    // Use synthetic span for all compiler-generated ABI transformation operations
+    // These operations are part of the return-via-pointer calling convention
+    // and don't correspond to any specific user source code
+    let span = synthetic_span();
     let ptr_u32 = builder.bitcast(ptr_arg, Type::U32, span).expect("failed bitcast to U32");
 
     let result_ty = midenc_hir::StructType::new(results.iter().map(|v| (*v).borrow().ty().clone()));

--- a/frontend/wasm/src/module/func_translator.rs
+++ b/frontend/wasm/src/module/func_translator.rs
@@ -24,16 +24,6 @@ use midenc_session::{
 };
 use wasmparser::{FuncValidator, FunctionBody, WasmModuleResources};
 
-/// Creates a synthetic SourceSpan for compiler-generated code.
-///
-/// A synthetic span is identified by having an unknown source_id and
-/// both start and end set to u32::MAX. This differentiates it from UNKNOWN
-/// spans (which have start and end at 0) and indicates the code doesn't
-/// correspond to any specific user source location.
-fn synthetic_span() -> SourceSpan {
-    SourceSpan::SYNTHETIC
-}
-
 use super::{
     debug_info::FunctionDebugInfo, function_builder_ext::SSABuilderListener,
     module_env::ParsedModule, module_translation_state::ModuleTranslationState,
@@ -245,9 +235,9 @@ fn parse_function_body<B: ?Sized + Builder>(
     debug_assert_eq!(state.control_stack.len(), 1, "State not initialized");
 
     let func_name = builder.name();
-    let mut end_span = synthetic_span();
-    // Track the most recent valid source span to inherit for ops without DWARF info.
-    let mut current_span = synthetic_span();
+    let mut end_span = SourceSpan::SYNTHETIC;
+    // Track the last valid span to use as a fallback for instructions without DWARF debug info.
+    let mut last_valid_span = SourceSpan::UNKNOWN;
     while !reader.eof() {
         let pos = reader.original_position();
         let (op, offset) = reader.read_with_offset().into_diagnostic()?;
@@ -265,22 +255,32 @@ fn parse_function_body<B: ?Sized + Builder>(
         } else {
             code_offset
         };
-
-        let resolved_span = resolve_instruction_span(addr2line, dwarf_lookup_offset, session, config)?;
-        let span = if resolved_span.is_unknown() {
+        let span = resolve_instruction_span(addr2line, dwarf_lookup_offset, session, config)?;
+        if !span.is_unknown() {
+            last_valid_span = span;
+        } else {
             log::debug!(target: "module-parser",
                 "failed to locate span for instruction at offset {offset} in function {func_name}"
             );
-            current_span
+        }
+
+        let effective_span = if span.is_unknown() {
+            if !last_valid_span.is_unknown() {
+                log::debug!(target: "module-parser",
+                    "using last valid span as fallback for {:?} at offset {offset} in function {func_name}", op
+                );
+                last_valid_span
+            } else {
+                SourceSpan::SYNTHETIC
+            }
         } else {
-            current_span = resolved_span;
-            resolved_span
+            span
         };
 
         // Track the span of every END we observe, so we have a span to assign to the return we
         // place in the final exit block
         if let wasmparser::Operator::End = op {
-            end_span = span;
+            end_span = effective_span;
         }
 
         translate_operator(
@@ -291,10 +291,10 @@ fn parse_function_body<B: ?Sized + Builder>(
             &module.module,
             mod_types,
             &session.diagnostics,
-            span,
+            effective_span,
         )?;
 
-        builder.apply_location_schedule(code_offset, span);
+        builder.apply_location_schedule(code_offset, effective_span);
     }
 
     // The final `End` operator left us in the exit block where we need to manually add a return

--- a/frontend/wasm/src/module/func_translator.rs
+++ b/frontend/wasm/src/module/func_translator.rs
@@ -24,6 +24,16 @@ use midenc_session::{
 };
 use wasmparser::{FuncValidator, FunctionBody, WasmModuleResources};
 
+/// Creates a synthetic SourceSpan for compiler-generated code.
+///
+/// A synthetic span is identified by having an unknown source_id and
+/// both start and end set to u32::MAX. This differentiates it from UNKNOWN
+/// spans (which have start and end at 0) and indicates the code doesn't
+/// correspond to any specific user source location.
+fn synthetic_span() -> SourceSpan {
+    SourceSpan::SYNTHETIC
+}
+
 use super::{
     debug_info::FunctionDebugInfo, function_builder_ext::SSABuilderListener,
     module_env::ParsedModule, module_translation_state::ModuleTranslationState,
@@ -235,42 +245,43 @@ fn parse_function_body<B: ?Sized + Builder>(
     debug_assert_eq!(state.control_stack.len(), 1, "State not initialized");
 
     let func_name = builder.name();
-    let mut end_span = SourceSpan::UNKNOWN;
-    // Track the last valid span to use as a fallback for instructions without DWARF debug info.
-    // This is particularly useful for `unreachable` instructions that follow panic calls,
-    // where the unreachable itself has no source location but should inherit the panic call's span.
-    let mut last_valid_span = SourceSpan::UNKNOWN;
+    let mut end_span = synthetic_span();
+    // Track the most recent valid source span to inherit for ops without DWARF info.
+    let mut current_span = synthetic_span();
     while !reader.eof() {
         let pos = reader.original_position();
         let (op, offset) = reader.read_with_offset().into_diagnostic()?;
         func_validator.op(pos, &op).into_diagnostic()?;
 
-        let offset = (offset as u64)
+        let code_offset = (offset as u64)
             .checked_sub(module.wasm_file.code_section_offset)
             .expect("offset occurs before start of code section");
-        let span = resolve_instruction_span(addr2line, offset, session, config)?;
-        if !span.is_unknown() {
-            last_valid_span = span;
+
+        // For DWARF lookup, we need different offset calculations depending on context:
+        // - For standalone modules: DWARF addresses are relative to the code section start
+        // - For modules in components: DWARF addresses are absolute (component file offsets)
+        let dwarf_lookup_offset = if module.wasm_file.module_base_offset > 0 {
+            module.wasm_file.module_base_offset + offset as u64
         } else {
+            code_offset
+        };
+
+        let resolved_span = resolve_instruction_span(addr2line, dwarf_lookup_offset, session, config)?;
+        let span = if resolved_span.is_unknown() {
             log::debug!(target: "module-parser",
                 "failed to locate span for instruction at offset {offset} in function {func_name}"
             );
-        }
+            current_span
+        } else {
+            current_span = resolved_span;
+            resolved_span
+        };
 
         // Track the span of every END we observe, so we have a span to assign to the return we
         // place in the final exit block
         if let wasmparser::Operator::End = op {
             end_span = span;
         }
-
-        let effective_span = if span.is_unknown() && !last_valid_span.is_unknown() {
-            log::debug!(target: "module-parser",
-                "using last valid span as fallback for {:?} at offset {offset} in function {func_name}", op
-            );
-            last_valid_span
-        } else {
-            span
-        };
 
         translate_operator(
             &op,
@@ -280,10 +291,10 @@ fn parse_function_body<B: ?Sized + Builder>(
             &module.module,
             mod_types,
             &session.diagnostics,
-            effective_span,
+            span,
         )?;
 
-        builder.apply_location_schedule(offset, span);
+        builder.apply_location_schedule(code_offset, span);
     }
 
     // The final `End` operator left us in the exit block where we need to manually add a return

--- a/frontend/wasm/src/module/module_env.rs
+++ b/frontend/wasm/src/module/module_env.rs
@@ -200,8 +200,8 @@ mod tests;
 #[derive(Default)]
 pub struct DebugInfoData<'a> {
     pub dwarf: Dwarf<'a>,
-    debug_loc: gimli::DebugLoc<DwarfReader<'a>>,
-    debug_loclists: gimli::DebugLocLists<DwarfReader<'a>>,
+    pub debug_loc: gimli::DebugLoc<DwarfReader<'a>>,
+    pub debug_loclists: gimli::DebugLocLists<DwarfReader<'a>>,
     pub debug_ranges: gimli::DebugRanges<DwarfReader<'a>>,
     pub debug_rnglists: gimli::DebugRngLists<DwarfReader<'a>>,
 }
@@ -216,6 +216,10 @@ pub struct WasmFileInfo {
     pub code_section_offset: u64,
     pub imported_func_count: u32,
     pub funcs: Vec<FunctionMetadata>,
+    /// The byte offset where this module starts within a component.
+    /// This is 0 for standalone modules, but non-zero when the module
+    /// is embedded in a wasm component. Used for DWARF address translation.
+    pub module_base_offset: u64,
 }
 
 #[derive(Debug)]

--- a/frontend/wasm/src/translation_utils.rs
+++ b/frontend/wasm/src/translation_utils.rs
@@ -12,16 +12,6 @@ use crate::{
     error::WasmResult, module::function_builder_ext::FunctionBuilderExt, unsupported_diag,
 };
 
-/// Returns a synthetic SourceSpan for compiler-generated code.
-///
-/// This uses SourceSpan::SYNTHETIC from miden-debug-types which is identified
-/// by having an unknown source_id and both start and end set to u32::MAX.
-/// This differentiates it from UNKNOWN spans (which have start and end at 0)
-/// and indicates the code doesn't correspond to any specific user source location.
-fn synthetic_span() -> SourceSpan {
-    SourceSpan::SYNTHETIC
-}
-
 /// Represents the possible sizes in bytes of the discriminant of a variant type in the component
 /// model
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -121,7 +111,7 @@ pub fn emit_zero<B: ?Sized + Builder>(
     builder: &mut FunctionBuilderExt<'_, B>,
     diagnostics: &DiagnosticsHandler,
 ) -> WasmResult<ValueRef> {
-    let span = synthetic_span();
+    let span = SourceSpan::SYNTHETIC;
     Ok(match ty {
         Type::I1 => builder.i1(false, span),
         Type::I8 => builder.i8(0, span),

--- a/frontend/wasm/src/translation_utils.rs
+++ b/frontend/wasm/src/translation_utils.rs
@@ -12,6 +12,16 @@ use crate::{
     error::WasmResult, module::function_builder_ext::FunctionBuilderExt, unsupported_diag,
 };
 
+/// Returns a synthetic SourceSpan for compiler-generated code.
+///
+/// This uses SourceSpan::SYNTHETIC from miden-debug-types which is identified
+/// by having an unknown source_id and both start and end set to u32::MAX.
+/// This differentiates it from UNKNOWN spans (which have start and end at 0)
+/// and indicates the code doesn't correspond to any specific user source location.
+fn synthetic_span() -> SourceSpan {
+    SourceSpan::SYNTHETIC
+}
+
 /// Represents the possible sizes in bytes of the discriminant of a variant type in the component
 /// model
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -104,23 +114,26 @@ const fn ceiling_divide(n: usize, d: usize) -> usize {
 }
 
 /// Emit instructions to produce a zero value in the given type.
+///
+/// These are compiler-generated values (local initialization), so they use synthetic span.
 pub fn emit_zero<B: ?Sized + Builder>(
     ty: &Type,
     builder: &mut FunctionBuilderExt<'_, B>,
     diagnostics: &DiagnosticsHandler,
 ) -> WasmResult<ValueRef> {
+    let span = synthetic_span();
     Ok(match ty {
-        Type::I1 => builder.i1(false, SourceSpan::default()),
-        Type::I8 => builder.i8(0, SourceSpan::default()),
-        Type::I16 => builder.i16(0, SourceSpan::default()),
-        Type::I32 => builder.i32(0, SourceSpan::default()),
-        Type::I64 => builder.i64(0, SourceSpan::default()),
-        Type::U8 => builder.u8(0, SourceSpan::default()),
-        Type::U16 => builder.u16(0, SourceSpan::default()),
-        Type::U32 => builder.u32(0, SourceSpan::default()),
-        Type::U64 => builder.u64(0, SourceSpan::default()),
-        Type::F64 => builder.f64(0.0, SourceSpan::default()),
-        Type::Felt => builder.felt(Felt::ZERO, SourceSpan::default()),
+        Type::I1 => builder.i1(false, span),
+        Type::I8 => builder.i8(0, span),
+        Type::I16 => builder.i16(0, span),
+        Type::I32 => builder.i32(0, span),
+        Type::I64 => builder.i64(0, span),
+        Type::U8 => builder.u8(0, span),
+        Type::U16 => builder.u16(0, span),
+        Type::U32 => builder.u32(0, span),
+        Type::U64 => builder.u64(0, span),
+        Type::F64 => builder.f64(0.0, span),
+        Type::Felt => builder.felt(Felt::ZERO, span),
         Type::Enum(enum_ty) => {
             assert!(
                 enum_ty.is_c_like(),

--- a/hir/src/dialects/builtin/attributes/location.rs
+++ b/hir/src/dialects/builtin/attributes/location.rs
@@ -62,6 +62,8 @@ impl Location {
         use midenc_session::path::Path;
         if span.is_unknown() {
             Self::Unknown
+        } else if span.is_synthetic() {
+            Self::Synthetic
         } else if let Some(index) = Self::is_deferred(span) {
             Self::Opaque(index)
         } else if let Ok(file) = context.session().source_manager.get(span.source_id()) {
@@ -124,7 +126,8 @@ impl Location {
     pub fn try_into_span(&self, context: &crate::Context) -> Option<SourceSpan> {
         use crate::diagnostics::SourceManagerExt;
         match self {
-            Self::Unknown | Self::Synthetic => Some(SourceSpan::UNKNOWN),
+            Self::Unknown => Some(SourceSpan::UNKNOWN),
+            Self::Synthetic => Some(SourceSpan::SYNTHETIC),
             Self::Opaque(index) => Some(Self::deferred((*index).try_into().unwrap())),
             Self::FileLineCol { uri, line, column } => {
                 let path = std::path::Path::new(uri.path());
@@ -151,7 +154,8 @@ impl Location {
     pub fn try_into_span(&self, context: &crate::Context) -> Option<SourceSpan> {
         use crate::diagnostics::SourceManagerExt;
         match self {
-            Self::Unknown | Self::Synthetic => Some(SourceSpan::UNKNOWN),
+            Self::Unknown => Some(SourceSpan::UNKNOWN),
+            Self::Synthetic => Some(SourceSpan::SYNTHETIC),
             Self::Opaque(index) => Some(Self::deferred((*index).try_into().unwrap())),
             Self::FileLineCol { uri, line, column } => {
                 let file = context.session().source_manager.get_by_uri(uri)?;

--- a/midenc-compile/src/stages/parse/wasm.rs
+++ b/midenc-compile/src/stages/parse/wasm.rs
@@ -69,6 +69,7 @@ impl Stage for ParseWasmStage {
                     source_name: name.file_stem().unwrap().to_owned().into(),
                     remap_path_prefixes: context.session().options.remap_path_prefixes.clone(),
                     world: Some(world),
+                    generate_native_debuginfo: context.session().options.emit_source_locations(),
                     ..Default::default()
                 };
                 self.parse_hir_from_wasm_bytes(&input, context.clone(), &config)?
@@ -156,6 +157,7 @@ impl ParseWasmStage {
             source_name: file_name.into(),
             remap_path_prefixes: context.session().options.remap_path_prefixes.clone(),
             world: Some(world),
+            generate_native_debuginfo: context.session().options.emit_source_locations(),
             ..Default::default()
         };
         self.parse_hir_from_wasm_bytes(&bytes, context, &config)

--- a/midenc-session/src/emit.rs
+++ b/midenc-session/src/emit.rs
@@ -15,7 +15,7 @@ pub trait Emit {
         &self,
         writer: W,
         mode: OutputMode,
-        session: &Session,
+        _session: &Session,
     ) -> anyhow::Result<()>;
 }
 

--- a/midenc-session/src/options/mod.rs
+++ b/midenc-session/src/options/mod.rs
@@ -278,10 +278,11 @@ impl Options {
         matches!(self.debug, DebugInfo::Line | DebugInfo::Full)
     }
 
-    /// Returns true if rich debugging information should be emitted by the compiler
+    /// Returns true if rich debugging information should be emitted by the compiler.
+    /// This enables AssemblyOp decorators which carry source location info for runtime errors.
     #[inline(always)]
     pub fn emit_debug_decorators(&self) -> bool {
-        matches!(self.debug, DebugInfo::Full)
+        matches!(self.debug, DebugInfo::Line | DebugInfo::Full)
     }
 
     /// Returns true if debug assertions are enabled

--- a/tests/lit/debug/inline-stubs.shtest
+++ b/tests/lit/debug/inline-stubs.shtest
@@ -1,7 +1,7 @@
-;; RUN: midenc %s --entrypoint=test_felt_add --emit=hir=- -Canalyze-only 2>&1 | filecheck %s --check-prefix=HIR-ADD
-;; RUN: midenc %s --entrypoint=test_felt_assert_eq --emit=hir=- -Canalyze-only 2>&1 | filecheck %s --check-prefix=HIR-ASSERT
-;; RUN: midenc %s --entrypoint=test_felt_arithmetic --emit=hir=- -Canalyze-only 2>&1 | filecheck %s --check-prefix=HIR-ARITH
-;; RUN: midenc %s --entrypoint=inline_stubs_test::test_felt_add -Zprint-hir-source-locations --emit=hir=- -Canalyze-only 2>&1 | filecheck %s --check-prefix=HIR-LOC
+;; RUN: midenc - --entrypoint=test_felt_add --emit=hir=- -Canalyze-only < %s 2>&1 | filecheck %s --check-prefix=HIR-ADD
+;; RUN: midenc - --entrypoint=test_felt_assert_eq --emit=hir=- -Canalyze-only < %s 2>&1 | filecheck %s --check-prefix=HIR-ASSERT
+;; RUN: midenc - --entrypoint=test_felt_arithmetic --emit=hir=- -Canalyze-only < %s 2>&1 | filecheck %s --check-prefix=HIR-ARITH
+;; RUN: midenc - --entrypoint=inline_stubs_test::test_felt_add -Zprint-hir-source-locations --emit=hir=- -Canalyze-only < %s 2>&1 | filecheck %s --check-prefix=HIR-LOC
 ;;
 ;; This test verifies that linker stubs (intrinsic functions like felt::add, felt::assert_eq)
 ;; are inlined at call sites rather than being emitted as separate function definitions.

--- a/tests/lit/debug/inline-stubs.wat
+++ b/tests/lit/debug/inline-stubs.wat
@@ -1,7 +1,7 @@
-;; RUN: midenc - --entrypoint=test_felt_add --emit=hir=- -Canalyze-only < %s 2>&1 | filecheck %s --check-prefix=HIR-ADD
-;; RUN: midenc - --entrypoint=test_felt_assert_eq --emit=hir=- -Canalyze-only < %s 2>&1 | filecheck %s --check-prefix=HIR-ASSERT
-;; RUN: midenc - --entrypoint=test_felt_arithmetic --emit=hir=- -Canalyze-only < %s 2>&1 | filecheck %s --check-prefix=HIR-ARITH
-;; RUN: midenc - --entrypoint=inline_stubs_test::test_felt_add -Zprint-hir-source-locations --emit=hir=- -Canalyze-only < %s 2>&1 | filecheck %s --check-prefix=HIR-LOC
+;; RUN: midenc %s --entrypoint=test_felt_add --emit=hir=- -Canalyze-only 2>&1 | filecheck %s --check-prefix=HIR-ADD
+;; RUN: midenc %s --entrypoint=test_felt_assert_eq --emit=hir=- -Canalyze-only 2>&1 | filecheck %s --check-prefix=HIR-ASSERT
+;; RUN: midenc %s --entrypoint=test_felt_arithmetic --emit=hir=- -Canalyze-only 2>&1 | filecheck %s --check-prefix=HIR-ARITH
+;; RUN: midenc %s --entrypoint=inline_stubs_test::test_felt_add -Zprint-hir-source-locations --emit=hir=- -Canalyze-only 2>&1 | filecheck %s --check-prefix=HIR-LOC
 ;;
 ;; This test verifies that linker stubs (intrinsic functions like felt::add, felt::assert_eq)
 ;; are inlined at call sites rather than being emitted as separate function definitions.

--- a/tests/lit/debug/inline-stubs.wat
+++ b/tests/lit/debug/inline-stubs.wat
@@ -1,6 +1,7 @@
 ;; RUN: midenc %s --entrypoint=test_felt_add --emit=hir=- -Canalyze-only 2>&1 | filecheck %s --check-prefix=HIR-ADD
 ;; RUN: midenc %s --entrypoint=test_felt_assert_eq --emit=hir=- -Canalyze-only 2>&1 | filecheck %s --check-prefix=HIR-ASSERT
 ;; RUN: midenc %s --entrypoint=test_felt_arithmetic --emit=hir=- -Canalyze-only 2>&1 | filecheck %s --check-prefix=HIR-ARITH
+;; RUN: midenc %s --entrypoint=inline_stubs_test::test_felt_add -Zprint-hir-source-locations --emit=hir=- -Canalyze-only 2>&1 | filecheck %s --check-prefix=HIR-LOC
 ;;
 ;; This test verifies that linker stubs (intrinsic functions like felt::add, felt::assert_eq)
 ;; are inlined at call sites rather than being emitted as separate function definitions.
@@ -16,6 +17,12 @@
 
 ;; Verify NO separate stub function is created for felt::add
 ;; HIR-ADD-NOT: builtin.function {{.+}} @intrinsics::felt::add
+
+;; Verify inlined compiler-generated stub ops are marked with synthetic source locations.
+;; HIR-LOC-LABEL: builtin.function public extern("C") @test_felt_add
+;; HIR-LOC: hir.load_local {{.*}} loc(synthetic);
+;; HIR-LOC: arith.add {{.*}} loc(synthetic);
+;; HIR-LOC: builtin.ret {{.*}} loc(synthetic);
 
 ;; === Test 2: felt::assert_eq should be inlined ===
 ;; The hir.assert_eq operation should appear directly in test_felt_assert_eq.

--- a/tests/lit/debug/lit.suite.toml
+++ b/tests/lit/debug/lit.suite.toml
@@ -1,5 +1,5 @@
 name = "debug"
-patterns = ["*.shtest", "*.rs"]
+patterns = ["*.shtest", "*.rs", "*.wat"]
 
 working_dir = "."
 


### PR DESCRIPTION
This adds sveral features/fixes for improved debugging:
    
1. Synthetic source locations: Compiler-generated code (like local
    initialization, ABI transforms) now uses SourceSpan::SYNTHETIC instead
    of UNKNOWN. This differentiates compiler-generated code from truly
    unknown locations and renders as #loc(synthetic) in output.
    
2. -Z print-masm-source-locations: New flag to print source locations
     as #loc("file":line:col) annotations in MASM output.
    
3. -Z remap-path-prefix=FROM=TO: Remap source path prefixes for resolving
     paths from DWARF when sources are in different locations (e.g., stdlib).
    
4. Use current_span to have more real source locations attached --
     currently we used Default locations a lot - for example, each
     operator would start with it.
    
5. Fix wasm component-level DWARF parsing
    
Requires miden-vm with SourceSpan::SYNTHETIC debug type.
    
    
To check locations on masm level, use:

```
$ ./bin/midenc examples/assert-debug-test/target/wasm32-unknown-unknown/release/assert_debug_test.wasm \
    --entrypoint=assert_debug_test::test_assert \
    -Ztrim-path-prefix=examples/assert-debug-test \
    -Zprint-masm-source-locations \
    --debug full --emit=masm=-
```
