### PR TITLE
[1/x] fix: remove sorting the targets in `br_table` Wasm op translation

### DIFF
--- a/frontend/wasm/src/code_translator/mod.rs
+++ b/frontend/wasm/src/code_translator/mod.rs
@@ -910,7 +910,6 @@ fn translate_br_table<B: ?Sized + Builder>(
 
         targets.push(depth);
     }
-    targets.sort();
 
     let default_depth = br_targets.default();
     let min_depth =


### PR DESCRIPTION
I stumbled on this in #808 

The `targets.sort();` was added in 38324c605d38e77a4c5ec34f0818ca4e06f41072. In that version of the code, it appears that the switch “case keys” were effectively derived from the target depths, so sorting made the switch’s arms deterministic and compatible with that lowering strategy. @bitwalker do you recall any details?

In today’s code at https://github.com/0xMiden/compiler/blob/f33b6cf47055ea1933625774bf0d3ee5ccc3c662/frontend/wasm/src/code_translator/mod.rs?plain=1#L943-L957 the switch “case keys” are the table indices (`label_idx as u32`). The `targets.sort()` can actually change `br_table` semantics (it remaps selector indices to different targets unless the input list was already sorted). In all .wat files we have the targets are in sorted order so `targets.sort();` changes nothing, but I did not find anything in the Wasm spec about targets always being in the sorted order.
