### PR TITLE
feat: add Word::empty() method to Miden SDK

### DIFF
--- a/sdk/stdlib-sys/src/intrinsics/word.rs
+++ b/sdk/stdlib-sys/src/intrinsics/word.rs
@@ -15,6 +15,13 @@ impl Word {
         }
     }
 
+    /// Creates a new `Word` with all four field elements set to zero.
+    pub fn empty() -> Self {
+        Self {
+            inner: (felt!(0), felt!(0), felt!(0), felt!(0)),
+        }
+    }
+
     pub fn reverse(&self) -> Word {
         // This is workaround for the https://github.com/0xMiden/compiler/issues/596 to avoid
         // i64.rotl op in the compiled Wasm

--- a/sdk/stdlib-sys/src/intrinsics/word.rs
+++ b/sdk/stdlib-sys/src/intrinsics/word.rs
@@ -15,13 +15,6 @@ impl Word {
         }
     }
 
-    /// Creates a new `Word` with all four field elements set to zero.
-    pub fn empty() -> Self {
-        Self {
-            inner: (felt!(0), felt!(0), felt!(0), felt!(0)),
-        }
-    }
-
     pub fn reverse(&self) -> Word {
         // This is workaround for the https://github.com/0xMiden/compiler/issues/596 to avoid
         // i64.rotl op in the compiled Wasm
@@ -91,5 +84,14 @@ impl IndexMut<usize> for Word {
 impl AsRef<Word> for Word {
     fn as_ref(&self) -> &Word {
         self
+    }
+}
+
+impl Default for Word {
+    /// Creates a new `Word` with all four field elements set to zero.
+    fn default() -> Self {
+        Self {
+            inner: (felt!(0), felt!(0), felt!(0), felt!(0)),
+        }
     }
 }

--- a/tests/integration/src/rust_masm_tests/rust_sdk/base/account.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk/base/account.rs
@@ -192,7 +192,7 @@ fn rust_sdk_account_has_procedure_binding() {
     run_account_binding_test(
         "rust_sdk_account_has_procedure_binding",
         "pub fn binding(&self) -> Felt {
-        let proc_root = Word::from([Felt::from_u32(0); 4]);
+        let proc_root = Word::empty();
         if self.has_procedure(proc_root) {
             Felt::from_u32(1)
         } else {
@@ -207,7 +207,7 @@ fn rust_sdk_account_was_procedure_called_binding() {
     run_account_binding_test(
         "rust_sdk_account_was_procedure_called_binding",
         "pub fn binding(&self) -> Felt {
-        let proc_root = Word::from([Felt::from_u32(0); 4]);
+        let proc_root = Word::empty();
         if self.was_procedure_called(proc_root) {
             Felt::from_u32(1)
         } else {
@@ -232,7 +232,7 @@ fn rust_sdk_account_storage_get_initial_map_item_binding() {
     run_account_binding_test(
         "rust_sdk_account_storage_get_initial_map_item_binding",
         "pub fn binding(&self) -> Word {
-        let key = Word::from([Felt::from_u32(0); 4]);
+        let key = Word::empty();
         storage::get_initial_map_item(0, &key)
     }",
     );

--- a/tests/integration/src/rust_masm_tests/rust_sdk/base/account.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk/base/account.rs
@@ -192,7 +192,7 @@ fn rust_sdk_account_has_procedure_binding() {
     run_account_binding_test(
         "rust_sdk_account_has_procedure_binding",
         "pub fn binding(&self) -> Felt {
-        let proc_root = Word::empty();
+        let proc_root = Word::default();
         if self.has_procedure(proc_root) {
             Felt::from_u32(1)
         } else {
@@ -207,7 +207,7 @@ fn rust_sdk_account_was_procedure_called_binding() {
     run_account_binding_test(
         "rust_sdk_account_was_procedure_called_binding",
         "pub fn binding(&self) -> Felt {
-        let proc_root = Word::empty();
+        let proc_root = Word::default();
         if self.was_procedure_called(proc_root) {
             Felt::from_u32(1)
         } else {
@@ -232,7 +232,7 @@ fn rust_sdk_account_storage_get_initial_map_item_binding() {
     run_account_binding_test(
         "rust_sdk_account_storage_get_initial_map_item_binding",
         "pub fn binding(&self) -> Word {
-        let key = Word::empty();
+        let key = Word::default();
         storage::get_initial_map_item(0, &key)
     }",
     );

--- a/tests/integration/src/rust_masm_tests/rust_sdk/base/asset.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk/base/asset.rs
@@ -88,7 +88,7 @@ fn rust_sdk_account_asset_build_non_fungible_asset_binding() {
         "rust_sdk_account_asset_build_non_fungible_asset_binding",
         "pub fn binding(&self) -> Asset {
         let faucet = AccountId { prefix: Felt::from_u32(1), suffix: Felt::from_u32(0) };
-        let hash = Word::from([Felt::from_u32(0); 4]);
+        let hash = Word::empty();
         asset::build_non_fungible_asset(faucet, hash)
     }",
     );

--- a/tests/integration/src/rust_masm_tests/rust_sdk/base/asset.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk/base/asset.rs
@@ -88,7 +88,7 @@ fn rust_sdk_account_asset_build_non_fungible_asset_binding() {
         "rust_sdk_account_asset_build_non_fungible_asset_binding",
         "pub fn binding(&self) -> Asset {
         let faucet = AccountId { prefix: Felt::from_u32(1), suffix: Felt::from_u32(0) };
-        let hash = Word::empty();
+        let hash = Word::default();
         asset::build_non_fungible_asset(faucet, hash)
     }",
     );

--- a/tests/integration/src/rust_masm_tests/rust_sdk/base/faucet.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk/base/faucet.rs
@@ -86,7 +86,7 @@ fn rust_sdk_account_faucet_create_non_fungible_asset_binding() {
     run_faucet_binding_test(
         "rust_sdk_account_faucet_create_non_fungible_asset_binding",
         "pub fn binding(&self) -> Asset {
-        let hash = Word::from([Felt::from_u32(0); 4]);
+        let hash = Word::empty();
         faucet::create_non_fungible_asset(hash)
     }",
     );

--- a/tests/integration/src/rust_masm_tests/rust_sdk/base/faucet.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk/base/faucet.rs
@@ -86,7 +86,7 @@ fn rust_sdk_account_faucet_create_non_fungible_asset_binding() {
     run_faucet_binding_test(
         "rust_sdk_account_faucet_create_non_fungible_asset_binding",
         "pub fn binding(&self) -> Asset {
-        let hash = Word::empty();
+        let hash = Word::default();
         faucet::create_non_fungible_asset(hash)
     }",
     );


### PR DESCRIPTION
Fixes #822

I've added a `Word::empty()` method that returns a Word with all four field elements set to zero. This replaces the repetitive `Word::from([Felt::from_u32(0); 4])` pattern we had scattered across the test files.

Updated all 5 occurrences in the integration tests to use the new method.