### PR TITLE
SDK v0.8.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "miden"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "miden-base",
  "miden-base-sys",
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "miden-base-macros",
  "miden-base-sys",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "heck",
  "miden-objects",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "miden-stdlib-sys",
 ]
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.7.0"
+version = "0.8.0"
 
 [[package]]
 name = "miden-stdlib"
@@ -2683,7 +2683,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.7.1"
+version = "0.8.0"
 
 [[package]]
 name = "miden-thiserror"

--- a/sdk/alloc/Cargo.toml
+++ b/sdk/alloc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-sdk-alloc"
 description = "A simple bump allocator for Miden SDK programs"
-version = "0.7.0"
+version = "0.8.0"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sdk/base-macros/Cargo.toml
+++ b/sdk/base-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-base-macros"
 description = "Provides proc macro support for Miden rollup SDK"
-version = "0.7.1"
+version = "0.8.0"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sdk/base-sys/Cargo.toml
+++ b/sdk/base-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-base-sys"
 description = "Miden rollup Rust bingings and MASM library"
-version = "0.8.0"
+version = "0.8.1"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -16,7 +16,7 @@ build = "build.rs"
 links = "miden_base_sys_stubs"
 
 [dependencies]
-miden-stdlib-sys = { version = "0.7.1", path = "../stdlib-sys" }
+miden-stdlib-sys = { version = "0.8.0", path = "../stdlib-sys" }
 
 [features]
 default = []

--- a/sdk/base/Cargo.toml
+++ b/sdk/base/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-base"
 description = "Miden rollup Rust SDK"
-version = "0.7.1"
+version = "0.8.0"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -13,8 +13,8 @@ edition.workspace = true
 
 [dependencies]
 miden-base-sys = { version = "0.8.0", path = "../base-sys" }
-miden-stdlib-sys = { version = "0.7.1", path = "../stdlib-sys" }
-miden-base-macros = { version = "0.7.1", path = "../base-macros" }
+miden-stdlib-sys = { version = "0.8.0", path = "../stdlib-sys" }
+miden-base-macros = { version = "0.8.0", path = "../base-macros" }
 
 [features]
 default = []

--- a/sdk/sdk/CHANGELOG.md
+++ b/sdk/sdk/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0]
+
+### BREAKING
+- Require `&mut` in mutating methods of the account storage;
+
+### Added
+
+- Pass an account as a parameter to note and tx script #798
+- `ActiveAccount` and `NativeAccount` traits to call tx kernel functions via `self.*` on an account #801
+- Expose `miden::note::build_recipient_hash` tx kernel function Rust equivalent as `Recipient::compute` #823
+
 ## [0.7.1](https://github.com/0xMiden/compiler/compare/miden-v0.7.0...miden-v0.7.1) - 2025-11-13
 
 ### Other

--- a/sdk/sdk/Cargo.toml
+++ b/sdk/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden"
 description = "Miden SDK"
-version = "0.7.1"
+version = "0.8.0"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -15,10 +15,10 @@ edition.workspace = true
 crate-type = ["rlib"]
 
 [dependencies]
-miden-sdk-alloc = { version = "0.7.0", path = "../alloc" }
-miden-stdlib-sys = { version = "0.7.1", path = "../stdlib-sys" }
-miden-base = { version = "0.7.1", path = "../base" }
-miden-base-sys = { version = "0.8.0", path = "../base-sys" }
+miden-sdk-alloc = { version = "0.8.0", path = "../alloc" }
+miden-stdlib-sys = { version = "0.8.0", path = "../stdlib-sys" }
+miden-base = { version = "0.8.0", path = "../base" }
+miden-base-sys = { version = "0.8.1", path = "../base-sys" }
 wit-bindgen = { version = "0.46", default-features = false, features = ["macros"] }
 
 [features]

--- a/sdk/stdlib-sys/Cargo.toml
+++ b/sdk/stdlib-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-stdlib-sys"
 description = "Low-level Rust bindings for the Miden standard library"
-version = "0.7.1"
+version = "0.8.0"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Bump SDK version to `v0.8.0`, update CHANGELOG.