### PR TITLE
chore: update docs to install cargo-miden without cloning the repo

### DIFF
--- a/docs/external/src/usage/cargo-miden.md
+++ b/docs/external/src/usage/cargo-miden.md
@@ -25,16 +25,11 @@ work.
 
 :::
 
-To install the extension, clone the compiler repo first:
+To install the extension:
 
 ```bash
-git clone https://github.com/0xMiden/compiler
-```
+cargo +nightly-2025-12-10 install cargo-miden --locked
 
-Then, run the following in your shell in the cloned repo folder:
-
-```bash
-cargo install --path tools/cargo-miden --locked
 ```
 
 This will take a minute to compile, but once complete, you can run `cargo help miden` or just


### PR DESCRIPTION
@bitwalker I don't remember the exact reason why we require installing cargo-miden from the repo. I think it was an issue with a dependency that prevented the build from succeeding. I tested `cargo +nightly-2025-12-10 install cargo-miden --locked` and it worked so I decided to simplify the installation instructions.