### PR TITLE
fix(hir): correct `ExactSizeIterator::len()` for SymbolNameComponents

### DIFF
--- a/hir/src/ir/symbols/path.rs
+++ b/hir/src/ir/symbols/path.rs
@@ -777,12 +777,61 @@ impl Iterator for SymbolNameComponents {
 }
 impl ExactSizeIterator for SymbolNameComponents {
     fn len(&self) -> usize {
-        let is_empty = self.name == interner::symbols::Empty;
-        if is_empty {
-            assert_eq!(self.parts.len(), 0, "malformed symbol name components");
+        if self.done || self.name == interner::symbols::Empty {
             0
         } else {
-            self.parts.len() + 1
+            self.parts.len() + 1 + usize::from(self.absolute)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn symbol_name_components_len_matches_iteration_count() {
+        // Test case: absolute path with parts
+        let iter = SymbolNameComponents {
+            parts: alloc::collections::VecDeque::from(["foo", "bar"]),
+            name: SymbolName::intern("baz"),
+            absolute: true,
+            done: false,
+        };
+        assert_eq!(iter.len(), 4); // Root + foo + bar + baz
+
+        // Test case: relative path (no Root)
+        let iter = SymbolNameComponents {
+            parts: alloc::collections::VecDeque::from(["foo"]),
+            name: SymbolName::intern("bar"),
+            absolute: false,
+            done: false,
+        };
+        assert_eq!(iter.len(), 2); // foo + bar
+
+        // Test case: done iterator returns 0
+        let iter = SymbolNameComponents {
+            parts: alloc::collections::VecDeque::new(),
+            name: SymbolName::intern("x"),
+            absolute: false,
+            done: true,
+        };
+        assert_eq!(iter.len(), 0);
+
+        // Test case: len decreases correctly during iteration
+        let mut iter = SymbolNameComponents {
+            parts: alloc::collections::VecDeque::from(["a"]),
+            name: SymbolName::intern("b"),
+            absolute: true,
+            done: false,
+        };
+        assert_eq!(iter.len(), 3); // Root + a + b
+        iter.next();
+        assert_eq!(iter.len(), 2); // a + b
+        iter.next();
+        assert_eq!(iter.len(), 1); // b
+        iter.next();
+        assert_eq!(iter.len(), 0); // done
+        assert!(iter.next().is_none());
     }
 }


### PR DESCRIPTION
`SymbolNameComponents::len()` returned an incorrect number.

Was:
- len() = parts.len() + 1
- For the absolute path [Root, A, B, Leaf], it returned 3 instead of 4
- After complete iteration (done=true), it returned 1 instead of 0

Now:
- The `absolute` flag is taken into account (+1 for Root)
- The `done` flag is taken into account (returns 0 when the iterator is exhausted)
