### PR TITLE
fix(hir): handle ZST correctly in `Arena::extend`

### DIFF
--- a/hir/src/adt/arena.rs
+++ b/hir/src/adt/arena.rs
@@ -126,7 +126,8 @@ impl<T> Arena<T> {
         I: IntoIterator<Item = T>,
     {
         if T::IS_ZST {
-            return NonNull::slice_from_raw_parts(NonNull::dangling(), 0);
+            let len = items.into_iter().count();
+            return NonNull::slice_from_raw_parts(NonNull::dangling(), len);
         }
 
         let mut chunks = self.chunks.borrow_mut();
@@ -477,5 +478,24 @@ impl<T, const N: usize> SpecArenaExtend for [T; N] {
         }
 
         ptr
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extend_zst_returns_correct_length() {
+        let arena: Arena<()> = Arena::new();
+        let slice = arena.extend([(), (), ()]);
+        assert_eq!(slice.len(), 3);
+    }
+
+    #[test]
+    fn extend_zst_empty_returns_zero_length() {
+        let arena: Arena<()> = Arena::new();
+        let slice = arena.extend(core::iter::empty::<()>());
+        assert_eq!(slice.len(), 0);
     }
 }


### PR DESCRIPTION
Previously, Arena::extend for zero-sized types returned an empty slice (len=0) and silently discarded the iterator without consuming it. This caused elements to be lost and incorrect slice length to be returned.

Now the iterator is properly consumed via `.count()`, which also correctly drops elements if T has Drop. Returns the actual number of elements in the slice.