### PR TITLE
fix(hir): prevent duplicate entries in PreservedAnalyses

### DIFF
--- a/hir/src/pass/analysis.rs
+++ b/hir/src/pass/analysis.rs
@@ -236,8 +236,13 @@ impl PreservedAnalyses {
     }
 
     fn insert(&mut self, id: TypeId) {
-        if let Err(index) = self.preserved.binary_search_by_key(&id, |probe| *probe) {
-            self.preserved.insert(index, id);
+        match self.preserved.binary_search_by_key(&id, |probe| *probe) {
+            Ok(index) => {
+                self.preserved[index] = id;
+            }
+            Err(index) => {
+                self.preserved.insert(index, id);
+            }
         }
     }
 


### PR DESCRIPTION
The [PreservedAnalyses::insert]https://github.com/0xMiden/compiler/blob/91be2d8a7db94cb046b442532d1b8012475de2d0/hir/src/attributes.rs#L556-L565 method was inserting a TypeId regardless of whether it already existed in the collection. 

Both `Ok` and `Err` branches of `binary_search_by_key` performed identical insert operations, causing duplicates when [preserve<A>()]https://github.com/0xMiden/compiler/blob/91be2d8a7db94cb046b442532d1b8012475de2d0/hir/src/pass/analysis.rs#L181-L184 was called multiple times for the same analysis type.

This led to memory waste and potential bugs during invalidation, since [remove]https://github.com/0xMiden/compiler/blob/91be2d8a7db94cb046b442532d1b8012475de2d0/hir/src/adt/smallordset.rs#L130-L139 only deleted one occurrence while duplicates remained.

Fix: only insert when the element is not found (Err case). Added a regression test to verify no duplicates are created.