### PR TITLE
fix: broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This will run all of the unit tests in the workspace, as well as all of our `lit
 
 The documentation in the `docs/external` folder is built using Docusaurus and is automatically absorbed into the main [miden-docs](https://github.com/0xMiden/miden-docs) repository for the main documentation website. Changes to the `next` branch trigger an automated deployment workflow. The docs folder requires npm packages to be installed before building.
 
-The `docs/internal` folder corresponds to internal docs, which are hosted using mdbook and Github Pages here: [0xmiden.github.io/compiler/](0xmiden.github.io/compiler/). These md files are not exported to the main docs.
+The `docs/internal` folder corresponds to internal docs, which are hosted using mdbook and Github Pages here: [The Miden compiler](https://0xmiden.github.io/compiler/). These md files are not exported to the main docs.
 
 ## Packaging
 


### PR DESCRIPTION
Initially, the link led to a 404 error:
<img width="1149" height="46" alt="image" src="https://github.com/user-attachments/assets/4fbd16e4-64df-4083-90c0-6b70025f1c00" />
<img width="697" height="226" alt="image" src="https://github.com/user-attachments/assets/ff0973f2-0112-474a-b321-9c1cf43859a5" />

I corrected the name of this link to “The Miden Compiler” as this name is the title of the documentation to which the link leads.
I also corrected the link itself by adding `https://`. The link now works:
<img width="990" height="417" alt="image" src="https://github.com/user-attachments/assets/9ec7bcc5-17a4-47e6-90cf-265dd3b6c8c1" />



