### PR TITLE
docs(sdk): add more details to changelog

### DIFF
--- a/sdk/sdk/CHANGELOG.md
+++ b/sdk/sdk/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.0]
 
 ### BREAKING
-- Note scripts now use a struct-based API: replace `#[note_script] fn run(...)` with `#[note]` on a note input `struct` and `#[note]` on an inherent `impl` block containing exactly one `#[note_script]` entrypoint method #890. See an [example](https://github.com/0xMiden/project-template/blob/main/contracts/increment-note/src/lib.rs)
-
+- Note scripts now use a struct-based API: replace `#[note_script] fn run(...)` with `#[note]` on a note input `struct` and `#[note]` on an inherent `impl` block containing exactly one `#[note_script]` entrypoint method #890. See an example: [before](https://github.com/0xMiden/project-template/blob/6cd50a3312dffba1826fd4f812bc431da7f51d5f/contracts/increment-note/src/lib.rs) and [after](https://github.com/0xMiden/project-template/blob/1dd023311021800002e3a9fb687e936991877e65/contracts/increment-note/src/lib.rs).
 - Storage slot IDs are now derived from slot names; `#[storage(slot(...))]`/`slot(...)` is no longer supported, and slot name / id collisions are detected at compile time #907
 - SDK bindings updated for VM v0.20 / protocol v0.13 (some bindings changed, e.g. `output_note::create(tag, note_type, recipient)`) #907
+  - Previously auxiliary data could be passed into `output_note::create`. Now it can be attached to a note with `output_note::set_word_attachment`.
 - Renamed `AccountId::from` to `AccountId::new` #808
 
 ### Added


### PR DESCRIPTION
Some things I came across while looking into the `swapp-note` migration.