### PR TITLE
fix(examples): remove unused dependency

### DIFF
--- a/examples/basic-wallet/src/lib.rs
+++ b/examples/basic-wallet/src/lib.rs
@@ -7,7 +7,7 @@
 //
 // extern crate alloc;
 
-use miden::{component, native_account, output_note, Asset, NoteIdx};
+use miden::{Asset, NoteIdx, component, output_note};
 
 #[component]
 struct MyAccount;


### PR DESCRIPTION
Removes compilation warnings due to `native_account` not being used (anymore).