### PR TITLE
chore: fix the release tag discovering in the release CI job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,9 +77,12 @@ jobs:
           echo "=================="
           echo "${RELEASES}" | jq -rM
           echo "=================="
-          release_tag=$(echo "${RELEASES}" | jq -r '.[] | select(.package_name == "midenc" or .package_name == "cargo-miden") | .tag' | head -n1)
+          # `cargo-miden` owns the GitHub release/tag (see `release-plz.toml`), and it uses an
+          # unprefixed tag name like `0.7.0`. Other crates may report prefixed tags (e.g.
+          # `midenc-v0.7.0`) which do not correspond to an actual GitHub release.
+          release_tag=$(echo "${RELEASES}" | jq -r '.[] | select(.package_name == "cargo-miden") | .tag' | head -n1)
           if [ -z "${release_tag}" ] || [ "${release_tag}" = "null" ]; then
-            echo "midenc or cargo-miden crate was not released in this run. Skipping artifact upload."
+            echo "cargo-miden crate was not released in this run. Skipping artifact upload."
             echo "release_tag=" >> "${GITHUB_OUTPUT}"
             exit 0
           fi


### PR DESCRIPTION
Close #954 

### Fix explanation

The `RELEASES` env var during the job run https://github.com/0xMiden/compiler/actions/runs/21938641353/job/63359786464 was:
```
[
...
  {
    "package_name": "cargo-miden",
    "prs": [],
    "tag": "0.7.0",
    "version": "0.7.0"
  }
]
```

And in the `release-plz.toml` we have https://github.com/0xMiden/compiler/blob/f66b8d938a7937a55f4b91476b0018c07e293ea6/release-plz.toml?plain=1#L20