### PR TITLE
chore: run the `release` CI job after the successful `publish` CI job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           echo "${RELEASES}" | jq -rM
           echo "=================="
           # `cargo-miden` owns the GitHub release/tag (see `release-plz.toml`), and it uses an
-          # unprefixed tag name like `0.7.0`. Other crates may report prefixed tags (e.g.
+          # unprefixed tag name like `v0.7.0`. Other crates may report prefixed tags (e.g.
           # `midenc-v0.7.0`) which do not correspond to an actual GitHub release.
           release_tag=$(echo "${RELEASES}" | jq -r '.[] | select(.package_name == "cargo-miden") | .tag' | head -n1)
           if [ -z "${release_tag}" ] || [ "${release_tag}" = "null" ]; then

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -17,8 +17,8 @@ changelog_path = "./CHANGELOG.md"
 name = "cargo-miden"
 git_release_enable = true
 git_tag_enable = true
-git_tag_name = "{{ version }}"
-git_release_name = "{{ version }}"
+git_tag_name = "v{{ version }}"
+git_release_name = "v{{ version }}"
 
 
 [changelog]


### PR DESCRIPTION
Close #955
Close #961 

After merging a release PR, until the release is actually “published” (registry/tag), `release-pr` is expected (by design) to consider the bumped-but-unpublished state and may generate a new PR (typically to refresh changelog content). Running `release-pr` in parallel with (or immediately after) `release` can produce the duplicate PRs.