### PR TITLE
chore: remove unused alloc_error_handler feature

### DIFF
--- a/examples/auth-component-no-auth/src/lib.rs
+++ b/examples/auth-component-no-auth/src/lib.rs
@@ -1,6 +1,5 @@
 // Do not link against libstd (i.e. anything defined in `std::`)
 #![no_std]
-#![feature(alloc_error_handler)]
 
 // However, we could still use some standard library types while
 // remaining no-std compatible, if we uncommented the following lines:


### PR DESCRIPTION
This example does not define a custom alloc error handler or use alloc, so the alloc_error_handler feature is unnecessary. Removing it simplifies the example and avoids requiring an unused nightly feature.