### PR TITLE
fix: typo in assert message

### DIFF
--- a/codegen/masm/src/emit/unary.rs
+++ b/codegen/masm/src/emit/unary.rs
@@ -166,7 +166,7 @@ impl OpEmitter<'_> {
         let dst_bits = dst.size_in_bits() as u32;
         assert!(
             src_bits <= dst_bits,
-            "invalid zero-extension from {src} to {dst}: cannot zero-extend to a smaller type"
+            "invalid sign-extension from {src} to {dst}: cannot sign-extend to a smaller type"
         );
         match (&src, dst) {
             // If the types are equivalent, it's a no-op


### PR DESCRIPTION
The assert is inside a function that sign-extends.