### PR TITLE
feat: add `I32Load8S` to `wasm` dialect

### DIFF
--- a/codegen/masm/src/lib.rs
+++ b/codegen/masm/src/lib.rs
@@ -167,4 +167,5 @@ fn lower_hir_ops(info: &mut midenc_hir::DialectInfo) {
 
 fn lower_wasm_ops(info: &mut midenc_hir::DialectInfo) {
     info.register_operation_trait::<wasm::SignExtend, dyn HirLowering>();
+    info.register_operation_trait::<wasm::I32Load8S, dyn HirLowering>();
 }

--- a/codegen/masm/src/lower/lowering.rs
+++ b/codegen/masm/src/lower/lowering.rs
@@ -1364,3 +1364,16 @@ impl HirLowering for wasm::SignExtend {
         Ok(())
     }
 }
+
+impl HirLowering for wasm::I32Load8S {
+    fn emit(&self, emitter: &mut BlockEmitter<'_>) -> Result<(), Report> {
+        let result = self.result();
+        let pointer_ty = self.addr().ty();
+        let pointee_ty = pointer_ty.pointee().expect("pointer should have been verified").clone();
+        let mut inst_emitter = emitter.inst_emitter(self.as_operation());
+        inst_emitter.load(pointee_ty, self.span());
+        inst_emitter.sext(result.ty(), self.span());
+
+        Ok(())
+    }
+}

--- a/dialects/wasm/src/builders.rs
+++ b/dialects/wasm/src/builders.rs
@@ -16,6 +16,12 @@ pub trait WasmOpBuilder<'f, B: ?Sized + Builder> {
         Ok(op.borrow().result().as_value_ref())
     }
 
+    fn i32_load8_s(&mut self, addr: ValueRef, span: SourceSpan) -> Result<ValueRef, Report> {
+        let op_builder = self.builder_mut().create::<crate::ops::I32Load8S, _>(span);
+        let op = op_builder(addr)?;
+        Ok(op.borrow().result().as_value_ref())
+    }
+
     fn builder(&self) -> &B;
     fn builder_mut(&mut self) -> &mut B;
 }

--- a/dialects/wasm/src/ops.rs
+++ b/dialects/wasm/src/ops.rs
@@ -4,7 +4,7 @@ use midenc_hir::{
     attributes::IntegerLikeAttr,
     derive::{EffectOpInterface, OpParser, OpPrinter, operation},
     dialects::builtin::attributes::TypeAttr,
-    effects::MemoryEffectOpInterface,
+    effects::{MemoryEffect, MemoryEffectOpInterface},
     matchers::Matcher,
     traits::*,
     *,
@@ -163,5 +163,28 @@ impl Foldable for SignExtend {
         }
 
         FoldResult::Failed
+    }
+}
+
+/// Load `result` from the heap at `addr` and sign-extend it to `i32`.
+///
+/// This corresponds to Wasm's `i32.load8_s`.
+#[derive(EffectOpInterface, OpPrinter, OpParser)]
+#[operation(
+    dialect = WasmDialect,
+    implements(InferTypeOpInterface, MemoryEffectOpInterface, OpPrinter)
+)]
+pub struct I32Load8S {
+    #[operand]
+    #[effects(MemoryEffect(MemoryEffect::Read))]
+    addr: PointerOf<Int8>,
+    #[result]
+    result: Int32,
+}
+
+impl InferTypeOpInterface for I32Load8S {
+    fn infer_return_types(&mut self, _context: &Context) -> Result<(), Report> {
+        self.result_mut().set_type(Type::I32);
+        Ok(())
     }
 }

--- a/eval/src/eval.rs
+++ b/eval/src/eval.rs
@@ -2056,3 +2056,45 @@ impl Eval for wasm::SignExtend {
         Ok(ControlFlowEffect::None)
     }
 }
+
+impl Eval for wasm::I32Load8S {
+    fn eval(&self, evaluator: &mut HirEvaluator) -> Result<ControlFlowEffect, Report> {
+        let addr = self.addr();
+        let addr_value = evaluator.use_value(&addr.as_value_ref())?;
+        let Immediate::U32(addr_value) = addr_value else {
+            return Err(evaluator.report(
+                "evaluation failed",
+                self.span(),
+                format!("expected pointer to be a u32 immediate, got {}", addr_value.ty()),
+            ));
+        };
+
+        let pointer_ty = addr.ty();
+        let pointee_ty = pointer_ty
+            .pointee()
+            .expect("expected pointer type to have been verified already");
+        let loaded = evaluator.read_memory(addr_value, pointee_ty)?;
+        let sign_extended = match loaded {
+            Value::Immediate(Immediate::I8(x)) => Value::Immediate(Immediate::I32(x as i32)),
+            Value::Poison {
+                origin,
+                used,
+                value: Immediate::I8(x),
+            } => Value::Poison {
+                origin,
+                used,
+                value: Immediate::I32(x as i32),
+            },
+            other => {
+                return Err(evaluator.report(
+                    "evaluation failed",
+                    self.span(),
+                    format!("expected i8 load, got {}", other.ty()),
+                ));
+            }
+        };
+
+        evaluator.set_value(self.result().as_value_ref(), sign_extended);
+        Ok(ControlFlowEffect::None)
+    }
+}

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -148,4 +148,5 @@ fn eval_hir_dialect(info: &mut ::midenc_hir::DialectInfo) {
 
 fn eval_wasm_dialect(info: &mut ::midenc_hir::DialectInfo) {
     info.register_operation_trait::<wasm::SignExtend, dyn Eval>();
+    info.register_operation_trait::<wasm::I32Load8S, dyn Eval>();
 }

--- a/frontend/wasm/src/code_translator/expected/i32_load8_s.hir
+++ b/frontend/wasm/src/code_translator/expected/i32_load8_s.hir
@@ -2,8 +2,7 @@ builtin.function public extern("C") @test_wrapper() {
     %0 = arith.constant 1024 : i32;
     %1 = hir.bitcast %0 <{ ty = #builtin.type<u32> }>;
     %2 = hir.int_to_ptr %1 <{ ty = #builtin.type<ptr<i8, byte>> }>;
-    %3 = hir.load %2;
-    %4 = arith.sext %3 <{ ty = #builtin.type<i32> }>;
+    %3 = wasm.i32_load_8s %2;
     cf.br ^block5;
 ^block5:
     builtin.ret;

--- a/frontend/wasm/src/code_translator/mod.rs
+++ b/frontend/wasm/src/code_translator/mod.rs
@@ -257,7 +257,10 @@ pub fn translate_operator<B: ?Sized + Builder>(
             translate_load_zext(U16, U32, memarg, state, builder, span)?;
         }
         Operator::I32Load8S { memarg } => {
-            translate_load_sext(I8, I32, memarg, state, builder, span)?;
+            let addr_int = state.pop1();
+            let addr = prepare_addr(addr_int, &I8, Some(memarg), builder, span)?;
+            let val = builder.i32_load8_s(addr, span)?;
+            state.push1(val);
         }
         Operator::I32Load16S { memarg } => {
             translate_load_sext(I16, I32, memarg, state, builder, span)?;

--- a/tests/integration/src/codegen/wasm.rs
+++ b/tests/integration/src/codegen/wasm.rs
@@ -1,8 +1,11 @@
 use miden_debug::ToMidenRepr;
+use midenc_dialect_hir::HirOpBuilder;
 use midenc_dialect_wasm::WasmOpBuilder;
-use midenc_hir::{Felt, SourceSpan, Type, ValueRef, dialects::builtin::BuiltinOpBuilder};
+use midenc_hir::{
+    Felt, PointerType, SourceSpan, Type, ValueRef, dialects::builtin::BuiltinOpBuilder,
+};
 
-use crate::testing::{compile_test_module, eval_package};
+use crate::testing::{Initializer, compile_test_module, eval_package};
 
 #[test]
 fn test_i32_extend8_s() {
@@ -372,5 +375,57 @@ fn test_i64_extend32_s() {
             Ok(())
         })
         .unwrap();
+    }
+}
+
+#[test]
+fn test_i32_load8_s() {
+    let span = SourceSpan::default();
+    let mem_addr = 17 * 2u32.pow(16);
+
+    let (package, context) = compile_test_module([Type::I32], [Type::I32], |builder| {
+        let block = builder.current_block();
+        let addr_i32 = block.borrow().arguments()[0] as ValueRef;
+
+        let addr_u32 = builder.bitcast(addr_i32, Type::U32, span).unwrap();
+        let ptr = builder
+            .inttoptr(addr_u32, Type::from(PointerType::new(Type::I8)), span)
+            .unwrap();
+        let result = builder.i32_load8_s(ptr, span).unwrap();
+
+        builder.ret(Some(result), span).unwrap();
+    });
+
+    // (value written to memory, expected result from i32.load8_s)
+    let test_cases = [
+        (0b0111_1111u8, 0b0000_0000_0000_0000_0000_0000_0111_1111u32),
+        (0b1000_0000u8, 0b1111_1111_1111_1111_1111_1111_1000_0000u32),
+        (0b1111_1111u8, 0b1111_1111_1111_1111_1111_1111_1111_1111u32),
+        (0b0000_0000u8, 0b0000_0000_0000_0000_0000_0000_0000_0000u32),
+        (0b1000_0001u8, 0b1111_1111_1111_1111_1111_1111_1000_0001u32),
+    ];
+
+    for (mem_value, expected) in test_cases {
+        assert_eq!(((mem_value as i8) as i32) as u32, expected, "invalid test case");
+
+        let initializers = [Initializer::MemoryBytes {
+            addr: mem_addr,
+            bytes: &[mem_value],
+        }];
+
+        let output = eval_package::<u32, _, _>(
+            &package,
+            initializers,
+            &[Felt::new(mem_addr as u64)],
+            context.session(),
+            |_trace| Ok(()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            output, expected,
+            "i32.load8_s failed for input 0b{:08b}: expected 0b{:032b}, got 0b{:032b}",
+            mem_value, expected, output
+        );
     }
 }


### PR DESCRIPTION
Motivation:

- more pecialized representation of Wasm semantics
- enable optimizations across multiple Wasm instructions later on

In isolation, the generated masm is the same as before when lowering through the more general `load_sext`, see details below.

I'm sending a PR adding only one op first to figure out the approach to handling the `I(32|64)Load(8|16|32)(U|S)` family of instructions. Once the first of them is in the Wasm dialect, it should be easier to decide on how to add the remaining ones (generalizing `I32Load8S` vs adding more ops).

### Analysis of generated masm

It's based on compiling this Wat:

```wat
(module
  (type (;0;) (func (param i32) (result i32)))
  (memory (;0;) 16384)
  (global $MyGlobalVal (;0;) (mut i32) i32.const 42)
  (export "test_wrapper" (func $test_wrapper))
  (func $test_wrapper (;0;) (type 0) (param i32) (result i32)
    local.get 0
    i32.load8_s
  )
)
```

with the command below to get the following `masm`, which is identical when compiled off `next` and off this branch:

```sh
cargo run -p midenc -- load.wat --entrypoint=load::test_wrapper --emit=ir
```

```
@locals("1")
@callconv("C")
pub proc test_wrapper(i32) -> i32
    u32divmod.4
    swap.1
    swap.1
    dup.1
    mem_load
    swap.1
    push.8
    u32wrapping_mul
    u32shr
    swap.1
    drop
    push.255
    u32and
    dup.0
    push.128
    u32and
    eq.128
    push.0
    push.4294967040
    movup.2
    cdrop
    u32or
end
```

#### Why no optimizations

The masm does the following. Even when working with a fixed set of types, I didn't see an easy way to emit more efficient masm:

- Convert byte address → word address + offset
  - needed due to the difference in address schemes
- Load 32 bit word
  - cannot load less than 32-bits
- Extract the specific byte using shift and mask
  - only need 8 out of 32 loaded bits but can't assume anything about the unused 24 bits
- Sign-extend from 8 bits to 32 bits

There are [bit twiddling hacks](https://graphics.stanford.edu/~seander/bithacks.html) for `sext`, but I didn't go for it because:

- not sure if we want to do that at the moment
- assessing their performance on a non-standard architecture is not trivial