### PR TITLE
docs: fix table column alignment for long double

### DIFF
--- a/docs/external/src/appendix/calling-conventions.md
+++ b/docs/external/src/appendix/calling-conventions.md
@@ -57,7 +57,7 @@ General type | C Type | IR Type | `sizeof` | Alignment (bytes) | Miden Type
  Pointer | *`any-type *`* / *`any-type (*)()`* | `Ptr(_)` | 4 | 4 | u32[^6][^7]
  Floating point | `float` | `F32` | 4 | 4 | u32[^4]
  Floating point | `double` | `F64` | 8 | 8 | u64[^4]
- Floating point | `long double` | 16 | 16 | (none)[^5]
+ Floating point | `long double` | (none) | 16 | 16 | (none)[^5]
 
 [^1]: i32 is not a native Miden type, but is implemented using compiler intrinsics on top of the native u32 type
 


### PR DESCRIPTION
In the data representation table, the `long double` row was missing an IR Type column value, causing the `sizeof` and alignment values to shift into the wrong columns.

Added `(none)` to the IR Type column to align with the table header and match the format used for unsupported types in the Miden Type column.