### PR TITLE
refactor: move `prepare_addr` from frontend to wasm dialect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3207,7 +3207,6 @@ dependencies = [
  "midenc-dialect-arith",
  "midenc-dialect-hir",
  "midenc-hir",
- "wasmparser 0.227.1",
 ]
 
 [[package]]

--- a/dialects/wasm/Cargo.toml
+++ b/dialects/wasm/Cargo.toml
@@ -19,4 +19,3 @@ std = ["midenc-hir/std"]
 midenc-dialect-arith.workspace = true
 midenc-dialect-hir.workspace = true
 midenc-hir.workspace = true
-wasmparser.workspace = true

--- a/dialects/wasm/src/builders.rs
+++ b/dialects/wasm/src/builders.rs
@@ -3,7 +3,9 @@ use midenc_hir::{
     dialects::builtin::FunctionBuilder,
 };
 
-pub trait WasmOpBuilder<'f, B: ?Sized + Builder> {
+use crate::{WasmMemArg, mem::WasmMemOpBuilder, prepare_addr};
+
+pub trait WasmOpBuilder<'f, B: ?Sized + Builder>: WasmMemOpBuilder<'f, B> {
     fn sign_extend(
         &mut self,
         arg: ValueRef,
@@ -11,23 +13,19 @@ pub trait WasmOpBuilder<'f, B: ?Sized + Builder> {
         dst_ty: Type,
         span: SourceSpan,
     ) -> Result<ValueRef, Report> {
-        let op_builder = self.builder_mut().create::<crate::ops::SignExtend, _>(span);
+        let op_builder = WasmOpBuilder::builder_mut(self).create::<crate::ops::SignExtend, _>(span);
         let op = op_builder(arg, src_ty, dst_ty)?;
         Ok(op.borrow().result().as_value_ref())
     }
 
-    // fn i32_load8_s(
-    //     &mut self,
-    //     addr_int: ValueRef,
-    //     memarg: Option<&MemArg>,
-    //     span: SourceSpan,
-    // ) -> Result<ValueRef, Report> {
-    //     let
-    //     // let addr = prepare_addr(addr_int, &Type::I8, memarg, &mut self, span);
-    // }
-
-    fn i32_load8_s(&mut self, addr: ValueRef, span: SourceSpan) -> Result<ValueRef, Report> {
-        let op_builder = self.builder_mut().create::<crate::ops::I32Load8S, _>(span);
+    fn i32_load8_s(
+        &mut self,
+        addr: ValueRef,
+        memarg: Option<WasmMemArg>,
+        span: SourceSpan,
+    ) -> Result<ValueRef, Report> {
+        let addr = prepare_addr(addr, &Type::I8, memarg, self, span)?;
+        let op_builder = WasmOpBuilder::builder_mut(self).create::<crate::ops::I32Load8S, _>(span);
         let op = op_builder(addr)?;
         Ok(op.borrow().result().as_value_ref())
     }

--- a/dialects/wasm/src/lib.rs
+++ b/dialects/wasm/src/lib.rs
@@ -22,7 +22,11 @@ use midenc_hir::{
     derive::DialectRegistration,
 };
 
-pub use self::{builders::WasmOpBuilder, mem::prepare_addr, ops::*};
+pub use self::{
+    builders::WasmOpBuilder,
+    mem::{WasmMemArg, prepare_addr},
+    ops::*,
+};
 
 #[derive(Debug, DialectRegistration)]
 pub struct WasmDialect {

--- a/dialects/wasm/src/mem.rs
+++ b/dialects/wasm/src/mem.rs
@@ -1,33 +1,68 @@
 use midenc_dialect_arith::ArithOpBuilder;
 use midenc_dialect_hir::{HirOpBuilder, assertions};
 use midenc_hir::{Builder, Immediate, PointerType, Report, SourceSpan, Type, ValueRef};
-use wasmparser::MemArg;
 
-// TODO compare with old `fn prepare_addr`
+/// Represents a memory immediate in a WebAssembly memory instruction.
+///
+/// Mirrors `MemArg` from the `wasmparser` crate.
+#[derive(Debug, Clone, Copy, Default, Hash, Eq, PartialEq)]
+pub struct WasmMemArg {
+    /// A fixed byte-offset that this memory immediate specifies.
+    ///
+    /// Note that the memory64 proposal can specify a full 64-bit byte offset while otherwise
+    /// only 32-bit offsets are allowed. Once validated memory immediates for 32-bit memories are
+    /// guaranteed to be at most `u32::MAX` whereas 64-bit memories can use the full 64-bits.
+    pub offset: u64,
+    /// Alignment, stored as `n` where the actual alignment is `2^n`
+    pub align: u8,
+}
+
+impl WasmMemArg {
+    pub const fn new(offset: u64, align: u8) -> Self {
+        Self { offset, align }
+    }
+}
+
+pub trait WasmMemOpBuilder<'a, B: ?Sized + Builder>:
+    ArithOpBuilder<'a, B> + HirOpBuilder<'a, B>
+{
+}
+
+impl<'a, B, T> WasmMemOpBuilder<'a, B> for T
+where
+    B: ?Sized + Builder,
+    T: ?Sized + ArithOpBuilder<'a, B> + HirOpBuilder<'a, B>,
+{
+}
+
+/// Prepares `addr_int` to be used as pointer to a value of type `ptr_ty`.
+///
+/// # Panics
+///
+/// Panics if `addr_int` does not have type `I32`.
 pub fn prepare_addr<'a, B: ?Sized + Builder>(
     addr_int: ValueRef,
     ptr_ty: &Type,
-    memarg: Option<&MemArg>,
-    builder: &mut (impl ArithOpBuilder<'a, B> + HirOpBuilder<'a, B>),
+    memarg: Option<WasmMemArg>,
+    builder: &mut (impl WasmMemOpBuilder<'a, B> + ?Sized),
     span: SourceSpan,
 ) -> Result<ValueRef, Report> {
     let addr_int_ty = addr_int.borrow().ty().clone();
-    let addr_u32 = if addr_int_ty == Type::U32 {
-        addr_int
-    } else if addr_int_ty == Type::I32 {
-        builder.bitcast(addr_int, Type::U32, span)?
-    } else if matches!(addr_int_ty, Type::Ptr(_)) {
-        builder.ptrtoint(addr_int, Type::U32, span)?
-    } else {
-        panic!("unexpected type used as pointer value: {addr_int_ty}");
-    };
+    assert!(
+        matches!(addr_int_ty, Type::I32),
+        "pointer address must have type I32, got {addr_int_ty}"
+    );
+    let addr_u32 = builder.bitcast(addr_int, Type::U32, span)?;
     let mut full_addr_int = addr_u32;
     if let Some(memarg) = memarg {
         if memarg.offset != 0 {
             let imm = builder.imm(Immediate::U32(memarg.offset as u32), span);
             full_addr_int = builder.add(addr_u32, imm, span)?;
         }
+        // TODO(pauls): For now, asserting alignment helps us catch mistakes/bugs, but we should
+        // probably make this something that can be disabled to avoid the overhead in release builds
         if memarg.align > 0 {
+            // Generate alignment assertion - aligned addresses should always produce 0 here
             let imm = builder.imm(Immediate::U32(2u32.pow(memarg.align as u32)), span);
             let align_offset = builder.r#mod(full_addr_int, imm, span)?;
             builder.assertz_with_error(align_offset, assertions::ASSERT_FAILED_ALIGNMENT, span)?;

--- a/frontend/wasm/src/code_translator/mod.rs
+++ b/frontend/wasm/src/code_translator/mod.rs
@@ -17,7 +17,7 @@ use midenc_dialect_arith::ArithOpBuilder;
 use midenc_dialect_cf::{ControlFlowOpBuilder, SwitchCase};
 use midenc_dialect_hir::HirOpBuilder;
 use midenc_dialect_ub::UndefinedBehaviorOpBuilder;
-use midenc_dialect_wasm::{WasmOpBuilder, prepare_addr};
+use midenc_dialect_wasm::{WasmMemArg, WasmOpBuilder, prepare_addr};
 use midenc_hir::{
     BlockRef, Builder, Felt, Immediate, Op,
     Type::{self, *},
@@ -258,8 +258,11 @@ pub fn translate_operator<B: ?Sized + Builder>(
         }
         Operator::I32Load8S { memarg } => {
             let addr_int = state.pop1();
-            let addr = prepare_addr(addr_int, &I8, Some(memarg), builder, span)?;
-            let val = builder.i32_load8_s(addr, span)?;
+            let val = builder.i32_load8_s(
+                addr_int,
+                Some(WasmMemArg::new(memarg.offset, memarg.align)),
+                span,
+            )?;
             state.push1(val);
         }
         Operator::I32Load16S { memarg } => {
@@ -683,7 +686,13 @@ fn translate_load<B: ?Sized + Builder>(
     span: SourceSpan,
 ) -> WasmResult<()> {
     let addr_int = state.pop1();
-    let addr = prepare_addr(addr_int, &ptr_ty, Some(memarg), builder, span)?;
+    let addr = prepare_addr(
+        addr_int,
+        &ptr_ty,
+        Some(WasmMemArg::new(memarg.offset, memarg.align)),
+        builder,
+        span,
+    )?;
     state.push1(builder.load(addr, span)?);
     Ok(())
 }
@@ -697,7 +706,13 @@ fn translate_load_sext<B: ?Sized + Builder>(
     span: SourceSpan,
 ) -> WasmResult<()> {
     let addr_int = state.pop1();
-    let addr = prepare_addr(addr_int, &ptr_ty, Some(memarg), builder, span)?;
+    let addr = prepare_addr(
+        addr_int,
+        &ptr_ty,
+        Some(WasmMemArg::new(memarg.offset, memarg.align)),
+        builder,
+        span,
+    )?;
     let val = builder.load(addr, span)?;
     let sext_val = builder.sext(val, sext_ty, span)?;
     state.push1(sext_val);
@@ -714,7 +729,13 @@ fn translate_load_zext<B: ?Sized + Builder>(
 ) -> WasmResult<()> {
     assert!(ptr_ty.is_unsigned_integer());
     let addr_int = state.pop1();
-    let addr = prepare_addr(addr_int, &ptr_ty, Some(memarg), builder, span)?;
+    let addr = prepare_addr(
+        addr_int,
+        &ptr_ty,
+        Some(WasmMemArg::new(memarg.offset, memarg.align)),
+        builder,
+        span,
+    )?;
     let val = builder.load(addr, span)?;
     let zext_val = builder.zext(val, zext_ty.clone(), span)?;
     let bitcast_val = match zext_ty {
@@ -748,7 +769,13 @@ fn translate_store<B: ?Sized + Builder>(
     } else {
         val
     };
-    let addr = prepare_addr(addr_int, &ptr_ty, Some(memarg), builder, span)?;
+    let addr = prepare_addr(
+        addr_int,
+        &ptr_ty,
+        Some(WasmMemArg::new(memarg.offset, memarg.align)),
+        builder,
+        span,
+    )?;
     builder.store(addr, arg, span)?;
     Ok(())
 }

--- a/tests/integration/src/codegen/wasm.rs
+++ b/tests/integration/src/codegen/wasm.rs
@@ -1,9 +1,6 @@
 use miden_debug::ToMidenRepr;
-use midenc_dialect_hir::HirOpBuilder;
 use midenc_dialect_wasm::WasmOpBuilder;
-use midenc_hir::{
-    Felt, PointerType, SourceSpan, Type, ValueRef, dialects::builtin::BuiltinOpBuilder,
-};
+use midenc_hir::{Felt, SourceSpan, Type, ValueRef, dialects::builtin::BuiltinOpBuilder};
 
 use crate::testing::{Initializer, compile_test_module, eval_package};
 
@@ -381,12 +378,7 @@ fn test_i32_load8_s() {
     let (package, context) = compile_test_module([Type::I32], [Type::I32], |builder| {
         let block = builder.current_block();
         let addr_i32 = block.borrow().arguments()[0] as ValueRef;
-
-        let addr_u32 = builder.bitcast(addr_i32, Type::U32, span).unwrap();
-        let ptr = builder
-            .inttoptr(addr_u32, Type::from(PointerType::new(Type::I8)), span)
-            .unwrap();
-        let result = builder.i32_load8_s(ptr, span).unwrap();
+        let result = builder.i32_load8_s(addr_i32, None, span).unwrap();
 
         builder.ret(Some(result), span).unwrap();
     });


### PR DESCRIPTION
Closes #1022

Previously the ops for `i32.load8_s` were built partly in the frontend and partly in the wasm dialect. This refactor allows building all of them in the wasm dialect. Ultimately all load ops constructed in the wasm frontend should go through the wasm dialect, which motivates moving `prepare_addr` there.

Needs to introduce something like `WasmMemOpBuilder` to allow the `builder` passed to `prepare_addr` calling `ArithOpBuilder, HirOpBuilder` methods. I feel like it's worth it for getting rid of the split mentioned above. So far all relevant `builders` already meet this requirement.