### PR TITLE
feat: rework test-harness for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,14 +317,6 @@ jobs:
           if ! cargo make --version 2>/dev/null; then
             cargo install cargo-make --force
           fi
-      # Some integration tests use midenup to compile the example projects
-      - name: Install midenup
-        run: |
-          if ! miden help 2>/dev/null; then
-            cargo install --git https://github.com/0xMiden/midenup
-            midenup init
-          fi
-
       - name: Test
         run: |
           cargo make test -E 'package(midenc-integration-network-tests)'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,6 +2432,7 @@ dependencies = [
  "miden-protocol",
  "miden-remote-prover-client",
  "miden-standards",
+ "miden-testing",
  "miden-tx",
  "miette",
  "prost",
@@ -2447,6 +2448,7 @@ dependencies = [
  "tonic-prost-build",
  "tonic-web-wasm-client",
  "tracing",
+ "uuid",
  "web-sys",
 ]
 
@@ -6285,6 +6287,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/tests/integration-network/Cargo.toml
+++ b/tests/integration-network/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 
 [dependencies]
 # miden-client = { version = "0.14", features = ["std", "tonic", "testing"] }
-miden-client = { git = "https://github.com/0xMiden/miden-client", branch = "release/v0.14.0-beta" }
+miden-client = { git = "https://github.com/0xMiden/miden-client", branch = "release/v0.14.0-beta", features = ["std", "testing"] }
 miden-core.workspace = true
 miden-protocol = { workspace = true, features = ["std", "testing"] }
 miden-standards = { workspace = true, features = ["std"] }

--- a/tests/integration-network/src/mockchain/basic_wallet.rs
+++ b/tests/integration-network/src/mockchain/basic_wallet.rs
@@ -1,23 +1,26 @@
 //! Basic wallet test module
 
 use miden_client::{
-    asset::FungibleAsset, crypto::RandomCoin, note::NoteAssets, transaction::RawOutputNote,
+    account::{
+        AccountComponent, AccountId,
+        component::{BasicWallet, InitStorageData},
+    },
+    asset::{Asset, FungibleAsset},
+    transaction::RawOutputNote,
 };
 use miden_core::Felt;
-use miden_protocol::account::{auth::AuthScheme, AccountId};
-use miden_testing::{AccountState, Auth, MockChain};
+use miden_protocol::{account::auth::AuthScheme, crypto::rand::RandomCoin};
+use miden_standards::testing::note::NoteBuilder;
+use miden_testing::{Auth, MockChain};
 use midenc_expect_test::expect;
 
 use super::{
     cycle_helpers::{note_cycles, prologue_cycles, tx_script_processing_cycles},
     helpers::{
-        assert_account_has_fungible_asset, build_asset_transfer_tx,
-        build_existing_basic_wallet_account_builder, build_send_notes_script, compile_rust_package,
-        create_note_from_package, execute_tx, to_core_felts, NoteCreationConfig,
+        assert_account_has_fungible_asset, build_asset_transfer_tx, build_send_notes_script,
+        compile_rust_package, execute_tx, to_core_felts,
     },
 };
-use crate::mockchain::helpers::compile_rust_package;
-
 /// Converts the P2IDE note payload into protocol storage order for the basic-wallet tests.
 fn to_p2ide_storage_felts(
     target: &AccountId,
@@ -65,7 +68,7 @@ pub fn test_basic_wallet_p2id() {
     let bob_account = builder
         .add_existing_account_from_components(
             Auth::BasicAuth {
-                auth_sceme: AuthScheme::Falcon512Poseidon2,
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
             },
             [wallet_component],
         )
@@ -80,11 +83,11 @@ pub fn test_basic_wallet_p2id() {
     let mint_amount = 100_000u64; // 100,000 tokens
     let mint_asset = FungibleAsset::new(faucet_id, mint_amount).unwrap();
 
-    let mut note_rng = RpoRandomCoin::new(note_package.unwrap_program().hash());
+    let mut note_rng = RandomCoin::new(note_package.unwrap_program().hash());
     let p2id_note_mint = NoteBuilder::new(faucet_id, &mut note_rng)
         .package((*note_package).clone())
         .add_assets([Asset::from(mint_asset)])
-        .note_inputs(to_core_felts(&alice_id))
+        .note_storage(to_core_felts(&alice_id))
         .unwrap()
         .build()
         .unwrap();
@@ -173,7 +176,7 @@ pub fn test_basic_wallet_p2ide() {
     let alice_account = builder
         .add_existing_account_from_components(
             Auth::BasicAuth {
-                auth_sceme: AuthScheme::Falcon512Poseidon2,
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
             },
             [wallet_component.clone(), BasicWallet.into()],
         )
@@ -183,7 +186,7 @@ pub fn test_basic_wallet_p2ide() {
     let bob_account = builder
         .add_existing_account_from_components(
             Auth::BasicAuth {
-                auth_sceme: AuthScheme::Falcon512Poseidon2,
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
             },
             [wallet_component],
         )
@@ -198,11 +201,11 @@ pub fn test_basic_wallet_p2ide() {
     let mint_amount = 100_000u64;
     let mint_asset = FungibleAsset::new(faucet_id, mint_amount).unwrap();
 
-    let p2id_rng = RpoRandomCoin::new(p2id_note_package.unwrap_program().hash());
+    let p2id_rng = RandomCoin::new(p2id_note_package.unwrap_program().hash());
     let p2id_note_mint = NoteBuilder::new(faucet_id, p2id_rng)
         .package((*p2id_note_package).clone())
         .add_assets([Asset::from(mint_asset)])
-        .note_inputs(to_core_felts(&alice_id))
+        .note_storage(to_core_felts(&alice_id))
         .unwrap()
         .build()
         .unwrap();
@@ -231,15 +234,11 @@ pub fn test_basic_wallet_p2ide() {
     let timelock_height = Felt::new(0);
     let reclaim_height = Felt::new(0);
 
-    let p2ide_rng = RpoRandomCoin::new(p2ide_note_package.unwrap_program().hash());
+    let p2ide_rng = RandomCoin::new(p2ide_note_package.unwrap_program().hash());
     let p2ide_note = NoteBuilder::new(alice_id, p2ide_rng)
         .package((*p2ide_note_package).clone())
         .add_assets([Asset::from(transfer_asset)])
-        .note_inputs({
-            let mut inputs = to_core_felts(&bob_id);
-            inputs.extend([timelock_height, reclaim_height]);
-            inputs
-        })
+        .note_storage(to_p2ide_storage_felts(&bob_id, reclaim_height, timelock_height))
         .unwrap()
         .build()
         .unwrap();
@@ -302,7 +301,7 @@ pub fn test_basic_wallet_p2ide_reclaim() {
     let alice_account = builder
         .add_existing_account_from_components(
             Auth::BasicAuth {
-                auth_sceme: AuthScheme::Falcon512Poseidon2,
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
             },
             [wallet_component.clone(), BasicWallet.into()],
         )
@@ -312,7 +311,7 @@ pub fn test_basic_wallet_p2ide_reclaim() {
     let bob_account = builder
         .add_existing_account_from_components(
             Auth::BasicAuth {
-                auth_sceme: AuthScheme::Falcon512Poseidon2,
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
             },
             [wallet_component],
         )
@@ -327,11 +326,11 @@ pub fn test_basic_wallet_p2ide_reclaim() {
     let mint_amount = 100_000u64;
     let mint_asset = FungibleAsset::new(faucet_id, mint_amount).unwrap();
 
-    let p2id_rng = RpoRandomCoin::new(p2id_note_package.unwrap_program().hash());
+    let p2id_rng = RandomCoin::new(p2id_note_package.unwrap_program().hash());
     let p2id_note_mint = NoteBuilder::new(faucet_id, p2id_rng)
         .package((*p2id_note_package).clone())
         .add_assets([Asset::from(mint_asset)])
-        .note_inputs(to_core_felts(&alice_id))
+        .note_storage(to_core_felts(&alice_id))
         .unwrap()
         .build()
         .unwrap();
@@ -360,15 +359,11 @@ pub fn test_basic_wallet_p2ide_reclaim() {
     let timelock_height = Felt::new(0);
     let reclaim_height = Felt::new(1);
 
-    let p2ide_rng = RpoRandomCoin::new(p2ide_note_package.unwrap_program().hash());
+    let p2ide_rng = RandomCoin::new(p2ide_note_package.unwrap_program().hash());
     let p2ide_note = NoteBuilder::new(alice_id, p2ide_rng)
         .package((*p2ide_note_package).clone())
         .add_assets([Asset::from(transfer_asset)])
-        .note_inputs({
-            let mut inputs = to_core_felts(&bob_id);
-            inputs.extend([timelock_height, reclaim_height]);
-            inputs
-        })
+        .note_storage(to_p2ide_storage_felts(&bob_id, reclaim_height, timelock_height))
         .unwrap()
         .build()
         .unwrap();

--- a/tests/integration-network/src/mockchain/counter_contract.rs
+++ b/tests/integration-network/src/mockchain/counter_contract.rs
@@ -1,28 +1,23 @@
 //! Counter contract test module
 
 use miden_client::{
-    account::component::BasicWallet,
-    crypto::{RandomCoin, RpoRandomCoin},
-    note::NoteTag,
-    transaction::RawOutputNote,
     Word,
+    account::{AccountComponent, component::InitStorageData},
+    transaction::RawOutputNote,
 };
 use miden_core::Felt;
-use miden_protocol::account::{
-    auth::AuthScheme, AccountBuilder, AccountStorageMode, AccountType, StorageMap, StorageMapKey,
-    StorageSlot, StorageSlotName,
-};
-use miden_testing::{AccountState, Auth, MockChain};
+use miden_protocol::{account::auth::AuthScheme, crypto::rand::RandomCoin};
+use miden_standards::testing::note::NoteBuilder;
+use miden_testing::{Auth, MockChain};
 use midenc_expect_test::expect;
 
 use super::{
     cycle_helpers::note_cycles,
     helpers::{
-        account_component_from_package, assert_counter_storage, compile_rust_package,
-        counter_storage_slot_name, create_note_from_package, execute_tx, NoteCreationConfig,
+        COUNTER_CONTRACT_STORAGE_KEY, assert_counter_storage, compile_rust_package,
+        counter_storage_slot_name, execute_tx,
     },
 };
-use crate::mockchain::helpers::COUNTER_CONTRACT_STORAGE_KEY;
 
 /// Tests the counter contract deployment and note consumption workflow on a mock chain.
 #[test]
@@ -33,33 +28,30 @@ pub fn test_counter_contract() {
 
     let value = Word::from([Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::ONE]);
     let counter_storage_slot = counter_storage_slot_name();
-    let storage_slots = vec![StorageSlot::with_map(
-        counter_storage_slot.clone(),
-        StorageMap::with_entries([(StorageMapKey::new(COUNTER_CONTRACT_STORAGE_KEY), value)])
-            .unwrap(),
-    )];
 
     let mut init_storage_data = InitStorageData::default();
     init_storage_data
-        .insert_map_entry(counter_storage_slot.clone(), key, value)
+        .insert_map_entry(counter_storage_slot.clone(), COUNTER_CONTRACT_STORAGE_KEY, value)
         .unwrap();
-    let contract_package = AccountComponent::from_package(&contract_package, &init_storage_data)
+    let contract_component = AccountComponent::from_package(&contract_package, &init_storage_data)
         .expect("Failed to build account component from counter project");
 
     let mut builder = MockChain::builder();
     let counter_account = builder
         .add_existing_account_from_components(
-            Auth::BasicAuth,
-            [BasicWallet.into(), contract_package],
+            Auth::BasicAuth {
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
+            },
+            [contract_component],
         )
         .unwrap();
 
-    let mut rng = RpoRandomCoin::new(note_package.clone().unwrap_program().hash());
+    let mut rng = RandomCoin::new(note_package.clone().unwrap_program().hash());
     let counter_note = NoteBuilder::new(counter_account.id(), &mut rng)
         .package((*note_package).clone())
         .build()
         .unwrap();
-    builder.add_output_note(OutputNote::Full(counter_note.clone()));
+    builder.add_output_note(RawOutputNote::Full(counter_note.clone()));
 
     let mut chain = builder.build().expect("failed to build mock chain");
     chain.prove_next_block().unwrap();

--- a/tests/integration-network/src/mockchain/counter_contract_no_auth.rs
+++ b/tests/integration-network/src/mockchain/counter_contract_no_auth.rs
@@ -1,31 +1,28 @@
 //! Counter contract test with no-auth authentication component
 
 use miden_client::{
-    account::component::BasicWallet, crypto::RandomCoin, note::NoteTag, transaction::RawOutputNote,
     Word,
+    account::{AccountComponent, component::InitStorageData},
+    note::NoteTag,
+    transaction::RawOutputNote,
 };
-use miden_core::{Felt, FieldElement};
-use miden_protocol::account::{
-    auth::AuthScheme, AccountBuilder, AccountStorageMode, AccountType, StorageMap, StorageMapKey,
-    StorageSlot, StorageSlotName,
+use miden_core::Felt;
+use miden_protocol::{
+    account::{AccountBuilder, AccountStorageMode, AccountType, auth::AuthScheme},
+    crypto::rand::RandomCoin,
 };
+use miden_standards::testing::note::NoteBuilder;
 use miden_testing::{AccountState, Auth, MockChain};
 use midenc_expect_test::expect;
 
 use super::{
-    crypto::RpoRandomCoin,
     cycle_helpers::{auth_procedure_cycles, note_cycles},
     helpers::{
-        assert_counter_storage, build_existing_counter_account_builder_with_auth_package,
-        compile_rust_package, counter_storage_slot_name, create_note_from_package, execute_tx,
-        NoteCreationConfig,
+        COUNTER_CONTRACT_STORAGE_KEY, assert_counter_storage,
+        build_existing_counter_account_builder_with_auth_package, compile_rust_package,
+        counter_storage_slot_name, execute_tx,
     },
-    note::NoteTag,
-    testing::{AccountState, Auth, MockChain, NoteBuilder},
-    transaction::OutputNote,
-    Word,
 };
-use crate::mockchain::helpers::compile_rust_package;
 
 /// Tests the counter contract with a "no-auth" authentication component.
 ///
@@ -44,26 +41,16 @@ pub fn test_counter_contract_no_auth() {
 
     let value = Word::from([Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::ONE]);
     let counter_storage_slot = counter_storage_slot_name();
-    let counter_storage_slots = vec![StorageSlot::with_map(
-        counter_storage_slot.clone(),
-        StorageMap::with_entries([(StorageMapKey::new(COUNTER_CONTRACT_STORAGE_KEY), value)])
-            .unwrap(),
-    )];
 
-    let mut builder = MockChain::builder();
     let counter_component = {
         let mut init_storage_data = InitStorageData::default();
         init_storage_data
-            .insert_map_entry(counter_storage_slot.clone(), key, value)
+            .insert_map_entry(counter_storage_slot.clone(), COUNTER_CONTRACT_STORAGE_KEY, value)
             .unwrap();
         AccountComponent::from_package(&counter_package, &init_storage_data).unwrap()
     };
 
-    let mut counter_init_storage_data = InitStorageData::default();
-    counter_init_storage_data
-        .insert_map_entry(counter_storage_slot.clone(), key, value)
-        .expect("failed to insert counter map entry");
-
+    let mut builder = MockChain::builder();
     let counter_account = build_existing_counter_account_builder_with_auth_package(
         counter_component,
         no_auth_auth_component,
@@ -82,7 +69,7 @@ pub fn test_counter_contract_no_auth() {
     let sender_builder = AccountBuilder::new(seed)
         .account_type(AccountType::RegularAccountUpdatableCode)
         .storage_mode(AccountStorageMode::Public)
-        .with_component(BasicWallet);
+        .with_component(miden_client::account::component::BasicWallet);
     let sender_account = builder
         .add_account_from_builder(
             Auth::BasicAuth {
@@ -95,7 +82,7 @@ pub fn test_counter_contract_no_auth() {
     eprintln!("Sender account ID: {:?}", sender_account.id().to_hex());
 
     // Sender creates the counter note (note script increments counter's storage on consumption)
-    let rng = RpoRandomCoin::new(note_package.unwrap_program().hash());
+    let rng = RandomCoin::new(note_package.unwrap_program().hash());
     let counter_note = NoteBuilder::new(sender_account.id(), rng)
         .package((*note_package).clone())
         .tag(NoteTag::with_account_target(counter_account.id()).into())

--- a/tests/integration-network/src/mockchain/counter_contract_rust_auth.rs
+++ b/tests/integration-network/src/mockchain/counter_contract_rust_auth.rs
@@ -4,13 +4,9 @@
 //! RPO-Falcon512 secret key cannot create notes on behalf of the counter
 //! contract account that uses the Rust-compiled auth component.
 
-use miden_client::{
-    auth::BasicAuthenticator,
-    crypto::RpoRandomCoin,
-    note::NoteTag,
-    testing::{MockChain, NoteBuilder},
-    transaction::{OutputNote, RawOutputNote},
-};
+use miden_client::{auth::BasicAuthenticator, note::NoteTag, transaction::RawOutputNote};
+use miden_protocol::crypto::rand::RandomCoin;
+use miden_standards::testing::note::NoteBuilder;
 use miden_testing::MockChain;
 use midenc_expect_test::expect;
 
@@ -19,10 +15,8 @@ use super::{
     helpers::{
         assert_counter_storage, block_on, build_counter_account_with_rust_rpo_auth,
         build_send_notes_script, compile_rust_package, counter_storage_slot_name,
-        create_note_from_package, NoteCreationConfig,
     },
 };
-use crate::mockchain::helpers::compile_rust_package;
 
 /// Verify that another client (without the RPO-Falcon512 key) cannot create notes for
 /// the counter account which uses the Rust-compiled RPO-Falcon512 authentication component.
@@ -60,7 +54,7 @@ pub fn test_counter_contract_rust_auth_blocks_unauthorized_note_creation() {
     );
 
     // Positive check: original client (with the key) can create a note
-    let rng = RpoRandomCoin::new(note_package.unwrap_program().hash());
+    let rng = RandomCoin::new(note_package.unwrap_program().hash());
     let own_note = NoteBuilder::new(counter_account.id(), rng)
         .package((*note_package).clone())
         .tag(NoteTag::with_account_target(counter_account.id()).into())
@@ -87,7 +81,7 @@ pub fn test_counter_contract_rust_auth_blocks_unauthorized_note_creation() {
 
     // Negative check: without the RPO-Falcon512 key, creating output notes should fail.
     let counter_account = chain.committed_account(counter_account_id).unwrap().clone();
-    let rng = RpoRandomCoin::new(note_package.unwrap_program().hash());
+    let rng = RandomCoin::new(note_package.unwrap_program().hash());
     let forged_note = NoteBuilder::new(counter_account.id(), rng)
         .package((*note_package).clone())
         .tag(NoteTag::with_account_target(counter_account.id()).into())

--- a/tests/integration-network/src/mockchain/helpers.rs
+++ b/tests/integration-network/src/mockchain/helpers.rs
@@ -3,36 +3,33 @@
 use std::{future::Future, sync::Arc};
 
 use miden_client::{
-    account::{
-        component::{BasicWallet, InitStorageData},
-        AccountStorage, StorageSlotName,
-    },
+    Word,
+    account::component::{BasicWallet, InitStorageData},
     asset::FungibleAsset,
     auth::AuthSecretKey,
     crypto::FeltRng,
-    note::{
-        Note, NoteAssets, NoteMetadata, NoteRecipient, NoteScript, NoteStorage, NoteTag, NoteType,
-    },
+    note::{Note, NoteType},
     transaction::RawOutputNote,
-    Deserializable, Word,
 };
-use miden_core::{crypto::hash::Rpo256, Felt, FieldElement};
+use miden_core::Felt;
 use miden_integration_tests::CompilerTestBuilder;
 use miden_mast_package::Package;
 use miden_protocol::{
     account::{
         Account, AccountBuilder, AccountComponent, AccountComponentMetadata, AccountId,
-        AccountStorage, AccountStorageMode, AccountType, StorageMap, StorageMapKey, StorageSlot,
-        StorageSlotNamefeat,
+        AccountStorage, AccountStorageMode, AccountType, StorageSlot, StorageSlotName,
     },
     asset::Asset,
     note::PartialNote,
     transaction::{TransactionMeasurements, TransactionScript},
 };
-use miden_standards::account::interface::{AccountInterface, AccountInterfaceExt};
+use miden_standards::{
+    account::interface::{AccountInterface, AccountInterfaceExt},
+    testing::note::NoteBuilder,
+};
 use miden_testing::{MockChain, TransactionContextBuilder};
 use midenc_frontend_wasm::WasmTranslationConfig;
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 
 /// Converts a value's felt representation into `miden_core::Felt` elements.
 pub(super) fn to_core_felts(value: &AccountId) -> Vec<Felt> {
@@ -156,7 +153,7 @@ pub(super) fn build_asset_transfer_tx(
     let output_note = NoteBuilder::new(sender_id, rng)
         .serial_number(serial_num)
         .package((*p2id_note_package).clone())
-        .note_inputs(to_core_felts(&recipient_id))
+        .note_storage(to_core_felts(&recipient_id))
         .unwrap()
         .add_assets([asset])
         .tag(0)
@@ -174,7 +171,7 @@ pub(super) fn build_asset_transfer_tx(
     let recipient_digest: [Felt; 4] = output_note.recipient().digest().into();
     commitment_input.extend(recipient_digest);
 
-    let asset_elements = miden_protocol::asset::Asset::from(asset).as_elements();
+    let asset_elements = asset.as_elements();
     commitment_input.extend(asset_elements);
     // Ensure word alignment for `adv_load_preimage` in the tx script.
     commitment_input.extend([Felt::ZERO, Felt::ZERO]);
@@ -240,13 +237,14 @@ pub(super) fn build_existing_counter_account_builder_with_auth_package(
     auth_storage_slots: Vec<StorageSlot>,
     seed: [u8; 32],
 ) -> AccountBuilder {
-    let supported_types = BTreeSet::from_iter([AccountType::RegularAccountUpdatableCode]);
+    let metadata =
+        AccountComponentMetadata::new("auth", [AccountType::RegularAccountUpdatableCode]);
     let auth_component = AccountComponent::new(
         auth_component_package.unwrap_library().as_ref().clone(),
         auth_storage_slots,
+        metadata,
     )
-    .unwrap()
-    .with_supported_types(supported_types);
+    .unwrap();
 
     AccountBuilder::new(seed)
         .account_type(AccountType::RegularAccountUpdatableCode)


### PR DESCRIPTION
Tackles #981 

This PR aims to remove some functionality from the compiler's testing crate and rely on `miden-protocol`'s testing crate.
This includes the following changes:
- Removed the `create_note_from_package` function. This now relies on `miden-protocol`'s `NoteBuilder` (which got `Package` support added into it in this [PR](https://github.com/0xMiden/protocol/pull/2502)).
- Removed the `account_component_from_package` function which was replaced by `AccountComponent::from_package`.
- Removed `build_existing_basic_wallet_account_builder` function in favor of`MockChainBuilder::add_existing_account_from_components` which was also added in [PR](https://github.com/0xMiden/protocol/pull/2502)
- Removed `NoteCreationConfig` since it was superseded by `NoteBuilder`.
