### PR TITLE
feat: add remaining `load + sext` ops to wasm dialect

### DIFF
--- a/codegen/masm/src/lib.rs
+++ b/codegen/masm/src/lib.rs
@@ -167,4 +167,8 @@ fn lower_hir_ops(info: &mut midenc_hir::DialectInfo) {
 fn lower_wasm_ops(info: &mut midenc_hir::DialectInfo) {
     info.register_operation_trait::<wasm::SignExtend, dyn HirLowering>();
     info.register_operation_trait::<wasm::I32Load8S, dyn HirLowering>();
+    info.register_operation_trait::<wasm::I32Load16S, dyn HirLowering>();
+    info.register_operation_trait::<wasm::I64Load8S, dyn HirLowering>();
+    info.register_operation_trait::<wasm::I64Load16S, dyn HirLowering>();
+    info.register_operation_trait::<wasm::I64Load32S, dyn HirLowering>();
 }

--- a/codegen/masm/src/lower/lowering.rs
+++ b/codegen/masm/src/lower/lowering.rs
@@ -1336,15 +1336,23 @@ impl HirLowering for wasm::SignExtend {
     }
 }
 
-impl HirLowering for wasm::I32Load8S {
-    fn emit(&self, emitter: &mut BlockEmitter<'_>) -> Result<(), Report> {
-        let result = self.result();
-        let pointer_ty = self.addr().ty();
-        let pointee_ty = pointer_ty.pointee().expect("pointer should have been verified").clone();
-        let mut inst_emitter = emitter.inst_emitter(self.as_operation());
-        inst_emitter.load(pointee_ty, self.span());
-        inst_emitter.sext(result.ty(), self.span());
-
-        Ok(())
-    }
+macro_rules! impl_hir_lowering_load_sext {
+    ($op:ty) => {
+        impl HirLowering for $op {
+            fn emit(&self, emitter: &mut BlockEmitter<'_>) -> Result<(), Report> {
+                let pointee_ty =
+                    self.addr().ty().pointee().expect("pointer should have been verified").clone();
+                let mut inst_emitter = emitter.inst_emitter(self.as_operation());
+                inst_emitter.load(pointee_ty, self.span());
+                inst_emitter.sext(self.result().ty(), self.span());
+                Ok(())
+            }
+        }
+    };
 }
+
+impl_hir_lowering_load_sext!(wasm::I32Load8S);
+impl_hir_lowering_load_sext!(wasm::I32Load16S);
+impl_hir_lowering_load_sext!(wasm::I64Load8S);
+impl_hir_lowering_load_sext!(wasm::I64Load16S);
+impl_hir_lowering_load_sext!(wasm::I64Load32S);

--- a/dialects/wasm/src/builders.rs
+++ b/dialects/wasm/src/builders.rs
@@ -30,6 +30,54 @@ pub trait WasmOpBuilder<'f, B: ?Sized + Builder>: WasmMemOpBuilder<'f, B> {
         Ok(op.borrow().result().as_value_ref())
     }
 
+    fn i32_load16_s(
+        &mut self,
+        addr: ValueRef,
+        memarg: Option<WasmMemArg>,
+        span: SourceSpan,
+    ) -> Result<ValueRef, Report> {
+        let addr = prepare_addr(addr, &Type::I16, memarg, self, span)?;
+        let op_builder = WasmOpBuilder::builder_mut(self).create::<crate::ops::I32Load16S, _>(span);
+        let op = op_builder(addr)?;
+        Ok(op.borrow().result().as_value_ref())
+    }
+
+    fn i64_load8_s(
+        &mut self,
+        addr: ValueRef,
+        memarg: Option<WasmMemArg>,
+        span: SourceSpan,
+    ) -> Result<ValueRef, Report> {
+        let addr = prepare_addr(addr, &Type::I8, memarg, self, span)?;
+        let op_builder = WasmOpBuilder::builder_mut(self).create::<crate::ops::I64Load8S, _>(span);
+        let op = op_builder(addr)?;
+        Ok(op.borrow().result().as_value_ref())
+    }
+
+    fn i64_load16_s(
+        &mut self,
+        addr: ValueRef,
+        memarg: Option<WasmMemArg>,
+        span: SourceSpan,
+    ) -> Result<ValueRef, Report> {
+        let addr = prepare_addr(addr, &Type::I16, memarg, self, span)?;
+        let op_builder = WasmOpBuilder::builder_mut(self).create::<crate::ops::I64Load16S, _>(span);
+        let op = op_builder(addr)?;
+        Ok(op.borrow().result().as_value_ref())
+    }
+
+    fn i64_load32_s(
+        &mut self,
+        addr: ValueRef,
+        memarg: Option<WasmMemArg>,
+        span: SourceSpan,
+    ) -> Result<ValueRef, Report> {
+        let addr = prepare_addr(addr, &Type::I32, memarg, self, span)?;
+        let op_builder = WasmOpBuilder::builder_mut(self).create::<crate::ops::I64Load32S, _>(span);
+        let op = op_builder(addr)?;
+        Ok(op.borrow().result().as_value_ref())
+    }
+
     fn builder(&self) -> &B;
     fn builder_mut(&mut self) -> &mut B;
 }

--- a/dialects/wasm/src/ops.rs
+++ b/dialects/wasm/src/ops.rs
@@ -34,7 +34,7 @@ use crate::WasmDialect;
 #[operation(
     dialect = WasmDialect,
     traits(UnaryOp),
-    implements(UnaryOp, InferTypeOpInterface, MemoryEffectOpInterface, Foldable, OpPrinter)
+    implements(InferTypeOpInterface, MemoryEffectOpInterface, Foldable, OpPrinter)
 )]
 pub struct SignExtend {
     #[operand]
@@ -166,12 +166,13 @@ impl Foldable for SignExtend {
     }
 }
 
-/// Load `result` from the heap at `addr` and sign-extend it to `i32`.
+/// Load an `i8` from the heap at `addr` and sign-extend it to `i32`.
 ///
 /// This corresponds to Wasm's `i32.load8_s`.
 #[derive(EffectOpInterface, OpPrinter, OpParser)]
 #[operation(
     dialect = WasmDialect,
+    traits(UnaryOp),
     implements(InferTypeOpInterface, MemoryEffectOpInterface, OpPrinter)
 )]
 pub struct I32Load8S {
@@ -185,6 +186,102 @@ pub struct I32Load8S {
 impl InferTypeOpInterface for I32Load8S {
     fn infer_return_types(&mut self, _context: &Context) -> Result<(), Report> {
         self.result_mut().set_type(Type::I32);
+        Ok(())
+    }
+}
+
+/// Load an `i16` from the heap at `addr` and sign-extend it to `i32`.
+///
+/// This corresponds to Wasm's `i32.load16_s`.
+#[derive(EffectOpInterface, OpPrinter, OpParser)]
+#[operation(
+    dialect = WasmDialect,
+    traits(UnaryOp),
+    implements(InferTypeOpInterface, MemoryEffectOpInterface, OpPrinter)
+)]
+pub struct I32Load16S {
+    #[operand]
+    #[effects(MemoryEffect(MemoryEffect::Read))]
+    addr: PointerOf<Int16>,
+    #[result]
+    result: Int32,
+}
+
+impl InferTypeOpInterface for I32Load16S {
+    fn infer_return_types(&mut self, _context: &Context) -> Result<(), Report> {
+        self.result_mut().set_type(Type::I32);
+        Ok(())
+    }
+}
+
+/// Load an `i8` from the heap at `addr` and sign-extend it to `i64`.
+///
+/// This corresponds to Wasm's `i64.load8_s`.
+#[derive(EffectOpInterface, OpPrinter, OpParser)]
+#[operation(
+    dialect = WasmDialect,
+    traits(UnaryOp),
+    implements(InferTypeOpInterface, MemoryEffectOpInterface, OpPrinter)
+)]
+pub struct I64Load8S {
+    #[operand]
+    #[effects(MemoryEffect(MemoryEffect::Read))]
+    addr: PointerOf<Int8>,
+    #[result]
+    result: Int64,
+}
+
+impl InferTypeOpInterface for I64Load8S {
+    fn infer_return_types(&mut self, _context: &Context) -> Result<(), Report> {
+        self.result_mut().set_type(Type::I64);
+        Ok(())
+    }
+}
+
+/// Load an `i16` from the heap at `addr` and sign-extend it to `i64`.
+///
+/// This corresponds to Wasm's `i64.load16_s`.
+#[derive(EffectOpInterface, OpPrinter, OpParser)]
+#[operation(
+    dialect = WasmDialect,
+    traits(UnaryOp),
+    implements(InferTypeOpInterface, MemoryEffectOpInterface, OpPrinter)
+)]
+pub struct I64Load16S {
+    #[operand]
+    #[effects(MemoryEffect(MemoryEffect::Read))]
+    addr: PointerOf<Int16>,
+    #[result]
+    result: Int64,
+}
+
+impl InferTypeOpInterface for I64Load16S {
+    fn infer_return_types(&mut self, _context: &Context) -> Result<(), Report> {
+        self.result_mut().set_type(Type::I64);
+        Ok(())
+    }
+}
+
+/// Load an `i32` from the heap at `addr` and sign-extend it to `i64`.
+///
+/// This corresponds to Wasm's `i64.load32_s`.
+#[derive(EffectOpInterface, OpPrinter, OpParser)]
+#[operation(
+    dialect = WasmDialect,
+    traits(UnaryOp),
+    implements(InferTypeOpInterface, MemoryEffectOpInterface, OpPrinter)
+)]
+pub struct I64Load32S {
+    #[operand]
+    #[effects(MemoryEffect(MemoryEffect::Read))]
+    addr: PointerOf<Int32>,
+    #[result]
+    result: Int64,
+}
+
+impl InferTypeOpInterface for I64Load32S {
+    fn infer_return_types(&mut self, _context: &Context) -> Result<(), Report> {
+        self.result_mut().set_type(Type::I64);
         Ok(())
     }
 }

--- a/eval/src/eval.rs
+++ b/eval/src/eval.rs
@@ -8,7 +8,7 @@ use midenc_dialect_cf as cf;
 use midenc_dialect_hir as hir;
 use midenc_dialect_scf as scf;
 use midenc_dialect_ub as ub;
-use midenc_dialect_wasm as wasm;
+use midenc_dialect_wasm::{self as wasm};
 use midenc_hir::{
     AttributeRef, Felt, Immediate, ImmediateAttr, Op, OperationRef, Overflow, RegionBranchPoint,
     RegionBranchTerminatorOpInterface, Report, SmallVec, SourceSpan, Spanned, SuccessorInfo, Type,
@@ -2065,44 +2065,55 @@ impl Eval for wasm::SignExtend {
     }
 }
 
-impl Eval for wasm::I32Load8S {
-    fn eval(&self, evaluator: &mut HirEvaluator) -> Result<ControlFlowEffect, Report> {
-        let addr = self.addr();
-        let addr_value = evaluator.use_value(&addr.as_value_ref())?;
-        let Immediate::U32(addr_value) = addr_value else {
-            return Err(evaluator.report(
-                "evaluation failed",
-                self.span(),
-                format!("expected pointer to be a u32 immediate, got {}", addr_value.ty()),
-            ));
-        };
+macro_rules! impl_eval_load_sext {
+    ($op:ty, $src_imm:ident, $dst_imm:ident, $dst_ty:ty) => {
+        impl Eval for $op {
+            fn eval(&self, evaluator: &mut HirEvaluator) -> Result<ControlFlowEffect, Report> {
+                let addr = self.addr();
+                let addr_value = evaluator.use_value(&addr.as_value_ref())?;
+                let Immediate::U32(addr_value) = addr_value else {
+                    return Err(evaluator.report(
+                        "evaluation failed",
+                        self.span(),
+                        format!("expected pointer to be a u32 immediate, got {}", addr_value.ty()),
+                    ));
+                };
 
-        let pointer_ty = addr.ty();
-        let pointee_ty = pointer_ty
-            .pointee()
-            .expect("expected pointer type to have been verified already");
-        let loaded = evaluator.read_memory(addr_value, pointee_ty)?;
-        let sign_extended = match loaded {
-            Value::Immediate(Immediate::I8(x)) => Value::Immediate(Immediate::I32(x as i32)),
-            Value::Poison {
-                origin,
-                used,
-                value: Immediate::I8(x),
-            } => Value::Poison {
-                origin,
-                used,
-                value: Immediate::I32(x as i32),
-            },
-            other => {
-                return Err(evaluator.report(
-                    "evaluation failed",
-                    self.span(),
-                    format!("expected i8 load, got {}", other.ty()),
-                ));
+                let pointer_ty = addr.ty();
+                let pointee_ty = pointer_ty
+                    .pointee()
+                    .expect("expected pointer type to have been verified already");
+                let loaded = evaluator.read_memory(addr_value, pointee_ty)?;
+
+                let sign_extended = match loaded {
+                    Value::Immediate(Immediate::$src_imm(x)) => {
+                        Ok(Value::Immediate(Immediate::$dst_imm(x as $dst_ty)))
+                    }
+                    Value::Poison {
+                        origin,
+                        used,
+                        value: Immediate::$src_imm(x),
+                    } => Ok(Value::Poison {
+                        origin,
+                        used,
+                        value: Immediate::$dst_imm(x as $dst_ty),
+                    }),
+                    other => Err(evaluator.report(
+                        "evaluation failed",
+                        self.span(),
+                        format!("expected {} load, got {}", stringify!($src_imm), other.ty()),
+                    )),
+                }?;
+
+                evaluator.set_value(self.result().as_value_ref(), sign_extended);
+                Ok(ControlFlowEffect::None)
             }
-        };
-
-        evaluator.set_value(self.result().as_value_ref(), sign_extended);
-        Ok(ControlFlowEffect::None)
-    }
+        }
+    };
 }
+
+impl_eval_load_sext!(wasm::I32Load8S, I8, I32, i32);
+impl_eval_load_sext!(wasm::I32Load16S, I16, I32, i32);
+impl_eval_load_sext!(wasm::I64Load8S, I8, I64, i64);
+impl_eval_load_sext!(wasm::I64Load16S, I16, I64, i64);
+impl_eval_load_sext!(wasm::I64Load32S, I32, I64, i64);

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -149,4 +149,8 @@ fn eval_hir_dialect(info: &mut ::midenc_hir::DialectInfo) {
 fn eval_wasm_dialect(info: &mut ::midenc_hir::DialectInfo) {
     info.register_operation_trait::<wasm::SignExtend, dyn Eval>();
     info.register_operation_trait::<wasm::I32Load8S, dyn Eval>();
+    info.register_operation_trait::<wasm::I32Load16S, dyn Eval>();
+    info.register_operation_trait::<wasm::I64Load8S, dyn Eval>();
+    info.register_operation_trait::<wasm::I64Load16S, dyn Eval>();
+    info.register_operation_trait::<wasm::I64Load32S, dyn Eval>();
 }

--- a/frontend/wasm/src/code_translator/expected/i32_load16_s.hir
+++ b/frontend/wasm/src/code_translator/expected/i32_load16_s.hir
@@ -5,8 +5,7 @@ builtin.function public extern("C") @test_wrapper() {
     %3 = arith.mod %1, %2;
     hir.assertz %3 <{ code = #builtin.u32<250> }> : (u32);
     %4 = hir.int_to_ptr %1 <{ ty = #builtin.type<ptr<i16, byte>> }>;
-    %5 = hir.load %4;
-    %6 = arith.sext %5 <{ ty = #builtin.type<i32> }>;
+    %5 = wasm.i32_load_16s %4;
     cf.br ^block5;
 ^block5:
     builtin.ret;

--- a/frontend/wasm/src/code_translator/expected/i64_load16_s.hir
+++ b/frontend/wasm/src/code_translator/expected/i64_load16_s.hir
@@ -5,8 +5,7 @@ builtin.function public extern("C") @test_wrapper() {
     %3 = arith.mod %1, %2;
     hir.assertz %3 <{ code = #builtin.u32<250> }> : (u32);
     %4 = hir.int_to_ptr %1 <{ ty = #builtin.type<ptr<i16, byte>> }>;
-    %5 = hir.load %4;
-    %6 = arith.sext %5 <{ ty = #builtin.type<i64> }>;
+    %5 = wasm.i64_load_16s %4;
     cf.br ^block5;
 ^block5:
     builtin.ret;

--- a/frontend/wasm/src/code_translator/expected/i64_load32_s.hir
+++ b/frontend/wasm/src/code_translator/expected/i64_load32_s.hir
@@ -5,8 +5,7 @@ builtin.function public extern("C") @test_wrapper() {
     %3 = arith.mod %1, %2;
     hir.assertz %3 <{ code = #builtin.u32<250> }> : (u32);
     %4 = hir.int_to_ptr %1 <{ ty = #builtin.type<ptr<i32, byte>> }>;
-    %5 = hir.load %4;
-    %6 = arith.sext %5 <{ ty = #builtin.type<i64> }>;
+    %5 = wasm.i64_load_32s %4;
     cf.br ^block5;
 ^block5:
     builtin.ret;

--- a/frontend/wasm/src/code_translator/expected/i64_load8_s.hir
+++ b/frontend/wasm/src/code_translator/expected/i64_load8_s.hir
@@ -2,8 +2,7 @@ builtin.function public extern("C") @test_wrapper() {
     %0 = arith.constant 1024 : i32;
     %1 = hir.bitcast %0 <{ ty = #builtin.type<u32> }>;
     %2 = hir.int_to_ptr %1 <{ ty = #builtin.type<ptr<i8, byte>> }>;
-    %3 = hir.load %2;
-    %4 = arith.sext %3 <{ ty = #builtin.type<i64> }>;
+    %3 = wasm.i64_load_8s %2;
     cf.br ^block5;
 ^block5:
     builtin.ret;

--- a/frontend/wasm/src/code_translator/mod.rs
+++ b/frontend/wasm/src/code_translator/mod.rs
@@ -266,7 +266,13 @@ pub fn translate_operator<B: ?Sized + Builder>(
             state.push1(val);
         }
         Operator::I32Load16S { memarg } => {
-            translate_load_sext(I16, I32, memarg, state, builder, span)?;
+            let addr_int = state.pop1();
+            let val = builder.i32_load16_s(
+                addr_int,
+                Some(WasmMemArg::new(memarg.offset, memarg.align)),
+                span,
+            )?;
+            state.push1(val);
         }
         Operator::I64Load8U { memarg } => {
             translate_load_zext(U8, U64, memarg, state, builder, span)?;
@@ -275,13 +281,31 @@ pub fn translate_operator<B: ?Sized + Builder>(
             translate_load_zext(U16, U64, memarg, state, builder, span)?;
         }
         Operator::I64Load8S { memarg } => {
-            translate_load_sext(I8, I64, memarg, state, builder, span)?;
+            let addr_int = state.pop1();
+            let val = builder.i64_load8_s(
+                addr_int,
+                Some(WasmMemArg::new(memarg.offset, memarg.align)),
+                span,
+            )?;
+            state.push1(val);
         }
         Operator::I64Load16S { memarg } => {
-            translate_load_sext(I16, I64, memarg, state, builder, span)?;
+            let addr_int = state.pop1();
+            let val = builder.i64_load16_s(
+                addr_int,
+                Some(WasmMemArg::new(memarg.offset, memarg.align)),
+                span,
+            )?;
+            state.push1(val);
         }
         Operator::I64Load32S { memarg } => {
-            translate_load_sext(I32, I64, memarg, state, builder, span)?;
+            let addr_int = state.pop1();
+            let val = builder.i64_load32_s(
+                addr_int,
+                Some(WasmMemArg::new(memarg.offset, memarg.align)),
+                span,
+            )?;
+            state.push1(val);
         }
         Operator::I64Load32U { memarg } => {
             translate_load_zext(U32, U64, memarg, state, builder, span)?;
@@ -694,28 +718,6 @@ fn translate_load<B: ?Sized + Builder>(
         span,
     )?;
     state.push1(builder.load(addr, span)?);
-    Ok(())
-}
-
-fn translate_load_sext<B: ?Sized + Builder>(
-    ptr_ty: Type,
-    sext_ty: Type,
-    memarg: &MemArg,
-    state: &mut FuncTranslationState,
-    builder: &mut FunctionBuilderExt<'_, B>,
-    span: SourceSpan,
-) -> WasmResult<()> {
-    let addr_int = state.pop1();
-    let addr = prepare_addr(
-        addr_int,
-        &ptr_ty,
-        Some(WasmMemArg::new(memarg.offset, memarg.align)),
-        builder,
-        span,
-    )?;
-    let val = builder.load(addr, span)?;
-    let sext_val = builder.sext(val, sext_ty, span)?;
-    state.push1(sext_val);
     Ok(())
 }
 

--- a/tests/integration/src/codegen/wasm.rs
+++ b/tests/integration/src/codegen/wasm.rs
@@ -416,3 +416,235 @@ fn test_i32_load8_s() {
         );
     }
 }
+
+#[test]
+fn test_i32_load16_s() {
+    let span = SourceSpan::default();
+    let mem_addr = 17 * 2u32.pow(16);
+
+    let (package, context) = compile_test_module([Type::I32], [Type::I32], |builder| {
+        let block = builder.current_block();
+        let addr_i32 = block.borrow().arguments()[0] as ValueRef;
+        let result = builder.i32_load16_s(addr_i32, None, span).unwrap();
+
+        builder.ret(Some(result), span).unwrap();
+    });
+
+    let test_cases = [
+        (0b0111_1111_1111_1111u16, 0b0000_0000_0000_0000_0111_1111_1111_1111u32),
+        (0b1000_0000_0000_0000u16, 0b1111_1111_1111_1111_1000_0000_0000_0000u32),
+        (0b1111_1111_1111_1111u16, 0b1111_1111_1111_1111_1111_1111_1111_1111u32),
+        (0b0000_0000_0000_0000u16, 0b0000_0000_0000_0000_0000_0000_0000_0000u32),
+        (0b1000_0000_0000_0001u16, 0b1111_1111_1111_1111_1000_0000_0000_0001u32),
+    ];
+
+    for (mem_value, expected) in test_cases {
+        assert_eq!(((mem_value as i16) as i32) as u32, expected, "invalid test case");
+
+        let initializers = [Initializer::MemoryBytes {
+            addr: mem_addr,
+            bytes: &mem_value.to_le_bytes(),
+        }];
+
+        let output = eval_package::<u32, _, _>(
+            &package,
+            initializers,
+            &[Felt::new(mem_addr as u64)],
+            context.session(),
+            |_trace| Ok(()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            output, expected,
+            "i32.load16_s failed for input 0b{:016b}: expected 0b{:032b}, got 0b{:032b}",
+            mem_value, expected, output
+        );
+    }
+}
+
+#[test]
+fn test_i64_load8_s() {
+    let span = SourceSpan::default();
+    let mem_addr = 17 * 2u32.pow(16);
+
+    let (package, context) = compile_test_module([Type::I32], [Type::I64], |builder| {
+        let block = builder.current_block();
+        let addr_i32 = block.borrow().arguments()[0] as ValueRef;
+        let result = builder.i64_load8_s(addr_i32, None, span).unwrap();
+
+        builder.ret(Some(result), span).unwrap();
+    });
+
+    // (value written to memory, expected result from i64.load8_s)
+    let test_cases = [
+        (
+            0b0111_1111u8,
+            0b0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0111_1111u64,
+        ),
+        (
+            0b1000_0000u8,
+            0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1000_0000u64,
+        ),
+        (
+            0b1111_1111u8,
+            0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111u64,
+        ),
+        (
+            0b0000_0000u8,
+            0b0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000u64,
+        ),
+        (
+            0b1000_0001u8,
+            0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1000_0001u64,
+        ),
+    ];
+
+    for (mem_value, expected) in test_cases {
+        assert_eq!(((mem_value as i8) as i64) as u64, expected, "invalid test case");
+
+        let initializers = [Initializer::MemoryBytes {
+            addr: mem_addr,
+            bytes: &[mem_value],
+        }];
+
+        let output = eval_package::<u64, _, _>(
+            &package,
+            initializers,
+            &[Felt::new(mem_addr as u64)],
+            context.session(),
+            |_trace| Ok(()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            output, expected,
+            "i64.load8_s failed for input 0b{:08b}: expected 0b{:064b}, got 0b{:064b}",
+            mem_value, expected, output
+        );
+    }
+}
+
+#[test]
+fn test_i64_load16_s() {
+    let span = SourceSpan::default();
+    let mem_addr = 17 * 2u32.pow(16);
+
+    let (package, context) = compile_test_module([Type::I32], [Type::I64], |builder| {
+        let block = builder.current_block();
+        let addr_i32 = block.borrow().arguments()[0] as ValueRef;
+        let result = builder.i64_load16_s(addr_i32, None, span).unwrap();
+
+        builder.ret(Some(result), span).unwrap();
+    });
+
+    // (value written to memory, expected result from i64.load16_s)
+    let test_cases = [
+        (
+            0b0111_1111_1111_1111u16,
+            0b0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0111_1111_1111_1111u64,
+        ),
+        (
+            0b1000_0000_0000_0000u16,
+            0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1000_0000_0000_0000u64,
+        ),
+        (
+            0b1111_1111_1111_1111u16,
+            0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111u64,
+        ),
+        (
+            0b0000_0000_0000_0000u16,
+            0b0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000u64,
+        ),
+        (
+            0b1000_0000_0000_0001u16,
+            0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1000_0000_0000_0001u64,
+        ),
+    ];
+
+    for (mem_value, expected) in test_cases {
+        assert_eq!(((mem_value as i16) as i64) as u64, expected, "invalid test case");
+
+        let initializers = [Initializer::MemoryBytes {
+            addr: mem_addr,
+            bytes: &mem_value.to_le_bytes(),
+        }];
+
+        let output = eval_package::<u64, _, _>(
+            &package,
+            initializers,
+            &[Felt::new(mem_addr as u64)],
+            context.session(),
+            |_trace| Ok(()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            output, expected,
+            "i64.load16_s failed for input 0b{:016b}: expected 0b{:064b}, got 0b{:064b}",
+            mem_value, expected, output
+        );
+    }
+}
+
+#[test]
+fn test_i64_load32_s() {
+    let span = SourceSpan::default();
+    let mem_addr = 17 * 2u32.pow(16);
+
+    let (package, context) = compile_test_module([Type::I32], [Type::I64], |builder| {
+        let block = builder.current_block();
+        let addr_i32 = block.borrow().arguments()[0] as ValueRef;
+        let result = builder.i64_load32_s(addr_i32, None, span).unwrap();
+
+        builder.ret(Some(result), span).unwrap();
+    });
+
+    // (value written to memory, expected result from i64.load32_s)
+    let test_cases = [
+        (
+            0b0111_1111_1111_1111_1111_1111_1111_1111u32,
+            0b0000_0000_0000_0000_0000_0000_0000_0000_0111_1111_1111_1111_1111_1111_1111_1111u64,
+        ),
+        (
+            0b1000_0000_0000_0000_0000_0000_0000_0000u32,
+            0b1111_1111_1111_1111_1111_1111_1111_1111_1000_0000_0000_0000_0000_0000_0000_0000u64,
+        ),
+        (
+            0b1111_1111_1111_1111_1111_1111_1111_1111u32,
+            0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111u64,
+        ),
+        (
+            0b0000_0000_0000_0000_0000_0000_0000_0000u32,
+            0b0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000u64,
+        ),
+        (
+            0b1000_0000_0000_0000_0000_0000_0000_0001u32,
+            0b1111_1111_1111_1111_1111_1111_1111_1111_1000_0000_0000_0000_0000_0000_0000_0001u64,
+        ),
+    ];
+
+    for (mem_value, expected) in test_cases {
+        assert_eq!(((mem_value as i32) as i64) as u64, expected, "invalid test case");
+
+        let initializers = [Initializer::MemoryBytes {
+            addr: mem_addr,
+            bytes: &mem_value.to_le_bytes(),
+        }];
+
+        let output = eval_package::<u64, _, _>(
+            &package,
+            initializers,
+            &[Felt::new(mem_addr as u64)],
+            context.session(),
+            |_trace| Ok(()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            output, expected,
+            "i64.load32_s failed for input 0b{:032b}: expected 0b{:064b}, got 0b{:064b}",
+            mem_value, expected, output
+        );
+    }
+}


### PR DESCRIPTION
#### Summary

- Factors out boilerplate of `wasm` op `I32Load8S` into traits, to make it reusable for the other `load + sext` ops
- Adds the remaining `i*.load*_s` ops to the `wasm` dialect

#### Generated code

- The `hir` changes, see the commited `.hir` expect files
- No changes in emitted `masm`, tested with the same approach is in #1019 

#### Review note

Can be reviewed per commit.