### PR TITLE
Add `README` to `tools/objtool` and `objtool` install task

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -235,6 +235,20 @@ args = [
     "${MIDENC_BIN_DIR}",
 ]
 
+[tasks.objtool]
+category = "Build"
+description = "Builds objtool and installs it to the bin folder"
+command = "cargo"
+args = [
+    "-Z",
+    "unstable-options",
+    "build",
+    "-p",
+    "objtool",
+    "--artifact-dir",
+    "${MIDENC_BIN_DIR}",
+]
+
 [tasks.build]
 category = "Build"
 description = "Runs cargo build on the workspace"
@@ -248,6 +262,7 @@ run_task = [
        "install-midenc",
        "install-hir-opt",
        "install-cargo-miden",
+       "install-objtool",
     ] },
 ]
 
@@ -364,6 +379,21 @@ args = [
     "--force",
     "--bin",
     "hir-opt",
+]
+
+[tasks.install-objtool]
+category = "Install"
+description = "Builds objtool and installs it globally via the cargo bin directory"
+command = "cargo"
+args = [
+    "install",
+    "--locked",
+    "--path",
+    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/tools/objtool",
+    "--${MIDENC_BUILD_PROFILE}",
+    "--force",
+    "--bin",
+    "objtool",
 ]
 
 [tasks.test-rust]

--- a/tools/objtool/README.md
+++ b/tools/objtool/README.md
@@ -6,21 +6,13 @@ Provides the `objtool` CLI to analyze compilation artifacts.
 
 The compilation artifacts to be examined must have been produced by a `midenup` toolchain version compatible with the `compiler` version used to build `objtool`. Otherwise you may run into errors like `unsupported version`.
 
-## Usage
+## Installation
 
-It can be built and run from the repository root, for example:
+Running `cargo make install-objtool` from the repository root installs the `objtool` binary globally via the cargo bin directory. Alternatively, `cargo make install` installs multiple tools, including `objtool`.
 
-```sh
-cargo run -p objtool -- decorators ./mypkg.masp
-```
-
-When using cargo run, arguments for objtool go after the `--` separator.
-
-Alternatively, you can build the package, move it to a directory in your `PATH` and then invoke it directly:
+Once installed, `objtool` can be executed with:
 
 ```sh
-cargo build -p objtool --release
-mv target/release/objtool <dir_on_your_path>
 objtool decorators ./mypkg.masp
 ```
 
@@ -33,7 +25,7 @@ Note that this computes sizes in memory and does *not* write packages stripped o
 **Example usage**
 
 ```sh
-cargo run -p objtool -- decorators ./mypkg.masp
+objtool decorators ./mypkg.masp
 
 Package kind: library
 Artifact: library
@@ -48,7 +40,7 @@ compacted forest    13.10  -23.03  -63.74%
 **Help**
 
 ```sh
-cargo run -p objtool -- decorators --help
+objtool decorators --help
 
 Compare serialized MAST forest sizes after stripping decorators
 


### PR DESCRIPTION
Explains set-up and usage of `objtool` and the `decorators` subcommand.