### PR TITLE
chore: SDK v0.11 release (take 3, switch to `cargo publish`) 

### DIFF
--- a/.github/workflows/release_old.yml
+++ b/.github/workflows/release_old.yml
@@ -1,74 +1,67 @@
-# The old release process left for releasing the Miden SDK until it moves to a separate repo.
+# The Miden SDK publishing until it moves to a separate repo.
 #
-# Runs `release-plz release` only after the release PR (starts with `release-plz-`)
-# is merged to the next branch. Publishes any unpublished Miden SDK crates.
-# Does nothing if all crates are already published (i.e. have their versions on crates.io).
-# Does not create/update release PRs.
-#
+# Runs `cargo publish` only after a merged PR whose source branch starts with
+# `release-plz` targets the `next` branch.
 # See CONTRIBUTING.md for more details.
 
 name: release-miden-sdk
 
 on:
-  push:
+  pull_request:
     branches:
       - next
+    types:
+      - closed
 
 jobs:
   publish:
-    name: publish any unpublished SDK packages
+    name: publish SDK packages
+    if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release-plz') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
       - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
           rustc --version
-      # Publish SDK crates in dependency order so package verification can resolve
-      # already-published versions for inter-crate dependencies.
-      - name: Release `miden-field-repr-derive` crate
-        uses: release-plz/action@v0.5
-        with:
-          command: release
-          manifest_path: sdk/field-repr/derive/Cargo.toml
-      - name: Release `miden-field-repr` crate
-        uses: release-plz/action@v0.5
-        with:
-          command: release
-          manifest_path: sdk/field-repr/repr/Cargo.toml
-      - name: Release `miden-stdlib-sys` crate
-        uses: release-plz/action@v0.5
-        with:
-          command: release
-          manifest_path: sdk/stdlib-sys/Cargo.toml
-      - name: Release `miden-base-macros` crate
-        uses: release-plz/action@v0.5
-        with:
-          command: release
-          manifest_path: sdk/base-macros/Cargo.toml
-      - name: Release `miden-sdk-alloc` crate
-        uses: release-plz/action@v0.5
-        with:
-          command: release
-          manifest_path: sdk/alloc/Cargo.toml
-      - name: Release `miden-base-sys` crate
-        uses: release-plz/action@v0.5
-        with:
-          command: release
-          manifest_path: sdk/base-sys/Cargo.toml
-      - name: Release `miden-base` crate
-        uses: release-plz/action@v0.5
-        with:
-          command: release
-          manifest_path: sdk/base/Cargo.toml
-      - name: Release `miden` crate
-        uses: release-plz/action@v0.5
-        with:
-          command: release
-          manifest_path: sdk/sdk/Cargo.toml
+      # Publish SDK crates in dependency order. Keep these as plain
+      # `cargo publish` invocations and continue if a crate is already published.
+      - name: Publish `miden-field-repr-derive` crate
+        working-directory: sdk/field-repr/derive
+        continue-on-error: true
+        run: cargo publish
+      - name: Publish `miden-field-repr` crate
+        working-directory: sdk/field-repr/repr
+        continue-on-error: true
+        run: cargo publish
+      - name: Publish `miden-stdlib-sys` crate
+        working-directory: sdk/stdlib-sys
+        continue-on-error: true
+        run: cargo publish
+      - name: Publish `miden-base-macros` crate
+        working-directory: sdk/base-macros
+        continue-on-error: true
+        run: cargo publish
+      - name: Publish `miden-sdk-alloc` crate
+        working-directory: sdk/alloc
+        continue-on-error: true
+        run: cargo publish
+      - name: Publish `miden-base-sys` crate
+        working-directory: sdk/base-sys
+        continue-on-error: true
+        run: cargo publish
+      - name: Publish `miden-base` crate
+        working-directory: sdk/base
+        continue-on-error: true
+        run: cargo publish
+      - name: Publish `miden` crate
+        working-directory: sdk/sdk
+        continue-on-error: true
+        run: cargo publish


### PR DESCRIPTION
After the https://github.com/0xMiden/compiler/actions/runs/23836923041/job/69482828415 failed.
Switch to `cargo publish` for the SDK crates publishing. 