### PR TITLE
docs: fix Rust toolchain version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repo is broken into the following high-level components:
 
 ## Building
 
-You'll need to have Rust installed (at time of writing, we're doing development against Rust 1.73).
+You'll need to have Rust installed. This repository pins the toolchain in `rust-toolchain.toml` at the repo root (currently a nightly channel); use `rustup` to install that exact channel after cloning so local builds match CI.
 
 Additionally, you'll want to have [`cargo-make`](https://github.com/sagiegurari/cargo-make) installed:
 


### PR DESCRIPTION
README previously stated development against Rust 1.73, but the repository pins `nightly-2025-12-10` in `rust-toolchain.toml`. This mismatch causes build errors for new contributors using stable.

Replace hardcoded version with instruction to use the pinned toolchain via `rustup` after cloning.