### PR TITLE
fix: update outdated doc paths in rust-toolchain.toml comment

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
 # REMINDER: After updating the channel, update:
-# - docs/src/usage/cargo-miden.md
-# - docs/src/usage/midenc.md
+# - docs/external/src/usage/cargo-miden.md
+# - docs/external/src/usage/midenc.md
 channel = "nightly-2025-12-10"
 components = ["rustfmt", "rust-src", "clippy", "rust-analyzer"]
 targets = ["wasm32-unknown-unknown", "wasm32-wasip1", "wasm32-wasip2"]


### PR DESCRIPTION
Update comment paths from docs/src/usage/ to docs/external/src/usage/ to reflect actual repository structure.