### PR TITLE
chore: release v0.8.0 (take 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Changes since `v0.7.1`.
 
 ### Added
 - initial `wasm` dialect support plus lowering for `i32.extend8_s`, `i32.extend16_s`, `i64.extend*_s`, and signed `i32`/`i64` loads
-- `objtool` CLI plus `install-objtool` and `install` tasks for inspecting MASP artifacts
+- `miden-objtool` CLI plus `install-miden-objtool` and `install` tasks for inspecting MASP artifacts
 - typed SDK storage and felt representation improvements, including `StorageValue<T>`, `StorageMap<K, V>`, `SchemaTypeId`, typed `FeltReader` reads, and richer decode errors
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,8 +2417,8 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.14.0-beta.1"
-source = "git+https://github.com/0xMiden/miden-client?branch=release%2Fv0.14.0-beta#07333c85ad85885b5de91c10b53a0953569536f9"
+version = "0.14.0"
+source = "git+https://github.com/0xMiden/miden-client#9aa6d0c0d23ebe0fb1c4d2df7a0d085a802d81bb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2762,7 +2762,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.14.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#a329b4c7fc5592bd2844242f8a325084e76c9512"
+source = "git+https://github.com/0xMiden/miden-node?rev=c2d61c0eee9f81dd6335ed51c3424a9bd5e34dd8#c2d61c0eee9f81dd6335ed51c3424a9bd5e34dd8"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -2874,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "miden-remote-prover-client"
 version = "0.14.0"
-source = "git+https://github.com/0xMiden/miden-node?branch=next#a329b4c7fc5592bd2844242f8a325084e76c9512"
+source = "git+https://github.com/0xMiden/miden-node?rev=c2d61c0eee9f81dd6335ed51c3424a9bd5e34dd8#c2d61c0eee9f81dd6335ed51c3424a9bd5e34dd8"
 dependencies = [
  "build-rs",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2784,6 +2784,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-objtool"
+version = "0.8.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "miden-core",
+ "miden-mast-package",
+]
+
+[[package]]
 name = "miden-processor"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3662,16 +3672,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "objtool"
-version = "0.8.0"
-dependencies = [
- "anyhow",
- "clap",
- "miden-core",
- "miden-mast-package",
 ]
 
 [[package]]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -235,9 +235,9 @@ args = [
     "${MIDENC_BIN_DIR}",
 ]
 
-[tasks.objtool]
+[tasks.miden-objtool]
 category = "Build"
-description = "Builds objtool and installs it to the bin folder"
+description = "Builds miden-objtool and installs it to the bin folder"
 command = "cargo"
 args = [
     "-Z",
@@ -262,7 +262,7 @@ run_task = [
        "install-midenc",
        "install-hir-opt",
        "install-cargo-miden",
-       "install-objtool",
+       "install-miden-objtool",
     ] },
 ]
 
@@ -386,9 +386,9 @@ args = [
     "hir-opt",
 ]
 
-[tasks.install-objtool]
+[tasks.install-miden-objtool]
 category = "Install"
-description = "Builds objtool and installs it globally via the cargo bin directory"
+description = "Builds miden-objtool and installs it globally via the cargo bin directory"
 command = "cargo"
 args = [
     "install",
@@ -398,7 +398,7 @@ args = [
     "--${MIDENC_BUILD_PROFILE}",
     "--force",
     "--bin",
-    "objtool",
+    "miden-objtool",
 ]
 
 [tasks.test-rust]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -244,7 +244,7 @@ args = [
     "unstable-options",
     "build",
     "-p",
-    "objtool",
+    "miden-objtool",
     "--artifact-dir",
     "${MIDENC_BIN_DIR}",
 ]

--- a/tests/integration-network/Cargo.toml
+++ b/tests/integration-network/Cargo.toml
@@ -13,7 +13,8 @@ publish = false
 
 [dependencies]
 # miden-client = { version = "0.14", features = ["std", "tonic", "testing"] }
-miden-client = { git = "https://github.com/0xMiden/miden-client", branch = "release/v0.14.0-beta", features = ["std", "testing"] }
+# Commit from the next branch
+miden-client = { git = "https://github.com/0xMiden/miden-client", ref = "9aa6d0c0d23ebe0fb1c4d2df7a0d085a802d81bb", features = ["std", "testing"] }
 miden-core.workspace = true
 miden-protocol = { workspace = true, features = ["std", "testing"] }
 miden-standards = { workspace = true, features = ["std"] }

--- a/tools/objtool/Cargo.toml
+++ b/tools/objtool/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "objtool"
+name = "miden-objtool"
 description = "Inspect Miden package MAST forest sizes"
 version.workspace = true
 rust-version.workspace = true

--- a/tools/objtool/README.md
+++ b/tools/objtool/README.md
@@ -1,19 +1,19 @@
-# `objtool`
+# `miden-objtool`
 
-Provides the `objtool` CLI to analyze compilation artifacts.
+Provides the `miden-objtool` CLI to analyze compilation artifacts.
 
 ## Compatibility
 
-The compilation artifacts to be examined must have been produced by a `midenup` toolchain version compatible with the `compiler` version used to build `objtool`. Otherwise you may run into errors like `unsupported version`.
+The compilation artifacts to be examined must have been produced by a `midenup` toolchain version compatible with the `compiler` version used to build `miden-objtool`. Otherwise you may run into errors like `unsupported version`.
 
 ## Installation
 
-Running `cargo make install-objtool` from the repository root installs the `objtool` binary globally via the cargo bin directory. Alternatively, `cargo make install` installs multiple tools, including `objtool`.
+Running `cargo make install-miden-objtool` from the repository root installs the `objtool` binary globally via the cargo bin directory. Alternatively, `cargo make install` installs multiple tools, including `objtool`.
 
-Once installed, `objtool` can be executed with:
+Once installed, `miden-objtool` can be executed with:
 
 ```sh
-objtool decorators ./mypkg.masp
+miden-objtool decorators ./mypkg.masp
 ```
 
 # Commands
@@ -25,7 +25,7 @@ Note that this computes sizes in memory and does *not* write packages stripped o
 **Example usage**
 
 ```sh
-objtool decorators ./mypkg.masp
+miden-objtool decorators ./mypkg.masp
 
 Package kind: library
 Artifact: library
@@ -40,11 +40,11 @@ compacted forest    13.10  -23.03  -63.74%
 **Help**
 
 ```sh
-objtool decorators --help
+miden-objtool decorators --help
 
 Compare serialized MAST forest sizes after stripping decorators
 
-Usage: objtool decorators <PATH>
+Usage: miden-objtool decorators <PATH>
 
 Arguments:
   <PATH>  Path to the input .masp file

--- a/tools/objtool/README.md
+++ b/tools/objtool/README.md
@@ -8,7 +8,7 @@ The compilation artifacts to be examined must have been produced by a `midenup` 
 
 ## Installation
 
-Running `cargo make install-miden-objtool` from the repository root installs the `objtool` binary globally via the cargo bin directory. Alternatively, `cargo make install` installs multiple tools, including `objtool`.
+Running `cargo make install-miden-objtool` from the repository root installs the `miden-objtool` binary globally via the cargo bin directory. Alternatively, `cargo make install` installs multiple tools, including `miden-objtool`.
 
 Once installed, `miden-objtool` can be executed with:
 

--- a/tools/objtool/src/main.rs
+++ b/tools/objtool/src/main.rs
@@ -5,8 +5,8 @@ use clap::{Parser, Subcommand};
 
 #[derive(Debug, Parser)]
 #[command(
-    name = "objtool",
-    bin_name = "objtool",
+    name = "miden-objtool",
+    bin_name = "miden-objtool",
     version,
     about = "Inspect Miden compilation artifact sizes",
     long_about = None,


### PR DESCRIPTION
Rename the `objtool` crate to `miden-objtool`.