### PR TITLE
fix: replace unwrap/expect with proper error propagation and add Panics docs

### DIFF
--- a/eval/src/evaluator.rs
+++ b/eval/src/evaluator.rs
@@ -72,13 +72,23 @@ impl HirEvaluator {
     }
 
     /// The current execution context (i.e. memory, registers)
+    ///
+    /// # Panics
+    ///
+    /// Panics if the context stack is empty. This should not happen after construction, as the
+    /// evaluator always maintains at least one context (the root context).
     pub fn current_context(&self) -> &ExecutionContext {
-        self.contexts.last().unwrap()
+        self.contexts.last().expect("invariant violated: context stack is empty")
     }
 
     /// The current execution context (i.e. memory, registers)
+    ///
+    /// # Panics
+    ///
+    /// Panics if the context stack is empty. This should not happen after construction, as the
+    /// evaluator always maintains at least one context (the root context).
     pub fn current_context_mut(&mut self) -> &mut ExecutionContext {
-        self.contexts.last_mut().unwrap()
+        self.contexts.last_mut().expect("invariant violated: context stack is empty")
     }
 
     /// Enter a fresh execution context (i.e. memory, registers), with an optional identifier

--- a/frontend/wasm/src/component/lower_imports.rs
+++ b/frontend/wasm/src/component/lower_imports.rs
@@ -20,7 +20,7 @@ use super::{
 };
 use crate::{
     callable::CallableFunction,
-    error::WasmResult,
+    error::{WasmError, WasmResult},
     module::function_builder_ext::{
         FunctionBuilderContext, FunctionBuilderExt, SSABuilderListener,
     },
@@ -197,7 +197,7 @@ fn generate_lowering_with_transformation(
             Visibility::Internal,
             new_import_func_sig.clone(),
         )
-        .expect("failed to define the import function");
+        .wrap_err("failed to define the import function")?;
 
     // Import lowering: The lowered function takes a pointer as the last parameter
     // where results should be stored. The import function returns a pointer to the result.
@@ -207,7 +207,17 @@ fn generate_lowering_with_transformation(
     //    flattened result
 
     // Get the pointer argument (last argument) where we need to store results
-    let output_ptr = args.last().expect("expected pointer argument");
+    if args.is_empty() {
+        return Err(WasmError::InvalidWebAssembly {
+            message: "expected at least one argument (output pointer)".into(),
+            offset: 0,
+        }
+        .into());
+    }
+    let output_ptr = args.last().ok_or_else(|| WasmError::InvalidWebAssembly {
+        message: "expected pointer argument in args".into(),
+        offset: 0,
+    })?;
     let args_without_ptr: Vec<_> = args[..args.len() - 1].to_vec();
 
     // Call the import function - it will return a tuple to the flattened result


### PR DESCRIPTION
## Summary

Replaces bare `unwrap()`/`expect()` calls in production code with proper error propagation or documented panic conditions.

## Changes

### 1. `frontend/wasm/src/component/lower_imports.rs`
- Line 200: `.expect("failed to define the import function")` → `.wrap_err(...)?`
- Lines 210-211: Added `args.is_empty()` guard returning `WasmError::InvalidWebAssembly` before `.last()` and slice access. Prevents panic and potential usize underflow on empty args.

### 2. `eval/src/evaluator.rs`
- Added `# Panics` doc sections to `current_context()` and `current_context_mut()` explaining the invariant
- Replaced silent `.unwrap()` with descriptive `.expect("invariant violated: context stack is empty")`

## Result
- 2 files changed
- Panics in production code paths replaced with proper error propagation or documented invariants