### PR TITLE
fix: propagate verification errors and add PassManager integrity test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,25 +134,25 @@ wasmparser = { version = "0.227", default-features = false, features = [
 ] }
 
 # Workspace crates
-midenc-codegen-masm = { version = "0.8.0", path = "codegen/masm" }
-midenc-dialect-arith = { version = "0.8.0", path = "dialects/arith" }
-midenc-dialect-hir = { version = "0.8.0", path = "dialects/hir" }
-midenc-dialect-scf = { version = "0.8.0", path = "dialects/scf" }
-midenc-dialect-cf = { version = "0.8.0", path = "dialects/cf" }
-midenc-dialect-ub = { version = "0.8.0", path = "dialects/ub" }
-midenc-dialect-wasm = { version = "0.8.0", path = "dialects/wasm" }
-midenc-hir = { version = "0.8.0", path = "hir" }
-midenc-hir-analysis = { version = "0.8.0", path = "hir-analysis" }
-midenc-hir-eval = { version = "0.8.0", path = "eval" }
-midenc-hir-macros = { version = "0.8.0", path = "hir-macros" }
-midenc-hir-symbol = { version = "0.8.0", path = "hir-symbol" }
-midenc-hir-transform = { version = "0.8.0", path = "hir-transform" }
-midenc-frontend-wasm = { version = "0.8.0", path = "frontend/wasm" }
-midenc-compile = { version = "0.8.0", path = "midenc-compile" }
-midenc-driver = { version = "0.8.0", path = "midenc-driver" }
-midenc-log = { version = "0.8.0", path = "midenc-log", features = ["kv"] }
-midenc-session = { version = "0.8.0", path = "midenc-session" }
-cargo-miden = { version = "0.8.0", path = "tools/cargo-miden" }
+midenc-codegen-masm = { version = "=0.8.0", path = "codegen/masm" }
+midenc-dialect-arith = { version = "=0.8.0", path = "dialects/arith" }
+midenc-dialect-hir = { version = "=0.8.0", path = "dialects/hir" }
+midenc-dialect-scf = { version = "=0.8.0", path = "dialects/scf" }
+midenc-dialect-cf = { version = "=0.8.0", path = "dialects/cf" }
+midenc-dialect-ub = { version = "=0.8.0", path = "dialects/ub" }
+midenc-dialect-wasm = { version = "=0.8.0", path = "dialects/wasm" }
+midenc-hir = { version = "=0.8.0", path = "hir" }
+midenc-hir-analysis = { version = "=0.8.0", path = "hir-analysis" }
+midenc-hir-eval = { version = "=0.8.0", path = "eval" }
+midenc-hir-macros = { version = "=0.8.0", path = "hir-macros" }
+midenc-hir-symbol = { version = "=0.8.0", path = "hir-symbol" }
+midenc-hir-transform = { version = "=0.8.0", path = "hir-transform" }
+midenc-frontend-wasm = { version = "=0.8.0", path = "frontend/wasm" }
+midenc-compile = { version = "=0.8.0", path = "midenc-compile" }
+midenc-driver = { version = "=0.8.0", path = "midenc-driver" }
+midenc-log = { version = "=0.8.0", path = "midenc-log", features = ["kv"] }
+midenc-session = { version = "=0.8.0", path = "midenc-session" }
+cargo-miden = { version = "=0.8.0", path = "tools/cargo-miden" }
 miden-integration-tests = { path = "tests/integration" }
 midenc-expect-test = { path = "tools/expect-test" }
 miden-field = { version = "0.22" }

--- a/hir/src/pass/manager.rs
+++ b/hir/src/pass/manager.rs
@@ -1120,10 +1120,7 @@ mod tests {
 
     use crate::{
         EntityMut, Operation, OperationName, Report, SourceSpan, Type,
-        dialects::{
-            builtin::BuiltinOpBuilder,
-            test::TestOpBuilder,
-        },
+        dialects::{builtin::BuiltinOpBuilder, test::TestOpBuilder},
         pass::{Pass, PassExecutionState},
         testing::Test,
     };

--- a/hir/src/pass/manager.rs
+++ b/hir/src/pass/manager.rs
@@ -1149,16 +1149,16 @@ mod tests {
             let op_ref = op.as_operation_ref();
             drop(op);
             let borrowed = op_ref.borrow();
-            if let Some(region) = borrowed.regions().front().as_pointer() {
-                if let Some(block) = region.borrow().body().front().as_pointer() {
-                    let mut next_op = block.borrow().front();
-                    while let Some(mut inner) = next_op.take() {
-                        if inner.borrow().num_operands() == 2 {
-                            inner.borrow_mut().set_operands(core::iter::empty());
-                            return Ok(());
-                        }
-                        next_op = inner.next();
+            if let Some(region) = borrowed.regions().front().as_pointer()
+                && let Some(block) = region.borrow().body().front().as_pointer()
+            {
+                let mut next_op = block.borrow().front();
+                while let Some(mut inner) = next_op.take() {
+                    if inner.borrow().num_operands() == 2 {
+                        inner.borrow_mut().set_operands(core::iter::empty());
+                        return Ok(());
                     }
+                    next_op = inner.next();
                 }
             }
             Ok(())

--- a/hir/src/pass/manager.rs
+++ b/hir/src/pass/manager.rs
@@ -1007,7 +1007,7 @@ impl OpToOpPassAdaptor {
             if run_verifier_now
                 && let Err(verification_result) = Self::verify(&op, run_verifier_recursively)
             {
-                result = result.map_err(|_| verification_result);
+                result = Err(verification_result);
             }
         }
 
@@ -1111,5 +1111,78 @@ impl Pass for OpToOpPassAdaptor {
         _state: &mut PassExecutionState,
     ) -> Result<(), Report> {
         unreachable!("unexpected call to `Pass::run_on_operation` for OpToOpPassAdaptor")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::boxed::Box;
+
+    use crate::{
+        EntityMut, Operation, OperationName, Report, SourceSpan, Type,
+        dialects::{
+            builtin::BuiltinOpBuilder,
+            test::TestOpBuilder,
+        },
+        pass::{Pass, PassExecutionState},
+        testing::Test,
+    };
+
+    /// A pass that corrupts BinaryOp operations by clearing their operands.
+    struct CorruptBinaryOp;
+
+    impl Pass for CorruptBinaryOp {
+        type Target = Operation;
+
+        fn name(&self) -> &'static str {
+            "corrupt-binary-op"
+        }
+
+        fn can_schedule_on(&self, _name: &OperationName) -> bool {
+            true
+        }
+
+        fn run_on_operation(
+            &mut self,
+            op: EntityMut<'_, Operation>,
+            _state: &mut PassExecutionState,
+        ) -> Result<(), Report> {
+            // Navigate to the first operation with 2 operands (a BinaryOp)
+            // and remove its operands, breaking the BinaryOp invariant
+            let op_ref = op.as_operation_ref();
+            drop(op);
+            let borrowed = op_ref.borrow();
+            if let Some(region) = borrowed.regions().front().as_pointer() {
+                if let Some(block) = region.borrow().body().front().as_pointer() {
+                    let mut next_op = block.borrow().front();
+                    while let Some(mut inner) = next_op.take() {
+                        if inner.borrow().num_operands() == 2 {
+                            inner.borrow_mut().set_operands(core::iter::empty());
+                            return Ok(());
+                        }
+                        next_op = inner.next();
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn pass_manager_detects_broken_invariant() {
+        let mut test = Test::new("test_verify", &[Type::I32, Type::I32], &[Type::I32]);
+
+        {
+            let entry = test.entry_block();
+            let lhs = entry.borrow().get_argument(0).borrow().as_value_ref();
+            let rhs = entry.borrow().get_argument(1).borrow().as_value_ref();
+            let mut fb = test.function_builder();
+            let sum = fb.add(lhs, rhs, SourceSpan::UNKNOWN).unwrap();
+            fb.ret([sum], SourceSpan::UNKNOWN).unwrap();
+        }
+
+        // Run the corrupting pass with verification enabled
+        let result = test.apply_boxed_pass(Box::new(CorruptBinaryOp), true);
+        assert!(result.is_err(), "PassManager should detect broken BinaryOp invariant");
     }
 }

--- a/midenc-session/src/color.rs
+++ b/midenc-session/src/color.rs
@@ -96,10 +96,10 @@ impl ColorChoice {
         // On Windows, if TERM isn't set, then we shouldn't automatically
         // assume that colors aren't allowed. This is unlike Unix environments
         // where TERM is more rigorously set.
-        if let Some(k) = std::env::var_os("TERM") {
-            if k == "dumb" {
-                return false;
-            }
+        if let Some(k) = std::env::var_os("TERM")
+            && k == "dumb"
+        {
+            return false;
         }
         // If TERM != dumb, then the only way we don't allow colors at this
         // point is if NO_COLOR is set.


### PR DESCRIPTION
## Summary

Fix a bug in `OpToOpPassAdaptor::run()` where verification errors were
silently dropped after a pass completed successfully. The original code
used `result.map_err(|_| verification_result)` which is a no-op when
`result` is `Ok(())`, meaning verification failures were never propagated
to the caller.

The fix changes this to `result = Err(verification_result)` so that
verification errors are always reported.

## Test

Add a test (`pass_manager_detects_broken_invariant`) that:
1. Creates a function with a `test::Add` operation (a BinaryOp requiring 2 operands)
2. Runs a `CorruptBinaryOp` pass that clears the operands of the first BinaryOp it finds
3. Asserts that the PassManager returns an error when verification is enabled

Without the bug fix, this test would pass silently (the verification error would be dropped).

Closes #605