### PR TITLE
fix: enable multiple `MemoryEffect`s on `operand`

### DIFF
--- a/hir-macros/src/operations/effects.rs
+++ b/hir-macros/src/operations/effects.rs
@@ -166,12 +166,11 @@ impl quote::ToTokens for EffectOpInterface {
                     let exprs = exprs.iter();
                     quote! {
                         {
-                            let target = self.#field();
                             values.extend([
                                 #(
                                     ::midenc_hir::effects::EffectInstance::new_for_value(
                                         #exprs,
-                                        target,
+                                        self.#field(),
                                     ),
                                 )*
                             ]);


### PR DESCRIPTION
### Problem

So far there is at most 1 `MemoryEffect` on `operand` fields and hence the code gets expanded only once. Having multiple like `MemoryEffect::Read, MemoryEffect::Write` causes this to expand multiple times, which causes `target` (not `Copy`) to be moved multiple times.

### Fix

Pass a fresh reference to each `EffectInstance`.