### PR TITLE
feat: add lowering for `hir::ConstantPointer`

### DIFF
--- a/codegen/masm/src/lib.rs
+++ b/codegen/masm/src/lib.rs
@@ -152,6 +152,7 @@ fn lower_hir_ops(info: &mut midenc_hir::DialectInfo) {
     info.register_operation_trait::<hir::Cast, dyn HirLowering>();
     info.register_operation_trait::<hir::Bitcast, dyn HirLowering>();
     //info.register_operation_trait::<hir::ConstantBytes, dyn HirLowering>();
+    info.register_operation_trait::<hir::ConstantPointer, dyn HirLowering>();
     info.register_operation_trait::<hir::Exec, dyn HirLowering>();
     info.register_operation_trait::<hir::Call, dyn HirLowering>();
     info.register_operation_trait::<hir::Store, dyn HirLowering>();

--- a/codegen/masm/src/lower/lowering.rs
+++ b/codegen/masm/src/lower/lowering.rs
@@ -441,6 +441,14 @@ impl HirLowering for hir::AssertEq {
     }
 }
 
+impl HirLowering for hir::ConstantPointer {
+    fn emit(&self, emitter: &mut BlockEmitter<'_>) -> Result<(), Report> {
+        let addr = self.get_value().addr();
+        emitter.inst_emitter(self.as_operation()).literal(addr, self.span());
+        Ok(())
+    }
+}
+
 impl HirLowering for ub::Unreachable {
     fn emit(&self, emitter: &mut BlockEmitter<'_>) -> Result<(), Report> {
         // This instruction, if reached, must cause the VM to trap, so we emit an assertion that


### PR DESCRIPTION
In my implementation for #1024 there's a `hir::ConstantPointer` reaching masm codegen. This PR adds lowering for it.

Or is there no lowering on purpose and the issue is that `ConstantPointer` shouldn't reach masm codegen?