### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-04-16
+
+### Changed
+- compile the note script as a library and generate `@note-script` and `@auth_script` MASM attribute #1051
+
 ## [0.8.0] - 2026-04-03
 
 Changes since `v0.7.1`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-miden"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "miden-integration-tests"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "miden-objtool"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "midenc"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "human-panic",
  "midenc-driver",
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-benchmark-runner"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-codegen-masm"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "inventory",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-compile"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3271,7 +3271,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-arith"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "midenc-hir",
  "paste",
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-cf"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "log",
  "midenc-dialect-arith",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-hir"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "litcheck-core",
  "litcheck-filecheck",
@@ -3304,7 +3304,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-scf"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bitvec",
  "log",
@@ -3318,14 +3318,14 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-ub"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "midenc-hir",
 ]
 
 [[package]]
 name = "midenc-dialect-wasm"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "midenc-dialect-arith",
  "midenc-dialect-hir",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-driver"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "clap",
  "log",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-expect-test"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "once_cell",
  "similar",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "addr2line 0.24.2",
  "anyhow",
@@ -3389,7 +3389,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-analysis"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bitvec",
  "blink-alloc",
@@ -3436,7 +3436,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-eval"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "log",
  "miden-core",
@@ -3453,7 +3453,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-macros"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "Inflector",
  "darling",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-opt"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-symbol"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "Inflector",
  "compact_str 0.9.0",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-transform"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "litcheck-core",
  "litcheck-filecheck",
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-integration-network-tests"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "miden-client",
  "miden-core",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-log"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-session"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 rust-version = "1.92"
 authors = ["Miden contributors"]
 description = "An intermediate representation and compiler for Miden Assembly"
@@ -135,26 +135,26 @@ wasmparser = { version = "0.227", default-features = false, features = [
 ] }
 
 # Workspace crates
-midenc-codegen-masm = { version = "0.8.0", path = "codegen/masm" }
-midenc-dialect-arith = { version = "0.8.0", path = "dialects/arith" }
-midenc-dialect-hir = { version = "0.8.0", path = "dialects/hir" }
-midenc-dialect-scf = { version = "0.8.0", path = "dialects/scf" }
-midenc-dialect-cf = { version = "0.8.0", path = "dialects/cf" }
-midenc-dialect-ub = { version = "0.8.0", path = "dialects/ub" }
-midenc-dialect-wasm = { version = "0.8.0", path = "dialects/wasm" }
-midenc-hir = { version = "0.8.0", path = "hir" }
-midenc-hir-analysis = { version = "0.8.0", path = "hir-analysis" }
-midenc-hir-eval = { version = "0.8.0", path = "eval" }
-midenc-hir-macros = { version = "0.8.0", path = "hir-macros" }
-midenc-hir-symbol = { version = "0.8.0", path = "hir-symbol" }
-midenc-hir-transform = { version = "0.8.0", path = "hir-transform" }
-midenc-frontend-wasm = { version = "0.8.0", path = "frontend/wasm" }
+midenc-codegen-masm = { version = "0.8.1", path = "codegen/masm" }
+midenc-dialect-arith = { version = "0.8.1", path = "dialects/arith" }
+midenc-dialect-hir = { version = "0.8.1", path = "dialects/hir" }
+midenc-dialect-scf = { version = "0.8.1", path = "dialects/scf" }
+midenc-dialect-cf = { version = "0.8.1", path = "dialects/cf" }
+midenc-dialect-ub = { version = "0.8.1", path = "dialects/ub" }
+midenc-dialect-wasm = { version = "0.8.1", path = "dialects/wasm" }
+midenc-hir = { version = "0.8.1", path = "hir" }
+midenc-hir-analysis = { version = "0.8.1", path = "hir-analysis" }
+midenc-hir-eval = { version = "0.8.1", path = "eval" }
+midenc-hir-macros = { version = "0.8.1", path = "hir-macros" }
+midenc-hir-symbol = { version = "0.8.1", path = "hir-symbol" }
+midenc-hir-transform = { version = "0.8.1", path = "hir-transform" }
+midenc-frontend-wasm = { version = "0.8.1", path = "frontend/wasm" }
 midenc-frontend-wasm-metadata = { version = "0.12.0", path = "sdk/wasm-metadata" }
-midenc-compile = { version = "0.8.0", path = "midenc-compile" }
-midenc-driver = { version = "0.8.0", path = "midenc-driver" }
-midenc-log = { version = "0.8.0", path = "midenc-log", features = ["kv"] }
-midenc-session = { version = "0.8.0", path = "midenc-session" }
-cargo-miden = { version = "0.8.0", path = "tools/cargo-miden" }
+midenc-compile = { version = "0.8.1", path = "midenc-compile" }
+midenc-driver = { version = "0.8.1", path = "midenc-driver" }
+midenc-log = { version = "0.8.1", path = "midenc-log", features = ["kv"] }
+midenc-session = { version = "0.8.1", path = "midenc-session" }
+cargo-miden = { version = "0.8.1", path = "tools/cargo-miden" }
 miden-integration-tests = { path = "tests/integration" }
 midenc-expect-test = { path = "tools/expect-test" }
 miden-field = { version = "0.22" }


### PR DESCRIPTION
Bump the workspace version to 0.8.1.
Update the CHANGELOG.md.