### PR TITLE
Use `opt-level = "s"` (optimize for size); Tolerate missing Wasm name section

### DIFF
--- a/frontend/wasm/src/module/build_ir.rs
+++ b/frontend/wasm/src/module/build_ir.rs
@@ -8,7 +8,6 @@ use midenc_hir::{
     dialects::builtin::{
         self, BuiltinOpBuilder, ComponentBuilder, ModuleBuilder, World, WorldBuilder,
     },
-    interner::Symbol,
     version::Version,
 };
 use midenc_session::diagnostics::{DiagnosticsHandler, IntoDiagnostic, Severity, SourceSpan};
@@ -213,12 +212,7 @@ fn build_globals(
 ) -> WasmResult<()> {
     let span = SourceSpan::default();
     for (global_idx, global) in &wasm_module.globals {
-        let global_name = wasm_module
-            .name_section
-            .globals_names
-            .get(&global_idx)
-            .cloned()
-            .unwrap_or(Symbol::intern(format!("gv{}", global_idx.as_u32())));
+        let global_name = wasm_module.global_name(global_idx);
         let global_init = wasm_module.try_global_initializer(global_idx, diagnostics)?;
         let visibility = if wasm_module.is_exported(global_idx.into()) {
             Visibility::Public
@@ -260,8 +254,7 @@ fn build_data_segments(
     diagnostics: &DiagnosticsHandler,
 ) -> WasmResult<()> {
     for (data_segment_idx, data_segment) in &translation.data_segments {
-        let data_segment_name =
-            translation.module.name_section.data_segment_names[&data_segment_idx];
+        let data_segment_name = translation.module.data_segment_name(data_segment_idx);
         let readonly = data_segment_name.as_str().contains(".rodata");
         let offset = data_segment.offset.as_i32(&translation.module, diagnostics)? as u32;
         let init = ConstantData::from(data_segment.data.to_vec());

--- a/frontend/wasm/src/module/mod.rs
+++ b/frontend/wasm/src/module/mod.rs
@@ -322,6 +322,20 @@ impl Module {
             .unwrap_or(Symbol::intern(format!("func{}", index.as_u32())))
     }
 
+    /// Returns the name of the given data segment.
+    ///
+    /// If the wasm name section does not include an entry for this segment
+    /// (e.g. when the binary was built with `strip = true` or the producer
+    /// did not emit a name subsection for data segments), falls back to a
+    /// synthesized `data{index}` name.
+    pub fn data_segment_name(&self, index: DataSegmentIndex) -> Symbol {
+        self.name_section
+            .data_segment_names
+            .get(&index)
+            .cloned()
+            .unwrap_or_else(|| Symbol::intern(format!("data{}", index.as_u32())))
+    }
+
     /// Sets the fallback name of this module, used if there is no module name in the name section
     pub fn set_name_fallback(&mut self, name_fallback: Cow<'static, str>) {
         self.name_fallback = Some(Ident::from(name_fallback.as_ref()));

--- a/tests/integration-network/src/mockchain/basic_wallet.rs
+++ b/tests/integration-network/src/mockchain/basic_wallet.rs
@@ -107,7 +107,7 @@ pub fn test_basic_wallet_p2id() {
         chain.build_tx_context(alice_id, &[p2id_note_mint.id()], &[]).unwrap();
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
     expect!["3216"].assert_eq(prologue_cycles(&tx_measurements));
-    expect!["26206"].assert_eq(note_cycles(&tx_measurements, p2id_note_mint.id()));
+    expect!["20211"].assert_eq(note_cycles(&tx_measurements, p2id_note_mint.id()));
 
     eprintln!("\n=== Checking Alice's account has the minted asset ===");
     let alice_account = chain.committed_account(alice_id).unwrap();
@@ -127,12 +127,12 @@ pub fn test_basic_wallet_p2id() {
         &mut note_rng,
     );
     let tx_measurements = execute_tx(&mut chain, alice_tx_context_builder);
-    expect!["29010"].assert_eq(tx_script_processing_cycles(&tx_measurements));
+    expect!["25232"].assert_eq(tx_script_processing_cycles(&tx_measurements));
 
     eprintln!("\n=== Step 4: Bob consumes p2id note ===");
     let consume_tx_context_builder = chain.build_tx_context(bob_id, &[bob_note.id()], &[]).unwrap();
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
-    expect!["26206"].assert_eq(note_cycles(&tx_measurements, bob_note.id()));
+    expect!["20211"].assert_eq(note_cycles(&tx_measurements, bob_note.id()));
 
     eprintln!("\n=== Checking Bob's account has the transferred asset ===");
     let bob_account = chain.committed_account(bob_id).unwrap();
@@ -257,7 +257,7 @@ pub fn test_basic_wallet_p2ide() {
     let consume_tx_context_builder =
         chain.build_tx_context(bob_id, &[p2ide_note.id()], &[]).unwrap();
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
-    expect!["27523"].assert_eq(note_cycles(&tx_measurements, p2ide_note.id()));
+    expect!["20686"].assert_eq(note_cycles(&tx_measurements, p2ide_note.id()));
 
     // Step 5: verify balances
     let bob_account = chain.committed_account(bob_id).unwrap();
@@ -382,7 +382,7 @@ pub fn test_basic_wallet_p2ide_reclaim() {
     let reclaim_tx_context_builder =
         chain.build_tx_context(alice_id, &[p2ide_note.id()], &[]).unwrap();
     let tx_measurements = execute_tx(&mut chain, reclaim_tx_context_builder);
-    expect!["29023"].assert_eq(note_cycles(&tx_measurements, p2ide_note.id()));
+    expect!["21699"].assert_eq(note_cycles(&tx_measurements, p2ide_note.id()));
 
     // Step 5: verify Alice has her original amount back
     let alice_account = chain.committed_account(alice_id).unwrap();

--- a/tests/integration-network/src/mockchain/counter_contract.rs
+++ b/tests/integration-network/src/mockchain/counter_contract.rs
@@ -68,7 +68,7 @@ pub fn test_counter_contract() {
         .build_tx_context(counter_account.clone(), &[counter_note.id()], &[])
         .unwrap();
     let tx_measurements = execute_tx(&mut chain, tx_context_builder);
-    expect!["28585"].assert_eq(note_cycles(&tx_measurements, counter_note.id()));
+    expect!["24863"].assert_eq(note_cycles(&tx_measurements, counter_note.id()));
 
     // The counter contract storage value should be 2 after the note is consumed (incremented by 1).
     assert_counter_storage(

--- a/tests/integration-network/src/mockchain/counter_contract_no_auth.rs
+++ b/tests/integration-network/src/mockchain/counter_contract_no_auth.rs
@@ -105,7 +105,7 @@ pub fn test_counter_contract_no_auth() {
         .unwrap();
     let tx_measurements = execute_tx(&mut chain, tx_context_builder);
     expect!["1824"].assert_eq(auth_procedure_cycles(&tx_measurements));
-    expect!["28585"].assert_eq(note_cycles(&tx_measurements, counter_note.id()));
+    expect!["24863"].assert_eq(note_cycles(&tx_measurements, counter_note.id()));
 
     // The counter contract storage value should be 2 after the note is consumed
     assert_counter_storage(

--- a/tests/integration/src/rust_masm_tests/examples.rs
+++ b/tests/integration/src/rust_masm_tests/examples.rs
@@ -329,7 +329,7 @@ fn basic_wallet_and_p2id() {
         CompilerTest::rust_source_cargo_miden("../../examples/basic-wallet", config.clone(), []);
     let account_package = account_test.compile_package();
     assert!(account_package.is_library(), "expected library");
-    expect!["29921"].assert_eq(stripped_mast_size_str(&account_package));
+    expect!["29016"].assert_eq(stripped_mast_size_str(&account_package));
 
     let mut tx_script_test = CompilerTest::rust_source_cargo_miden(
         "../../examples/basic-wallet-tx-script",
@@ -338,19 +338,19 @@ fn basic_wallet_and_p2id() {
     );
     let tx_script_package = tx_script_test.compile_package();
     assert!(tx_script_package.is_program(), "expected program");
-    expect!["50961"].assert_eq(stripped_mast_size_str(&tx_script_package));
+    expect!["45884"].assert_eq(stripped_mast_size_str(&tx_script_package));
 
     let mut p2id_test =
         CompilerTest::rust_source_cargo_miden("../../examples/p2id-note", config.clone(), []);
     let note_package = p2id_test.compile_package();
     assert!(note_package.is_library(), "expected library");
-    expect!["44348"].assert_eq(stripped_mast_size_str(&note_package));
+    expect!["38430"].assert_eq(stripped_mast_size_str(&note_package));
 
     let mut p2ide_test =
         CompilerTest::rust_source_cargo_miden("../../examples/p2ide-note", config, []);
     let p2ide_package = p2ide_test.compile_package();
     assert!(p2ide_package.is_library(), "expected library");
-    expect!["51565"].assert_eq(stripped_mast_size_str(&p2ide_package));
+    expect!["43003"].assert_eq(stripped_mast_size_str(&p2ide_package));
 }
 
 #[test]

--- a/tests/integration/src/rust_masm_tests/examples.rs
+++ b/tests/integration/src/rust_masm_tests/examples.rs
@@ -12,7 +12,11 @@ use midenc_hir::{
 use prop::test_runner::{Config, TestRunner};
 use proptest::prelude::*;
 
-use crate::{CompilerTest, CompilerTestBuilder, cargo_proj::project, testing::executor_with_std};
+use crate::{
+    CompilerTest, CompilerTestBuilder,
+    cargo_proj::project,
+    testing::{executor_with_std, stripped_mast_size_str},
+};
 
 /// Asserts that the exported procedure carrying `attribute` is unique and preserves its leaf
 /// export name.
@@ -321,25 +325,32 @@ fn counter_note() {
 #[test]
 fn basic_wallet_and_p2id() {
     let config = WasmTranslationConfig::default();
-    let mut test =
+    let mut account_test =
         CompilerTest::rust_source_cargo_miden("../../examples/basic-wallet", config.clone(), []);
-    let account_package = test.compile_package();
+    let account_package = account_test.compile_package();
     assert!(account_package.is_library(), "expected library");
+    expect!["29921"].assert_eq(stripped_mast_size_str(&account_package));
 
-    let mut test = CompilerTest::rust_source_cargo_miden(
+    let mut tx_script_test = CompilerTest::rust_source_cargo_miden(
         "../../examples/basic-wallet-tx-script",
         config.clone(),
         [],
     );
-    let package = test.compile_package();
-    assert!(package.is_program(), "expected program");
+    let tx_script_package = tx_script_test.compile_package();
+    assert!(tx_script_package.is_program(), "expected program");
+    expect!["50961"].assert_eq(stripped_mast_size_str(&tx_script_package));
 
-    let mut test = CompilerTest::rust_source_cargo_miden("../../examples/p2id-note", config, []);
-    let note_package = test.compile_package();
+    let mut p2id_test =
+        CompilerTest::rust_source_cargo_miden("../../examples/p2id-note", config.clone(), []);
+    let note_package = p2id_test.compile_package();
     assert!(note_package.is_library(), "expected library");
-    let _note_script =
-        NoteScript::from_package(note_package.as_ref()).expect("expected a note-script package");
-    assert_unique_protocol_export(note_package.as_ref(), "note_script", "script");
+    expect!["44348"].assert_eq(stripped_mast_size_str(&note_package));
+
+    let mut p2ide_test =
+        CompilerTest::rust_source_cargo_miden("../../examples/p2ide-note", config, []);
+    let p2ide_package = p2ide_test.compile_package();
+    assert!(p2ide_package.is_library(), "expected library");
+    expect!["51565"].assert_eq(stripped_mast_size_str(&p2ide_package));
 }
 
 #[test]

--- a/tests/integration/src/testing/mod.rs
+++ b/tests/integration/src/testing/mod.rs
@@ -1,11 +1,13 @@
 //! This module provides core utilities for constructing tests outside of the primary
 //! [crate::CompilerTest] infrastructure.
+
 mod eval;
 mod initializer;
 pub mod setup;
 
 use std::sync::Arc;
 
+use miden_assembly::serde::Serializable;
 use miden_core::Felt;
 use miden_debug::Executor;
 use miden_mast_package::Package;
@@ -60,4 +62,12 @@ pub fn format_report(report: miden_assembly::diagnostics::Report) -> String {
     writeln!(&mut str, "{labels_str}").unwrap();
 
     str
+}
+
+/// Returns the serialized byte size of the MastForest with stripped debug info
+pub fn stripped_mast_size_str(package: &Package) -> &str {
+    let mut note_mast = package.mast.mast_forest().as_ref().clone();
+    note_mast.clear_debug_info();
+    let compacted_size = note_mast.to_bytes().len();
+    Box::leak(compacted_size.to_string().into_boxed_str())
 }

--- a/tests/rust-apps-wasm/rust-sdk/add/Cargo.toml
+++ b/tests/rust-apps-wasm/rust-sdk/add/Cargo.toml
@@ -17,23 +17,7 @@ miden = { path = "../../../../sdk/sdk" }
 
 
 [profile.release]
-# optimize the output for size
-opt-level = "z"
-# Explicitly disable panic infrastructure on Wasm, as
-# there is no proper support for them anyway, and it
-# ensures that panics do not pull in a bunch of standard
-# library code unintentionally
-panic = "abort"
 trim-paths = ["diagnostics", "object"]
 
 [profile.dev]
-# Explicitly disable panic infrastructure on Wasm, as
-# there is no proper support for them anyway, and it
-# ensures that panics do not pull in a bunch of standard
-# library code unintentionally
-panic = "abort"
-opt-level = 1
-debug-assertions = true
-overflow-checks = false
-debug = true
 trim-paths = ["diagnostics", "object"]

--- a/tests/rust-apps-wasm/rust-sdk/cross-ctx-account-word-arg/Cargo.toml
+++ b/tests/rust-apps-wasm/rust-sdk/cross-ctx-account-word-arg/Cargo.toml
@@ -16,25 +16,9 @@ crate-type = ["cdylib"]
 miden = { path = "../../../../sdk/sdk" }
 
 [profile.release]
-# optimize the output for size
-opt-level = "z"
-# Explicitly disable panic infrastructure on Wasm, as
-# there is no proper support for them anyway, and it
-# ensures that panics do not pull in a bunch of standard
-# library code unintentionally
-panic = "abort"
 trim-paths = ["diagnostics", "object"]
 
 [profile.dev]
-# Explicitly disable panic infrastructure on Wasm, as
-# there is no proper support for them anyway, and it
-# ensures that panics do not pull in a bunch of standard
-# library code unintentionally
-panic = "abort"
-opt-level = 1
-debug-assertions = true
-overflow-checks = false
-debug = true
 trim-paths = ["diagnostics", "object"]
 
 [package.metadata.miden]

--- a/tests/rust-apps-wasm/rust-sdk/cross-ctx-account-word/Cargo.toml
+++ b/tests/rust-apps-wasm/rust-sdk/cross-ctx-account-word/Cargo.toml
@@ -17,25 +17,9 @@ miden = { path = "../../../../sdk/sdk" }
 
 
 [profile.release]
-# optimize the output for size
-opt-level = "z"
-# Explicitly disable panic infrastructure on Wasm, as
-# there is no proper support for them anyway, and it
-# ensures that panics do not pull in a bunch of standard
-# library code unintentionally
-panic = "abort"
 trim-paths = ["diagnostics", "object"]
 
 [profile.dev]
-# Explicitly disable panic infrastructure on Wasm, as
-# there is no proper support for them anyway, and it
-# ensures that panics do not pull in a bunch of standard
-# library code unintentionally
-panic = "abort"
-opt-level = 1
-debug-assertions = true
-overflow-checks = false
-debug = true
 trim-paths = ["diagnostics", "object"]
 
 [package.metadata.miden]

--- a/tests/rust-apps-wasm/rust-sdk/cross-ctx-account/Cargo.toml
+++ b/tests/rust-apps-wasm/rust-sdk/cross-ctx-account/Cargo.toml
@@ -16,25 +16,9 @@ crate-type = ["cdylib"]
 miden = { path = "../../../../sdk/sdk" }
 
 [profile.release]
-# optimize the output for size
-opt-level = "z"
-# Explicitly disable panic infrastructure on Wasm, as
-# there is no proper support for them anyway, and it
-# ensures that panics do not pull in a bunch of standard
-# library code unintentionally
-panic = "abort"
 trim-paths = ["diagnostics", "object"]
 
 [profile.dev]
-# Explicitly disable panic infrastructure on Wasm, as
-# there is no proper support for them anyway, and it
-# ensures that panics do not pull in a bunch of standard
-# library code unintentionally
-panic = "abort"
-opt-level = 1
-debug-assertions = true
-overflow-checks = false
-debug = true
 trim-paths = ["diagnostics", "object"]
 
 [package.metadata.miden]

--- a/tests/rust-apps-wasm/rust-sdk/cross-ctx-note-word-arg/Cargo.toml
+++ b/tests/rust-apps-wasm/rust-sdk/cross-ctx-note-word-arg/Cargo.toml
@@ -16,25 +16,9 @@ crate-type = ["cdylib"]
 miden = { path = "../../../../sdk/sdk" }
 
 [profile.release]
-# optimize the output for size
-opt-level = "z"
-# Explicitly disable panic infrastructure on Wasm, as
-# there is no proper support for them anyway, and it
-# ensures that panics do not pull in a bunch of standard
-# library code unintentionally
-panic = "abort"
 trim-paths = ["diagnostics", "object"]
 
 [profile.dev]
-# Explicitly disable panic infrastructure on Wasm, as
-# there is no proper support for them anyway, and it
-# ensures that panics do not pull in a bunch of standard
-# library code unintentionally
-panic = "abort"
-opt-level = 1
-debug-assertions = true
-overflow-checks = false
-debug = true
 trim-paths = ["diagnostics", "object"]
 
 [package.metadata.miden]

--- a/tests/rust-apps-wasm/rust-sdk/cross-ctx-note-word/Cargo.toml
+++ b/tests/rust-apps-wasm/rust-sdk/cross-ctx-note-word/Cargo.toml
@@ -16,25 +16,9 @@ crate-type = ["cdylib"]
 miden = { path = "../../../../sdk/sdk" }
 
 [profile.release]
-# optimize the output for size
-opt-level = "z"
-# Explicitly disable panic infrastructure on Wasm, as
-# there is no proper support for them anyway, and it
-# ensures that panics do not pull in a bunch of standard
-# library code unintentionally
-panic = "abort"
 trim-paths = ["diagnostics", "object"]
 
 [profile.dev]
-# Explicitly disable panic infrastructure on Wasm, as
-# there is no proper support for them anyway, and it
-# ensures that panics do not pull in a bunch of standard
-# library code unintentionally
-panic = "abort"
-opt-level = 1
-debug-assertions = true
-overflow-checks = false
-debug = true
 trim-paths = ["diagnostics", "object"]
 
 [package.metadata.miden]

--- a/tests/rust-apps-wasm/rust-sdk/cross-ctx-note/Cargo.toml
+++ b/tests/rust-apps-wasm/rust-sdk/cross-ctx-note/Cargo.toml
@@ -16,25 +16,9 @@ crate-type = ["cdylib"]
 miden = { path = "../../../../sdk/sdk" }
 
 [profile.release]
-# optimize the output for size
-opt-level = "z"
-# Explicitly disable panic infrastructure on Wasm, as
-# there is no proper support for them anyway, and it
-# ensures that panics do not pull in a bunch of standard
-# library code unintentionally
-panic = "abort"
 trim-paths = ["diagnostics", "object"]
 
 [profile.dev]
-# Explicitly disable panic infrastructure on Wasm, as
-# there is no proper support for them anyway, and it
-# ensures that panics do not pull in a bunch of standard
-# library code unintentionally
-panic = "abort"
-opt-level = 1
-debug-assertions = true
-overflow-checks = false
-debug = true
 trim-paths = ["diagnostics", "object"]
 
 [package.metadata.miden]

--- a/tests/rust-apps-wasm/rust-sdk/issue-invalid-stack-offset-movup/Cargo.toml
+++ b/tests/rust-apps-wasm/rust-sdk/issue-invalid-stack-offset-movup/Cargo.toml
@@ -18,15 +18,7 @@ package = "miden:issue-invalid-stack-offset-movup"
 project-kind = "note-script"
 
 [profile.release]
-opt-level = "z"
-panic = "abort"
-debug = false
 trim-paths = ["diagnostics", "object"]
 
 [profile.dev]
-panic = "abort"
-opt-level = 1
-debug-assertions = true
-overflow-checks = false
-debug = true
 trim-paths = ["diagnostics", "object"]

--- a/tools/cargo-miden/src/commands/build.rs
+++ b/tools/cargo-miden/src/commands/build.rs
@@ -210,7 +210,7 @@ fn build_cargo_args(cargo_opts: &CargoOptions) -> Vec<String> {
         ("profile.dev.overflow-checks", "false"),
         ("profile.dev.debug", "true"),
         ("profile.dev.debug-assertions", "false"),
-        ("profile.release.opt-level", "\"z\""),
+        ("profile.release.opt-level", "\"s\""),
         ("profile.release.panic", "\"abort\""),
     ];
 


### PR DESCRIPTION
#1065 

In this PR:
- remove profile options from the example/tests; 
- switch to `profile.release.opt-level = "s"` (size down 3%-15%, see ff6e2256bfef27905b0fc9650150fa71ca97388e commit for exact numbers)
- fix: tolerate missing wasm name section in wasm frontend (when `strip = true`)