### PR TITLE
chore: update toolchain to nightly-2026-04-29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,36 +259,7 @@ jobs:
       - name: Test
         # Skip running the some test since they are a disc space hog.
         run: |
-          cargo make test -E 'package(cargo-miden) - test(new_project_integration_tests_pass) - test(test_all_templates_and_examples)'
-
-  cargo_miden_tests_mpt:
-    name: cargo-miden test Miden project template
-    runs-on: ubuntu-latest
-    # We only want to run the integration tests if the unit tests pass, and that has the added
-    # benefit that we can re-use the cache from the unit test job for all integration tests
-    needs: [unit_tests]
-    steps:
-      - uses: actions/checkout@v5
-      - uses: ./.github/actions/cleanup-runner
-      - name: Install Rust
-        run: |
-          rustup update --no-self-update
-          rustc --version
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ${{ github.workflow }}-shared-tests
-          prefix-key: ${{ env.RUST_CACHE_KEY }}
-          # Do not persist the cache, leave that to the unit tests, we just use the cache here
-          save-if: false
-      - name: Install cargo-make
-        run: |
-          if ! cargo make --version 2>/dev/null; then
-            cargo install cargo-make --force
-          fi
-      - name: Test
-        run: |
-          cargo make test -E 'test(new_project_integration_tests_pass)'
+          cargo make test -E 'package(cargo-miden) - test(test_all_templates_and_examples)'
 
   cargo_miden_tests_templates_and_examples:
     name: cargo-miden test new project templates and examples

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,27 +14,27 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "cpp_demangle",
- "fallible-iterator",
- "gimli 0.31.1",
- "memmap2",
- "object 0.36.7",
- "rustc-demangle",
- "smallvec",
- "typed-arena",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli 0.32.3",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+dependencies = [
+ "cpp_demangle",
+ "fallible-iterator",
+ "gimli 0.33.0",
+ "memmap2",
+ "object 0.39.1",
+ "rustc-demangle",
+ "smallvec",
+ "typed-arena",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -175,27 +175,12 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -208,15 +193,6 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "anstyle-parse"
@@ -383,9 +359,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitmaps"
@@ -410,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -441,6 +417,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "build-rs"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc87f52297187fb5d25bde3d368f0480f88ac1d8f3cf4c80ac5575435511114"
+checksum = "fe808acca98fccf920154ee7833e791bfb683299be4aae7ec222ddffad8cd4f8"
 dependencies = [
  "unicode-ident",
 ]
@@ -504,24 +489,25 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.11+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "cargo-util"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a4b72539a4e322539ac3cd07d7e63d60ca3823f3143a2d39a9f8fcdace0e8ca"
+checksum = "a4162900cab52029d1e29a44ba98277ec9936948b8cefbd7a2269c990ac7d58a"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -532,7 +518,7 @@ dependencies = [
  "libc",
  "miow",
  "same-file",
- "sha2",
+ "sha2 0.10.9",
  "shell-escape",
  "tempfile",
  "tracing",
@@ -542,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -577,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -663,16 +649,16 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -684,7 +670,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -693,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -772,6 +758,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,9 +796,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
 ]
@@ -831,17 +823,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.120.2"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7b2ee9eec6ca8a716d900d5264d678fb2c290c58c46c8da7f94ee268175d17"
+checksum = "f25c06993a681be9cf3140798a3d4ac5bec955e7444416a2fdc87fda8567285d"
+dependencies = [
+ "wasmtime-internal-core",
+]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.120.2"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75418674520cb400c8772bfd6e11a62736c78fc1b6e418195696841d1bf91f1"
+checksum = "5e62ef34c6e720f347a79ece043e8584e242d168911da640bac654a33a6aaaf5"
 dependencies = [
  "cranelift-bitset",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -969,6 +965,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,7 +982,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version 0.4.1",
  "subtle",
@@ -1035,7 +1040,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -1083,10 +1088,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1108,7 +1124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1134,7 +1150,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1153,7 +1169,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -1190,7 +1206,7 @@ version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "env_filter",
  "jiff",
@@ -1317,6 +1333,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "fs-err"
@@ -1491,19 +1513,18 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-dependencies = [
- "fallible-iterator",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
@@ -1585,7 +1606,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2 0.2.21",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1593,6 +1614,20 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2 0.2.21",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1621,7 +1656,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1675,7 +1710,7 @@ version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2815d0c49773c6e0a9753960b3d0e50b822e48e08c77bcb4780be8474c9cc3d"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "backtrace",
  "serde",
@@ -1683,6 +1718,15 @@ dependencies = [
  "sysinfo",
  "toml 1.1.2+spec-1.1.0",
  "uuid",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -1734,7 +1778,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1814,12 +1858,12 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1857,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "intrusive-collections"
-version = "0.9.7"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+checksum = "ec0375b6b871e424e9e052e1107d57dc6952f77ff882bd4bf74333a833779bab"
 dependencies = [
  "memoffset",
 ]
@@ -1911,9 +1955,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -1924,9 +1968,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1945,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1965,7 +2009,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -2033,9 +2077,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2045,14 +2089,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2333,7 +2377,7 @@ dependencies = [
  "miden-base",
  "miden-base-macros",
  "miden-base-sys",
- "miden-field 0.22.6",
+ "miden-field 0.24.0",
  "miden-field-repr",
  "miden-sdk-alloc",
  "miden-stdlib-sys",
@@ -2342,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a12734b3bf5e8c88580c4c173368865d1efd6f51f48365df76b59f12d8dc53"
+checksum = "44929802246cf00c5ff76ae9f9648e079f64245e5fa8344a2aefc33bab9cd346"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
@@ -2357,15 +2401,17 @@ dependencies = [
  "miden-utils-sync",
  "primitive-types",
  "regex",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "walkdir",
 ]
 
 [[package]]
 name = "miden-air"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15646ebc95906b2a7cb66711d1e184f53fd6edc2605730bbcf0c2a129f792cf"
+checksum = "b45551e1417cb2be47064c36fe6e1e69ab10ad7b4b55f0731d8cac109b7738b9"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2376,9 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6013b3a390e0dcb29242f4480a7727965887bbf0903466c88f362b4cb20c0e"
+checksum = "1d2094e2b943f7bf955a2bc3b44b0ad7c4f45a286f170eaa7e5060871c44847a"
 dependencies = [
  "env_logger",
  "log",
@@ -2393,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996156b8f7c5fe6be17dea71089c6d7985c2dec1e3a4fec068b1dfc690e25df5"
+checksum = "b5a3212614ad28399612f39024c1e321dc8cebc8998def06058e60462ddc3856"
 dependencies = [
  "aho-corasick",
  "env_logger",
@@ -2429,7 +2475,7 @@ name = "miden-base-macros"
 version = "0.12.0"
 dependencies = [
  "heck",
- "miden-field 0.22.6",
+ "miden-field 0.24.0",
  "miden-field-repr",
  "miden-formatting",
  "miden-protocol",
@@ -2438,7 +2484,7 @@ dependencies = [
  "quote",
  "semver 1.0.28",
  "syn 2.0.117",
- "toml 0.8.23",
+ "toml 1.1.2+spec-1.1.0",
  "wit-bindgen-core 0.46.0",
  "wit-bindgen-rust 0.46.0",
 ]
@@ -2453,9 +2499,9 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334340b0b2e6993f6b71af359a77cf8730c4a19ac366f77aee734a5faa993897"
+checksum = "fec217cf565a2c7272a4cc409939bd8a5a43bfd02b7f7a16bd6abd3cfcb2b514"
 dependencies = [
  "miden-protocol",
  "thiserror 2.0.18",
@@ -2463,9 +2509,9 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.14.0"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49957f76717961769c911237113bb9c1841c3b13970c15ca09a0ae639c33fc45"
+checksum = "15007f2cf4e80316a8141665b43f454e77ce0dfd2ac0307ce6cdf7a5d552d58b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2474,6 +2520,7 @@ dependencies = [
  "getrandom 0.3.4",
  "gloo-timers",
  "hex",
+ "miden-debug",
  "miden-node-proto-build",
  "miden-note-transport-proto-build",
  "miden-protocol",
@@ -2484,9 +2531,10 @@ dependencies = [
  "miette",
  "prost",
  "prost-types",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -2501,9 +2549,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdec54a321cdf3d23e9ef615e91cb858038c6b4d4202507bdec048fc6d7763e4"
+checksum = "39a4a2e2de49213ec899e88fe399d4ec568c8eb9e8c747d6ed58938c40031daa"
 dependencies = [
  "derive_more",
  "itertools 0.14.0",
@@ -2523,9 +2571,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "621e8fa911a790bcf3cd3aedce80bc10922a19d6181f08ff3ca078f955cff70b"
+checksum = "2d2ea7e17c4382255c6e0cb1e4b90693449dcf5a286a844e2918af66b371c0ab"
 dependencies = [
  "env_logger",
  "fs-err",
@@ -2559,22 +2607,22 @@ dependencies = [
  "num",
  "num-complex",
  "p3-blake3",
- "p3-challenger 0.5.2",
- "p3-dft 0.5.2",
- "p3-goldilocks 0.5.2",
+ "p3-challenger",
+ "p3-dft",
+ "p3-goldilocks",
  "p3-keccak",
- "p3-matrix 0.5.2",
- "p3-maybe-rayon 0.5.2",
+ "p3-matrix",
+ "p3-maybe-rayon",
  "p3-miden-lifted-stark",
- "p3-symmetric 0.5.2",
- "p3-util 0.5.2",
- "rand 0.9.2",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_core 0.9.5",
  "rand_hc",
  "rayon",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "subtle",
  "thiserror 2.0.18",
@@ -2672,9 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e50274d11c80b901cf6c90362de8c98c8c8ad6030c80624d683b63d899a0fb"
+checksum = "16570786d938b7f795921b3a84890708a7d72708442c622eb58c2fb5480821e9"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -2690,34 +2738,36 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546ac41444d6f1ab015daa0bf420759405d3cf0a5cb2b552140ad60443ddf39c"
-dependencies = [
- "miden-serde-utils 0.22.6",
- "num-bigint",
- "p3-challenger 0.4.2",
- "p3-field 0.4.2",
- "p3-goldilocks 0.4.2",
- "paste",
- "rand 0.9.2",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "miden-field"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38011348f4fb4c9e5ce1f471203d024721c00e3b60a91aa91aaefe6738d8b5ea"
 dependencies = [
  "miden-serde-utils 0.23.0",
  "num-bigint",
- "p3-challenger 0.5.2",
- "p3-field 0.5.2",
- "p3-goldilocks 0.5.2",
+ "p3-challenger",
+ "p3-field",
+ "p3-goldilocks",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.1",
+ "serde",
+ "subtle",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "miden-field"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ea5945a9bc14419b1b4cafc9762217c3f553330aa770af65c61c37268725d2e"
+dependencies = [
+ "miden-serde-utils 0.24.0",
+ "num-bigint",
+ "p3-challenger",
+ "p3-field",
+ "p3-goldilocks",
+ "p3-util",
+ "paste",
+ "rand 0.10.1",
  "serde",
  "subtle",
  "thiserror 2.0.18",
@@ -2728,7 +2778,7 @@ name = "miden-field-repr"
 version = "0.12.0"
 dependencies = [
  "miden-core",
- "miden-field 0.22.6",
+ "miden-field 0.24.0",
  "miden-field-repr-derive",
 ]
 
@@ -2747,7 +2797,7 @@ version = "0.12.0"
 dependencies = [
  "miden-core",
  "miden-debug",
- "miden-field 0.22.6",
+ "miden-field 0.24.0",
  "miden-field-repr",
  "miden-integration-tests",
  "miden-processor",
@@ -2800,16 +2850,16 @@ dependencies = [
  "midenc-session",
  "num-traits",
  "proptest",
- "sha2",
+ "sha2 0.11.0",
  "walkdir",
- "wasmprinter",
+ "wasmprinter 0.227.1",
 ]
 
 [[package]]
 name = "miden-mast-package"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8b2e3447fcde1f0e6b76e5219f129517639772cb02ca543177f0584e315288"
+checksum = "0953396dc5e575b79bccb8b7da6e0d18ce71bcde899901bb4293a433f9003b94"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
@@ -2857,9 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.14.3"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c78309c58cbffd5fd92c944d6f7f3ed6d59340587c74d4eab4e6edf9e31e8d3"
+checksum = "c75a51deb54acc447f4497b50214965e2c973be19319ae1db36d96627646f365"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -2893,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969ba3942052e52b3968e34dbd1c52c707e75777ee42ebdae2c8f57af56cf6cf"
+checksum = "e07af92dc184a71132a34d89ad15e69633435bfd36fb5af4ce18b200bd1952e5"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2908,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ec6cecbf22bd92b73a931ee80b424e46b8b7cdf4f2f3c364c25c5c15d2840da"
+checksum = "340c424f9f62b56a808c9a479cef016f25478e227555ce39cb2684e8baf26542"
 dependencies = [
  "itertools 0.14.0",
  "miden-air",
@@ -2927,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3840520c01881534fbbceb6b3687ec1c407fbaf310a35ce415fd3510abc52fdb"
+checksum = "541619ccdf566c2fac0d24bfc3806bc36e1d57a698a937621f1874ceb36a55d4"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2943,9 +2993,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595b3d43ceb562d05e248a6c52bdc2992dc270b60d6d0e8c0a6480aa30672b8e"
+checksum = "140b1b3d6b2a3a2bfaeca8b0d2ca15a8ee6a7e0abebbc4f1a2a3a1f1b7f7f58d"
 dependencies = [
  "bech32",
  "fs-err",
@@ -2960,7 +3010,7 @@ dependencies = [
  "miden-protocol-macros",
  "miden-utils-sync",
  "miden-verifier",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xoshiro 0.7.0",
  "regex",
@@ -2973,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol-macros"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c287782953c94452c2f7431feff137e4fe8b8d1eb5aa9112eab83a6f11c8f2"
+checksum = "3cbd8195ba7804fab6ab22f042715fab55c842ac29e99534490243c6a12a3cb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2984,9 +3034,9 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb2c94e36f57684d7fa0cd382adeedc1728d502dbbe69ad1c12f4a931f45511"
+checksum = "fadcff2d171f81f2737a35a007c756753a8298d067555c7a556bd72f570b32f9"
 dependencies = [
  "bincode",
  "miden-air",
@@ -3002,9 +3052,9 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.14.3"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd619f60846ce890309d65f9a5c1d8f6fcbe800c9a61f4c822d25145827ae6b3"
+checksum = "beae091bf49b31e1a067b4e93326a6bf60cf6cbb6d02767504483e89b3f37838"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -3028,29 +3078,29 @@ version = "0.12.0"
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bedaf94fb4bb6806e4af99fadce74e4cdd0e8664c571107b255f86b00b3149b"
-dependencies = [
- "p3-field 0.4.2",
- "p3-goldilocks 0.4.2",
-]
-
-[[package]]
-name = "miden-serde-utils"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff78082e9b4ca89863e68da01b35f8a4029ee6fd912e39fa41fde4273a7debab"
 dependencies = [
- "p3-field 0.5.2",
- "p3-goldilocks 0.5.2",
+ "p3-field",
+ "p3-goldilocks",
+]
+
+[[package]]
+name = "miden-serde-utils"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94c2ae629849e1e6d851fa6ba85f9fb9715a10d6b9a8bed29a5a5403164c7595"
+dependencies = [
+ "p3-field",
+ "p3-goldilocks",
 ]
 
 [[package]]
 name = "miden-standards"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f63cd9264dc1f9f124fe644ee631828cc9bfd71022a75cd5bc1678f3ba7b56"
+checksum = "a08e4e4edb289460b1b676a9cdb1727131c2749218dd85a333571d09e1cfa621"
 dependencies = [
  "fs-err",
  "miden-assembly",
@@ -3058,7 +3108,7 @@ dependencies = [
  "miden-core-lib",
  "miden-processor",
  "miden-protocol",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "thiserror 2.0.18",
  "walkdir",
@@ -3068,14 +3118,14 @@ dependencies = [
 name = "miden-stdlib-sys"
 version = "0.12.0"
 dependencies = [
- "miden-field 0.22.6",
+ "miden-field 0.24.0",
 ]
 
 [[package]]
 name = "miden-testing"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2761dd1f8baa744c91d1ff143d954c623d5fb1d2dfec8c8ab1dac2254343d7cd"
+checksum = "44aa821e2e285e6a8a262f964794313c35abea3716eda7af2e0588cae4ff7751"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -3089,7 +3139,7 @@ dependencies = [
  "miden-standards",
  "miden-tx",
  "miden-tx-batch-prover",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "thiserror 2.0.18",
 ]
@@ -3116,9 +3166,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e894e952e2819545e9351f7427779f82538e51553dfaca3294301ff308086497"
+checksum = "3b5264ce262d3a0a9983785d9f944cbda35dc51550715be674309e7d6112fc80"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -3130,9 +3180,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch-prover"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e7aac0d511aa412138ea7dfa4a6d8c76340c6028fa91313727b7ad3614711b"
+checksum = "62cc436bd810b9712a52183a0dd52a65006238ea7177470056e7edab50ab9deb"
 dependencies = [
  "miden-protocol",
  "miden-tx",
@@ -3140,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3846c8674ccec0c37005f99c1a599a24790ba2a5e5f4e1c7aec5f456821df835"
+checksum = "cdd5103e9b6527ad396dce12c135cea1984dfd77ebbffa76f260f4e139906cc4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3151,9 +3201,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397f5d1e8679cf17cf7713ffd9654840791a6ed5818b025bbc2fbfdce846579a"
+checksum = "72226906c968c2e7c37435d67be9e29aeba05336db30c4e57d290cc6efb1da9d"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -3164,9 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8834e76299686bcce3de1685158aa4cff49b7fa5e0e00a6cc811e8f2cf5775f"
+checksum = "5cc2e62161113179a370ae0bf1fd33eb8d20b6131e8559d2dc0bead5cffae586"
 dependencies = [
  "miden-crypto",
  "serde",
@@ -3175,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9e9747e9664c1a0997bb040ae291306ea0a1c74a572141ec66cec855c1b0e8"
+checksum = "4e9210b3592b577843710daf68293087c68b53d8482c82f6875ad83d578cb51e"
 dependencies = [
  "lock_api",
  "loom",
@@ -3187,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4580df640d889c9f3c349cd2268968e44a99a8cf0df6c36ae5b1fb273712b00"
+checksum = "83f47bf33268ffb31c2fc452debf8e4ba76fbb3175566efbfe850c4886fb5b37"
 dependencies = [
  "bincode",
  "miden-air",
@@ -3352,17 +3402,17 @@ name = "midenc-expect-test"
 version = "0.8.1"
 dependencies = [
  "once_cell",
- "similar",
+ "similar 3.1.0",
 ]
 
 [[package]]
 name = "midenc-frontend-wasm"
 version = "0.8.1"
 dependencies = [
- "addr2line 0.24.2",
+ "addr2line 0.26.1",
  "anyhow",
  "cranelift-entity",
- "gimli 0.31.1",
+ "gimli 0.33.0",
  "indexmap",
  "log",
  "miden-core",
@@ -3377,8 +3427,8 @@ dependencies = [
  "midenc-hir",
  "midenc-hir-symbol",
  "midenc-session",
- "wasmparser 0.227.1",
- "wasmprinter",
+ "wasmparser 0.248.0",
+ "wasmprinter 0.248.0",
  "wat",
 ]
 
@@ -3400,7 +3450,7 @@ dependencies = [
  "bitvec",
  "blink-alloc",
  "compact_str 0.9.0",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
  "intrusive-collections",
  "inventory",
  "litcheck-core",
@@ -3490,13 +3540,13 @@ version = "0.8.1"
 dependencies = [
  "Inflector",
  "compact_str 0.9.0",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
  "lock_api",
  "miden-formatting",
  "parking_lot",
  "rustc-hash",
  "serde",
- "toml 0.8.23",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -3541,7 +3591,7 @@ dependencies = [
  "miden-testing",
  "midenc-expect-test",
  "midenc-frontend-wasm",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tokio",
 ]
 
@@ -3549,7 +3599,7 @@ dependencies = [
 name = "midenc-log"
 version = "0.8.1"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "jiff",
  "log",
@@ -3798,22 +3848,22 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "flate2",
- "memchr",
- "ruzstd",
-]
-
-[[package]]
-name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "flate2",
+ "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -3830,9 +3880,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
-version = "6.5.1"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
  "bitflags",
  "libc",
@@ -3842,9 +3892,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.9.1"
+version = "69.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3880,8 +3930,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f2ec9cbfc642fc5173817287c3f8b789d07743b5f7e812d058b7a03e344f9ab"
 dependencies = [
- "p3-field 0.5.2",
- "p3-matrix 0.5.2",
+ "p3-field",
+ "p3-matrix",
  "tracing",
 ]
 
@@ -3892,22 +3942,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b667f43b19499dd939c9e2553aa95688936a88360d50117dae3c8848d07dbc70"
 dependencies = [
  "blake3",
- "p3-symmetric 0.5.2",
- "p3-util 0.5.2",
-]
-
-[[package]]
-name = "p3-challenger"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20e42ba74a49c08c6e99f74cd9b343bfa31aa5721fea55079b18e3fd65f1dcbc"
-dependencies = [
- "p3-field 0.4.2",
- "p3-maybe-rayon 0.4.2",
- "p3-monty-31 0.4.2",
- "p3-symmetric 0.4.2",
- "p3-util 0.4.2",
- "tracing",
+ "p3-symmetric",
+ "p3-util",
 ]
 
 [[package]]
@@ -3916,11 +3952,11 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a0b490c745a7d2adeeafff06411814c8078c432740162332b3cd71be0158a76"
 dependencies = [
- "p3-field 0.5.2",
- "p3-maybe-rayon 0.5.2",
- "p3-monty-31 0.5.2",
- "p3-symmetric 0.5.2",
- "p3-util 0.5.2",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-monty-31",
+ "p3-symmetric",
+ "p3-util",
  "tracing",
 ]
 
@@ -3931,25 +3967,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "916ae7989d5c3b49f887f5c55b2f9826bdbb81aaebf834503c4145d8b267c829"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.5.2",
- "p3-matrix 0.5.2",
- "p3-util 0.5.2",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
  "serde",
-]
-
-[[package]]
-name = "p3-dft"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63fa5eb1bd12a240089e72ae3fe10350944d9c166d00a3bfd2a1794db65cf5c"
-dependencies = [
- "itertools 0.14.0",
- "p3-field 0.4.2",
- "p3-matrix 0.4.2",
- "p3-maybe-rayon 0.4.2",
- "p3-util 0.4.2",
- "spin 0.10.0",
- "tracing",
 ]
 
 [[package]]
@@ -3959,27 +3980,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55301e91544440254977108b85c32c09d7ea05f2f0dd61092a2825339906a4a7"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.5.2",
- "p3-matrix 0.5.2",
- "p3-maybe-rayon 0.5.2",
- "p3-util 0.5.2",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "spin 0.10.0",
- "tracing",
-]
-
-[[package]]
-name = "p3-field"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ebfdb6ef992ae64e9e8f449ac46516ffa584f11afbdf9ee244288c2a633cdf4"
-dependencies = [
- "itertools 0.14.0",
- "num-bigint",
- "p3-maybe-rayon 0.4.2",
- "p3-util 0.4.2",
- "paste",
- "rand 0.9.2",
- "serde",
  "tracing",
 ]
 
@@ -3991,31 +3996,12 @@ checksum = "85affca7fc983889f260655c4cf74163eebb94605f702e4b6809ead707cba54f"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
- "p3-maybe-rayon 0.5.2",
- "p3-util 0.5.2",
+ "p3-maybe-rayon",
+ "p3-util",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "tracing",
-]
-
-[[package]]
-name = "p3-goldilocks"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64716244b5612622d4e78a4f48b74f6d3bb7b4085b7b6b25364b1dfca7198c66"
-dependencies = [
- "num-bigint",
- "p3-challenger 0.4.2",
- "p3-dft 0.4.2",
- "p3-field 0.4.2",
- "p3-mds 0.4.2",
- "p3-poseidon2 0.4.2",
- "p3-symmetric 0.4.2",
- "p3-util 0.4.2",
- "paste",
- "rand 0.9.2",
- "serde",
 ]
 
 [[package]]
@@ -4025,16 +4011,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca1081f5c47b940f2d75a11c04f62ea1cc58a5d480dd465fef3861c045c63cd"
 dependencies = [
  "num-bigint",
- "p3-challenger 0.5.2",
- "p3-dft 0.5.2",
- "p3-field 0.5.2",
- "p3-mds 0.5.2",
+ "p3-challenger",
+ "p3-dft",
+ "p3-field",
+ "p3-mds",
  "p3-poseidon1",
- "p3-poseidon2 0.5.2",
- "p3-symmetric 0.5.2",
- "p3-util 0.5.2",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "p3-util",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
 ]
 
@@ -4044,25 +4030,9 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebcf27615ece1995e4fcf4c69740f1cf515d1481367a20b4b3ce7f4f1b8d70f7"
 dependencies = [
- "p3-symmetric 0.5.2",
- "p3-util 0.5.2",
+ "p3-symmetric",
+ "p3-util",
  "tiny-keccak",
-]
-
-[[package]]
-name = "p3-matrix"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5542f96504dae8100c91398fb1e3f5ec669eb9c73d9e0b018a93b5fe32bad230"
-dependencies = [
- "itertools 0.14.0",
- "p3-field 0.4.2",
- "p3-maybe-rayon 0.4.2",
- "p3-util 0.4.2",
- "rand 0.9.2",
- "serde",
- "tracing",
- "transpose",
 ]
 
 [[package]]
@@ -4072,19 +4042,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53428126b009071563d1d07305a9de8be0d21de00b57d2475289ee32ffca6577"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.5.2",
- "p3-maybe-rayon 0.5.2",
- "p3-util 0.5.2",
- "rand 0.10.0",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-util",
+ "rand 0.10.1",
  "serde",
  "tracing",
 ]
-
-[[package]]
-name = "p3-maybe-rayon"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5669ca75645f99cd001e9d0289a4eeff2bc2cd9dc3c6c3aaf22643966e83df"
 
 [[package]]
 name = "p3-maybe-rayon"
@@ -4097,28 +4061,15 @@ dependencies = [
 
 [[package]]
 name = "p3-mds"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038763af23df9da653065867fd85b38626079031576c86fd537097e5be6a0da0"
-dependencies = [
- "p3-dft 0.4.2",
- "p3-field 0.4.2",
- "p3-symmetric 0.4.2",
- "p3-util 0.4.2",
- "rand 0.9.2",
-]
-
-[[package]]
-name = "p3-mds"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35209e6214102ea6ec6b8cb1b9c15a9b8e597a39f9173597c957f123bced81b3"
 dependencies = [
- "p3-dft 0.5.2",
- "p3-field 0.5.2",
- "p3-symmetric 0.5.2",
- "p3-util 0.5.2",
- "rand 0.10.0",
+ "p3-dft",
+ "p3-field",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -4128,9 +4079,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5c31c65fdc88952d7b301546add9670676e5b878aa0066dd929f107c203b006"
 dependencies = [
  "p3-air",
- "p3-field 0.5.2",
- "p3-matrix 0.5.2",
- "p3-util 0.5.2",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
  "thiserror 2.0.18",
 ]
 
@@ -4140,16 +4091,16 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab9932f1b0a16609a45cd4ee10a4d35412728bc4b38837c7979d7c85d8dcc9fc"
 dependencies = [
- "p3-challenger 0.5.2",
+ "p3-challenger",
  "p3-commit",
- "p3-dft 0.5.2",
- "p3-field 0.5.2",
- "p3-matrix 0.5.2",
- "p3-maybe-rayon 0.5.2",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
  "p3-miden-lmcs",
  "p3-miden-transcript",
- "p3-util 0.5.2",
- "rand 0.10.0",
+ "p3-util",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -4160,17 +4111,17 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3956ab7270c3cdd53ca9796d39ae1821984eb977415b0672110f9666bff5d8"
 dependencies = [
- "p3-challenger 0.5.2",
- "p3-dft 0.5.2",
- "p3-field 0.5.2",
- "p3-matrix 0.5.2",
- "p3-maybe-rayon 0.5.2",
+ "p3-challenger",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
  "p3-miden-lifted-air",
  "p3-miden-lifted-fri",
  "p3-miden-lmcs",
  "p3-miden-stateful-hasher",
  "p3-miden-transcript",
- "p3-util 0.5.2",
+ "p3-util",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -4182,14 +4133,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c46791c983e772136db3d48f102431457451447abb9087deb6c8ce3c1efc86"
 dependencies = [
  "p3-commit",
- "p3-field 0.5.2",
- "p3-matrix 0.5.2",
- "p3-maybe-rayon 0.5.2",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
  "p3-miden-stateful-hasher",
  "p3-miden-transcript",
- "p3-symmetric 0.5.2",
- "p3-util 0.5.2",
- "rand 0.10.0",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.10.1",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -4201,8 +4152,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec47a9d9615eb3d9d2a59b00d19751d9ad85384b55886827913d680d912eac6a"
 dependencies = [
- "p3-field 0.5.2",
- "p3-symmetric 0.5.2",
+ "p3-field",
+ "p3-symmetric",
 ]
 
 [[package]]
@@ -4211,34 +4162,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c565647487e4a949f67e6f115b0391d6cb82ac8e561165789939bab23d0ae7"
 dependencies = [
- "p3-challenger 0.5.2",
- "p3-field 0.5.2",
+ "p3-challenger",
+ "p3-field",
  "serde",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "p3-monty-31"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a981d60da3d8cbf8561014e2c186068578405fd69098fa75b43d4afb364a47"
-dependencies = [
- "itertools 0.14.0",
- "num-bigint",
- "p3-dft 0.4.2",
- "p3-field 0.4.2",
- "p3-matrix 0.4.2",
- "p3-maybe-rayon 0.4.2",
- "p3-mds 0.4.2",
- "p3-poseidon2 0.4.2",
- "p3-symmetric 0.4.2",
- "p3-util 0.4.2",
- "paste",
- "rand 0.9.2",
- "serde",
- "spin 0.10.0",
- "tracing",
- "transpose",
 ]
 
 [[package]]
@@ -4249,17 +4176,17 @@ checksum = "ffa8c99ec50c035020bbf5457c6a729ba6a975719c1a8dd3f16421081e4f650c"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
- "p3-dft 0.5.2",
- "p3-field 0.5.2",
- "p3-matrix 0.5.2",
- "p3-maybe-rayon 0.5.2",
- "p3-mds 0.5.2",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-mds",
  "p3-poseidon1",
- "p3-poseidon2 0.5.2",
- "p3-symmetric 0.5.2",
- "p3-util 0.5.2",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "p3-util",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "spin 0.10.0",
  "tracing",
@@ -4271,22 +4198,9 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a018b618e3fa0aec8be933b1d8e404edd23f46991f6bf3f5c2f3f95e9413fe9"
 dependencies = [
- "p3-field 0.5.2",
- "p3-symmetric 0.5.2",
- "rand 0.10.0",
-]
-
-[[package]]
-name = "p3-poseidon2"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903b73e4f9a7781a18561c74dc169cf03333497b57a8dd02aaeb130c0f386599"
-dependencies = [
- "p3-field 0.4.2",
- "p3-mds 0.4.2",
- "p3-symmetric 0.4.2",
- "p3-util 0.4.2",
- "rand 0.9.2",
+ "p3-field",
+ "p3-symmetric",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -4295,22 +4209,11 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "256a668a9ba916f8767552f13d0ba50d18968bc74a623bfdafa41e2970c944d0"
 dependencies = [
- "p3-field 0.5.2",
- "p3-mds 0.5.2",
- "p3-symmetric 0.5.2",
- "p3-util 0.5.2",
- "rand 0.10.0",
-]
-
-[[package]]
-name = "p3-symmetric"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd788f04e86dd5c35dd87cad29eefdb6371d2fd5f7664451382eeacae3c3ed0"
-dependencies = [
- "itertools 0.14.0",
- "p3-field 0.4.2",
- "serde",
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -4320,17 +4223,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c60a71a1507c13611b0f2b0b6e83669fd5b76f8e3115bcbced5ccfdf3ca7807"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.5.2",
- "p3-util 0.5.2",
- "serde",
-]
-
-[[package]]
-name = "p3-util"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "663b16021930bc600ecada915c6c3965730a3b9d6a6c23434ccf70bfc29d6881"
-dependencies = [
+ "p3-field",
+ "p3-util",
  "serde",
 ]
 
@@ -4448,7 +4342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4519,9 +4413,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -4576,9 +4470,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -4686,7 +4580,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -4867,18 +4761,18 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -4886,11 +4780,11 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4923,9 +4817,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -4986,9 +4880,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -5015,9 +4909,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -5077,13 +4971,13 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "proptest",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.4",
  "ruint-macro",
  "serde_core",
  "valuable",
@@ -5154,9 +5048,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -5181,18 +5075,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5219,9 +5113,9 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.7.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
+checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
 dependencies = [
  "twox-hash",
 ]
@@ -5416,16 +5310,27 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -5487,7 +5392,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -5502,6 +5407,15 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "similar"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d93e861ede2e497b47833469b8ec9d5c07fa4c78ce7a00f6eb7dd8168b4b3f"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "siphasher"
@@ -5542,24 +5456,24 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "snapbox"
-version = "0.6.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1abc378119f77310836665f8523018532cf7e3faeb3b10b01da5a7321bf8e1"
+checksum = "f92ac911648d788a6435401d9b4803959039d4de9919fdabdb415a8bebd027be"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "normalize-line-endings",
- "similar",
+ "similar 2.7.0",
  "snapbox-macros",
 ]
 
 [[package]]
 name = "snapbox-macros"
-version = "0.4.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b750c344002d7cc69afb9da00ebd9b5c0f8ac2eb7d115d9d45d5b5f47718d74"
+checksum = "ed4a172e483585ebbc7c7f7d1705ca7e3f94f606ed78caa14805673189fd5455"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
 ]
 
 [[package]]
@@ -5942,9 +5856,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -6041,7 +5955,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6087,17 +6001,17 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned 1.1.1",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6106,7 +6020,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6205,9 +6119,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-web-wasm-client"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e21e20b94f808d6f2244a5d960d02c28dd82066abddd2f27019bac0535f310"
+checksum = "3c0469c353de5f665c95f898074b5b004b500c6722214c3249f1dc79c0a2a3f6"
 dependencies = [
  "base64",
  "byteorder",
@@ -6364,13 +6278,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typed-arena"
@@ -6386,9 +6296,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -6473,7 +6383,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -6491,9 +6401,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6509,9 +6419,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version-ranges"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3595ffe225639f1e0fd8d7269dcc05d2fbfea93cfac2fea367daf1adb60aae91"
+checksum = "31e9bd4e9c9ff6a2a9b5969462ba26216af3e010df0377dad8320ab515262ef8"
 dependencies = [
  "smallvec",
 ]
@@ -6567,11 +6477,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -6585,9 +6495,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6598,9 +6508,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6608,9 +6518,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6618,9 +6528,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6631,9 +6541,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -6660,12 +6570,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.246.2"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.246.2",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -6742,9 +6652,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.246.2"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
 dependencies = [
  "bitflags",
  "indexmap",
@@ -6763,32 +6673,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "wast"
-version = "246.0.2"
+name = "wasmprinter"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3fe8e3bf88ad96d031b4181ddbd64634b17cb0d06dfc3de589ef43591a9a62"
+checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f2c7fa6523647262bfb4095dbdf4087accefe525813e783f81a0c682f418ce4"
+dependencies = [
+ "hashbrown 0.16.1",
+ "libm",
+]
+
+[[package]]
+name = "wast"
+version = "248.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acc54622ed5a5cddafcdf152043f9d4aed54d4a653d686b7dfe874809fca99d7"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.246.2",
+ "wasm-encoder 0.248.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.246.2"
+version = "1.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
+checksum = "d75cd9e510603909748e6ebab89f27cd04472c1d9d85a3c88a7a6fc51a1a7934"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7037,9 +6968,12 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -7058,6 +6992,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro 0.51.0",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ exclude = [
 
 [workspace.package]
 version = "0.8.1"
-rust-version = "1.92"
+rust-version = "1.97"
 authors = ["Miden contributors"]
 description = "An intermediate representation and compiler for Miden Assembly"
 repository = "https://github.com/0xMiden/compiler"
@@ -51,13 +51,13 @@ publish = false
 
 [workspace.dependencies]
 anyhow = { version = "1.0", default-features = false }
-bitflags = "2.4"
+bitflags = "2.11"
 bitvec = { version = "1.0", default-features = false, features = ["alloc"] }
 blink-alloc = { version = "0.4", default-features = false, features = [
     "alloc",
     "nightly",
 ] }
-clap = { version = "4.5", default-features = false, features = [
+clap = { version = "4.6", default-features = false, features = [
     "derive",
     "std",
     "env",
@@ -66,11 +66,11 @@ clap = { version = "4.5", default-features = false, features = [
     "suggestions",
     "error-context",
 ] }
-cranelift-entity = "0.120"
+cranelift-entity = "0.131"
 compact_str = { version = "0.9", default-features = false }
-hashbrown = { version = "0.15", features = ["nightly"] }
+hashbrown = { version = "0.17", features = ["nightly"] }
 Inflector = "0.11"
-intrusive-collections = "0.9"
+intrusive-collections = "0.10"
 inventory = "0.3"
 litcheck = { package = "litcheck-core", version = "0.4" }
 litcheck-filecheck = "0.4"
@@ -98,11 +98,11 @@ parking_lot_core = "0.9"
 petgraph = { version = "0.8", default-features = false, features = [
     "graphmap"
 ] }
-pretty_assertions = "1.0"
-proptest = "1.4"
+pretty_assertions = "1.4"
+proptest = "1.11"
 proc-macro2 = "1.0"
 quote = "1.0"
-rustc-hash = { version = "2.0", default-features = false }
+rustc-hash = { version = "2.1", default-features = false }
 semver = { version = "1.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = [
     "serde_derive",
@@ -110,8 +110,7 @@ serde = { version = "1.0", default-features = false, features = [
     "rc",
 ] }
 heck = "0.5"
-
-smallvec = { version = "1.14", default-features = false, features = [
+smallvec = { version = "1.15", default-features = false, features = [
     "union",
     "const_generics",
     "const_new",
@@ -125,11 +124,11 @@ syn = { version = "2.0", features = [
     "printing",
 ] }
 thiserror = { package = "miden-thiserror", version = "1.0" }
-toml = { version = "0.8", features = ["preserve_order"] }
-tokio = { version = "1.39.2", features = ["rt", "time", "macros", "rt-multi-thread"] }
-wat = "1.0.69"
-wasmprinter = "0.227"
-wasmparser = { version = "0.227", default-features = false, features = [
+toml = { version = "^1.1.2", features = ["preserve_order"] }
+tokio = { version = "^1.39.2", features = ["rt", "time", "macros", "rt-multi-thread"] }
+wat = "^1.248"
+wasmprinter = "^0.248"
+wasmparser = { version = "^0.248", default-features = false, features = [
     "features",
     "component-model",
     "validate",
@@ -159,7 +158,7 @@ midenc-session = { version = "0.8.1", path = "midenc-session" }
 cargo-miden = { version = "0.8.1", path = "tools/cargo-miden" }
 miden-integration-tests = { path = "tests/integration" }
 midenc-expect-test = { path = "tools/expect-test" }
-miden-field = { version = "0.22" }
+miden-field = { version = "^0.24" }
 
 [patch.crates-io]
 #miden-assembly = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -414,6 +414,7 @@ args = [
     "@@split(CARGO_MAKE_CARGO_BUILD_TEST_FLAGS, )",
     "${@}",
 ]
+dependencies = ["cargo-miden"]
 
 [tasks.test-release-rust]
 category = "Test"
@@ -429,6 +430,7 @@ args = [
     "@@split(CARGO_MAKE_CARGO_BUILD_TEST_FLAGS, )",
     "${@}",
 ]
+dependencies = ["cargo-miden"]
 
 [tasks.test-lit]
 category = "Test"

--- a/codegen/masm/src/artifact.rs
+++ b/codegen/masm/src/artifact.rs
@@ -91,11 +91,11 @@ impl Rodata {
     }
 
     pub fn size_in_felts(&self) -> usize {
-        self.data.len().next_multiple_of(4) / 4
+        self.data.len().div_ceil(4)
     }
 
     pub fn size_in_words(&self) -> usize {
-        self.size_in_felts().next_multiple_of(4) / 4
+        self.size_in_felts().div_ceil(4)
     }
 
     /// Attempt to convert this rodata object to its equivalent representation in felts
@@ -125,8 +125,8 @@ impl Rodata {
             felts.push(Felt::new(u32::from_le_bytes(chunk) as u64));
         }
 
-        let size_in_felts = bytes.len().next_multiple_of(4) / 4;
-        let size_in_words = size_in_felts.next_multiple_of(4) / 4;
+        let size_in_felts = bytes.len().div_ceil(4);
+        let size_in_words = size_in_felts.div_ceil(4);
         let padding = (size_in_words * 4).abs_diff(felts.len());
         felts.resize(felts.len() + padding, Felt::ZERO);
         debug_assert_eq!(felts.len() % 4, 0, "expected to be a valid number of words");

--- a/codegen/masm/src/artifact/project_support.rs
+++ b/codegen/masm/src/artifact/project_support.rs
@@ -92,10 +92,8 @@ fn register_external_dependencies(
     let link_library_versions =
         resolve_link_library_versions(link_library_specs, link_libraries, link_packages)?;
     let mut dependencies = BTreeMap::default();
-    for ((link_lib, library), version) in link_library_specs
-        .iter()
-        .zip(link_libraries.iter())
-        .zip(link_library_versions.into_iter())
+    for ((link_lib, library), version) in
+        link_library_specs.iter().zip(link_libraries.iter()).zip(link_library_versions)
     {
         let package = Arc::from(MastPackage::from_library(
             link_lib.name.to_string().into(),

--- a/codegen/masm/src/emit/binary.rs
+++ b/codegen/masm/src/emit/binary.rs
@@ -1,4 +1,4 @@
-use core::assert_matches::assert_matches;
+use core::assert_matches;
 
 use miden_core::Felt;
 use midenc_hir::{Immediate, Overflow, SourceSpan, Type};

--- a/codegen/masm/src/lib.rs
+++ b/codegen/masm/src/lib.rs
@@ -1,7 +1,5 @@
 #![feature(debug_closure_helpers)]
-#![feature(assert_matches)]
 #![feature(iter_array_chunks)]
-#![feature(iterator_try_collect)]
 #![deny(warnings)]
 
 extern crate alloc;

--- a/codegen/masm/src/opt/operands/solver.rs
+++ b/codegen/masm/src/opt/operands/solver.rs
@@ -423,7 +423,7 @@ impl OperandMovementConstraintSolver {
             // Run the solver for more than 1 argument
             _ => {
                 let actions = self.solve()?;
-                for action in actions.into_iter() {
+                for action in actions {
                     match action {
                         Action::Copy(index) => {
                             emitter.copy_operand_to_position(index as usize, 0, false, span);
@@ -647,7 +647,7 @@ mod tests {
 
         let tests = [[v2, v1, v3, v4, v5, v6], [v2, v4, v3, v1, v5, v6]];
 
-        for test in tests.into_iter() {
+        for test in tests {
             let mut stack = crate::OperandStack::new(context.clone());
             for value in test.into_iter().rev() {
                 stack.push(value);
@@ -694,7 +694,7 @@ mod tests {
             [v4, v3, v2, v1, v5, v6],
         ];
 
-        for test in tests.into_iter() {
+        for test in tests {
             let mut stack = crate::OperandStack::new(context.clone());
             for value in test.into_iter().rev() {
                 stack.push(value);
@@ -740,7 +740,7 @@ mod tests {
             [v2, v1, v3, v4, v5, v6],
         ];
 
-        for test in tests.into_iter() {
+        for test in tests {
             let mut stack = crate::OperandStack::new(context.clone());
             for value in test.into_iter().rev() {
                 stack.push(value);
@@ -782,7 +782,7 @@ mod tests {
 
         let tests = [[v32, v7, v16, v0]];
 
-        for test in tests.into_iter() {
+        for test in tests {
             let mut stack = crate::OperandStack::new(context.clone());
             for value in test.into_iter().rev() {
                 stack.push(value);

--- a/codegen/masm/src/opt/operands/tactics/linear.rs
+++ b/codegen/masm/src/opt/operands/tactics/linear.rs
@@ -144,7 +144,7 @@ impl Tactic for Linear {
                 "found the following connected components when analyzing required operand moves: \
                  {components:?}"
             );
-            for component in components.into_iter() {
+            for component in components {
                 // A component of two or more elements indicates a cycle of operands.
                 //
                 // To determine the order in which swaps must be performed, we first look

--- a/codegen/masm/src/opt/operands/testing.rs
+++ b/codegen/masm/src/opt/operands/testing.rs
@@ -330,7 +330,7 @@ pub fn solve_problem(problem: ProblemInputs) -> Result<(), TestCaseError> {
             // that has all of the expected operands on top of the stack,
             // ordered by id, e.g. [v1, v2, ..vN]
             let mut stack = problem.stack.clone();
-            for action in actions.into_iter() {
+            for action in actions {
                 reject_out_of_scope(action)?;
                 match action {
                     Action::Copy(index) => {
@@ -397,7 +397,7 @@ pub fn solve_problem_with_tactic<T: tactics::Tactic + Default>(
             // that has all of the expected operands on top of the stack,
             // ordered by id, e.g. [v1, v2, ..vN]
             let mut stack = problem.stack.clone();
-            for action in actions.into_iter() {
+            for action in actions {
                 reject_out_of_scope(action)?;
                 match action {
                     Action::Copy(index) => {

--- a/dialects/arith/src/lib.rs
+++ b/dialects/arith/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
-#![feature(debug_closure_helpers)]
 #![feature(unboxed_closures)]
 #![feature(fn_traits)]
-#![feature(ptr_metadata)]
 #![feature(specialization)]
 #![allow(incomplete_features)]
 #![deny(warnings)]

--- a/dialects/cf/src/lib.rs
+++ b/dialects/cf/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
-#![feature(debug_closure_helpers)]
 #![feature(unboxed_closures)]
 #![feature(fn_traits)]
-#![feature(ptr_metadata)]
 #![feature(specialization)]
 #![allow(incomplete_features)]
 #![deny(warnings)]

--- a/dialects/hir/src/lib.rs
+++ b/dialects/hir/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(debug_closure_helpers)]
 #![feature(unboxed_closures)]
 #![feature(fn_traits)]
 #![feature(ptr_metadata)]

--- a/dialects/hir/src/transforms/local2reg.rs
+++ b/dialects/hir/src/transforms/local2reg.rs
@@ -111,7 +111,7 @@ impl Pass for Local2Reg {
         });
 
         let mut changed = PostPassStatus::Unchanged;
-        'next_local: for local in locals.into_iter() {
+        'next_local: for local in locals {
             if let Some(loads) = loaded.get(&local) {
                 if loads.len() > 1 {
                     // Ignore locals that are loaded multiple times for now

--- a/dialects/scf/src/canonicalization/fold_redundant_yields.rs
+++ b/dialects/scf/src/canonicalization/fold_redundant_yields.rs
@@ -116,7 +116,7 @@ impl RewritePattern for FoldRedundantYields {
             // The entire operation is actually redundant; just remove it.  Make sure the yield
             // vals are sorted first.
             let mut sorted_vals = redundant_yield_vals.into_vec();
-            sorted_vals.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+            sorted_vals.sort_unstable_by_key(|val| val.0);
 
             // Wrap each of the values in Some.
             let some_vals =

--- a/dialects/scf/src/lib.rs
+++ b/dialects/scf/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
-#![feature(debug_closure_helpers)]
 #![feature(unboxed_closures)]
 #![feature(fn_traits)]
-#![feature(ptr_metadata)]
 #![feature(specialization)]
 #![allow(incomplete_features)]
 #![deny(warnings)]

--- a/dialects/ub/src/lib.rs
+++ b/dialects/ub/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
-#![feature(debug_closure_helpers)]
 #![feature(unboxed_closures)]
 #![feature(fn_traits)]
-#![feature(ptr_metadata)]
 #![feature(specialization)]
 #![allow(incomplete_features)]
 #![deny(warnings)]

--- a/dialects/wasm/src/lib.rs
+++ b/dialects/wasm/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
-#![feature(debug_closure_helpers)]
 #![feature(unboxed_closures)]
 #![feature(fn_traits)]
-#![feature(ptr_metadata)]
 #![feature(specialization)]
 #![allow(incomplete_features)]
 #![deny(warnings)]

--- a/docs/external/src/guides/develop_miden_in_rust.md
+++ b/docs/external/src/guides/develop_miden_in_rust.md
@@ -32,7 +32,7 @@ let a = felt!(42);
 Otherwise, use the `Felt::new` constructor:
 
 ```rust
-let a = Felt::new(some_integer_var).unwrap();
+let a = Felt::new(some_integer_var).unwrap().unwrap();
 ```
 
 The constructor returns an error if the value is not a valid field element, e.g. if it is not in the

--- a/docs/external/src/usage/cargo-miden.md
+++ b/docs/external/src/usage/cargo-miden.md
@@ -17,7 +17,7 @@ Currently, `midenc` (and as a result, `cargo-miden`), requires the nightly Rust 
 make sure you have it installed first:
 
 ```bash
-rustup toolchain install nightly-2025-12-10
+rustup toolchain install nightly-2026-04-29
 ```
 
 NOTE: You can also use the latest nightly, but the specific nightly shown here is known to
@@ -28,7 +28,7 @@ work.
 To install the extension:
 
 ```bash
-cargo +nightly-2025-12-10 install cargo-miden --locked
+cargo +nightly-2026-04-29 install cargo-miden --locked
 
 ```
 

--- a/docs/external/src/usage/midenc.md
+++ b/docs/external/src/usage/midenc.md
@@ -22,7 +22,7 @@ Currently, `midenc` (and as a result, `cargo-miden`), requires the nightly Rust 
 make sure you have it installed first:
 
 ```bash
-rustup toolchain install nightly-2025-12-10
+rustup toolchain install nightly-2026-04-29
 ```
 
 NOTE: You can also use the latest nightly, but the specific nightly shown here is known to

--- a/eval/src/evaluator/frame.rs
+++ b/eval/src/evaluator/frame.rs
@@ -1,5 +1,3 @@
-#![expect(unused_assignments)]
-
 use alloc::{format, vec};
 
 use midenc_hir::{

--- a/eval/src/evaluator/memory.rs
+++ b/eval/src/evaluator/memory.rs
@@ -1,5 +1,3 @@
-#![expect(unused_assignments)]
-
 use alloc::{format, string::String, vec, vec::Vec};
 use core::ops::{Index, IndexMut, Range};
 

--- a/examples/auth-component-no-auth/rust-toolchain.toml
+++ b/examples/auth-component-no-auth/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-12-10"
+channel = "nightly-2026-04-29"
 components = ["rustfmt", "rust-src", "clippy"]
 targets = ["wasm32-wasip2"]
 profile = "minimal"

--- a/examples/auth-component-rpo-falcon512/rust-toolchain.toml
+++ b/examples/auth-component-rpo-falcon512/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-12-10"
+channel = "nightly-2026-04-29"
 components = ["rustfmt", "rust-src", "clippy"]
 targets = ["wasm32-wasip2"]
 profile = "minimal"

--- a/examples/basic-wallet-tx-script/rust-toolchain.toml
+++ b/examples/basic-wallet-tx-script/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-12-10"
+channel = "nightly-2026-04-29"
 components = ["rustfmt", "rust-src", "clippy"]
 targets = ["wasm32-wasip2"]
 profile = "minimal"

--- a/examples/basic-wallet-tx-script/src/lib.rs
+++ b/examples/basic-wallet-tx-script/src/lib.rs
@@ -26,7 +26,7 @@ fn run(arg: Word, account: &mut Account) {
     let num_felts = adv_push_mapvaln(arg);
     let num_felts_u64 = num_felts.as_canonical_u64();
     assert_eq(Felt::from_u32((num_felts_u64 % 4) as u32), felt!(0));
-    let num_words = Felt::new(num_felts_u64 / 4);
+    let num_words = Felt::new(num_felts_u64 / 4).unwrap();
     let commitment = arg;
     let input = adv_load_preimage(num_words, commitment);
     let tag = input[TAG_INDEX];

--- a/examples/basic-wallet/rust-toolchain.toml
+++ b/examples/basic-wallet/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-12-10"
+channel = "nightly-2026-04-29"
 components = ["rustfmt", "rust-src", "clippy"]
 targets = ["wasm32-wasip2"]
 profile = "minimal"

--- a/examples/collatz/rust-toolchain.toml
+++ b/examples/collatz/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-12-10"
+channel = "nightly-2026-04-29"
 components = ["rustfmt", "rust-src"]
 targets = ["wasm32-wasip1"]
 profile = "minimal"

--- a/examples/counter-contract/rust-toolchain.toml
+++ b/examples/counter-contract/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-12-10"
+channel = "nightly-2026-04-29"
 components = ["rustfmt", "rust-src", "clippy"]
 targets = ["wasm32-wasip2"]
 profile = "minimal"

--- a/examples/counter-note/rust-toolchain.toml
+++ b/examples/counter-note/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-12-10"
+channel = "nightly-2026-04-29"
 components = ["rustfmt", "rust-src", "clippy"]
 targets = ["wasm32-wasip2"]
 profile = "minimal"

--- a/examples/fibonacci/rust-toolchain.toml
+++ b/examples/fibonacci/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-12-10"
+channel = "nightly-2026-04-29"
 components = ["rustfmt", "rust-src"]
 targets = ["wasm32-wasip1"]
 profile = "minimal"

--- a/examples/is-prime/rust-toolchain.toml
+++ b/examples/is-prime/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-12-10"
+channel = "nightly-2026-04-29"
 components = ["rustfmt", "rust-src"]
 targets = ["wasm32-wasip1"]
 profile = "minimal"

--- a/examples/p2id-note/rust-toolchain.toml
+++ b/examples/p2id-note/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-12-10"
+channel = "nightly-2026-04-29"
 components = ["rustfmt", "rust-src", "clippy"]
 targets = ["wasm32-wasip2"]
 profile = "minimal"

--- a/examples/p2ide-note/rust-toolchain.toml
+++ b/examples/p2ide-note/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-12-10"
+channel = "nightly-2026-04-29"
 components = ["rustfmt", "rust-src", "clippy"]
 targets = ["wasm32-wasip2"]
 profile = "minimal"

--- a/examples/storage-example/rust-toolchain.toml
+++ b/examples/storage-example/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-12-10"
+channel = "nightly-2026-04-29"
 components = ["rustfmt", "rust-src", "clippy"]
 targets = ["wasm32-wasip2"]
 profile = "minimal"

--- a/frontend/wasm/Cargo.toml
+++ b/frontend/wasm/Cargo.toml
@@ -17,9 +17,9 @@ std = ["wasmparser/std", "gimli/std", "midenc-hir-symbol/std", "dep:wasmprinter"
 
 [dependencies]
 anyhow.workspace = true
-addr2line = "0.24"
+addr2line = "^0.26"
 cranelift-entity.workspace = true
-gimli = { version = "0.31", default-features = false, features = ['read'] }
+gimli = { version = "^0.33", default-features = false, features = ['read'] }
 indexmap = "2.7"
 log.workspace = true
 miden-core.workspace = true

--- a/frontend/wasm/src/code_translator/mod.rs
+++ b/frontend/wasm/src/code_translator/mod.rs
@@ -19,7 +19,7 @@ use midenc_dialect_hir::HirOpBuilder;
 use midenc_dialect_ub::UndefinedBehaviorOpBuilder;
 use midenc_dialect_wasm::{WasmMemArg, WasmOpBuilder, prepare_addr};
 use midenc_hir::{
-    BlockRef, Builder, Felt, Immediate, Op,
+    BlockRef, Builder, Immediate, Op,
     Type::{self, *},
     ValueRef,
     dialects::builtin::BuiltinOpBuilder,
@@ -149,7 +149,7 @@ pub fn translate_operator<B: ?Sized + Builder>(
             let (arg1, arg2, cond) = state.pop3();
             match ty {
                 wasmparser::ValType::F32 => {
-                    let imm = builder.felt(Felt::ZERO, span);
+                    let imm = builder.felt(midenc_hir::Felt::ZERO, span);
                     let cond = builder.gt(cond, imm, span)?;
                     state.push1(builder.select(cond, arg1, arg2, span)?);
                 }

--- a/frontend/wasm/src/component/parser.rs
+++ b/frontend/wasm/src/component/parser.rs
@@ -291,7 +291,9 @@ pub struct LocalCanonicalOptions {
     pub realloc: Option<FuncIndex>,
     pub post_return: Option<FuncIndex>,
     pub is_async: bool,
+    pub gc: bool,
     pub async_callback: Option<FuncIndex>,
+    pub core_type: Option<crate::module::types::TypeIndex>,
 }
 
 /// Action to take after parsing a payload.
@@ -455,10 +457,11 @@ impl<'a, 'data> ComponentParser<'a, 'data> {
         // Note that the push/pop of the component types scope happens above in
         // `Version` and `End` since multiple type sections can appear within a
         // component.
-        let mut component_type_index = self.validator.types(0).unwrap().component_type_count();
         self.validator.component_type_section(&s).into_diagnostic()?;
         let types = self.validator.types(0).unwrap();
-        for ty in s {
+        for (component_type_index, ty) in
+            (0..self.validator.types(0).unwrap().component_type_count()).zip(s)
+        {
             match ty.into_diagnostic()? {
                 wasmparser::ComponentType::Resource { rep, dtor } => {
                     let rep = convert_valtype(rep);
@@ -473,8 +476,6 @@ impl<'a, 'data> ComponentParser<'a, 'data> {
                 | wasmparser::ComponentType::Instance(_)
                 | wasmparser::ComponentType::Component(_) => {}
             }
-
-            component_type_index += 1;
         }
         Ok(())
     }
@@ -563,10 +564,19 @@ impl<'a, 'data> ComponentParser<'a, 'data> {
                 wasmparser::CanonicalFunction::ErrorContextNew { .. }
                 | wasmparser::CanonicalFunction::ErrorContextDrop
                 | wasmparser::CanonicalFunction::ErrorContextDebugMessage { .. }
-                | wasmparser::CanonicalFunction::ThreadSpawn { .. }
+                | wasmparser::CanonicalFunction::ThreadSpawnRef { .. }
+                | wasmparser::CanonicalFunction::ThreadSpawnIndirect { .. }
+                | wasmparser::CanonicalFunction::ThreadNewIndirect { .. }
                 | wasmparser::CanonicalFunction::ThreadAvailableParallelism
-                | wasmparser::CanonicalFunction::Yield { .. }
-                | wasmparser::CanonicalFunction::BackpressureSet
+                | wasmparser::CanonicalFunction::ThreadIndex
+                | wasmparser::CanonicalFunction::ThreadSuspend { .. }
+                | wasmparser::CanonicalFunction::ThreadSuspendTo { .. }
+                | wasmparser::CanonicalFunction::ThreadSuspendToSuspended { .. }
+                | wasmparser::CanonicalFunction::ThreadUnsuspend
+                | wasmparser::CanonicalFunction::ThreadYield { .. }
+                | wasmparser::CanonicalFunction::ThreadYieldToSuspended { .. }
+                | wasmparser::CanonicalFunction::BackpressureInc
+                | wasmparser::CanonicalFunction::BackpressureDec
                 | wasmparser::CanonicalFunction::WaitableJoin
                 | wasmparser::CanonicalFunction::WaitableSetNew
                 | wasmparser::CanonicalFunction::WaitableSetDrop
@@ -577,17 +587,21 @@ impl<'a, 'data> ComponentParser<'a, 'data> {
                 | wasmparser::CanonicalFunction::FutureWrite { .. }
                 | wasmparser::CanonicalFunction::FutureCancelRead { .. }
                 | wasmparser::CanonicalFunction::FutureCancelWrite { .. }
-                | wasmparser::CanonicalFunction::FutureCloseWritable { .. }
-                | wasmparser::CanonicalFunction::FutureCloseReadable { .. }
+                | wasmparser::CanonicalFunction::FutureDropWritable { .. }
+                | wasmparser::CanonicalFunction::FutureDropReadable { .. }
                 | wasmparser::CanonicalFunction::SubtaskDrop
+                | wasmparser::CanonicalFunction::SubtaskCancel { .. }
+                | wasmparser::CanonicalFunction::ContextGet { .. }
+                | wasmparser::CanonicalFunction::ContextSet { .. }
+                | wasmparser::CanonicalFunction::TaskCancel
                 | wasmparser::CanonicalFunction::TaskReturn { .. }
                 | wasmparser::CanonicalFunction::StreamNew { .. }
                 | wasmparser::CanonicalFunction::StreamRead { .. }
                 | wasmparser::CanonicalFunction::StreamWrite { .. }
                 | wasmparser::CanonicalFunction::StreamCancelRead { .. }
                 | wasmparser::CanonicalFunction::StreamCancelWrite { .. }
-                | wasmparser::CanonicalFunction::StreamCloseWritable { .. }
-                | wasmparser::CanonicalFunction::StreamCloseReadable { .. } => unimplemented!(),
+                | wasmparser::CanonicalFunction::StreamDropWritable { .. }
+                | wasmparser::CanonicalFunction::StreamDropReadable { .. } => unimplemented!(),
             };
             log::debug!(target: "component-parser", "Adding canonical initializer: {init:?}");
             self.result.initializers.push(init);
@@ -682,9 +696,10 @@ impl<'a, 'data> ComponentParser<'a, 'data> {
         &mut self,
         s: wasmparser::ComponentInstanceSectionReader<'data>,
     ) -> WasmResult<()> {
-        let mut index = self.validator.types(0).unwrap().component_instance_count();
         self.validator.component_instance_section(&s).into_diagnostic()?;
-        for instance in s {
+        for (index, instance) in
+            (0..self.validator.types(0).unwrap().component_instance_count()).zip(s)
+        {
             let init = match instance.into_diagnostic()? {
                 wasmparser::ComponentInstance::Instantiate {
                     component_index,
@@ -700,7 +715,6 @@ impl<'a, 'data> ComponentParser<'a, 'data> {
                 }
             };
             self.result.initializers.push(init);
-            index += 1;
         }
         Ok(())
     }
@@ -910,7 +924,7 @@ fn instantiate_module_from_exports<'data>(
     let mut map = FxHashMap::with_capacity_and_hasher(exports.len(), FxBuildHasher);
     for export in exports {
         let idx = match export.kind {
-            wasmparser::ExternalKind::Func => {
+            wasmparser::ExternalKind::Func | wasmparser::ExternalKind::FuncExact => {
                 let index = FuncIndex::from_u32(export.index);
                 EntityIndex::Function(index)
             }
@@ -943,7 +957,9 @@ fn canonical_options(opts: &[wasmparser::CanonicalOption]) -> LocalCanonicalOpti
         realloc: None,
         post_return: None,
         is_async: false,
+        gc: false,
         async_callback: None,
+        core_type: None,
     };
     for opt in opts {
         match opt {
@@ -974,6 +990,13 @@ fn canonical_options(opts: &[wasmparser::CanonicalOption]) -> LocalCanonicalOpti
             wasmparser::CanonicalOption::Callback(idx) => {
                 ret.async_callback = Some(FuncIndex::from_u32(*idx));
             }
+            wasmparser::CanonicalOption::Gc => {
+                ret.gc = true;
+            }
+            wasmparser::CanonicalOption::CoreType(ty) => {
+                // TODO(pauls): Figure out what we do with this option
+                ret.core_type = Some(crate::module::types::TypeIndex::from_u32(*ty));
+            }
         }
     }
     ret
@@ -986,7 +1009,9 @@ fn alias_module_instance_export(
     name: &str,
 ) -> LocalInitializer<'_> {
     match kind {
-        wasmparser::ExternalKind::Func => LocalInitializer::AliasExportFunc(instance, name),
+        wasmparser::ExternalKind::Func | wasmparser::ExternalKind::FuncExact => {
+            LocalInitializer::AliasExportFunc(instance, name)
+        }
         wasmparser::ExternalKind::Memory => LocalInitializer::AliasExportMemory(instance, name),
         wasmparser::ExternalKind::Table => LocalInitializer::AliasExportTable(instance, name),
         wasmparser::ExternalKind::Global => LocalInitializer::AliasExportGlobal(instance, name),

--- a/frontend/wasm/src/component/types/mod.rs
+++ b/frontend/wasm/src/component/types/mod.rs
@@ -601,7 +601,7 @@ impl ComponentTypesBuilder {
 
     fn entity_type(&mut self, types: TypesRef<'_>, ty: &types::EntityType) -> Result<EntityType> {
         Ok(match ty {
-            types::EntityType::Func(idx) => {
+            types::EntityType::Func(idx) | types::EntityType::FuncExact(idx) => {
                 let ty = types[*idx].unwrap_func();
                 let ty = convert_func_type(ty);
                 EntityType::Function(self.module_types_builder_mut().wasm_func_type(*idx, ty))
@@ -654,6 +654,10 @@ impl ComponentTypesBuilder {
             | component_types::ComponentDefinedType::Future(_) => {
                 unimplemented!("support for the async proposal is not implemented")
             }
+            component_types::ComponentDefinedType::Map(..)
+            | component_types::ComponentDefinedType::FixedLengthList(..) => {
+                todo!("support for maps/fixed-length lists has not been implemented yet")
+            }
         };
         let info = self.type_information(&ret);
         if info.depth > MAX_TYPE_DEPTH {
@@ -703,9 +707,6 @@ impl ComponentTypesBuilder {
             .cases
             .iter()
             .map(|(name, case)| {
-                if case.refines.is_some() {
-                    bail!("refines is not supported at this time");
-                }
                 Ok(VariantCase {
                     name: name.to_string(),
                     ty: match &case.ty.as_ref() {

--- a/frontend/wasm/src/module/func_translator.rs
+++ b/frontend/wasm/src/module/func_translator.rs
@@ -314,8 +314,6 @@ fn parse_function_body<B: ?Sized + Builder>(
             effective_span,
         )?;
     }
-    let pos = reader.original_position();
-    func_validator.finish(pos).into_diagnostic()?;
 
     // The final `End` operator left us in the exit block where we need to manually add a return
     // instruction.

--- a/frontend/wasm/src/module/module_env.rs
+++ b/frontend/wasm/src/module/module_env.rs
@@ -399,36 +399,38 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
         let cnt = usize::try_from(imports.count()).unwrap();
         self.result.module.imports.reserve(cnt);
         for entry in imports {
-            let import = entry.into_diagnostic()?;
-            let ty = match import.ty {
-                TypeRef::Func(index) => {
-                    let index = TypeIndex::from_u32(index);
-                    let sig_index = self.result.module.types[index].unwrap_function();
-                    self.result.module.num_imported_funcs += 1;
-                    self.result.wasm_file.imported_func_count += 1;
-                    EntityType::Function(sig_index)
-                }
-                TypeRef::Memory(ty) => {
-                    self.result.module.memories.push(super::Memory {
-                        minimum: ty.initial,
-                        maximum: ty.maximum,
-                        imported: true,
-                    });
-                    EntityType::Memory(ty.into())
-                }
-                TypeRef::Global(ty) => {
-                    self.result.module.num_imported_globals += 1;
-                    EntityType::Global(convert_global_type(&ty))
-                }
-                TypeRef::Table(ty) => {
-                    self.result.module.num_imported_tables += 1;
-                    EntityType::Table(convert_table_type(&ty))
-                }
+            for import in entry.into_diagnostic()? {
+                let (_, import) = import.into_diagnostic()?;
+                let ty = match import.ty {
+                    TypeRef::Func(index) | TypeRef::FuncExact(index) => {
+                        let index = TypeIndex::from_u32(index);
+                        let sig_index = self.result.module.types[index].unwrap_function();
+                        self.result.module.num_imported_funcs += 1;
+                        self.result.wasm_file.imported_func_count += 1;
+                        EntityType::Function(sig_index)
+                    }
+                    TypeRef::Memory(ty) => {
+                        self.result.module.memories.push(super::Memory {
+                            minimum: ty.initial,
+                            maximum: ty.maximum,
+                            imported: true,
+                        });
+                        EntityType::Memory(ty.into())
+                    }
+                    TypeRef::Global(ty) => {
+                        self.result.module.num_imported_globals += 1;
+                        EntityType::Global(convert_global_type(&ty))
+                    }
+                    TypeRef::Table(ty) => {
+                        self.result.module.num_imported_tables += 1;
+                        EntityType::Table(convert_table_type(&ty))
+                    }
 
-                // doesn't get past validation
-                TypeRef::Tag(_) => unreachable!(),
-            };
-            self.declare_import(import.module, import.name, ty);
+                    // doesn't get past validation
+                    TypeRef::Tag(_) => unreachable!(),
+                };
+                self.declare_import(import.module, import.name, ty);
+            }
         }
         Ok(())
     }
@@ -466,8 +468,8 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                     precomputed: Vec::new(),
                 },
                 wasmparser::TableInit::Expr(cexpr) => {
-                    let mut init_expr_reader = cexpr.get_binary_reader();
-                    match init_expr_reader.read_operator().into_diagnostic()? {
+                    let mut init_expr_reader = cexpr.get_operators_reader();
+                    match init_expr_reader.read().into_diagnostic()? {
                         Operator::RefNull { hty: _ } => TableInitialValue::Null {
                             precomputed: Vec::new(),
                         },
@@ -515,8 +517,8 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
         self.result.module.globals.reserve_exact(cnt);
         for entry in globals {
             let wasmparser::Global { ty, init_expr } = entry.into_diagnostic()?;
-            let mut init_expr_reader = init_expr.get_binary_reader();
-            let initializer = match init_expr_reader.read_operator().into_diagnostic()? {
+            let mut init_expr_reader = init_expr.get_operators_reader();
+            let initializer = match init_expr_reader.read().into_diagnostic()? {
                 Operator::I32Const { value } => GlobalInit::I32Const(value),
                 Operator::I64Const { value } => GlobalInit::I64Const(value),
                 Operator::F32Const { value } => GlobalInit::F32Const(value.bits()),
@@ -552,7 +554,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
         for entry in exports {
             let wasmparser::Export { name, kind, index } = entry.into_diagnostic()?;
             let entity = match kind {
-                ExternalKind::Func => {
+                ExternalKind::Func | ExternalKind::FuncExact => {
                     let index = FuncIndex::from_u32(index);
                     self.flag_func_escaped(index);
                     EntityIndex::Function(index)
@@ -611,8 +613,8 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                     for func in funcs {
                         let func = match func
                             .into_diagnostic()?
-                            .get_binary_reader()
-                            .read_operator()
+                            .get_operators_reader()
+                            .read()
                             .into_diagnostic()?
                         {
                             Operator::RefNull { .. } => FuncIndex::reserved_value(),
@@ -640,21 +642,20 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                     offset_expr,
                 } => {
                     let table_index = TableIndex::from_u32(table_index.unwrap_or(0));
-                    let mut offset_expr_reader = offset_expr.get_binary_reader();
-                    let (base, offset) =
-                        match offset_expr_reader.read_operator().into_diagnostic()? {
-                            Operator::I32Const { value } => (None, value as u32),
-                            Operator::GlobalGet { global_index } => {
-                                (Some(GlobalIndex::from_u32(global_index)), 0)
-                            }
-                            ref s => {
-                                unsupported_diag!(
-                                    diagnostics,
-                                    "wasm error: unsupported init expr in element section: {:?}",
-                                    s
-                                );
-                            }
-                        };
+                    let mut offset_expr_reader = offset_expr.get_operators_reader();
+                    let (base, offset) = match offset_expr_reader.read().into_diagnostic()? {
+                        Operator::I32Const { value } => (None, value as u32),
+                        Operator::GlobalGet { global_index } => {
+                            (Some(GlobalIndex::from_u32(global_index)), 0)
+                        }
+                        ref s => {
+                            unsupported_diag!(
+                                diagnostics,
+                                "wasm error: unsupported init expr in element section: {:?}",
+                                s
+                            );
+                        }
+                    };
 
                     self.result.module.table_initialization.segments.push(TableSegment {
                         table_index,
@@ -678,7 +679,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
     }
 
     fn code_section_start(&mut self, count: u32, range: Range<usize>) -> Result<(), Report> {
-        self.validator.code_section_start(count, &range).into_diagnostic()?;
+        self.validator.code_section_start(&range).into_diagnostic()?;
         let cnt = usize::try_from(count).unwrap();
         self.result.function_body_inputs.reserve_exact(cnt);
         self.result.wasm_file.code_section_offset = range.start as u64;
@@ -716,7 +717,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
         self.validator.data_section(&data_section).into_diagnostic()?;
         let cnt = usize::try_from(data_section.count()).unwrap();
         self.result.data_segments.reserve_exact(cnt);
-        for entry in data_section.into_iter() {
+        for entry in data_section {
             let wasmparser::Data {
                 kind,
                 data,
@@ -732,8 +733,8 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                         "data section memory index must be 0 (only one memory per module is \
                          supported)"
                     );
-                    let mut offset_expr_reader = offset_expr.get_binary_reader();
-                    let offset = match offset_expr_reader.read_operator().into_diagnostic()? {
+                    let mut offset_expr_reader = offset_expr.get_operators_reader();
+                    let offset = match offset_expr_reader.read().into_diagnostic()? {
                         Operator::I32Const { value } => DataSegmentOffset::I32Const(value),
                         Operator::GlobalGet { global_index } => {
                             DataSegmentOffset::GetGlobal(GlobalIndex::from_u32(global_index))

--- a/frontend/wasm/src/module/types.rs
+++ b/frontend/wasm/src/module/types.rs
@@ -676,7 +676,7 @@ pub fn convert_heap_type(ty: wasmparser::HeapType) -> WasmHeapType {
             AbstractHeapType::Extern => WasmHeapType::Extern,
             ty => unimplemented!("unsupported abstract heap type {ty:?}"),
         },
-        wasmparser::HeapType::Concrete(_) => {
+        wasmparser::HeapType::Concrete(_) | wasmparser::HeapType::Exact(_) => {
             unimplemented!("user-defined types are not supported yet")
         }
     }

--- a/hir-analysis/src/analyses/constant_propagation.rs
+++ b/hir-analysis/src/analyses/constant_propagation.rs
@@ -190,7 +190,7 @@ impl SparseForwardDataFlowAnalysis for SparseConstantPropagation {
 
         // Merge the fold results into the lattice for this operation.
         assert_eq!(fold_results.len(), op.num_results());
-        for (lattice, fold_result) in results.iter_mut().zip(fold_results.into_iter()) {
+        for (lattice, fold_result) in results.iter_mut().zip(fold_results) {
             // Merge in the result of the fold, either a constant or a value.
             match fold_result {
                 OpFoldResult::Attribute(value) => {

--- a/hir-analysis/src/analyses/spills.rs
+++ b/hir-analysis/src/analyses/spills.rs
@@ -2152,7 +2152,7 @@ impl SpillAnalysis {
             }
             // Remove op results from `to_reload`, and replace them, as needed, with reloads of the
             // value in the predecessor which was used as the successor argument
-            ProgramPoint::Op { op: _, .. } => {
+            ProgramPoint::Op { .. } => {
                 todo!()
             }
             _ => unreachable!(),

--- a/hir-analysis/src/sparse/backward.rs
+++ b/hir-analysis/src/sparse/backward.rs
@@ -305,7 +305,7 @@ where
                         call.results().all(),
                         solver,
                     );
-                    for (op, result) in operands.iter_mut().zip(call_result_lattices.into_iter()) {
+                    for (op, result) in operands.iter_mut().zip(call_result_lattices) {
                         op.meet(result.lattice());
                     }
                 }

--- a/hir-symbol/build.rs
+++ b/hir-symbol/build.rs
@@ -112,8 +112,7 @@ fn main() {
     println!("cargo:rustc-env=SYMBOLS_RS={}", out_file.display());
 
     let contents = fs::read_to_string("src/symbols.toml").unwrap();
-    let root = contents.parse::<Value>().unwrap();
-    let root = root.as_table().unwrap();
+    let root = contents.parse::<Table>().unwrap();
     let mut sections = vec![];
     for (name, value) in root.iter() {
         sections.push(Section::from_table(name.to_string(), value.as_table().unwrap()));

--- a/hir-transform/src/lib.rs
+++ b/hir-transform/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(new_range_api)]
 #![deny(warnings)]
 
 extern crate alloc;

--- a/hir-transform/src/sink.rs
+++ b/hir-transform/src/sink.rs
@@ -301,14 +301,11 @@ impl Pass for SinkOperandDefs {
 
             let mut builder = OpBuilder::new(op.context_rc());
             builder.set_insertion_point(sink_state.ip);
-            'next_operand: loop {
-                // The next operand index starts at `op.num_operands()` when first initialized, so
-                // we subtract 1 immediately to get the actual index of the current operand
-                let Some(next_operand_index) = sink_state.next_operand_index.checked_sub(1) else {
-                    // We're done processing this operation's operands
-                    break;
-                };
-
+            // The next operand index starts at `op.num_operands()` when first initialized, so
+            // we subtract 1 immediately to get the actual index of the current operand
+            'next_operand: while let Some(next_operand_index) =
+                sink_state.next_operand_index.checked_sub(1)
+            {
                 log::debug!(target: Self::NAME, "  sinking next operand def for {op} at index {next_operand_index}");
 
                 let mut operand = op.operands()[next_operand_index];
@@ -597,7 +594,7 @@ fn get_singly_executed_regions_to_sink(
 
     // For a simple control-flow sink, only consider regions that are executed at most once.
     for (region, bound) in branch.regions().iter().zip(bounds) {
-        use core::range::Bound;
+        use core::ops::Bound;
         match bound.max() {
             Bound::Unbounded => continue,
             Bound::Excluded(bound) if *bound > 2 => continue,

--- a/hir/src/adt/arena.rs
+++ b/hir/src/adt/arena.rs
@@ -229,7 +229,7 @@ impl<T> Drop for IntoIter<T> {
     }
 }
 
-intrusive_adapter!(ChunkHeaderAdapter<T> = Rc<ChunkHeader<T>>: ChunkHeader<T> { link: LinkedListLink });
+intrusive_adapter!(ChunkHeaderAdapter<T> = Rc<ChunkHeader<T>>: ChunkHeader<T> { link => LinkedListLink });
 
 type ChunkList<T> = intrusive_collections::LinkedList<ChunkHeaderAdapter<T>>;
 

--- a/hir/src/any.rs
+++ b/hir/src/any.rs
@@ -1,7 +1,7 @@
 use alloc::{boxed::Box, rc::Rc};
 use core::{any::Any, marker::Unsize};
 
-pub trait AsAny: Any + Unsize<dyn Any> + 'static {
+pub trait AsAny: Any + 'static {
     fn type_name(&self) -> &'static str;
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;

--- a/hir/src/ir/dominance/tree.rs
+++ b/hir/src/ir/dominance/tree.rs
@@ -362,7 +362,7 @@ impl DomTreeBase<false> {
                 _ => None,
             })
             .collect::<Vec<_>>();
-        nodes.sort_by(|a, b| a.num_in.get().cmp(&b.num_in.get()));
+        nodes.sort_by_key(|node| node.num_in.get());
         nodes
     }
 
@@ -376,7 +376,7 @@ impl DomTreeBase<false> {
                 _ => None,
             })
             .collect::<Vec<_>>();
-        nodes.sort_by(|a, b| a.num_out.get().cmp(&b.num_out.get()));
+        nodes.sort_by_key(|node| node.num_out.get());
         nodes
     }
 
@@ -713,15 +713,13 @@ impl<const IS_POST_DOM: bool> DomTreeBase<IS_POST_DOM> {
 
         // Extra checks depending on verification level. Up to O(n^3)
         match level {
-            DomTreeVerificationLevel::Basic => {
-                if !snca.verify_parent_property(self) {
-                    return false;
-                }
+            DomTreeVerificationLevel::Basic if !snca.verify_parent_property(self) => {
+                return false;
             }
-            DomTreeVerificationLevel::Full => {
-                if !snca.verify_parent_property(self) || !snca.verify_sibling_property(self) {
-                    return false;
-                }
+            DomTreeVerificationLevel::Full
+                if !snca.verify_parent_property(self) || !snca.verify_sibling_property(self) =>
+            {
+                return false;
             }
             _ => (),
         }

--- a/hir/src/ir/entity.rs
+++ b/hir/src/ir/entity.rs
@@ -1168,25 +1168,24 @@ impl<T: ?Sized, Metadata> RawEntityMetadata<T, Metadata> {
     /// The pointer must point to (and have valid metadata for) a previously valid instance of T, but
     /// the T is allowed to be dropped.
     unsafe fn data_offset(ptr: *const T) -> usize {
-        use core::mem::align_of_val_raw;
-
         // Align the unsized value to the end of the RawEntityMetadata.
         // Because RawEntityMetadata/RawEntity is repr(C), it will always be the last field in memory.
         //
         // SAFETY: since the only unsized types possible are slices, trait objects, and extern types,
         // the input safety requirement is currently enough to satisfy the requirements of
         // align_of_val_raw; but this is an implementation detail of the language that is unstable
-        unsafe { RawEntityMetadata::<(), Metadata>::data_offset_align(align_of_val_raw(ptr)) }
+        let align = unsafe { core::mem::Alignment::of_val_raw(ptr) };
+        RawEntityMetadata::<(), Metadata>::data_offset_align(align)
     }
 
     #[inline]
-    fn data_offset_align(align: usize) -> usize {
+    fn data_offset_align(align: core::mem::Alignment) -> usize {
         raw_entity_value_offset_for_align::<Metadata>(align)
     }
 }
 
 fn raw_entity_metadata_layout_for_value_layout<Metadata>(layout: Layout) -> Layout {
-    let value_offset = raw_entity_value_offset_for_align::<Metadata>(layout.align());
+    let value_offset = raw_entity_value_offset_for_align::<Metadata>(layout.alignment());
     let header_layout = Layout::new::<RawEntity<()>>();
     let align = Layout::new::<Metadata>().align().max(header_layout.align()).max(layout.align());
     Layout::from_size_align(value_offset + layout.size(), align)
@@ -1194,10 +1193,10 @@ fn raw_entity_metadata_layout_for_value_layout<Metadata>(layout: Layout) -> Layo
         .pad_to_align()
 }
 
-fn raw_entity_value_offset_for_align<Metadata>(value_align: usize) -> usize {
+fn raw_entity_value_offset_for_align<Metadata>(value_align: core::mem::Alignment) -> usize {
     let metadata_layout = Layout::new::<Metadata>();
     let header_layout = Layout::new::<RawEntity<()>>();
-    let entity_align = header_layout.align().max(value_align);
+    let entity_align = header_layout.alignment().max(value_align);
     let entity_offset = metadata_layout.size() + metadata_layout.padding_needed_for(entity_align);
     let cell_offset = header_layout.size() + header_layout.padding_needed_for(value_align);
     entity_offset + cell_offset

--- a/hir/src/ir/symbols.rs
+++ b/hir/src/ir/symbols.rs
@@ -1,5 +1,3 @@
-#![expect(unused_assignments)]
-
 mod name;
 mod path;
 mod symbol;

--- a/hir/src/lib.rs
+++ b/hir/src/lib.rs
@@ -1,12 +1,12 @@
 #![no_std]
 #![feature(allocator_api)]
-#![feature(alloc_layout_extra)]
 #![feature(coerce_unsized)]
 #![feature(const_type_name)]
 #![feature(unsize)]
 #![feature(ptr_metadata)]
 #![feature(ptr_as_uninit)]
 #![feature(layout_for_ptr)]
+#![feature(ptr_alignment_type)]
 #![feature(slice_ptr_get)]
 #![feature(specialization)]
 #![feature(rustc_attrs)]
@@ -21,7 +21,6 @@
 #![feature(exact_size_is_empty)]
 #![feature(generic_const_exprs)]
 #![feature(clone_to_uninit)]
-#![feature(new_range_api)]
 // The following are used in impls of custom collection types based on SmallVec
 #![feature(std_internals)] // for ByRefSized
 #![feature(extend_one)]

--- a/midenc-log/Cargo.toml
+++ b/midenc-log/Cargo.toml
@@ -21,12 +21,12 @@ regex = ["dep:regex"]
 kv = ["log/kv"]
 
 [dependencies]
-anstream = { version = "0.6", default-features = false, features = ["wincon"], optional = true }
-anstyle = { version = "1.0", optional = true }
+anstream = { version = "^1.0", default-features = false, features = ["wincon"], optional = true }
+anstyle = { version = "^1.0", optional = true }
 log = { workspace = true, features = ["std"] }
 jiff = { version = "0.2.3", default-features = false, features = ["std"], optional = true }
 regex = { version = "1.0", default-features = false, features = ["std", "perf"], optional = true }
 
 [dev-dependencies]
 # NOTE: Use local paths for dev-only dependency to avoid relying on crates.io during packaging
-snapbox = "0.6"
+snapbox = "^1.2"

--- a/midenc-session/src/diagnostics.rs
+++ b/midenc-session/src/diagnostics.rs
@@ -1,5 +1,3 @@
-#![expect(unused_assignments)]
-
 use alloc::{
     boxed::Box,
     collections::BTreeMap,

--- a/midenc-session/src/lib.rs
+++ b/midenc-session/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![feature(debug_closure_helpers)]
 #![feature(specialization)]
-#![feature(slice_split_once)]
 // Specialization
 #![allow(incomplete_features)]
 #![deny(warnings)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,7 +2,7 @@
 # REMINDER: After updating the channel, update:
 # - docs/src/usage/cargo-miden.md
 # - docs/src/usage/midenc.md
-channel = "nightly-2025-12-10"
+channel = "nightly-2026-04-30"
 components = ["rustfmt", "rust-src", "clippy", "rust-analyzer"]
 targets = ["wasm32-unknown-unknown", "wasm32-wasip1", "wasm32-wasip2"]
 profile = "minimal"

--- a/sdk/base-macros/src/component_macro/metadata.rs
+++ b/sdk/base-macros/src/component_macro/metadata.rs
@@ -2,7 +2,6 @@ use std::{fs, path::Path};
 
 use proc_macro::Span;
 use semver::Version;
-use toml::Value;
 
 /// Cargo metadata relevant for the `#[component]` macro expansion.
 pub struct CargoMetadata {
@@ -38,7 +37,7 @@ pub fn get_package_metadata(call_site_span: Span) -> Result<CargoMetadata, syn::
             format!("Failed to read {}: {}", cargo_toml_path.display(), e),
         )
     })?;
-    let cargo_toml: Value = cargo_toml_content.parse::<Value>().map_err(|e| {
+    let cargo_toml = cargo_toml_content.parse::<toml::Table>().map_err(|e| {
         syn::Error::new(
             call_site_span.into(),
             format!("Failed to parse {}: {}", cargo_toml_path.display(), e),

--- a/sdk/base-macros/src/component_macro/storage.rs
+++ b/sdk/base-macros/src/component_macro/storage.rs
@@ -106,8 +106,8 @@ fn slot_id_tokens(id: miden_protocol::account::StorageSlotId) -> proc_macro2::To
     let prefix = id.prefix().as_canonical_u64();
     quote! {
         ::miden::StorageSlotId::new(
-            ::miden::Felt::new(#suffix),
-            ::miden::Felt::new(#prefix),
+            ::miden::Felt::new(#suffix).unwrap(),
+            ::miden::Felt::new(#prefix).unwrap(),
         )
     }
 }

--- a/sdk/base-macros/src/manifest_paths.rs
+++ b/sdk/base-macros/src/manifest_paths.rs
@@ -43,7 +43,7 @@ pub(crate) fn resolve_wit_paths(options: ResolveOptions) -> Result<ResolvedWit, 
         )
     })?;
 
-    let manifest: Value = manifest_content.parse().map_err(|err| {
+    let manifest = manifest_content.parse::<toml::Table>().map_err(|err| {
         Error::new(
             Span::call_site(),
             format!("failed to parse manifest '{}': {err}", manifest_path.display()),

--- a/sdk/base-macros/src/wit_world.rs
+++ b/sdk/base-macros/src/wit_world.rs
@@ -32,7 +32,7 @@ impl ManifestPackage {
                 format!("failed to read manifest '{}': {err}", manifest_path.display()),
             )
         })?;
-        let manifest: Value = manifest_content.parse().map_err(|err| {
+        let manifest = manifest_content.parse::<toml::Table>().map_err(|err| {
             syn::Error::new(
                 error_span,
                 format!("failed to parse manifest '{}': {err}", manifest_path.display()),

--- a/sdk/base-macros/tests/note_trailing_data.rs
+++ b/sdk/base-macros/tests/note_trailing_data.rs
@@ -23,7 +23,7 @@ struct OneFeltNote {
 
 #[test]
 fn unit_note_rejects_trailing_data() {
-    let felts = [miden::Felt::new(0)];
+    let felts = [miden::Felt::new(0).unwrap()];
 
     let err = UnitNote::try_from(felts.as_slice()).unwrap_err();
     assert_eq!(err, miden::felt_repr::FeltReprError::TrailingData { pos: 0, len: 1 });
@@ -31,7 +31,7 @@ fn unit_note_rejects_trailing_data() {
 
 #[test]
 fn note_struct_rejects_trailing_data() {
-    let felts = [miden::Felt::new(1), miden::Felt::new(2)];
+    let felts = [miden::Felt::new(1).unwrap(), miden::Felt::new(2).unwrap()];
 
     let err = OneFeltNote::try_from(felts.as_slice()).unwrap_err();
     assert_eq!(err, miden::felt_repr::FeltReprError::TrailingData { pos: 1, len: 2 });

--- a/sdk/base-sys/src/bindings/active_account.rs
+++ b/sdk/base-sys/src/bindings/active_account.rs
@@ -185,7 +185,7 @@ pub fn has_non_fungible_asset(asset: Asset) -> bool {
             asset.key[1],
             asset.key[2],
             asset.key[3],
-        ) != Felt::new(0)
+        ) != Felt::new(0).unwrap()
     }
 }
 
@@ -220,7 +220,10 @@ pub fn get_num_procedures() -> Felt {
 pub fn get_procedure_root(index: u8) -> Word {
     unsafe {
         let mut ret_area = ::core::mem::MaybeUninit::<Word>::uninit();
-        extern_active_account_get_procedure_root(Felt::new(index as u64), ret_area.as_mut_ptr());
+        extern_active_account_get_procedure_root(
+            Felt::new(index as u64).unwrap(),
+            ret_area.as_mut_ptr(),
+        );
         ret_area.assume_init()
     }
 }
@@ -230,7 +233,7 @@ pub fn get_procedure_root(index: u8) -> Word {
 pub fn has_procedure(proc_root: Word) -> bool {
     unsafe {
         extern_active_account_has_procedure(proc_root[0], proc_root[1], proc_root[2], proc_root[3])
-            != Felt::new(0)
+            != Felt::new(0).unwrap()
     }
 }
 

--- a/sdk/base-sys/src/bindings/native_account.rs
+++ b/sdk/base-sys/src/bindings/native_account.rs
@@ -133,7 +133,7 @@ pub fn was_procedure_called(proc_root: Word) -> bool {
             proc_root[1],
             proc_root[2],
             proc_root[3],
-        ) != Felt::new(0)
+        ) != Felt::new(0).unwrap()
     }
 }
 

--- a/sdk/field-repr/derive/README.md
+++ b/sdk/field-repr/derive/README.md
@@ -22,8 +22,8 @@ struct AccountId {
 }
 
 let value = AccountId {
-    prefix: Felt::new(1),
-    suffix: Felt::new(2),
+    prefix: Felt::new(1).unwrap(),
+    suffix: Felt::new(2).unwrap(),
 };
 let felts = value.to_felt_repr();
 let roundtrip = AccountId::try_from(felts.as_slice()).unwrap();
@@ -47,7 +47,7 @@ enum Message {
 // Ping -> tag = 0
 // Transfer -> tag = 1
 let value = Message::Transfer {
-    to: Felt::new(7),
+    to: Felt::new(7).unwrap(),
     amount: 10,
 };
 let felts = value.to_felt_repr();

--- a/sdk/field-repr/derive/src/lib.rs
+++ b/sdk/field-repr/derive/src/lib.rs
@@ -21,7 +21,7 @@
 //!     suffix: Felt,
 //! }
 //!
-//! let value = AccountId { prefix: Felt::new(1), suffix: Felt::new(2) };
+//! let value = AccountId { prefix: Felt::new(1).unwrap(), suffix: Felt::new(2).unwrap() };
 //! let felts = value.to_felt_repr();
 //! let roundtrip = AccountId::try_from(felts.as_slice()).unwrap();
 //! assert_eq!(roundtrip, value);
@@ -43,7 +43,7 @@
 //! // Encoded as: [tag, payload...], where `tag` is the variant ordinal in declaration order.
 //! // Ping -> tag = 0
 //! // Transfer -> tag = 1
-//! let value = Message::Transfer { to: Felt::new(7), amount: 10 };
+//! let value = Message::Transfer { to: Felt::new(7).unwrap(), amount: 10 };
 //! let felts = value.to_felt_repr();
 //! let roundtrip = Message::try_from(felts.as_slice()).unwrap();
 //! assert_eq!(roundtrip, value);

--- a/sdk/field-repr/repr/src/lib.rs
+++ b/sdk/field-repr/repr/src/lib.rs
@@ -370,29 +370,29 @@ impl ToFeltRepr for u64 {
     fn write_felt_repr(&self, writer: &mut FeltWriter<'_>) {
         let lo = (*self & 0xffff_ffff) as u32;
         let hi = (*self >> 32) as u32;
-        writer.write(Felt::new(lo as u64));
-        writer.write(Felt::new(hi as u64));
+        writer.write(Felt::new(lo as u64).unwrap());
+        writer.write(Felt::new(hi as u64).unwrap());
     }
 }
 
 impl ToFeltRepr for u32 {
     #[inline(always)]
     fn write_felt_repr(&self, writer: &mut FeltWriter<'_>) {
-        writer.write(Felt::new(*self as u64));
+        writer.write(Felt::new(*self as u64).unwrap());
     }
 }
 
 impl ToFeltRepr for u8 {
     #[inline(always)]
     fn write_felt_repr(&self, writer: &mut FeltWriter<'_>) {
-        writer.write(Felt::new(*self as u64));
+        writer.write(Felt::new(*self as u64).unwrap());
     }
 }
 
 impl ToFeltRepr for bool {
     #[inline(always)]
     fn write_felt_repr(&self, writer: &mut FeltWriter<'_>) {
-        writer.write(Felt::new(*self as u64));
+        writer.write(Felt::new(*self as u64).unwrap());
     }
 }
 
@@ -408,9 +408,9 @@ where
     #[inline(always)]
     fn write_felt_repr(&self, writer: &mut FeltWriter<'_>) {
         match self {
-            None => writer.write(Felt::new(0)),
+            None => writer.write(Felt::new(0).unwrap()),
             Some(value) => {
-                writer.write(Felt::new(1));
+                writer.write(Felt::new(1).unwrap());
                 value.write_felt_repr(writer);
             }
         }
@@ -428,7 +428,7 @@ where
     fn write_felt_repr(&self, writer: &mut FeltWriter<'_>) {
         let len = self.len();
         assert!(len <= u32::MAX as usize, "Vec: length out of range");
-        writer.write(Felt::new(len as u64));
+        writer.write(Felt::new(len as u64).unwrap());
 
         let mut i = 0usize;
         while i < len {

--- a/sdk/field-repr/tests/src/offchain.rs
+++ b/sdk/field-repr/tests/src/offchain.rs
@@ -27,33 +27,33 @@ struct TwoFelts {
 #[test]
 fn test_serialization() {
     let value = TwoFelts {
-        a: Felt::new(12345),
-        b: Felt::new(67890),
+        a: Felt::new(12345).unwrap(),
+        b: Felt::new(67890).unwrap(),
     };
 
     let felts = value.to_felt_repr();
 
     assert_eq!(felts.len(), 2);
-    assert_eq!(felts[0], Felt::new(12345));
-    assert_eq!(felts[1], Felt::new(67890));
+    assert_eq!(felts[0], Felt::new(12345).unwrap());
+    assert_eq!(felts[1], Felt::new(67890).unwrap());
 }
 
 #[test]
 fn test_deserialization() {
-    let felts = [Felt::new(12345), Felt::new(67890)];
+    let felts = [Felt::new(12345).unwrap(), Felt::new(67890).unwrap()];
 
     let mut reader = FeltReader::new(&felts);
     let value = TwoFelts::from_felt_repr(&mut reader).unwrap();
 
-    assert_eq!(value.a, Felt::new(12345));
-    assert_eq!(value.b, Felt::new(67890));
+    assert_eq!(value.a, Felt::new(12345).unwrap());
+    assert_eq!(value.b, Felt::new(67890).unwrap());
 }
 
 #[test]
 fn test_roundtrip() {
     let original = TwoFelts {
-        a: Felt::new(12345),
-        b: Felt::new(67890),
+        a: Felt::new(12345).unwrap(),
+        b: Felt::new(67890).unwrap(),
     };
 
     assert_roundtrip(&original);
@@ -64,8 +64,8 @@ fn test_try_from_slice_roundtrip() {
     use core::convert::TryFrom;
 
     let original = TwoFelts {
-        a: Felt::new(12345),
-        b: Felt::new(67890),
+        a: Felt::new(12345).unwrap(),
+        b: Felt::new(67890).unwrap(),
     };
     let felts = original.to_felt_repr();
 
@@ -78,11 +78,11 @@ fn test_try_from_slice_rejects_trailing_data() {
     use core::convert::TryFrom;
 
     let original = TwoFelts {
-        a: Felt::new(12345),
-        b: Felt::new(67890),
+        a: Felt::new(12345).unwrap(),
+        b: Felt::new(67890).unwrap(),
     };
     let mut felts = original.to_felt_repr();
-    felts.push(Felt::new(0));
+    felts.push(Felt::new(0).unwrap());
 
     let err = TwoFelts::try_from(felts.as_slice()).unwrap_err();
     assert_eq!(err, miden_field_repr::FeltReprError::TrailingData { pos: 2, len: 3 });
@@ -90,7 +90,7 @@ fn test_try_from_slice_rejects_trailing_data() {
 
 #[test]
 fn test_value_out_of_range_includes_position() {
-    let felts = [Felt::new(256)];
+    let felts = [Felt::new(256).unwrap()];
     let mut reader = FeltReader::new(&felts);
 
     let err = <u8 as FromFeltRepr>::from_felt_repr(&mut reader).unwrap_err();
@@ -108,7 +108,7 @@ fn test_value_out_of_range_includes_position() {
 
 #[test]
 fn test_invalid_bool_includes_position() {
-    let felts = [Felt::new(2)];
+    let felts = [Felt::new(2).unwrap()];
     let mut reader = FeltReader::new(&felts);
 
     let err = <bool as FromFeltRepr>::from_felt_repr(&mut reader).unwrap_err();
@@ -124,7 +124,7 @@ fn test_invalid_bool_includes_position() {
 
 #[test]
 fn test_invalid_option_tag_includes_position() {
-    let felts = [Felt::new(2)];
+    let felts = [Felt::new(2).unwrap()];
     let mut reader = FeltReader::new(&felts);
 
     let err = <Option<u8> as FromFeltRepr>::from_felt_repr(&mut reader).unwrap_err();
@@ -146,7 +146,7 @@ fn test_unknown_enum_tag_includes_position() {
         B,
     }
 
-    let felts = [Felt::new(2)];
+    let felts = [Felt::new(2).unwrap()];
     let mut reader = FeltReader::new(&felts);
 
     let err = TestEnum::from_felt_repr(&mut reader).unwrap_err();
@@ -173,7 +173,7 @@ struct MixedStruct {
 #[test]
 fn test_struct_roundtrip_mixed_types() {
     let original = MixedStruct {
-        a: Felt::new(11),
+        a: Felt::new(11).unwrap(),
         b: 22,
         c: true,
         d: 33,
@@ -181,10 +181,10 @@ fn test_struct_roundtrip_mixed_types() {
 
     let felts = original.to_felt_repr();
     assert_eq!(felts.len(), 4);
-    assert_eq!(felts[0], Felt::new(11));
-    assert_eq!(felts[1], Felt::new(22));
-    assert_eq!(felts[2], Felt::new(1));
-    assert_eq!(felts[3], Felt::new(33));
+    assert_eq!(felts[0], Felt::new(11).unwrap());
+    assert_eq!(felts[1], Felt::new(22).unwrap());
+    assert_eq!(felts[2], Felt::new(1).unwrap());
+    assert_eq!(felts[3], Felt::new(33).unwrap());
 
     assert_roundtrip(&original);
 }
@@ -209,7 +209,7 @@ fn test_struct_roundtrip_nested() {
     let original = Outer {
         head: 1,
         inner: Inner {
-            x: Felt::new(2),
+            x: Felt::new(2).unwrap(),
             y: 3,
         },
         tail: false,
@@ -217,11 +217,11 @@ fn test_struct_roundtrip_nested() {
 
     let felts = original.to_felt_repr();
     assert_eq!(felts.len(), 5);
-    assert_eq!(felts[0], Felt::new(1));
-    assert_eq!(felts[1], Felt::new(2));
-    assert_eq!(felts[2], Felt::new(3));
-    assert_eq!(felts[3], Felt::new(0));
-    assert_eq!(felts[4], Felt::new(0));
+    assert_eq!(felts[0], Felt::new(1).unwrap());
+    assert_eq!(felts[1], Felt::new(2).unwrap());
+    assert_eq!(felts[2], Felt::new(3).unwrap());
+    assert_eq!(felts[3], Felt::new(0).unwrap());
+    assert_eq!(felts[4], Felt::new(0).unwrap());
 
     assert_roundtrip(&original);
 }
@@ -238,7 +238,7 @@ enum SimpleEnum {
 fn test_enum_roundtrip_unit() {
     let original = SimpleEnum::B;
     let felts = original.to_felt_repr();
-    assert_eq!(felts, vec![Felt::new(1)]);
+    assert_eq!(felts, vec![Felt::new(1).unwrap()]);
     assert_roundtrip(&original);
 }
 
@@ -253,12 +253,12 @@ enum MixedEnum {
 
 #[test]
 fn test_enum_roundtrip_tuple_variant() {
-    let original = MixedEnum::Pair(Felt::new(7), 8);
+    let original = MixedEnum::Pair(Felt::new(7).unwrap(), 8);
     let felts = original.to_felt_repr();
     assert_eq!(felts.len(), 3);
-    assert_eq!(felts[0], Felt::new(1));
-    assert_eq!(felts[1], Felt::new(7));
-    assert_eq!(felts[2], Felt::new(8));
+    assert_eq!(felts[0], Felt::new(1).unwrap());
+    assert_eq!(felts[1], Felt::new(7).unwrap());
+    assert_eq!(felts[2], Felt::new(8).unwrap());
     assert_roundtrip(&original);
 }
 
@@ -267,10 +267,10 @@ fn test_enum_roundtrip_struct_variant() {
     let original = MixedEnum::Struct { n: 9, flag: true };
     let felts = original.to_felt_repr();
     assert_eq!(felts.len(), 4);
-    assert_eq!(felts[0], Felt::new(2));
-    assert_eq!(felts[1], Felt::new(9));
-    assert_eq!(felts[2], Felt::new(0));
-    assert_eq!(felts[3], Felt::new(1));
+    assert_eq!(felts[0], Felt::new(2).unwrap());
+    assert_eq!(felts[1], Felt::new(9).unwrap());
+    assert_eq!(felts[2], Felt::new(0).unwrap());
+    assert_eq!(felts[3], Felt::new(1).unwrap());
     assert_roundtrip(&original);
 }
 
@@ -285,9 +285,9 @@ struct WithEnum {
 #[test]
 fn test_struct_with_enum_roundtrip() {
     let original = WithEnum {
-        prefix: Felt::new(10),
+        prefix: Felt::new(10).unwrap(),
         msg: MixedEnum::Nested(Inner {
-            x: Felt::new(11),
+            x: Felt::new(11).unwrap(),
             y: 12,
         }),
         suffix: 13,
@@ -296,12 +296,12 @@ fn test_struct_with_enum_roundtrip() {
     // prefix (1) + msg(tag=3 + Inner(3)) + suffix (1) = 6 felts
     let felts = original.to_felt_repr();
     assert_eq!(felts.len(), 6);
-    assert_eq!(felts[0], Felt::new(10));
-    assert_eq!(felts[1], Felt::new(3));
-    assert_eq!(felts[2], Felt::new(11));
-    assert_eq!(felts[3], Felt::new(12));
-    assert_eq!(felts[4], Felt::new(0));
-    assert_eq!(felts[5], Felt::new(13));
+    assert_eq!(felts[0], Felt::new(10).unwrap());
+    assert_eq!(felts[1], Felt::new(3).unwrap());
+    assert_eq!(felts[2], Felt::new(11).unwrap());
+    assert_eq!(felts[3], Felt::new(12).unwrap());
+    assert_eq!(felts[4], Felt::new(0).unwrap());
+    assert_eq!(felts[5], Felt::new(13).unwrap());
 
     assert_roundtrip(&original);
 }
@@ -316,7 +316,7 @@ enum Top {
 #[test]
 fn test_enum_nested_with_struct_roundtrip() {
     let original = Top::Some(WithEnum {
-        prefix: Felt::new(21),
+        prefix: Felt::new(21).unwrap(),
         msg: MixedEnum::Struct { n: 22, flag: false },
         suffix: 23,
     });
@@ -338,14 +338,22 @@ struct WithOption {
 #[test]
 fn test_struct_roundtrip_option_some() {
     let original = WithOption {
-        prefix: Felt::new(5),
+        prefix: Felt::new(5).unwrap(),
         maybe: Some(42),
         suffix: true,
     };
 
     let felts = original.to_felt_repr();
     assert_eq!(felts.len(), 4);
-    assert_eq!(felts, vec![Felt::new(5), Felt::new(1), Felt::new(42), Felt::new(1)]);
+    assert_eq!(
+        felts,
+        vec![
+            Felt::new(5).unwrap(),
+            Felt::new(1).unwrap(),
+            Felt::new(42).unwrap(),
+            Felt::new(1).unwrap()
+        ]
+    );
 
     assert_roundtrip(&original);
 }
@@ -353,14 +361,14 @@ fn test_struct_roundtrip_option_some() {
 #[test]
 fn test_struct_roundtrip_option_none() {
     let original = WithOption {
-        prefix: Felt::new(7),
+        prefix: Felt::new(7).unwrap(),
         maybe: None,
         suffix: false,
     };
 
     let felts = original.to_felt_repr();
     assert_eq!(felts.len(), 3);
-    assert_eq!(felts, vec![Felt::new(7), Felt::new(0), Felt::new(0)]);
+    assert_eq!(felts, vec![Felt::new(7).unwrap(), Felt::new(0).unwrap(), Felt::new(0).unwrap()]);
 
     assert_roundtrip(&original);
 }
@@ -376,7 +384,7 @@ struct WithVec {
 #[test]
 fn test_struct_roundtrip_vec_non_empty() {
     let original = WithVec {
-        prefix: Felt::new(9),
+        prefix: Felt::new(9).unwrap(),
         items: vec![1, 2, 3],
         suffix: true,
     };
@@ -387,12 +395,12 @@ fn test_struct_roundtrip_vec_non_empty() {
     assert_eq!(
         felts,
         vec![
-            Felt::new(9),
-            Felt::new(3),
-            Felt::new(1),
-            Felt::new(2),
-            Felt::new(3),
-            Felt::new(1),
+            Felt::new(9).unwrap(),
+            Felt::new(3).unwrap(),
+            Felt::new(1).unwrap(),
+            Felt::new(2).unwrap(),
+            Felt::new(3).unwrap(),
+            Felt::new(1).unwrap(),
         ]
     );
 
@@ -402,14 +410,17 @@ fn test_struct_roundtrip_vec_non_empty() {
 #[test]
 fn test_struct_roundtrip_vec_empty() {
     let original = WithVec {
-        prefix: Felt::new(10),
+        prefix: Felt::new(10).unwrap(),
         items: vec![],
         suffix: false,
     };
 
     let felts = original.to_felt_repr();
     assert_eq!(felts.len(), 3);
-    assert_eq!(felts, vec![Felt::new(10), Felt::new(0), Felt::new(0)]);
+    assert_eq!(
+        felts,
+        vec![Felt::new(10).unwrap(), Felt::new(0).unwrap(), Felt::new(0).unwrap()]
+    );
 
     assert_roundtrip(&original);
 }
@@ -420,10 +431,13 @@ struct TupleStruct(u32, bool, Felt);
 
 #[test]
 fn test_tuple_struct_roundtrip() {
-    let original = TupleStruct(22, true, Felt::new(33));
+    let original = TupleStruct(22, true, Felt::new(33).unwrap());
     let felts = original.to_felt_repr();
 
-    assert_eq!(felts, vec![Felt::new(22), Felt::new(1), Felt::new(33)]);
+    assert_eq!(
+        felts,
+        vec![Felt::new(22).unwrap(), Felt::new(1).unwrap(), Felt::new(33).unwrap()]
+    );
     assert_roundtrip(&original);
 }
 

--- a/sdk/field-repr/tests/src/onchain.rs
+++ b/sdk/field-repr/tests/src/onchain.rs
@@ -44,7 +44,7 @@ fn read_vec_felts(
         let elem: TestFelt = trace
             .read_from_rust_memory(byte_addr)
             .unwrap_or_else(|| panic!("Failed to read element {i}"));
-        result.push(ReprFelt::new(elem.0.as_canonical_u64()));
+        result.push(ReprFelt::new(elem.0.as_canonical_u64()).unwrap());
     }
 
     result
@@ -61,8 +61,8 @@ struct TwoFelts {
 #[test]
 fn test_felt_reader() {
     let original = TwoFelts {
-        a: Felt::new(12345),
-        b: Felt::new(67890),
+        a: Felt::new(12345).unwrap(),
+        b: Felt::new(67890).unwrap(),
     };
     let serialized = original.to_felt_repr();
 
@@ -113,8 +113,8 @@ fn test_felt_reader() {
             .expect("Failed to read result from memory");
 
         let result_felts = [
-            ReprFelt::new(result_word[0].0.as_canonical_u64()),
-            ReprFelt::new(result_word[1].0.as_canonical_u64()),
+            ReprFelt::new(result_word[0].0.as_canonical_u64()).unwrap(),
+            ReprFelt::new(result_word[1].0.as_canonical_u64()).unwrap(),
         ];
         let mut reader = FeltReader::new(&result_felts);
         let result_struct = TwoFelts::from_felt_repr(&mut reader).unwrap();
@@ -134,8 +134,8 @@ fn test_felt_reader() {
 #[test]
 fn test_two_felts_struct_round_trip() {
     let original = TwoFelts {
-        a: Felt::new(12345),
-        b: Felt::new(67890),
+        a: Felt::new(12345).unwrap(),
+        b: Felt::new(67890).unwrap(),
     };
     let serialized = original.to_felt_repr();
 
@@ -204,16 +204,16 @@ struct FiveFelts {
 #[test]
 fn test_five_felts_struct_round_trip() {
     let original = FiveFelts {
-        a: Felt::new(11111),
-        b: Felt::new(22222),
-        c: Felt::new(33333),
-        d: Felt::new(44444),
-        e: Felt::new(55555),
+        a: Felt::new(11111).unwrap(),
+        b: Felt::new(22222).unwrap(),
+        c: Felt::new(33333).unwrap(),
+        d: Felt::new(44444).unwrap(),
+        e: Felt::new(55555).unwrap(),
     };
     let serialized = original.to_felt_repr();
 
     assert_eq!(serialized.len(), 5);
-    assert_eq!(serialized[4], Felt::new(55555));
+    assert_eq!(serialized[4], Felt::new(55555).unwrap());
 
     let onchain_code = r#"(input: [Felt; 5]) -> Vec<Felt> {
         use miden_field_repr::{FeltReader, FromFeltRepr, ToFeltRepr};
@@ -370,10 +370,10 @@ struct MixedTypesNoU64 {
 #[test]
 fn test_mixed_types_no_u64_round_trip() {
     let original = MixedTypesNoU64 {
-        f1: Felt::new(111111),
-        f2: Felt::new(222222),
-        f3: Felt::new(333333),
-        f4: Felt::new(444444),
+        f1: Felt::new(111111).unwrap(),
+        f2: Felt::new(222222).unwrap(),
+        f3: Felt::new(333333).unwrap(),
+        f4: Felt::new(444444).unwrap(),
         x: 55555,
         y: 66,
     };
@@ -461,9 +461,9 @@ struct Outer {
 #[test]
 fn test_nested_struct_round_trip() {
     let original = Outer {
-        a: Felt::new(111111),
+        a: Felt::new(111111).unwrap(),
         inner: Inner {
-            x: Felt::new(222222),
+            x: Felt::new(222222).unwrap(),
             y: 333333,
         },
         b: 44444,
@@ -555,14 +555,14 @@ fn test_enum_unit_round_trip() {
     }
 
     let original = Wrapper {
-        pad: Felt::new(999),
+        pad: Felt::new(999).unwrap(),
         value: SimpleEnum::B,
     };
     let serialized = original.to_felt_repr();
 
     assert_eq!(serialized.len(), 2);
-    assert_eq!(serialized[0], Felt::new(999));
-    assert_eq!(serialized[1], Felt::new(1));
+    assert_eq!(serialized[0], Felt::new(999).unwrap());
+    assert_eq!(serialized[1], Felt::new(1).unwrap());
 
     let onchain_code = r#"(input: [Felt; 2]) -> Vec<Felt> {
         use miden_field_repr::{FeltReader, FromFeltRepr, ToFeltRepr};
@@ -624,13 +624,13 @@ fn test_enum_tuple_round_trip() {
         Struct { x: u64, flag: bool },
     }
 
-    let original = MixedEnum::Pair(Felt::new(111), 222);
+    let original = MixedEnum::Pair(Felt::new(111).unwrap(), 222);
     let serialized = original.to_felt_repr();
 
     assert_eq!(serialized.len(), 3);
-    assert_eq!(serialized[0], Felt::new(1));
-    assert_eq!(serialized[1], Felt::new(111));
-    assert_eq!(serialized[2], Felt::new(222));
+    assert_eq!(serialized[0], Felt::new(1).unwrap());
+    assert_eq!(serialized[1], Felt::new(111).unwrap());
+    assert_eq!(serialized[2], Felt::new(222).unwrap());
 
     let onchain_code = r#"(input: [Felt; 3]) -> Vec<Felt> {
         use miden_field_repr::{FeltReader, FromFeltRepr, ToFeltRepr};
@@ -700,10 +700,10 @@ fn test_struct_with_enum_round_trip() {
     }
 
     let original = Outer {
-        prefix: Felt::new(999),
+        prefix: Felt::new(999).unwrap(),
         kind: Kind::Inline {
             inner: Inner {
-                a: Felt::new(111),
+                a: Felt::new(111).unwrap(),
                 b: 222,
             },
             ok: true,
@@ -794,8 +794,8 @@ fn test_enum_nested_with_struct_round_trip() {
     }
 
     let original = Top::Wrap(Wrapper {
-        left: Felt::new(7),
-        right: Felt::new(8),
+        left: Felt::new(7).unwrap(),
+        right: Felt::new(8).unwrap(),
         state: State::B {
             n: 999_999,
             f: false,
@@ -873,12 +873,12 @@ struct WithOption {
 #[test]
 fn test_struct_with_option_round_trip() {
     let original_none = WithOption {
-        prefix: Felt::new(7),
+        prefix: Felt::new(7).unwrap(),
         maybe: None,
         suffix: false,
     };
     let original_some = WithOption {
-        prefix: Felt::new(5),
+        prefix: Felt::new(5).unwrap(),
         maybe: Some(42),
         suffix: true,
     };
@@ -919,7 +919,7 @@ fn test_struct_with_option_round_trip() {
     // `[Felt; 4]` so we can reuse the same compiled package for both `None` and `Some`.
     // The extra trailing `0` is never read by `FromFeltRepr`.
     let mut input_none = serialized_none.clone();
-    input_none.resize(4, ReprFelt::new(0));
+    input_none.resize(4, ReprFelt::new(0).unwrap());
     let initializers = [Initializer::MemoryFelts {
         addr: in_elem_addr,
         felts: Cow::from(to_core_felts(&input_none)),
@@ -963,7 +963,7 @@ struct WithVec {
 #[test]
 fn test_struct_with_vec_round_trip() {
     let original = WithVec {
-        prefix: Felt::new(9),
+        prefix: Felt::new(9).unwrap(),
         items: vec![1, 2, 3],
         suffix: true,
     };
@@ -1021,9 +1021,16 @@ struct TupleStruct(u32, bool, Felt);
 
 #[test]
 fn test_tuple_struct_round_trip() {
-    let original = TupleStruct(22, true, Felt::new(33));
+    let original = TupleStruct(22, true, Felt::new(33).unwrap());
     let serialized = original.to_felt_repr();
-    assert_eq!(serialized, vec![ReprFelt::new(22), ReprFelt::new(1), ReprFelt::new(33),]);
+    assert_eq!(
+        serialized,
+        vec![
+            ReprFelt::new(22).unwrap(),
+            ReprFelt::new(1).unwrap(),
+            ReprFelt::new(33).unwrap(),
+        ]
+    );
 
     let onchain_code = r#"(input: [Felt; 3]) -> Vec<Felt> {
         use miden_field_repr::{FeltReader, FromFeltRepr, ToFeltRepr};

--- a/sdk/stdlib-sys/src/intrinsics/felt.rs
+++ b/sdk/stdlib-sys/src/intrinsics/felt.rs
@@ -39,7 +39,7 @@ pub fn assert_eq(a: Felt, b: Felt) {
 #[cfg(not(all(target_family = "wasm", miden)))]
 #[inline(always)]
 pub fn assert(a: Felt) {
-    if a != Felt::new(1) {
+    if a != Felt::new(1).unwrap() {
         panic!("assert: expected 1");
     }
 }
@@ -48,7 +48,7 @@ pub fn assert(a: Felt) {
 #[cfg(not(all(target_family = "wasm", miden)))]
 #[inline(always)]
 pub fn assertz(a: Felt) {
-    if a != Felt::new(0) {
+    if a != Felt::new(0).unwrap() {
         panic!("assertz: expected 0");
     }
 }
@@ -70,6 +70,6 @@ macro_rules! felt {
     ($value:literal) => {{
         const VALUE: u64 = $value as u64;
         // assert!(VALUE <= Felt::M, "Invalid Felt value, must be >= 0 and <= 2^64 - 2^32 + 1");
-        $crate::Felt::new(VALUE)
+        $crate::Felt::new(VALUE).unwrap()
     }};
 }

--- a/sdk/stdlib-sys/src/stdlib/crypto/hashes.rs
+++ b/sdk/stdlib-sys/src/stdlib/crypto/hashes.rs
@@ -258,7 +258,7 @@ mod imp {
             let result_ptr = ret_area.as_mut_ptr() as *mut Felt;
             let miden_ptr = rust_ptr / 4;
             // Since our BumpAlloc produces word-aligned allocations the pointer should be word-aligned
-            assert_eq(Felt::new((miden_ptr % 4) as u64), felt!(0));
+            assert_eq(Felt::new((miden_ptr % 4) as u64).unwrap(), felt!(0));
 
             if element_count.is_multiple_of(4) {
                 let start_addr = miden_ptr;
@@ -285,7 +285,7 @@ mod imp {
 
         let miden_ptr = rust_ptr / 4;
         // It's safe to assume the `words` ptr is word-aligned.
-        assert_eq(Felt::new((miden_ptr % 4) as u64), felt!(0));
+        assert_eq(Felt::new((miden_ptr % 4) as u64).unwrap(), felt!(0));
 
         unsafe {
             let mut ret_area = core::mem::MaybeUninit::<Word>::uninit();

--- a/tests/integration-network/src/mockchain/basic_wallet.rs
+++ b/tests/integration-network/src/mockchain/basic_wallet.rs
@@ -107,7 +107,7 @@ pub fn test_basic_wallet_p2id() {
         chain.build_tx_context(alice_id, &[p2id_note_mint.id()], &[]).unwrap();
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
     expect!["3216"].assert_eq(prologue_cycles(&tx_measurements));
-    expect!["20211"].assert_eq(note_cycles(&tx_measurements, p2id_note_mint.id()));
+    expect!["20072"].assert_eq(note_cycles(&tx_measurements, p2id_note_mint.id()));
 
     eprintln!("\n=== Checking Alice's account has the minted asset ===");
     let alice_account = chain.committed_account(alice_id).unwrap();
@@ -127,12 +127,12 @@ pub fn test_basic_wallet_p2id() {
         &mut note_rng,
     );
     let tx_measurements = execute_tx(&mut chain, alice_tx_context_builder);
-    expect!["25232"].assert_eq(tx_script_processing_cycles(&tx_measurements));
+    expect!["26217"].assert_eq(tx_script_processing_cycles(&tx_measurements));
 
     eprintln!("\n=== Step 4: Bob consumes p2id note ===");
     let consume_tx_context_builder = chain.build_tx_context(bob_id, &[bob_note.id()], &[]).unwrap();
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
-    expect!["20211"].assert_eq(note_cycles(&tx_measurements, bob_note.id()));
+    expect!["20072"].assert_eq(note_cycles(&tx_measurements, bob_note.id()));
 
     eprintln!("\n=== Checking Bob's account has the transferred asset ===");
     let bob_account = chain.committed_account(bob_id).unwrap();
@@ -257,7 +257,7 @@ pub fn test_basic_wallet_p2ide() {
     let consume_tx_context_builder =
         chain.build_tx_context(bob_id, &[p2ide_note.id()], &[]).unwrap();
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
-    expect!["20686"].assert_eq(note_cycles(&tx_measurements, p2ide_note.id()));
+    expect!["21211"].assert_eq(note_cycles(&tx_measurements, p2ide_note.id()));
 
     // Step 5: verify balances
     let bob_account = chain.committed_account(bob_id).unwrap();
@@ -382,7 +382,7 @@ pub fn test_basic_wallet_p2ide_reclaim() {
     let reclaim_tx_context_builder =
         chain.build_tx_context(alice_id, &[p2ide_note.id()], &[]).unwrap();
     let tx_measurements = execute_tx(&mut chain, reclaim_tx_context_builder);
-    expect!["21699"].assert_eq(note_cycles(&tx_measurements, p2ide_note.id()));
+    expect!["22871"].assert_eq(note_cycles(&tx_measurements, p2ide_note.id()));
 
     // Step 5: verify Alice has her original amount back
     let alice_account = chain.committed_account(alice_id).unwrap();

--- a/tests/integration-network/src/mockchain/counter_contract.rs
+++ b/tests/integration-network/src/mockchain/counter_contract.rs
@@ -68,7 +68,7 @@ pub fn test_counter_contract() {
         .build_tx_context(counter_account.clone(), &[counter_note.id()], &[])
         .unwrap();
     let tx_measurements = execute_tx(&mut chain, tx_context_builder);
-    expect!["24863"].assert_eq(note_cycles(&tx_measurements, counter_note.id()));
+    expect!["49505"].assert_eq(note_cycles(&tx_measurements, counter_note.id()));
 
     // The counter contract storage value should be 2 after the note is consumed (incremented by 1).
     assert_counter_storage(

--- a/tests/integration-network/src/mockchain/counter_contract_no_auth.rs
+++ b/tests/integration-network/src/mockchain/counter_contract_no_auth.rs
@@ -104,8 +104,8 @@ pub fn test_counter_contract_no_auth() {
         .build_tx_context(counter_account.clone(), &[counter_note.id()], &[])
         .unwrap();
     let tx_measurements = execute_tx(&mut chain, tx_context_builder);
-    expect!["1824"].assert_eq(auth_procedure_cycles(&tx_measurements));
-    expect!["24863"].assert_eq(note_cycles(&tx_measurements, counter_note.id()));
+    expect!["1803"].assert_eq(auth_procedure_cycles(&tx_measurements));
+    expect!["49505"].assert_eq(note_cycles(&tx_measurements, counter_note.id()));
 
     // The counter contract storage value should be 2 after the note is consumed
     assert_counter_storage(

--- a/tests/integration-network/src/mockchain/counter_contract_rust_auth.rs
+++ b/tests/integration-network/src/mockchain/counter_contract_rust_auth.rs
@@ -72,7 +72,7 @@ pub fn test_counter_contract_rust_auth_blocks_unauthorized_note_creation() {
     let tx_context = tx_context_builder.build().unwrap();
     let executed_tx =
         block_on(tx_context.execute()).expect("authorized client should be able to create a note");
-    expect!["83038"].assert_eq(auth_procedure_cycles(executed_tx.measurements()));
+    expect!["86895"].assert_eq(auth_procedure_cycles(executed_tx.measurements()));
     assert_eq!(executed_tx.output_notes().num_notes(), 1);
     assert_eq!(executed_tx.output_notes().get_note(0).id(), own_note.id());
 

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -41,7 +41,7 @@ num-traits = "0.2"
 cargo-miden.workspace = true
 wasmprinter = "0.227"
 proptest.workspace = true
-sha2 = "0.10"
+sha2 = "0.11"
 walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/tests/integration/src/compiler_test.rs
+++ b/tests/integration/src/compiler_test.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use miden_assembly::PathBuf as LibraryPath;
+use miden_core::utils::ToHex;
 use midenc_compile::{
     compile_link_output_to_masm_with_pre_assembly_stage, compile_to_unoptimized_hir,
 };
@@ -1125,6 +1126,5 @@ fn sanitize_filename_component(name: &str) -> String {
 }
 
 fn hash_string(inputs: &str) -> String {
-    let hash = <sha2::Sha256 as sha2::Digest>::digest(inputs.as_bytes());
-    format!("{hash:x}")
+    <sha2::Sha256 as sha2::Digest>::digest(inputs.as_bytes()).as_slice().to_hex()
 }

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -1,5 +1,4 @@
 //! Compilation and semantic tests for the whole compiler pipeline
-#![feature(iter_array_chunks)]
 #![feature(debug_closure_helpers)]
 #![deny(warnings)]
 #![deny(missing_docs)]

--- a/tests/integration/src/rust_masm_tests/abi_transform/advice_map.rs
+++ b/tests/integration/src/rust_masm_tests/abi_transform/advice_map.rs
@@ -31,8 +31,8 @@ fn test_adv_load_preimage() {
         let num_felts = intrinsics::advice::adv_push_mapvaln(key.clone());
 
         let num_felts_u64 = num_felts.as_canonical_u64();
-        assert_eq(Felt::new((num_felts_u64 % 4) as u64), felt!(0));
-        let num_words = Felt::new(num_felts_u64 / 4);
+        assert_eq(Felt::new((num_felts_u64 % 4) as u64).unwrap(), felt!(0));
+        let num_words = Felt::new(num_felts_u64 / 4).unwrap();
 
         let commitment = key;
         let input = adv_load_preimage(num_words, commitment);

--- a/tests/integration/src/rust_masm_tests/examples.rs
+++ b/tests/integration/src/rust_masm_tests/examples.rs
@@ -329,7 +329,7 @@ fn basic_wallet_and_p2id() {
         CompilerTest::rust_source_cargo_miden("../../examples/basic-wallet", config.clone(), []);
     let account_package = account_test.compile_package();
     assert!(account_package.is_library(), "expected library");
-    expect!["29016"].assert_eq(stripped_mast_size_str(&account_package));
+    expect!["35906"].assert_eq(stripped_mast_size_str(&account_package));
 
     let mut tx_script_test = CompilerTest::rust_source_cargo_miden(
         "../../examples/basic-wallet-tx-script",
@@ -338,19 +338,19 @@ fn basic_wallet_and_p2id() {
     );
     let tx_script_package = tx_script_test.compile_package();
     assert!(tx_script_package.is_program(), "expected program");
-    expect!["45884"].assert_eq(stripped_mast_size_str(&tx_script_package));
+    expect!["56437"].assert_eq(stripped_mast_size_str(&tx_script_package));
 
     let mut p2id_test =
         CompilerTest::rust_source_cargo_miden("../../examples/p2id-note", config.clone(), []);
     let note_package = p2id_test.compile_package();
     assert!(note_package.is_library(), "expected library");
-    expect!["38430"].assert_eq(stripped_mast_size_str(&note_package));
+    expect!["53082"].assert_eq(stripped_mast_size_str(&note_package));
 
     let mut p2ide_test =
         CompilerTest::rust_source_cargo_miden("../../examples/p2ide-note", config, []);
     let p2ide_package = p2ide_test.compile_package();
     assert!(p2ide_package.is_library(), "expected library");
-    expect!["43003"].assert_eq(stripped_mast_size_str(&p2ide_package));
+    expect!["62672"].assert_eq(stripped_mast_size_str(&p2ide_package));
 }
 
 #[test]

--- a/tests/integration/src/rust_masm_tests/rust_sdk/base/account.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk/base/account.rs
@@ -129,7 +129,7 @@ fn rust_sdk_account_get_initial_balance_binding() {
     run_account_binding_test(
         "rust_sdk_account_get_initial_balance_binding",
         "pub fn binding(&self) -> Felt {
-        let faucet = AccountId { prefix: Felt::new(1), suffix: Felt::new(0) };
+        let faucet = AccountId { prefix: Felt::new(1).unwrap(), suffix: Felt::new(0).unwrap() };
         self.get_initial_balance(faucet)
     }",
     );
@@ -140,7 +140,7 @@ fn rust_sdk_account_get_asset_binding() {
     run_account_binding_test(
         "rust_sdk_account_get_asset_binding",
         "pub fn binding(&self) -> Word {
-        let asset_key = Word::from([Felt::new(0); 4]);
+        let asset_key = Word::from([Felt::new(0).unwrap(); 4]);
         self.get_asset(asset_key)
     }",
     );
@@ -151,7 +151,7 @@ fn rust_sdk_account_get_initial_asset_binding() {
     run_account_binding_test(
         "rust_sdk_account_get_initial_asset_binding",
         "pub fn binding(&self) -> Word {
-        let asset_key = Word::from([Felt::new(0); 4]);
+        let asset_key = Word::from([Felt::new(0).unwrap(); 4]);
         self.get_initial_asset(asset_key)
     }",
     );
@@ -162,11 +162,12 @@ fn rust_sdk_account_has_non_fungible_asset_binding() {
     run_account_binding_test(
         "rust_sdk_account_has_non_fungible_asset_binding",
         "pub fn binding(&self) -> Felt {
-        let asset = Asset::new(Word::from([Felt::new(0); 4]), Word::from([Felt::new(0); 4]));
+        let asset = Asset::new(Word::from([Felt::new(0).unwrap(); 4]), \
+         Word::from([Felt::new(0).unwrap(); 4]));
         if self.has_non_fungible_asset(asset) {
-            Felt::new(1)
+            Felt::new(1).unwrap()
         } else {
-            Felt::new(0)
+            Felt::new(0).unwrap()
         }
     }",
     );
@@ -217,11 +218,11 @@ fn rust_sdk_account_has_procedure_binding() {
     run_account_binding_test(
         "rust_sdk_account_has_procedure_binding",
         "pub fn binding(&self) -> Felt {
-        let proc_root = Word::from([Felt::new(0); 4]);
+        let proc_root = Word::from([Felt::new(0).unwrap(); 4]);
         if self.has_procedure(proc_root) {
-            Felt::new(1)
+            Felt::new(1).unwrap()
         } else {
-            Felt::new(0)
+            Felt::new(0).unwrap()
         }
     }",
     );
@@ -232,11 +233,11 @@ fn rust_sdk_account_was_procedure_called_binding() {
     run_account_binding_test(
         "rust_sdk_account_was_procedure_called_binding",
         "pub fn binding(&self) -> Felt {
-        let proc_root = Word::from([Felt::new(0); 4]);
+        let proc_root = Word::from([Felt::new(0).unwrap(); 4]);
         if self.was_procedure_called(proc_root) {
-            Felt::new(1)
+            Felt::new(1).unwrap()
         } else {
-            Felt::new(0)
+            Felt::new(0).unwrap()
         }
     }",
     );
@@ -265,7 +266,7 @@ fn rust_sdk_account_storage_get_initial_map_item_binding() {
     map: StorageMap<Word, Word>,
 }"#,
         "pub fn binding(&self) -> Word {
-        let key = Word::from([Felt::new(0); 4]);
+        let key = Word::from([Felt::new(0).unwrap(); 4]);
         storage::get_initial_map_item(Self::default().map.slot, &key)
     }",
     );

--- a/tests/integration/src/rust_masm_tests/rust_sdk/base/asset.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk/base/asset.rs
@@ -72,8 +72,8 @@ fn rust_sdk_account_asset_create_fungible_asset_binding() {
     run_asset_binding_test(
         "rust_sdk_account_asset_create_fungible_asset_binding",
         "pub fn binding(&self) -> Asset {
-        let faucet = AccountId { prefix: Felt::new(1), suffix: Felt::new(0) };
-        asset::create_fungible_asset(faucet, Felt::new(10))
+        let faucet = AccountId { prefix: Felt::new(1).unwrap(), suffix: Felt::new(0).unwrap() };
+        asset::create_fungible_asset(faucet, Felt::new(10).unwrap())
     }",
     );
 }
@@ -83,8 +83,8 @@ fn rust_sdk_account_asset_create_non_fungible_asset_binding() {
     run_asset_binding_test(
         "rust_sdk_account_asset_create_non_fungible_asset_binding",
         "pub fn binding(&self) -> Asset {
-        let faucet = AccountId { prefix: Felt::new(1), suffix: Felt::new(0) };
-        let hash = Word::from([Felt::new(0); 4]);
+        let faucet = AccountId { prefix: Felt::new(1).unwrap(), suffix: Felt::new(0).unwrap() };
+        let hash = Word::from([Felt::new(0).unwrap(); 4]);
         asset::create_non_fungible_asset(faucet, hash)
     }",
     );

--- a/tests/integration/src/rust_masm_tests/rust_sdk/base/faucet.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk/base/faucet.rs
@@ -72,7 +72,7 @@ fn rust_sdk_account_faucet_create_fungible_asset_binding() {
     run_faucet_binding_test(
         "rust_sdk_account_faucet_create_fungible_asset_binding",
         "pub fn binding(&self) -> Asset {
-        faucet::create_fungible_asset(Felt::new(10))
+        faucet::create_fungible_asset(Felt::new(10).unwrap())
     }",
     );
 }
@@ -82,7 +82,7 @@ fn rust_sdk_account_faucet_create_non_fungible_asset_binding() {
     run_faucet_binding_test(
         "rust_sdk_account_faucet_create_non_fungible_asset_binding",
         "pub fn binding(&self) -> Asset {
-        let hash = Word::from([Felt::new(0); 4]);
+        let hash = Word::from([Felt::new(0).unwrap(); 4]);
         faucet::create_non_fungible_asset(hash)
     }",
     );
@@ -93,7 +93,8 @@ fn rust_sdk_account_faucet_mint_binding() {
     run_faucet_binding_test(
         "rust_sdk_account_faucet_mint_binding",
         "pub fn binding(&self) -> Asset {
-        let asset = Asset::new(Word::from([Felt::new(0); 4]), Word::from([Felt::new(0); 4]));
+        let asset = Asset::new(Word::from([Felt::new(0).unwrap(); 4]), \
+         Word::from([Felt::new(0).unwrap(); 4]));
         faucet::mint(asset)
     }",
     );
@@ -104,7 +105,8 @@ fn rust_sdk_account_faucet_burn_binding() {
     run_faucet_binding_test(
         "rust_sdk_account_faucet_burn_binding",
         "pub fn binding(&self) -> Asset {
-        let asset = Asset::new(Word::from([Felt::new(0); 4]), Word::from([Felt::new(0); 4]));
+        let asset = Asset::new(Word::from([Felt::new(0).unwrap(); 4]), \
+         Word::from([Felt::new(0).unwrap(); 4]));
         faucet::burn(asset)
     }",
     );
@@ -115,7 +117,8 @@ fn rust_sdk_account_faucet_mint_value_binding() {
     run_faucet_binding_test(
         "rust_sdk_account_faucet_mint_value_binding",
         "pub fn binding(&self) -> Word {
-        let asset = Asset::new(Word::from([Felt::new(0); 4]), Word::from([Felt::new(0); 4]));
+        let asset = Asset::new(Word::from([Felt::new(0).unwrap(); 4]), \
+         Word::from([Felt::new(0).unwrap(); 4]));
         faucet::mint_value(asset)
     }",
     );
@@ -126,7 +129,8 @@ fn rust_sdk_account_faucet_burn_value_binding() {
     run_faucet_binding_test(
         "rust_sdk_account_faucet_burn_value_binding",
         "pub fn binding(&self) -> Word {
-        let asset = Asset::new(Word::from([Felt::new(0); 4]), Word::from([Felt::new(0); 4]));
+        let asset = Asset::new(Word::from([Felt::new(0).unwrap(); 4]), \
+         Word::from([Felt::new(0).unwrap(); 4]));
         faucet::burn_value(asset)
     }",
     );

--- a/tests/integration/src/rust_masm_tests/rust_sdk/base/input_note.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk/base/input_note.rs
@@ -75,7 +75,7 @@ fn rust_sdk_input_note_get_assets_info_binding() {
     run_input_note_binding_test(
         "rust_sdk_input_note_get_assets_info_binding",
         "pub fn binding(&self) -> Felt {
-        let info = input_note::get_assets_info(NoteIdx { inner: Felt::new(0) });
+        let info = input_note::get_assets_info(NoteIdx { inner: Felt::new(0).unwrap() });
         info.num_assets
     }",
     );
@@ -86,8 +86,8 @@ fn rust_sdk_input_note_get_assets_binding() {
     run_input_note_binding_test(
         "rust_sdk_input_note_get_assets_binding",
         "pub fn binding(&self) -> Felt {
-        let assets = input_note::get_assets(NoteIdx { inner: Felt::new(0) });
-        Felt::new(assets.len() as u64)
+        let assets = input_note::get_assets(NoteIdx { inner: Felt::new(0).unwrap() });
+        Felt::new(assets.len() as u64).unwrap()
     }",
     );
 }
@@ -97,7 +97,7 @@ fn rust_sdk_input_note_get_recipient_binding() {
     run_input_note_binding_test(
         "rust_sdk_input_note_get_recipient_binding",
         "pub fn binding(&self) -> Recipient {
-        input_note::get_recipient(NoteIdx { inner: Felt::new(0) })
+        input_note::get_recipient(NoteIdx { inner: Felt::new(0).unwrap() })
     }",
     );
 }
@@ -107,7 +107,7 @@ fn rust_sdk_input_note_get_metadata_binding() {
     run_input_note_binding_test(
         "rust_sdk_input_note_get_metadata_binding",
         "pub fn binding(&self) -> Word {
-        input_note::get_metadata(NoteIdx { inner: Felt::new(0) }).header
+        input_note::get_metadata(NoteIdx { inner: Felt::new(0).unwrap() }).header
     }",
     );
 }
@@ -117,7 +117,7 @@ fn rust_sdk_input_note_get_sender_binding() {
     run_input_note_binding_test(
         "rust_sdk_input_note_get_sender_binding",
         "pub fn binding(&self) -> AccountId {
-        input_note::get_sender(NoteIdx { inner: Felt::new(0) })
+        input_note::get_sender(NoteIdx { inner: Felt::new(0).unwrap() })
     }",
     );
 }
@@ -127,7 +127,7 @@ fn rust_sdk_input_note_get_storage_info_binding() {
     run_input_note_binding_test(
         "rust_sdk_input_note_get_storage_info_binding",
         "pub fn binding(&self) -> Felt {
-        let info = input_note::get_storage_info(NoteIdx { inner: Felt::new(0) });
+        let info = input_note::get_storage_info(NoteIdx { inner: Felt::new(0).unwrap() });
         info.num_storage_items
     }",
     );
@@ -138,7 +138,7 @@ fn rust_sdk_input_note_get_script_root_binding() {
     run_input_note_binding_test(
         "rust_sdk_input_note_get_script_root_binding",
         "pub fn binding(&self) -> Word {
-        input_note::get_script_root(NoteIdx { inner: Felt::new(0) })
+        input_note::get_script_root(NoteIdx { inner: Felt::new(0).unwrap() })
     }",
     );
 }
@@ -148,7 +148,7 @@ fn rust_sdk_input_note_get_serial_number_binding() {
     run_input_note_binding_test(
         "rust_sdk_input_note_get_serial_number_binding",
         "pub fn binding(&self) -> Word {
-        input_note::get_serial_number(NoteIdx { inner: Felt::new(0) })
+        input_note::get_serial_number(NoteIdx { inner: Felt::new(0).unwrap() })
     }",
     );
 }

--- a/tests/integration/src/rust_masm_tests/rust_sdk/base/note.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk/base/note.rs
@@ -78,9 +78,9 @@ fn rust_sdk_note_build_recipient_binding() {
         "rust_sdk_note_build_recipient_binding",
         "pub fn binding(&self) -> Recipient {
         note::build_recipient(
-            Word::from([Felt::new(0); 4]),
-            Word::from([Felt::new(0); 4]),
-            alloc::vec![Felt::new(0); 4],
+            Word::from([Felt::new(0).unwrap(); 4]),
+            Word::from([Felt::new(0).unwrap(); 4]),
+            alloc::vec![Felt::new(0).unwrap(); 4],
         )
     }",
     );

--- a/tests/integration/src/rust_masm_tests/rust_sdk/base/output_note.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk/base/output_note.rs
@@ -78,7 +78,7 @@ fn rust_sdk_output_note_get_assets_info_binding() {
     run_output_note_binding_test(
         "rust_sdk_output_note_get_assets_info_binding",
         "pub fn binding(&self) -> Felt {
-        let info = output_note::get_assets_info(NoteIdx { inner: Felt::new(0) });
+        let info = output_note::get_assets_info(NoteIdx { inner: Felt::new(0).unwrap() });
         info.num_assets
     }",
     );
@@ -89,8 +89,8 @@ fn rust_sdk_output_note_get_assets_binding() {
     run_output_note_binding_test(
         "rust_sdk_output_note_get_assets_binding",
         "pub fn binding(&self) -> Felt {
-        let assets = output_note::get_assets(NoteIdx { inner: Felt::new(0) });
-        Felt::new(assets.len() as u64)
+        let assets = output_note::get_assets(NoteIdx { inner: Felt::new(0).unwrap() });
+        Felt::new(assets.len() as u64).unwrap()
     }",
     );
 }
@@ -100,7 +100,7 @@ fn rust_sdk_output_note_get_recipient_binding() {
     run_output_note_binding_test(
         "rust_sdk_output_note_get_recipient_binding",
         "pub fn binding(&self) -> Recipient {
-        output_note::get_recipient(NoteIdx { inner: Felt::new(0) })
+        output_note::get_recipient(NoteIdx { inner: Felt::new(0).unwrap() })
     }",
     );
 }
@@ -110,7 +110,7 @@ fn rust_sdk_output_note_get_metadata_binding() {
     run_output_note_binding_test(
         "rust_sdk_output_note_get_metadata_binding",
         "pub fn binding(&self) -> Word {
-        output_note::get_metadata(NoteIdx { inner: Felt::new(0) }).header
+        output_note::get_metadata(NoteIdx { inner: Felt::new(0).unwrap() }).header
     }",
     );
 }
@@ -120,9 +120,9 @@ fn rust_sdk_output_note_create_binding() {
     run_output_note_binding_test(
         "rust_sdk_output_note_create_binding",
         "pub fn binding(&self) -> NoteIdx {
-        let recipient = Recipient::from([Felt::new(0); 4]);
-        let tag = Tag { inner: Felt::new(0) };
-        let note_type = NoteType { inner: Felt::new(1) };
+        let recipient = Recipient::from([Felt::new(0).unwrap(); 4]);
+        let tag = Tag { inner: Felt::new(0).unwrap() };
+        let note_type = NoteType { inner: Felt::new(1).unwrap() };
         output_note::create(tag, note_type, recipient)
     }",
     );
@@ -133,10 +133,11 @@ fn rust_sdk_output_note_add_asset_binding() {
     run_output_note_binding_test(
         "rust_sdk_output_note_add_asset_binding",
         "pub fn binding(&self) -> Felt {
-        let asset = Asset::new(Word::from([Felt::new(0); 4]), Word::from([Felt::new(0); 4]));
-        let idx = NoteIdx { inner: Felt::new(0) };
+        let asset = Asset::new(Word::from([Felt::new(0).unwrap(); 4]), \
+         Word::from([Felt::new(0).unwrap(); 4]));
+        let idx = NoteIdx { inner: Felt::new(0).unwrap() };
         output_note::add_asset(asset, idx);
-        Felt::new(0)
+        Felt::new(0).unwrap()
     }",
     );
 }
@@ -146,12 +147,12 @@ fn rust_sdk_output_note_set_attachment_binding() {
     run_output_note_binding_test(
         "rust_sdk_output_note_set_attachment_binding",
         "pub fn binding(&self) -> Felt {
-        let idx = NoteIdx { inner: Felt::new(0) };
-        let attachment_scheme = Felt::new(0);
-        let attachment_kind = Felt::new(0);
-        let attachment = Word::from([Felt::new(0); 4]);
+        let idx = NoteIdx { inner: Felt::new(0).unwrap() };
+        let attachment_scheme = Felt::new(0).unwrap();
+        let attachment_kind = Felt::new(0).unwrap();
+        let attachment = Word::from([Felt::new(0).unwrap(); 4]);
         output_note::set_attachment(idx, attachment_scheme, attachment_kind, attachment);
-        Felt::new(0)
+        Felt::new(0).unwrap()
     }",
     );
 }
@@ -161,11 +162,11 @@ fn rust_sdk_output_note_set_word_attachment_binding() {
     run_output_note_binding_test(
         "rust_sdk_output_note_set_word_attachment_binding",
         "pub fn binding(&self) -> Felt {
-        let idx = NoteIdx { inner: Felt::new(0) };
-        let attachment_scheme = Felt::new(0);
-        let attachment = Word::from([Felt::new(0); 4]);
+        let idx = NoteIdx { inner: Felt::new(0).unwrap() };
+        let attachment_scheme = Felt::new(0).unwrap();
+        let attachment = Word::from([Felt::new(0).unwrap(); 4]);
         output_note::set_word_attachment(idx, attachment_scheme, attachment);
-        Felt::new(0)
+        Felt::new(0).unwrap()
     }",
     );
 }
@@ -175,11 +176,11 @@ fn rust_sdk_output_note_set_array_attachment_binding() {
     run_output_note_binding_test(
         "rust_sdk_output_note_set_array_attachment_binding",
         "pub fn binding(&self) -> Felt {
-        let idx = NoteIdx { inner: Felt::new(0) };
-        let attachment_scheme = Felt::new(0);
-        let attachment = Word::from([Felt::new(0); 4]);
+        let idx = NoteIdx { inner: Felt::new(0).unwrap() };
+        let attachment_scheme = Felt::new(0).unwrap();
+        let attachment = Word::from([Felt::new(0).unwrap(); 4]);
         output_note::set_array_attachment(idx, attachment_scheme, attachment);
-        Felt::new(0)
+        Felt::new(0).unwrap()
     }",
     );
 }

--- a/tests/integration/src/rust_masm_tests/rust_sdk/base/tx.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk/base/tx.rs
@@ -119,7 +119,7 @@ fn rust_sdk_account_tx_get_expiration_block_delta_binding() {
 fn rust_sdk_account_tx_update_expiration_block_delta_binding() {
     run_tx_binding_test(
         "rust_sdk_account_tx_update_expiration_block_delta_binding",
-        "tx::update_expiration_block_delta(Felt::new(42));",
+        "tx::update_expiration_block_delta(Felt::new(42).unwrap());",
     );
 }
 

--- a/tests/integration/src/rust_masm_tests/rust_sdk/stdlib/collections.rs
+++ b/tests/integration/src/rust_masm_tests/rust_sdk/stdlib/collections.rs
@@ -102,10 +102,10 @@ fn test_smt_get_binding() {
         let returned_root = result.root;
 
 	        let expected = Word::new([
-	            Felt::new({ev0}),
-	            Felt::new({ev1}),
-	            Felt::new({ev2}),
-	            Felt::new({ev3}),
+	            Felt::new({ev0}).unwrap(),
+	            Felt::new({ev1}).unwrap(),
+	            Felt::new({ev2}).unwrap(),
+	            Felt::new({ev3}).unwrap(),
 	        ]);
 	        assert_eq!(value, expected, "smt_get returned unexpected value");
 	        assert_eq!(returned_root, root, "smt_get should not mutate the root");
@@ -180,16 +180,16 @@ fn test_smt_set_binding() {
         let new_root = result.new_root;
 
 	        let expected_old = Word::new([
-	            Felt::new({eo0}),
-	            Felt::new({eo1}),
-	            Felt::new({eo2}),
-	            Felt::new({eo3}),
+	            Felt::new({eo0}).unwrap(),
+	            Felt::new({eo1}).unwrap(),
+	            Felt::new({eo2}).unwrap(),
+	            Felt::new({eo3}).unwrap(),
 	        ]);
 	        let expected_new = Word::new([
-	            Felt::new({en0}),
-	            Felt::new({en1}),
-	            Felt::new({en2}),
-	            Felt::new({en3}),
+	            Felt::new({en0}).unwrap(),
+	            Felt::new({en1}).unwrap(),
+	            Felt::new({en2}).unwrap(),
+	            Felt::new({en3}).unwrap(),
 	        ]);
 	        assert_eq!(old_value, expected_old, "smt_set returned unexpected old value");
 	        assert_eq!(new_root, expected_new, "smt_set returned unexpected new root");

--- a/tests/lit/debuginfo/source-locations/test-project/rust-toolchain.toml
+++ b/tests/lit/debuginfo/source-locations/test-project/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-12-10"
+channel = "nightly-2026-04-29"
 components = ["rust-src"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"

--- a/tests/rust-apps-wasm/rust-sdk/account-test/src/lib.rs
+++ b/tests/rust-apps-wasm/rust-sdk/account-test/src/lib.rs
@@ -41,7 +41,7 @@ impl Account {
             b / a
         } else if a == b {
             miden::assert_eq(a, b);
-            a + Felt::new(d)
+            a + Felt::new(d).unwrap()
         } else if a != b {
             -a
         } else if b.is_odd() {
@@ -59,7 +59,7 @@ pub struct Note;
 impl Note {
     #[unsafe(no_mangle)]
     pub fn note_script() -> Felt {
-        let mut sum = Felt::new(0);
+        let mut sum = Felt::new(0).unwrap();
         for input in miden::active_note::get_storage() {
             sum = sum + input;
         }

--- a/tests/rust-apps-wasm/rust-sdk/cross-ctx-account/src/lib.rs
+++ b/tests/rust-apps-wasm/rust-sdk/cross-ctx-account/src/lib.rs
@@ -40,7 +40,7 @@ struct MyFoo;
 
 impl foo::Guest for MyFoo {
     fn process_felt(input: Felt) -> Felt {
-        let res = input + Felt::new(unsafe { FOO } as u64);
+        let res = input + Felt::new(unsafe { FOO } as u64).unwrap();
         unsafe { FOO = res.as_canonical_u64() as u32 };
         res
     }

--- a/tests/rust-apps-wasm/rust-sdk/cross-ctx-note-word/src/lib.rs
+++ b/tests/rust-apps-wasm/rust-sdk/cross-ctx-note-word/src/lib.rs
@@ -58,7 +58,7 @@ impl MyNote {
 
         let mixed_input = MixedStruct {
             f: u64::MAX - 1000,
-            a: Felt::new(Felt::ORDER_U64 - 1 - 6),
+            a: Felt::new(Felt::ORDER_U64 - 1 - 6).unwrap(),
             b: u32::MAX - 10,
             c: felt!(50),
             d: 111,
@@ -70,12 +70,12 @@ impl MyNote {
             // fail
             assert_eq!(0, 1);
         }
-        assert_eq(mixed_output.a, Felt::new(Felt::ORDER_U64 - 1)); // M - 1 - 6 + 6
-        assert_eq(mixed_output.b.into(), Felt::new(u32::MAX as u64)); // u32::MAX - 10 + 10
+        assert_eq(mixed_output.a, Felt::new(Felt::ORDER_U64 - 1).unwrap()); // M - 1 - 6 + 6
+        assert_eq(mixed_output.b.into(), Felt::new(u32::MAX as u64).unwrap()); // u32::MAX - 10 + 10
         assert_eq(mixed_output.c, felt!(57)); // 50 + 7
-        assert_eq(mixed_output.d.into(), Felt::new(122));
-        assert_eq(Felt::new(mixed_output.e as u64), felt!(1));
-        assert_eq(mixed_output.g.into(), Felt::new(12));
+        assert_eq(mixed_output.d.into(), Felt::new(122).unwrap());
+        assert_eq(Felt::new(mixed_output.e as u64).unwrap(), felt!(1));
+        assert_eq(mixed_output.g.into(), Felt::new(12).unwrap());
 
         let nested_input = NestedStruct {
             inner: Pair {

--- a/tests/rust-apps-wasm/rust-sdk/cross-ctx-note/src/lib.rs
+++ b/tests/rust-apps-wasm/rust-sdk/cross-ctx-note/src/lib.rs
@@ -16,7 +16,7 @@ struct MyNote;
 impl MyNote {
     #[note_script]
     pub fn execute(self, _arg: Word) {
-        let input = Felt::new(unsafe { BAR } as u64);
+        let input = Felt::new(unsafe { BAR } as u64).unwrap();
         assert_eq(input, felt!(11));
         let output = process_felt(input);
         assert_eq(output, felt!(53));

--- a/tests/rust-apps-wasm/rust-sdk/issue-invalid-stack-offset-movup/src/lib.rs
+++ b/tests/rust-apps-wasm/rust-sdk/issue-invalid-stack-offset-movup/src/lib.rs
@@ -53,7 +53,7 @@ impl InvalidStackOffsetMovupNote {
 
         let note_assets = active_note::get_assets();
         let num_assets = note_assets.len();
-        assert_eq(Felt::new(num_assets as u64), felt!(1));
+        assert_eq(Felt::new(num_assets as u64).unwrap(), felt!(1));
 
         let note_asset = note_assets[0];
         let assets_match = if offered_asset_word == note_asset {
@@ -81,10 +81,8 @@ impl InvalidStackOffsetMovupNote {
 
         // active_note::add_assets_to_account();
 
-        let routing_serial = add_word(
-            current_note_serial,
-            Word::new([felt!(0), felt!(0), felt!(0), felt!(1)]),
-        );
+        let routing_serial =
+            add_word(current_note_serial, Word::new([felt!(0), felt!(0), felt!(0), felt!(1)]));
 
         let aux_value = offered_out;
         let input_asset = Asset::new(
@@ -99,12 +97,7 @@ impl InvalidStackOffsetMovupNote {
             let remainder_aux = offered_out;
             let remainder_requested_asset = Asset::new(
                 requested_asset.key,
-                Word::from([
-                    requested_asset_total - input_amount,
-                    felt!(0),
-                    felt!(0),
-                    felt!(0),
-                ]),
+                Word::from([requested_asset_total - input_amount, felt!(0), felt!(0), felt!(0)]),
             );
             let remainder_offered_asset = Asset::new(
                 offered_asset_word.key,
@@ -124,7 +117,7 @@ impl InvalidStackOffsetMovupNote {
 
 /// Calculates the output amount for the given swap parameters.
 fn calculate_output_amount(offered_total: Felt, requested_total: Felt, input_amount: Felt) -> Felt {
-    let precision_factor = Felt::new(100000);
+    let precision_factor = Felt::new(100000).unwrap();
 
     if offered_total > requested_total {
         let ratio = (offered_total * precision_factor) / requested_total;
@@ -146,10 +139,10 @@ fn create_p2id_note(serial_num: Word, input_asset: Asset, recipient_id: AccountI
     let note_type = get_note_type();
 
     let _p2id_note_root_digest = Digest::from_word(Word::new([
-        Felt::new(6412241294473976817),
-        Felt::new(10671567784403105513),
-        Felt::new(4275774806771663409),
-        Felt::new(17933276983439992403),
+        Felt::new(6412241294473976817).unwrap(),
+        Felt::new(10671567784403105513).unwrap(),
+        Felt::new(4275774806771663409).unwrap(),
+        Felt::new(17933276983439992403).unwrap(),
     ]));
 
     let recipient = note::build_recipient(
@@ -220,8 +213,8 @@ fn create_swapp_note(
 /// Extracts the note tag from the active note metadata.
 fn get_note_tag() -> Tag {
     let metadata = active_note::get_metadata().header;
-    let left_shifted_32 = metadata[2] * Felt::new(2u64.pow(32));
-    let tag_felt = left_shifted_32 / (Felt::new(2u64.pow(32)));
+    let left_shifted_32 = metadata[2] * Felt::new(2u64.pow(32)).unwrap();
+    let tag_felt = left_shifted_32 / (Felt::new(2u64.pow(32)).unwrap());
     Tag::from(tag_felt)
 }
 
@@ -229,8 +222,8 @@ fn get_note_tag() -> Tag {
 fn get_note_type() -> NoteType {
     let metadata = active_note::get_metadata().header;
     let second_felt = metadata[1];
-    let pow_56 = Felt::new(2u64.pow(56));
-    let pow_62 = Felt::new(2u64.pow(62));
+    let pow_56 = Felt::new(2u64.pow(56)).unwrap();
+    let pow_62 = Felt::new(2u64.pow(62)).unwrap();
     let left_shifted_56 = second_felt * pow_56;
     let note_type_felt = left_shifted_56 / pow_62;
     NoteType::from(note_type_felt)

--- a/tools/cargo-miden/Cargo.toml
+++ b/tools/cargo-miden/Cargo.toml
@@ -28,11 +28,11 @@ midenc-log.workspace = true
 log.workspace = true
 clap.workspace = true
 anyhow.workspace = true
-cargo_metadata = "0.19"
-path-absolutize = "3.1.1"
+cargo_metadata = "^0.23"
+path-absolutize = "^3.1"
 serde.workspace = true
 serde_json = "1.0"
-toml_edit = { version = "0.23", features = ["serde"] }
+toml_edit = { version = "^0.25", features = ["serde"] }
 semver.workspace = true
 liquid = "0.26"
 tempfile = "3.19"

--- a/tools/cargo-miden/tests/build.rs
+++ b/tools/cargo-miden/tests/build.rs
@@ -153,6 +153,7 @@ fn build_new_project_from_template(template: &str) -> Package {
     fs::remove_dir_all(&temp_dir).unwrap();
     package
 }
+
 #[test]
 fn new_project_integration_tests_pass() {
     let _cwd_lock = current_dir_lock();

--- a/tools/cargo-miden/tests/build.rs
+++ b/tools/cargo-miden/tests/build.rs
@@ -155,6 +155,7 @@ fn build_new_project_from_template(template: &str) -> Package {
 }
 
 #[test]
+#[ignore = "pending move to project-template repo"]
 fn new_project_integration_tests_pass() {
     let _cwd_lock = current_dir_lock();
     let _ = midenc_log::Builder::from_env("MIDENC_TRACE")

--- a/tools/expect-test/Cargo.toml
+++ b/tools/expect-test/Cargo.toml
@@ -12,5 +12,5 @@ readme.workspace = true
 edition.workspace = true
 
 [dependencies]
-similar = "2"
+similar = "3"
 once_cell = "1"


### PR DESCRIPTION
Updates our Rust toolchain to 1.97/nightly-2026-04-29, and updates all of our dependencies as much as possible (though there are still a couple cases where we keep an older version) - I also didn't update any of the `wit-bindgen`-related deps.

I'm hoping this might make #1090 a little cleaner now that Rust has removed `--allow-undefined` from its default `wasm-ld` flags, but we'll see.