### PR TITLE
test: ignore tests that are known to be broken

### DIFF
--- a/tests/integration/src/rust_masm_tests/instructions.rs
+++ b/tests/integration/src/rust_masm_tests/instructions.rs
@@ -396,6 +396,7 @@ fn test_overflowing_mul_i8() {
 }
 
 #[test]
+#[ignore = "https://github.com/0xMiden/compiler/issues/1091"]
 fn test_overflowing_mul_i16() {
     test_overflowing_arith(i16::overflowing_mul, "overflowing_mul", NumericStrategy::full_range());
 }
@@ -673,6 +674,7 @@ fn test_checked_mul_i8() {
 }
 
 #[test]
+#[ignore = "https://github.com/0xMiden/compiler/issues/1091"]
 fn test_checked_mul_i16() {
     test_checked_arith(i16::checked_mul, "checked_mul", NumericStrategy::full_range());
 }


### PR DESCRIPTION
After a regression `checked` and `overflowing` arith for small integers (`i8`, `i16`) are broken, see #1091. The corresponding tests in `instructions.rs` are ignored, however the following two slipped throgh:

- `test_overflowing_mul_i16`
- `test_checked_mul_i16`

This PR ignores them. The issue is tracked in #1091.