### PR TITLE
fix(sdk): preserve intrinsic stubs under LTO

### DIFF
--- a/sdk/alloc/build.rs
+++ b/sdk/alloc/build.rs
@@ -65,5 +65,5 @@ fn main() {
 
     // Link for dependents of this crate
     println!("cargo:rustc-link-search=native={}", out_dir.display());
-    println!("cargo:rustc-link-lib=static=miden_alloc_intrinsics");
+    println!("cargo:rustc-link-lib=static:+whole-archive=miden_alloc_intrinsics");
 }

--- a/sdk/alloc/src/lib.rs
+++ b/sdk/alloc/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(target_family = "wasm", feature(linkage))]
 #![deny(warnings)]
 
 extern crate alloc;
@@ -128,6 +129,7 @@ unsafe impl GlobalAlloc for BumpAlloc {
 
 #[cfg(target_family = "wasm")]
 unsafe extern "C" {
+    #[linkage = "extern_weak"]
     #[link_name = "intrinsics::mem::heap_base"]
     fn heap_base() -> *mut u8;
 }

--- a/sdk/alloc/stubs/heap_base.rs
+++ b/sdk/alloc/stubs/heap_base.rs
@@ -1,9 +1,13 @@
 #![no_std]
+#![feature(optimize_attribute)]
 
 // Provide a local definition for the allocator to link against, and export it
 // under the MASM intrinsic path so the frontend recognizes and lowers it.
 
+/// Unreachable stub for `intrinsics::mem::heap_base`.
 #[unsafe(export_name = "intrinsics::mem::heap_base")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn __intrinsics_mem_heap_base_stub() -> *mut u8 {
     unsafe { core::hint::unreachable_unchecked() }
 }

--- a/sdk/base-sys/build.rs
+++ b/sdk/base-sys/build.rs
@@ -104,5 +104,5 @@ fn main() {
     // Emit link directives for dependents
     println!("cargo:rustc-link-search=native={}", out_dir.display());
     // `lib` prefix is adde by the linker automatically when it searches for the file
-    println!("cargo:rustc-link-lib=miden_base_sys_stubs");
+    println!("cargo:rustc-link-lib=static:+whole-archive=miden_base_sys_stubs");
 }

--- a/sdk/base-sys/src/bindings/active_account.rs
+++ b/sdk/base-sys/src/bindings/active_account.rs
@@ -4,20 +4,28 @@ use super::types::{AccountId, Asset, RawAccountId};
 
 #[allow(improper_ctypes)]
 unsafe extern "C" {
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_id"]
     fn extern_active_account_get_id(ptr: *mut RawAccountId);
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_nonce"]
     fn extern_active_account_get_nonce() -> Felt;
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_initial_commitment"]
     fn extern_active_account_get_initial_commitment(ptr: *mut Word);
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::compute_commitment"]
     fn extern_active_account_compute_commitment(ptr: *mut Word);
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_code_commitment"]
     fn extern_active_account_get_code_commitment(ptr: *mut Word);
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_initial_storage_commitment"]
     fn extern_active_account_get_initial_storage_commitment(ptr: *mut Word);
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::compute_storage_commitment"]
     fn extern_active_account_compute_storage_commitment(ptr: *mut Word);
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_asset"]
     fn extern_active_account_get_asset(
         asset_key_0: Felt,
@@ -26,6 +34,7 @@ unsafe extern "C" {
         asset_key_3: Felt,
         ptr: *mut Word,
     );
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_initial_asset"]
     fn extern_active_account_get_initial_asset(
         asset_key_0: Felt,
@@ -34,13 +43,16 @@ unsafe extern "C" {
         asset_key_3: Felt,
         ptr: *mut Word,
     );
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_balance"]
     fn extern_active_account_get_balance(faucet_id_suffix: Felt, faucet_id_prefix: Felt) -> Felt;
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_initial_balance"]
     fn extern_active_account_get_initial_balance(
         faucet_id_suffix: Felt,
         faucet_id_prefix: Felt,
     ) -> Felt;
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::has_non_fungible_asset"]
     fn extern_active_account_has_non_fungible_asset(
         asset_0: Felt,
@@ -48,14 +60,19 @@ unsafe extern "C" {
         asset_2: Felt,
         asset_3: Felt,
     ) -> Felt;
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_initial_vault_root"]
     fn extern_active_account_get_initial_vault_root(ptr: *mut Word);
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_vault_root"]
     fn extern_active_account_get_vault_root(ptr: *mut Word);
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_num_procedures"]
     fn extern_active_account_get_num_procedures() -> Felt;
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_procedure_root"]
     fn extern_active_account_get_procedure_root(index: Felt, ptr: *mut Word);
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::has_procedure"]
     fn extern_active_account_has_procedure(
         proc_root_0: Felt,

--- a/sdk/base-sys/src/bindings/active_note.rs
+++ b/sdk/base-sys/src/bindings/active_note.rs
@@ -8,18 +8,25 @@ use super::{AccountId, Asset, NoteMetadata, RawAccountId, Recipient};
 #[allow(improper_ctypes)]
 unsafe extern "C" {
     // NOTE: In protocol v0.14, note "inputs" are exposed via `active_note::get_storage`.
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_note::get_storage"]
     fn extern_note_get_storage(ptr: *mut Felt) -> usize;
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_note::get_assets"]
     fn extern_note_get_assets(ptr: *mut Felt) -> usize;
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_note::get_sender"]
     fn extern_note_get_sender(ptr: *mut RawAccountId);
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_note::get_recipient"]
     fn extern_note_get_recipient(ptr: *mut Recipient);
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_note::get_script_root"]
     fn extern_note_get_script_root(ptr: *mut Word);
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_note::get_serial_number"]
     fn extern_note_get_serial_number(ptr: *mut Word);
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_note::get_metadata"]
     fn extern_note_get_metadata(ptr: *mut NoteMetadata);
 }

--- a/sdk/base-sys/src/bindings/asset.rs
+++ b/sdk/base-sys/src/bindings/asset.rs
@@ -4,6 +4,7 @@ use super::types::{AccountId, Asset};
 
 #[allow(improper_ctypes)]
 unsafe extern "C" {
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::asset::create_fungible_asset"]
     pub fn extern_asset_create_fungible_asset(
         faucet_id_suffix: Felt,
@@ -11,7 +12,7 @@ unsafe extern "C" {
         amount: Felt,
         ptr: *mut Asset,
     );
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::asset::create_non_fungible_asset"]
     pub fn extern_asset_create_non_fungible_asset(
         faucet_id_suffix: Felt,

--- a/sdk/base-sys/src/bindings/faucet.rs
+++ b/sdk/base-sys/src/bindings/faucet.rs
@@ -4,9 +4,10 @@ use super::types::Asset;
 
 #[allow(improper_ctypes)]
 unsafe extern "C" {
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::faucet::create_fungible_asset"]
     pub fn extern_faucet_create_fungible_asset(amount: Felt, ptr: *mut Asset);
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::faucet::create_non_fungible_asset"]
     pub fn extern_faucet_create_non_fungible_asset(
         data_hash_0: Felt,
@@ -15,7 +16,7 @@ unsafe extern "C" {
         data_hash_3: Felt,
         ptr: *mut Asset,
     );
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::faucet::mint"]
     pub fn extern_faucet_mint(
         asset_key_0: Felt,
@@ -28,7 +29,7 @@ unsafe extern "C" {
         asset_value_3: Felt,
         ptr: *mut Word,
     );
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::faucet::burn"]
     pub fn extern_faucet_burn(
         asset_key_0: Felt,

--- a/sdk/base-sys/src/bindings/input_note.rs
+++ b/sdk/base-sys/src/bindings/input_note.rs
@@ -7,27 +7,28 @@ use super::types::{AccountId, Asset, NoteIdx, NoteMetadata, RawAccountId, Recipi
 
 #[allow(improper_ctypes)]
 unsafe extern "C" {
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::input_note::get_assets_info"]
     fn extern_input_note_get_assets_info(note_index: Felt, ptr: *mut (Word, Felt));
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::input_note::get_assets"]
     fn extern_input_note_get_assets(dest_ptr: *mut Felt, note_index: Felt) -> usize;
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::input_note::get_recipient"]
     fn extern_input_note_get_recipient(note_index: Felt, ptr: *mut Recipient);
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::input_note::get_metadata"]
     fn extern_input_note_get_metadata(note_index: Felt, ptr: *mut NoteMetadata);
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::input_note::get_sender"]
     fn extern_input_note_get_sender(note_index: Felt, ptr: *mut RawAccountId);
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::input_note::get_storage_info"]
     fn extern_input_note_get_storage_info(note_index: Felt, ptr: *mut (Word, Felt));
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::input_note::get_script_root"]
     fn extern_input_note_get_script_root(note_index: Felt, ptr: *mut Word);
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::input_note::get_serial_number"]
     fn extern_input_note_get_serial_number(note_index: Felt, ptr: *mut Word);
 }

--- a/sdk/base-sys/src/bindings/native_account.rs
+++ b/sdk/base-sys/src/bindings/native_account.rs
@@ -4,6 +4,7 @@ use super::types::Asset;
 
 #[allow(improper_ctypes)]
 unsafe extern "C" {
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::native_account::add_asset"]
     fn extern_native_account_add_asset(
         asset_key_0: Felt,
@@ -16,6 +17,7 @@ unsafe extern "C" {
         asset_value_3: Felt,
         ptr: *mut Word,
     );
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::native_account::remove_asset"]
     fn extern_native_account_remove_asset(
         asset_key_0: Felt,
@@ -28,10 +30,13 @@ unsafe extern "C" {
         asset_value_3: Felt,
         ptr: *mut Word,
     );
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::native_account::incr_nonce"]
     fn extern_native_account_incr_nonce() -> Felt;
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::native_account::compute_delta_commitment"]
     fn extern_native_account_compute_delta_commitment(ptr: *mut Word);
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::native_account::was_procedure_called"]
     fn extern_native_account_was_procedure_called(
         proc_root_0: Felt,

--- a/sdk/base-sys/src/bindings/note.rs
+++ b/sdk/base-sys/src/bindings/note.rs
@@ -10,6 +10,7 @@ const MAX_NOTE_STORAGE_ITEMS: usize = 1024;
 
 #[allow(improper_ctypes)]
 unsafe extern "C" {
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::note::build_recipient"]
     fn extern_note_build_recipient(
         storage_ptr: *mut Felt,

--- a/sdk/base-sys/src/bindings/output_note.rs
+++ b/sdk/base-sys/src/bindings/output_note.rs
@@ -7,6 +7,7 @@ use super::types::{Asset, NoteIdx, NoteMetadata, NoteType, Recipient, Tag};
 
 #[allow(improper_ctypes)]
 unsafe extern "C" {
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::output_note::create"]
     pub fn extern_output_note_create(
         tag: Tag,
@@ -16,7 +17,7 @@ unsafe extern "C" {
         recipient_f2: Felt,
         recipient_f3: Felt,
     ) -> NoteIdx;
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::output_note::add_asset"]
     pub fn extern_output_note_add_asset(
         asset_key_f0: Felt,
@@ -29,19 +30,19 @@ unsafe extern "C" {
         asset_value_f3: Felt,
         note_idx: NoteIdx,
     );
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::output_note::get_assets_info"]
     pub fn extern_output_note_get_assets_info(note_index: Felt, ptr: *mut (Word, Felt));
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::output_note::get_assets"]
     pub fn extern_output_note_get_assets(dest_ptr: *mut Felt, note_index: Felt) -> usize;
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::output_note::get_recipient"]
     pub fn extern_output_note_get_recipient(note_index: Felt, ptr: *mut Recipient);
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::output_note::get_metadata"]
     pub fn extern_output_note_get_metadata(note_index: Felt, ptr: *mut NoteMetadata);
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::output_note::set_attachment"]
     pub fn extern_output_note_set_attachment(
         note_idx: NoteIdx,
@@ -52,7 +53,7 @@ unsafe extern "C" {
         attachment_f2: Felt,
         attachment_f3: Felt,
     );
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::output_note::set_word_attachment"]
     pub fn extern_output_note_set_word_attachment(
         note_idx: NoteIdx,
@@ -62,7 +63,7 @@ unsafe extern "C" {
         attachment_f2: Felt,
         attachment_f3: Felt,
     );
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::output_note::set_array_attachment"]
     pub fn extern_output_note_set_array_attachment(
         note_idx: NoteIdx,

--- a/sdk/base-sys/src/bindings/storage.rs
+++ b/sdk/base-sys/src/bindings/storage.rs
@@ -6,12 +6,13 @@ use super::StorageSlotId;
 unsafe extern "C" {
     // The public SDK models storage slots as `(prefix, suffix)`, but the host ABI expects the slot
     // coordinates in storage order: `(suffix, prefix)`.
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_item"]
     pub fn extern_get_storage_item(index_suffix: Felt, index_prefix: Felt, ptr: *mut Word);
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_initial_item"]
     pub fn extern_get_initial_storage_item(index_suffix: Felt, index_prefix: Felt, ptr: *mut Word);
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::native_account::set_item"]
     pub fn extern_set_storage_item(
         index_suffix: Felt,
@@ -22,7 +23,7 @@ unsafe extern "C" {
         v3: Felt,
         ptr: *mut Word,
     );
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_map_item"]
     pub fn extern_get_storage_map_item(
         index_suffix: Felt,
@@ -33,7 +34,7 @@ unsafe extern "C" {
         k3: Felt,
         ptr: *mut Word,
     );
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_account::get_initial_map_item"]
     pub fn extern_get_initial_storage_map_item(
         index_suffix: Felt,
@@ -44,7 +45,7 @@ unsafe extern "C" {
         k3: Felt,
         ptr: *mut Word,
     );
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::native_account::set_map_item"]
     pub fn extern_set_storage_map_item(
         index_suffix: Felt,

--- a/sdk/base-sys/src/bindings/tx.rs
+++ b/sdk/base-sys/src/bindings/tx.rs
@@ -2,30 +2,31 @@ use miden_stdlib_sys::{Felt, Word};
 
 #[allow(improper_ctypes)]
 unsafe extern "C" {
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::tx::get_block_number"]
     pub fn extern_tx_get_block_number() -> Felt;
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::tx::get_block_commitment"]
     pub fn extern_tx_get_block_commitment(ptr: *mut Word);
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::tx::get_block_timestamp"]
     pub fn extern_tx_get_block_timestamp() -> Felt;
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::tx::get_input_notes_commitment"]
     pub fn extern_tx_get_input_notes_commitment(ptr: *mut Word);
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::tx::get_output_notes_commitment"]
     pub fn extern_tx_get_output_notes_commitment(ptr: *mut Word);
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::tx::get_num_input_notes"]
     pub fn extern_tx_get_num_input_notes() -> Felt;
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::tx::get_num_output_notes"]
     pub fn extern_tx_get_num_output_notes() -> Felt;
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::tx::get_expiration_block_delta"]
     pub fn extern_tx_get_expiration_block_delta() -> Felt;
-
+    #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::tx::update_expiration_block_delta"]
     pub fn extern_tx_update_expiration_block_delta(delta: Felt);
 }

--- a/sdk/base-sys/src/lib.rs
+++ b/sdk/base-sys/src/lib.rs
@@ -1,5 +1,6 @@
 // Enable no_std for the bindings module
 #![no_std]
+#![cfg_attr(target_family = "wasm", feature(linkage))]
 #![deny(warnings)]
 
 pub mod bindings;

--- a/sdk/base-sys/stubs/active_account.rs
+++ b/sdk/base-sys/stubs/active_account.rs
@@ -1,41 +1,57 @@
 use core::ffi::c_void;
 
 #[unsafe(export_name = "miden::protocol::active_account::get_id")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_id_plain(_out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_nonce")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_nonce_plain() -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_initial_commitment")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_initial_commitment_plain(_out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::compute_commitment")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_compute_commitment_plain(_out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_code_commitment")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_code_commitment_plain(_out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_initial_storage_commitment")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_initial_storage_commitment_plain(_out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::compute_storage_commitment")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_compute_storage_commitment_plain(_out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_asset")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_asset_plain(
     _asset_key_0: f32,
     _asset_key_1: f32,
@@ -47,6 +63,8 @@ pub extern "C" fn active_account_get_asset_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_initial_asset")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_initial_asset_plain(
     _asset_key_0: f32,
     _asset_key_1: f32,
@@ -58,6 +76,8 @@ pub extern "C" fn active_account_get_initial_asset_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_item")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_item_plain(
     _index_suffix: f32,
     _index_prefix: f32,
@@ -67,6 +87,8 @@ pub extern "C" fn active_account_get_item_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_initial_item")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_initial_item_plain(
     _index_suffix: f32,
     _index_prefix: f32,
@@ -76,6 +98,8 @@ pub extern "C" fn active_account_get_initial_item_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_map_item")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_map_item_plain(
     _index_suffix: f32,
     _index_prefix: f32,
@@ -89,6 +113,8 @@ pub extern "C" fn active_account_get_map_item_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_initial_map_item")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_initial_map_item_plain(
     _index_suffix: f32,
     _index_prefix: f32,
@@ -102,16 +128,22 @@ pub extern "C" fn active_account_get_initial_map_item_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_balance")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_balance_plain(_suffix: f32, _prefix: f32) -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_initial_balance")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_initial_balance_plain(_suffix: f32, _prefix: f32) -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::has_non_fungible_asset")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_has_non_fungible_asset_plain(
     _a0: f32,
     _a1: f32,
@@ -122,26 +154,36 @@ pub extern "C" fn active_account_has_non_fungible_asset_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_initial_vault_root")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_initial_vault_root_plain(_out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_vault_root")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_vault_root_plain(_out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_num_procedures")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_num_procedures_plain() -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::get_procedure_root")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_get_procedure_root_plain(_index: f32, _out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_account::has_procedure")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn active_account_has_procedure_plain(
     _r0: f32,
     _r1: f32,

--- a/sdk/base-sys/stubs/active_note.rs
+++ b/sdk/base-sys/stubs/active_note.rs
@@ -3,36 +3,50 @@ use core::ffi::c_void;
 /// Note interface stubs
 // NOTE: In protocol v0.14, note "inputs" are exposed via `active_note::get_storage`.
 #[unsafe(export_name = "miden::protocol::active_note::get_storage")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn note_get_inputs_plain(_ptr: *mut c_void) -> usize {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_note::get_assets")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn note_get_assets_plain(_ptr: *mut c_void) -> usize {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_note::get_sender")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn note_get_sender_plain(_ptr: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_note::get_recipient")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn note_get_recipient_plain(_ptr: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_note::get_script_root")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn note_get_script_root_plain(_ptr: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_note::get_serial_number")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn note_get_serial_number_plain(_ptr: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::active_note::get_metadata")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn note_get_metadata_plain(_ptr: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }

--- a/sdk/base-sys/stubs/asset.rs
+++ b/sdk/base-sys/stubs/asset.rs
@@ -1,6 +1,8 @@
 use core::ffi::c_void;
 
 #[unsafe(export_name = "miden::protocol::asset::create_fungible_asset")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn asset_create_fungible_asset_plain(
     _prefix: f32,
     _suffix: f32,
@@ -11,6 +13,8 @@ pub extern "C" fn asset_create_fungible_asset_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::asset::create_non_fungible_asset")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn asset_create_non_fungible_asset_plain(
     _prefix: f32,
     _suffix: f32,

--- a/sdk/base-sys/stubs/faucet.rs
+++ b/sdk/base-sys/stubs/faucet.rs
@@ -1,11 +1,15 @@
 use core::ffi::c_void;
 
 #[unsafe(export_name = "miden::protocol::faucet::create_fungible_asset")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn faucet_create_fungible_asset_plain(_amount: f32, _out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::faucet::create_non_fungible_asset")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn faucet_create_non_fungible_asset_plain(
     _h0: f32,
     _h1: f32,
@@ -17,6 +21,8 @@ pub extern "C" fn faucet_create_non_fungible_asset_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::faucet::mint")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn faucet_mint_plain(
     _k0: f32,
     _k1: f32,
@@ -32,6 +38,8 @@ pub extern "C" fn faucet_mint_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::faucet::burn")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn faucet_burn_plain(
     _k0: f32,
     _k1: f32,

--- a/sdk/base-sys/stubs/input_note.rs
+++ b/sdk/base-sys/stubs/input_note.rs
@@ -2,41 +2,57 @@ use core::ffi::c_void;
 
 /// Input note interface stubs
 #[unsafe(export_name = "miden::protocol::input_note::get_assets_info")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn input_note_get_assets_info_plain(_note_index: f32, _out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::input_note::get_assets")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn input_note_get_assets_plain(_dest_ptr: *mut c_void, _note_index: f32) -> usize {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::input_note::get_recipient")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn input_note_get_recipient_plain(_note_index: f32, _out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::input_note::get_metadata")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn input_note_get_metadata_plain(_note_index: f32, _out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::input_note::get_sender")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn input_note_get_sender_plain(_note_index: f32, _out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::input_note::get_storage_info")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn input_note_get_storage_info_plain(_note_index: f32, _out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::input_note::get_script_root")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn input_note_get_script_root_plain(_note_index: f32, _out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::input_note::get_serial_number")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn input_note_get_serial_number_plain(_note_index: f32, _out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }

--- a/sdk/base-sys/stubs/lib.rs
+++ b/sdk/base-sys/stubs/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![feature(optimize_attribute)]
 
 //! Unreachable stubs for Miden base SDK functions.
 //!

--- a/sdk/base-sys/stubs/native_account.rs
+++ b/sdk/base-sys/stubs/native_account.rs
@@ -1,6 +1,8 @@
 use core::ffi::c_void;
 
 #[unsafe(export_name = "miden::protocol::native_account::add_asset")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn native_account_add_asset_plain(
     _k0: f32,
     _k1: f32,
@@ -16,6 +18,8 @@ pub extern "C" fn native_account_add_asset_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::native_account::remove_asset")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn native_account_remove_asset_plain(
     _k0: f32,
     _k1: f32,
@@ -31,16 +35,22 @@ pub extern "C" fn native_account_remove_asset_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::native_account::incr_nonce")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn native_account_incr_nonce_plain() -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::native_account::compute_delta_commitment")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn native_account_compute_delta_commitment_plain(_out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::native_account::set_item")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn native_account_set_item_plain(
     _index_suffix: f32,
     _index_prefix: f32,
@@ -54,6 +64,8 @@ pub extern "C" fn native_account_set_item_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::native_account::set_map_item")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn native_account_set_map_item_plain(
     _index_suffix: f32,
     _index_prefix: f32,
@@ -71,6 +83,8 @@ pub extern "C" fn native_account_set_map_item_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::native_account::was_procedure_called")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn native_account_was_procedure_called_plain(
     _r0: f32,
     _r1: f32,

--- a/sdk/base-sys/stubs/note.rs
+++ b/sdk/base-sys/stubs/note.rs
@@ -2,6 +2,8 @@ use core::ffi::c_void;
 
 /// Note interface stubs.
 #[unsafe(export_name = "miden::protocol::note::build_recipient")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn note_build_recipient_plain(
     _storage_ptr: *mut c_void,
     _num_storage_items: usize,

--- a/sdk/base-sys/stubs/output_note.rs
+++ b/sdk/base-sys/stubs/output_note.rs
@@ -2,6 +2,8 @@ use core::ffi::c_void;
 
 /// Output note interface stubs
 #[unsafe(export_name = "miden::protocol::output_note::create")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn output_note_create_plain(
     _tag: f32,
     _note_type: f32,
@@ -14,6 +16,8 @@ pub extern "C" fn output_note_create_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::output_note::add_asset")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn output_note_add_asset_plain(
     _k0: f32,
     _k1: f32,
@@ -29,26 +33,36 @@ pub extern "C" fn output_note_add_asset_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::output_note::get_assets_info")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn output_note_get_assets_info_plain(_note_index: f32, _out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::output_note::get_assets")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn output_note_get_assets_plain(_dest_ptr: *mut c_void, _note_index: f32) -> usize {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::output_note::get_recipient")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn output_note_get_recipient_plain(_note_index: f32, _out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::output_note::get_metadata")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn output_note_get_metadata_plain(_note_index: f32, _out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::output_note::set_attachment")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn output_note_set_attachment_plain(
     _note_index: f32,
     _attachment_scheme: f32,
@@ -62,6 +76,8 @@ pub extern "C" fn output_note_set_attachment_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::output_note::set_word_attachment")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn output_note_set_word_attachment_plain(
     _note_index: f32,
     _attachment_scheme: f32,
@@ -74,6 +90,8 @@ pub extern "C" fn output_note_set_word_attachment_plain(
 }
 
 #[unsafe(export_name = "miden::protocol::output_note::set_array_attachment")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn output_note_set_array_attachment_plain(
     _note_index: f32,
     _attachment_scheme: f32,

--- a/sdk/base-sys/stubs/tx.rs
+++ b/sdk/base-sys/stubs/tx.rs
@@ -1,46 +1,64 @@
 use core::ffi::c_void;
 
 #[unsafe(export_name = "miden::protocol::tx::get_block_number")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn tx_get_block_number_plain() -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::tx::get_block_commitment")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn tx_get_block_commitment_plain(_out: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::tx::get_block_timestamp")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn tx_get_block_timestamp_plain() -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::tx::get_input_notes_commitment")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn tx_get_input_notes_commitment_plain(_out: *mut core::ffi::c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::tx::get_output_notes_commitment")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn tx_get_output_notes_commitment_plain(_out: *mut core::ffi::c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::tx::get_num_input_notes")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn tx_get_num_input_notes_plain() -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::tx::get_num_output_notes")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn tx_get_num_output_notes_plain() -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::tx::get_expiration_block_delta")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn tx_get_expiration_block_delta_plain() -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::protocol::tx::update_expiration_block_delta")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn tx_update_expiration_block_delta_plain(_delta: f32) {
     unsafe { core::hint::unreachable_unchecked() }
 }

--- a/sdk/stdlib-sys/build.rs
+++ b/sdk/stdlib-sys/build.rs
@@ -142,6 +142,6 @@ fn main() {
 
     // Emit link directives for dependents
     println!("cargo:rustc-link-search=native={}", out_dir.display());
-    println!("cargo:rustc-link-lib=static=miden_stdlib_sys_intrinsics_stubs");
-    println!("cargo:rustc-link-lib=static=miden_stdlib_sys_stdlib_stubs");
+    println!("cargo:rustc-link-lib=static:+whole-archive=miden_stdlib_sys_intrinsics_stubs");
+    println!("cargo:rustc-link-lib=static:+whole-archive=miden_stdlib_sys_stdlib_stubs");
 }

--- a/sdk/stdlib-sys/src/intrinsics/advice.rs
+++ b/sdk/stdlib-sys/src/intrinsics/advice.rs
@@ -7,6 +7,7 @@ unsafe extern "C" {
     /// Pushes a list of field elements onto the advice stack.
     /// The list is looked up in the advice map using `key` as the key.
     /// Returns the number of elements pushed on the advice stack.
+    #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
     #[link_name = "intrinsics::advice::adv_push_mapvaln"]
     fn extern_adv_push_mapvaln(key0: Felt, key1: Felt, key2: Felt, key3: Felt) -> Felt;
 }
@@ -30,6 +31,7 @@ pub fn adv_push_mapvaln(_key: Word) -> Felt {
 unsafe extern "C" {
     /// Emits an event to request a Falcon signature for the provided message/public key.
     /// This maps to the MASM instruction: `emit.AUTH_REQUEST_EVENT`.
+    #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
     #[link_name = "intrinsics::advice::emit_falcon_sig_to_stack"]
     fn extern_emit_falcon_sig_to_stack(
         msg0: Felt,
@@ -67,6 +69,7 @@ unsafe extern "C" {
     /// Inserts values from memory into the advice map using the provided key and memory range.
     /// Maps to the VM op: adv.insert_mem
     /// Signature: (key0..key3, start_addr, end_addr)
+    #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
     #[link_name = "intrinsics::advice::adv_insert_mem"]
     fn extern_adv_insert_mem(
         k0: Felt,

--- a/sdk/stdlib-sys/src/intrinsics/crypto.rs
+++ b/sdk/stdlib-sys/src/intrinsics/crypto.rs
@@ -72,6 +72,7 @@ unsafe extern "C" {
     /// Outputs: `[C, ...]` where `C = Poseidon2(A || B)`
     ///
     /// The digest output is returned to the caller via `result_ptr`.
+    #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
     #[link_name = "miden::core::crypto::hashes::poseidon2::merge"]
     fn extern_poseidon2_merge(
         a0: Felt,

--- a/sdk/stdlib-sys/src/intrinsics/debug.rs
+++ b/sdk/stdlib-sys/src/intrinsics/debug.rs
@@ -1,8 +1,9 @@
 #[cfg(all(target_family = "wasm", miden))]
 unsafe extern "C" {
+    #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
     #[link_name = "intrinsics::debug::break"]
     fn extern_break();
-
+    #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
     #[link_name = "intrinsics::debug::println"]
     fn extern_println(ptr: *const u8, len: usize);
 }

--- a/sdk/stdlib-sys/src/intrinsics/felt.rs
+++ b/sdk/stdlib-sys/src/intrinsics/felt.rs
@@ -4,12 +4,13 @@ pub use miden_field::Felt;
 
 #[cfg(all(target_family = "wasm", miden))]
 unsafe extern "C" {
+    #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
     #[link_name = "intrinsics::felt::assert"]
     fn extern_assert(a: Felt);
-
+    #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
     #[link_name = "intrinsics::felt::assertz"]
     fn extern_assertz(a: Felt);
-
+    #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
     #[link_name = "intrinsics::felt::assert_eq"]
     fn extern_assert_eq(a: Felt, b: Felt);
 }

--- a/sdk/stdlib-sys/src/lib.rs
+++ b/sdk/stdlib-sys/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(all(target_family = "wasm", miden), feature(linkage))]
 #![deny(warnings)]
 
 extern crate alloc;

--- a/sdk/stdlib-sys/src/stdlib/collections/smt.rs
+++ b/sdk/stdlib-sys/src/stdlib/collections/smt.rs
@@ -29,6 +29,7 @@ unsafe extern "C" {
     ///
     /// Fails if the tree with the specified `root` does not exist in the VM's advice provider. When
     /// no value has previously been inserted under `key`, the procedure returns the empty word.
+    #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
     #[link_name = "miden::core::collections::smt::get"]
     fn extern_smt_get(
         k0: Felt,
@@ -53,6 +54,7 @@ unsafe extern "C" {
     /// `value` is the empty word, the new tree state is equivalent to omitting the update.
     ///
     /// Fails if the tree with the specified `root` does not exist in the VM's advice provider.
+    #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
     #[link_name = "miden::core::collections::smt::set"]
     fn extern_smt_set(
         v0: Felt,

--- a/sdk/stdlib-sys/src/stdlib/crypto/dsa.rs
+++ b/sdk/stdlib-sys/src/stdlib/crypto/dsa.rs
@@ -5,6 +5,7 @@ use crate::intrinsics::{Felt, Word};
 
 #[cfg(all(target_family = "wasm", miden))]
 unsafe extern "C" {
+    #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
     #[link_name = "miden::core::crypto::dsa::falcon512_poseidon2::verify"]
     fn extern_rpo_falcon512_verify(
         pk0: Felt,

--- a/sdk/stdlib-sys/src/stdlib/crypto/hashes.rs
+++ b/sdk/stdlib-sys/src/stdlib/crypto/hashes.rs
@@ -17,6 +17,7 @@ mod imp {
         /// Input: 32-bytes stored in the first 8 elements of the stack (32 bits per element).
         /// Output: A 32-byte digest stored in the first 8 elements of stack (32 bits per element).
         /// The output is passed back to the caller via a pointer.
+        #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
         #[link_name = "miden::core::crypto::hashes::blake3::hash"]
         fn extern_blake3_hash(
             e1: u32,
@@ -35,6 +36,7 @@ mod imp {
         /// Input: 64-bytes stored in the first 16 elements of the stack (32 bits per element).
         /// Output: A 32-byte digest stored in the first 8 elements of stack (32 bits per element)
         /// The output is passed back to the caller via a pointer.
+        #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
         #[link_name = "miden::core::crypto::hashes::blake3::merge"]
         fn extern_blake3_merge(
             e1: u32,
@@ -63,6 +65,7 @@ mod imp {
         /// Input: 32-bytes stored in the first 8 elements of the stack (32 bits per element).
         /// Output: A 32-byte digest stored in the first 8 elements of stack (32 bits per element).
         /// The output is passed back to the caller via a pointer.
+        #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
         #[link_name = "miden::core::crypto::hashes::sha256::hash"]
         fn extern_sha256_hash(
             e1: u32,
@@ -81,6 +84,7 @@ mod imp {
         /// Input: 64-bytes stored in the first 16 elements of the stack (32 bits per element).
         /// Output: A 32-byte digest stored in the first 8 elements of stack (32 bits per element).
         /// The output is passed back to the caller via a pointer.
+        #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
         #[link_name = "miden::core::crypto::hashes::sha256::merge"]
         fn extern_sha256_merge(
             e1: u32,
@@ -112,6 +116,7 @@ mod imp {
         /// Input: A pointer to the memory location and the number of elements to hash
         /// Output: One digest (4 field elements)
         /// The output is passed back to the caller via a pointer.
+        #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
         #[link_name = "miden::core::crypto::hashes::poseidon2::hash_elements"]
         pub fn extern_hash_elements(ptr: u32, num_elements: u32, result_ptr: *mut Felt);
 
@@ -123,6 +128,7 @@ mod imp {
         /// Input: The start and end addresses (in field elements) of the words to hash.
         /// Output: One digest (4 field elements)
         /// The output is passed back to the caller via a pointer.
+        #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
         #[link_name = "miden::core::crypto::hashes::poseidon2::hash_words"]
         pub fn extern_hash_words(start_addr: u32, end_addr: u32, result_ptr: *mut Felt);
     }

--- a/sdk/stdlib-sys/src/stdlib/mem.rs
+++ b/sdk/stdlib-sys/src/stdlib/mem.rs
@@ -21,6 +21,7 @@ unsafe extern "C" {
     /// Cycles:
     /// - Even num_words: 43 + 9 * num_words / 2
     /// - Odd num_words: 60 + 9 * round_down(num_words / 2)
+    #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
     #[link_name = "miden::core::mem::pipe_words_to_memory"]
     fn extern_pipe_words_to_memory(num_words: Felt, write_ptr: *mut Felt, out_ptr: *mut Felt);
 
@@ -36,6 +37,7 @@ unsafe extern "C" {
     /// - The value num_words = end_ptr - write_ptr must be positive and even
     ///
     /// Cycles: 9 + 6 * (num_words / 2)
+    #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
     #[link_name = "miden::core::mem::pipe_double_words_to_memory"]
     fn extern_pipe_double_words_to_memory(
         r00: Felt,
@@ -63,6 +65,7 @@ unsafe extern "C" {
     /// Cycles:
     /// - Even num_words: 58 + 9 * (num_words / 2)
     /// - Odd num_words: 75 + 9 * round_down(num_words / 2)
+    #[cfg_attr(all(target_family = "wasm", miden), linkage = "extern_weak")]
     #[link_name = "miden::core::mem::pipe_preimage_to_memory"]
     pub(crate) fn extern_pipe_preimage_to_memory(
         num_words: Felt,

--- a/sdk/stdlib-sys/stubs/collections.rs
+++ b/sdk/stdlib-sys/stubs/collections.rs
@@ -3,37 +3,39 @@ use core::ffi::c_void;
 /// Unreachable stubs for std::collections::smt procedures used via the SDK
 
 #[unsafe(export_name = "miden::core::collections::smt::get")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn std_collections_smt_get_stub(
-    k0: f32,
-    k1: f32,
-    k2: f32,
-    k3: f32,
-    r0: f32,
-    r1: f32,
-    r2: f32,
-    r3: f32,
-    result_ptr: *mut c_void,
+    _k0: f32,
+    _k1: f32,
+    _k2: f32,
+    _k3: f32,
+    _r0: f32,
+    _r1: f32,
+    _r2: f32,
+    _r3: f32,
+    _result_ptr: *mut c_void,
 ) {
-    let _ = (k0, k1, k2, k3, r0, r1, r2, r3, result_ptr);
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "miden::core::collections::smt::set")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn std_collections_smt_set_stub(
-    v0: f32,
-    v1: f32,
-    v2: f32,
-    v3: f32,
-    k0: f32,
-    k1: f32,
-    k2: f32,
-    k3: f32,
-    r0: f32,
-    r1: f32,
-    r2: f32,
-    r3: f32,
-    result_ptr: *mut c_void,
+    _v0: f32,
+    _v1: f32,
+    _v2: f32,
+    _v3: f32,
+    _k0: f32,
+    _k1: f32,
+    _k2: f32,
+    _k3: f32,
+    _r0: f32,
+    _r1: f32,
+    _r2: f32,
+    _r3: f32,
+    _result_ptr: *mut c_void,
 ) {
-    let _ = (v0, v1, v2, v3, k0, k1, k2, k3, r0, r1, r2, r3, result_ptr);
     unsafe { core::hint::unreachable_unchecked() }
 }

--- a/sdk/stdlib-sys/stubs/crypto/hashes_blake3.rs
+++ b/sdk/stdlib-sys/stubs/crypto/hashes_blake3.rs
@@ -3,6 +3,8 @@ use core::ffi::c_void;
 /// Unreachable stubs for std::crypto::hashes::blake3
 
 #[unsafe(export_name = "miden::core::crypto::hashes::blake3::hash")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn blake3_hash_stub(
     _e1: u32,
     _e2: u32,
@@ -18,6 +20,8 @@ pub extern "C" fn blake3_hash_stub(
 }
 
 #[unsafe(export_name = "miden::core::crypto::hashes::blake3::merge")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn blake3_merge_stub(
     _e1: u32,
     _e2: u32,

--- a/sdk/stdlib-sys/stubs/crypto/hashes_rpo.rs
+++ b/sdk/stdlib-sys/stubs/crypto/hashes_rpo.rs
@@ -3,12 +3,16 @@ use core::ffi::c_void;
 /// Unreachable stub for std::crypto::hashes::poseidon2::hash_elements
 
 #[unsafe(export_name = "miden::core::crypto::hashes::poseidon2::hash_elements")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn rpo_hash_elements_stub(_ptr: u32, _num_elements: u32, _result_ptr: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 /// Unreachable stub for std::crypto::hashes::poseidon2::hash_words
 #[unsafe(export_name = "miden::core::crypto::hashes::poseidon2::hash_words")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn rpo_hash_words_stub(_start_addr: u32, _end_addr: u32, _result_ptr: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }
@@ -18,6 +22,8 @@ pub extern "C" fn rpo_hash_words_stub(_start_addr: u32, _end_addr: u32, _result_
 /// The ABI maps this to a function which consumes 8 felts (two digests) and returns a 4-felt digest.
 /// In Rust bindings, the return value is passed back via a pointer to a result area.
 #[unsafe(export_name = "miden::core::crypto::hashes::poseidon2::merge")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn poseidon2_merge_stub(
     _b0: f32,
     _b1: f32,

--- a/sdk/stdlib-sys/stubs/crypto/hashes_sha256.rs
+++ b/sdk/stdlib-sys/stubs/crypto/hashes_sha256.rs
@@ -3,6 +3,8 @@ use core::ffi::c_void;
 /// Unreachable stubs for std::crypto::hashes::sha256
 
 #[unsafe(export_name = "miden::core::crypto::hashes::sha256::hash")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn sha256_hash_stub(
     _e1: u32,
     _e2: u32,
@@ -18,6 +20,8 @@ pub extern "C" fn sha256_hash_stub(
 }
 
 #[unsafe(export_name = "miden::core::crypto::hashes::sha256::merge")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn sha256_merge_stub(
     _e1: u32,
     _e2: u32,

--- a/sdk/stdlib-sys/stubs/crypto/rpo_falcon_dsa.rs
+++ b/sdk/stdlib-sys/stubs/crypto/rpo_falcon_dsa.rs
@@ -4,6 +4,8 @@
 ///
 /// This satisfies link-time references and allows the compiler to lower calls to MASM.
 #[unsafe(export_name = "miden::core::crypto::dsa::falcon512_poseidon2::verify")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn rpo_falcon512_verify_stub(
     _pk1: f32,
     _pk2: f32,

--- a/sdk/stdlib-sys/stubs/intrinsics/advice.rs
+++ b/sdk/stdlib-sys/stubs/intrinsics/advice.rs
@@ -1,6 +1,8 @@
 /// Unreachable stubs for intrinsics::advice interface
 
 #[unsafe(export_name = "intrinsics::advice::adv_push_mapvaln")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn advice_adv_push_mapvaln_stub(
     _key0: f32,
     _key1: f32,
@@ -11,6 +13,8 @@ pub extern "C" fn advice_adv_push_mapvaln_stub(
 }
 
 #[unsafe(export_name = "intrinsics::advice::emit_falcon_sig_to_stack")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn advice_emit_falcon_sig_to_stack_stub(
     _m0: f32,
     _m1: f32,
@@ -25,6 +29,8 @@ pub extern "C" fn advice_emit_falcon_sig_to_stack_stub(
 }
 
 #[unsafe(export_name = "intrinsics::advice::adv_insert_mem")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn advice_adv_insert_mem_stub(
     _k0: f32,
     _k1: f32,
@@ -37,6 +43,8 @@ pub extern "C" fn advice_adv_insert_mem_stub(
 }
 
 #[unsafe(export_name = "intrinsics::advice::emit_and_verify_falcon")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn advice_emit_and_verify_falcon_stub(
     _m0: f32,
     _m1: f32,

--- a/sdk/stdlib-sys/stubs/intrinsics/crypto.rs
+++ b/sdk/stdlib-sys/stubs/intrinsics/crypto.rs
@@ -3,6 +3,8 @@ use core::ffi::c_void;
 /// Unreachable stub for intrinsics::crypto::hmerge.
 /// Signature in Wasm is (i32 digests_ptr, i32 result_ptr)
 #[unsafe(export_name = "intrinsics::crypto::hmerge")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn hmerge_stub(_digests_ptr: *const c_void, _result_ptr: *mut c_void) {
     unsafe { core::hint::unreachable_unchecked() }
 }

--- a/sdk/stdlib-sys/stubs/intrinsics/debug.rs
+++ b/sdk/stdlib-sys/stubs/intrinsics/debug.rs
@@ -1,11 +1,15 @@
 /// Unreachable stubs for intrinsics::debug interface
 
 #[unsafe(export_name = "intrinsics::debug::break")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn debug_break_stub() {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::debug::println")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn debug_println_stub(_ptr: *const u8, _len: usize) {
     unsafe { core::hint::unreachable_unchecked() }
 }

--- a/sdk/stdlib-sys/stubs/intrinsics/felt.rs
+++ b/sdk/stdlib-sys/stubs/intrinsics/felt.rs
@@ -3,101 +3,141 @@
 /// to MASM operations or functions accordingly.
 
 #[unsafe(export_name = "intrinsics::felt::add")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_add_stub(_a: f32, _b: f32) -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::from_u64_unchecked")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_from_u64_unchecked_stub(_v: u64) -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::from_u32")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_from_u32_stub(_v: u32) -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::as_u64")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_as_u64_stub(_a: f32) -> u64 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::sub")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_sub_stub(_a: f32, _b: f32) -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::mul")]
+#[optimize(none)]
+#[inline(never)]
 pub fn felt_mul_stub(_a: f32, _b: f32) -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::div")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_div_stub(_a: f32, _b: f32) -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::neg")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_neg_stub(_a: f32) -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::inv")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_inv_stub(_a: f32) -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::pow2")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_pow2_stub(_a: f32) -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::exp")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_exp_stub(_a: f32, _b: f32) -> f32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::eq")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_eq_stub(_a: f32, _b: f32) -> i32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::gt")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_gt_stub(_a: f32, _b: f32) -> i32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::lt")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_lt_stub(_a: f32, _b: f32) -> i32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::ge")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_ge_stub(_a: f32, _b: f32) -> i32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::le")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_le_stub(_a: f32, _b: f32) -> i32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::is_odd")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_is_odd_stub(_a: f32) -> i32 {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::assert")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_assert_stub(_a: f32) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::assertz")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_assertz_stub(_a: f32) {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
 #[unsafe(export_name = "intrinsics::felt::assert_eq")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn felt_assert_eq_stub(_a: f32, _b: f32) {
     unsafe { core::hint::unreachable_unchecked() }
 }

--- a/sdk/stdlib-sys/stubs/intrinsics_root.rs
+++ b/sdk/stdlib-sys/stubs/intrinsics_root.rs
@@ -1,4 +1,4 @@
 #![no_std]
+#![feature(optimize_attribute)]
 
 mod intrinsics;
-

--- a/sdk/stdlib-sys/stubs/mem.rs
+++ b/sdk/stdlib-sys/stubs/mem.rs
@@ -3,6 +3,8 @@ use core::ffi::c_void;
 /// Unreachable stubs for std::mem procedures used via SDK
 
 #[unsafe(export_name = "miden::core::mem::pipe_words_to_memory")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn std_mem_pipe_words_to_memory_stub(
     _num_words: f32,
     _write_ptr: *mut c_void,
@@ -12,6 +14,8 @@ pub extern "C" fn std_mem_pipe_words_to_memory_stub(
 }
 
 #[unsafe(export_name = "miden::core::mem::pipe_double_words_to_memory")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn std_mem_pipe_double_words_to_memory_stub(
     _r00: f32,
     _r01: f32,
@@ -33,6 +37,8 @@ pub extern "C" fn std_mem_pipe_double_words_to_memory_stub(
 }
 
 #[unsafe(export_name = "miden::core::mem::pipe_preimage_to_memory")]
+#[optimize(none)]
+#[inline(never)]
 pub extern "C" fn std_mem_pipe_preimage_to_memory_stub(
     _num_words: f32,
     _write_ptr: *mut c_void,

--- a/sdk/stdlib-sys/stubs/stdlib_root.rs
+++ b/sdk/stdlib-sys/stubs/stdlib_root.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![feature(optimize_attribute)]
 
 mod mem;
 mod crypto;

--- a/tests/integration-network/src/mockchain/counter/basic_auth.rs
+++ b/tests/integration-network/src/mockchain/counter/basic_auth.rs
@@ -65,7 +65,7 @@ pub fn counter_note_basic_auth_increments_storage() {
         .build_tx_context(counter_account.clone(), &[counter_note.id()], &[])
         .unwrap();
     let tx_measurements = execute_tx(&mut chain, tx_context_builder);
-    expect!["49505"].assert_eq(note_cycles(&tx_measurements, counter_note.id()));
+    expect!["10474"].assert_eq(note_cycles(&tx_measurements, counter_note.id()));
 
     // The counter contract storage value should be 2 after the note is consumed (incremented by 1).
     assert_counter_storage(

--- a/tests/integration-network/src/mockchain/counter/no_auth.rs
+++ b/tests/integration-network/src/mockchain/counter/no_auth.rs
@@ -101,8 +101,8 @@ pub fn counter_note_no_auth_increments_storage_without_signature() {
         .build_tx_context(counter_account.clone(), &[counter_note.id()], &[])
         .unwrap();
     let tx_measurements = execute_tx(&mut chain, tx_context_builder);
-    expect!["1803"].assert_eq(auth_procedure_cycles(&tx_measurements));
-    expect!["49505"].assert_eq(note_cycles(&tx_measurements, counter_note.id()));
+    expect!["1778"].assert_eq(auth_procedure_cycles(&tx_measurements));
+    expect!["10474"].assert_eq(note_cycles(&tx_measurements, counter_note.id()));
 
     // The counter contract storage value should be 2 after the note is consumed
     assert_counter_storage(

--- a/tests/integration-network/src/mockchain/counter/rpo_auth.rs
+++ b/tests/integration-network/src/mockchain/counter/rpo_auth.rs
@@ -70,7 +70,7 @@ pub fn counter_rpo_auth_rejects_unauthenticated_note_creation() {
     let tx_context = tx_context_builder.build().unwrap();
     let executed_tx =
         block_on(tx_context.execute()).expect("authorized client should be able to create a note");
-    expect!["86895"].assert_eq(auth_procedure_cycles(executed_tx.measurements()));
+    expect!["74561"].assert_eq(auth_procedure_cycles(executed_tx.measurements()));
     assert_eq!(executed_tx.output_notes().num_notes(), 1);
     assert_eq!(executed_tx.output_notes().get_note(0).id(), own_note.id());
 

--- a/tests/integration-network/src/mockchain/notes/basic_wallet.rs
+++ b/tests/integration-network/src/mockchain/notes/basic_wallet.rs
@@ -14,11 +14,12 @@ use miden_standards::testing::note::NoteBuilder;
 use miden_testing::{Auth, MockChain};
 use midenc_expect_test::expect;
 
-use super::super::support::{
+use crate::mockchain::support::{
     assert_account_has_fungible_asset, build_asset_transfer_tx, build_send_notes_script,
     compile_rust_package, execute_tx, note_cycles, note_script_root, prologue_cycles,
     to_core_felts, tx_script_processing_cycles,
 };
+
 /// Converts the P2IDE note payload into protocol storage order for the basic-wallet tests.
 fn to_p2ide_storage_felts(
     target: &AccountId,
@@ -105,7 +106,7 @@ pub fn basic_wallet_p2id_transfers_asset_with_custom_tx_script() {
         chain.build_tx_context(alice_id, &[p2id_note_mint.id()], &[]).unwrap();
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
     expect!["3216"].assert_eq(prologue_cycles(&tx_measurements));
-    expect!["20072"].assert_eq(note_cycles(&tx_measurements, p2id_note_mint.id()));
+    expect!["7275"].assert_eq(note_cycles(&tx_measurements, p2id_note_mint.id()));
 
     eprintln!("\n=== Checking Alice's account has the minted asset ===");
     let alice_account = chain.committed_account(alice_id).unwrap();
@@ -125,12 +126,12 @@ pub fn basic_wallet_p2id_transfers_asset_with_custom_tx_script() {
         &mut note_rng,
     );
     let tx_measurements = execute_tx(&mut chain, alice_tx_context_builder);
-    expect!["26223"].assert_eq(tx_script_processing_cycles(&tx_measurements));
+    expect!["6723"].assert_eq(tx_script_processing_cycles(&tx_measurements));
 
     eprintln!("\n=== Step 4: Bob consumes p2id note ===");
     let consume_tx_context_builder = chain.build_tx_context(bob_id, &[bob_note.id()], &[]).unwrap();
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
-    expect!["20072"].assert_eq(note_cycles(&tx_measurements, bob_note.id()));
+    expect!["7275"].assert_eq(note_cycles(&tx_measurements, bob_note.id()));
 
     eprintln!("\n=== Checking Bob's account has the transferred asset ===");
     let bob_account = chain.committed_account(bob_id).unwrap();
@@ -255,7 +256,7 @@ pub fn basic_wallet_p2ide_allows_recipient_claim() {
     let consume_tx_context_builder =
         chain.build_tx_context(bob_id, &[p2ide_note.id()], &[]).unwrap();
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
-    expect!["21212"].assert_eq(note_cycles(&tx_measurements, p2ide_note.id()));
+    expect!["7721"].assert_eq(note_cycles(&tx_measurements, p2ide_note.id()));
 
     // Step 5: verify balances
     let bob_account = chain.committed_account(bob_id).unwrap();
@@ -380,7 +381,7 @@ pub fn basic_wallet_p2ide_allows_sender_reclaim() {
     let reclaim_tx_context_builder =
         chain.build_tx_context(alice_id, &[p2ide_note.id()], &[]).unwrap();
     let tx_measurements = execute_tx(&mut chain, reclaim_tx_context_builder);
-    expect!["22872"].assert_eq(note_cycles(&tx_measurements, p2ide_note.id()));
+    expect!["8280"].assert_eq(note_cycles(&tx_measurements, p2ide_note.id()));
 
     // Step 5: verify Alice has her original amount back
     let alice_account = chain.committed_account(alice_id).unwrap();

--- a/tests/integration/src/end_to_end/examples/basic_wallet_package_sizes.rs
+++ b/tests/integration/src/end_to_end/examples/basic_wallet_package_sizes.rs
@@ -10,7 +10,7 @@ fn basic_wallet_and_p2id() {
         CompilerTest::rust_source_cargo_miden("../../examples/basic-wallet", config.clone(), []);
     let account_package = account_test.compile_package();
     assert!(account_package.is_library(), "expected library");
-    expect!["36014"].assert_eq(stripped_mast_size_str(&account_package));
+    expect!["18945"].assert_eq(stripped_mast_size_str(&account_package));
 
     let mut tx_script_test = CompilerTest::rust_source_cargo_miden(
         "../../examples/basic-wallet-tx-script",
@@ -19,17 +19,17 @@ fn basic_wallet_and_p2id() {
     );
     let tx_script_package = tx_script_test.compile_package();
     assert!(tx_script_package.is_program(), "expected program");
-    expect!["56555"].assert_eq(stripped_mast_size_str(&tx_script_package));
+    expect!["17527"].assert_eq(stripped_mast_size_str(&tx_script_package));
 
     let mut p2id_test =
         CompilerTest::rust_source_cargo_miden("../../examples/p2id-note", config.clone(), []);
     let note_package = p2id_test.compile_package();
     assert!(note_package.is_library(), "expected library");
-    expect!["53190"].assert_eq(stripped_mast_size_str(&note_package));
+    expect!["21448"].assert_eq(stripped_mast_size_str(&note_package));
 
     let mut p2ide_test =
         CompilerTest::rust_source_cargo_miden("../../examples/p2ide-note", config, []);
     let p2ide_package = p2ide_test.compile_package();
     assert!(p2ide_package.is_library(), "expected library");
-    expect!["62781"].assert_eq(stripped_mast_size_str(&p2ide_package));
+    expect!["24930"].assert_eq(stripped_mast_size_str(&p2ide_package));
 }

--- a/tools/cargo-miden/src/commands/build.rs
+++ b/tools/cargo-miden/src/commands/build.rs
@@ -216,6 +216,8 @@ fn build_cargo_args(cargo_opts: &CargoOptions) -> Vec<String> {
         ("profile.dev.debug", "true"),
         ("profile.dev.debug-assertions", "false"),
         ("profile.release.opt-level", "\"s\""),
+        ("profile.release.lto", "true"),
+        ("profile.release.codegen-units", "1"),
         ("profile.release.panic", "\"abort\""),
     ];
 


### PR DESCRIPTION
Close #1089 

LTO can see through the Rust unreachable stubs used to carry Miden intrinsic signatures and rewrite callers as if those stubs were the real implementations. That breaks frontend lowering because the final wasm no longer reliably preserves the call ABI the linker-stub recognizer expects.

Mark SDK intrinsic declarations as weak externs, keep stub bodies uninlined and unoptimized, and force the tiny stub archives into linked wasm with whole-archive. This keeps the stubs available for signature recognition without letting LTO propagate their unreachable bodies into callers.

## MAST Sizes

Values are from `tests/integration/src/rust_masm_tests/examples.rs`.

| Package | next | current | Delta | Reduction |
| --- | ---: | ---: | ---: | ---: |
| `examples/basic-wallet` | 35,906 | 18,893 | -17,013 | 47.38% |
| `examples/basic-wallet-tx-script` | 56,437 | 17,475 | -38,962 | 69.04% |
| `examples/p2id-note` | 53,082 | 21,396 | -31,686 | 59.69% |
| `examples/p2ide-note` | 62,672 | 24,878 | -37,794 | 60.30% |
| Total | 208,097 | 82,642 | -125,455 | 60.29% |

## Mockchain Cycle Counts

Values are from the `tests/integration-network/src/mockchain` expectations.

| Test measurement | next | current | Delta | Reduction |
| --- | ---: | ---: | ---: | ---: |
| `basic_wallet::test_basic_wallet_p2id` mint note cycles | 20,072 | 7,275 | -12,797 | 63.76% |
| `basic_wallet::test_basic_wallet_p2id` tx script processing cycles | 26,217 | 6,723 | -19,494 | 74.36% |
| `basic_wallet::test_basic_wallet_p2id` Bob note cycles | 20,072 | 7,275 | -12,797 | 63.76% |
| `basic_wallet::test_basic_wallet_p2ide` Bob note cycles | 21,211 | 7,721 | -13,490 | 63.60% |
| `basic_wallet::test_basic_wallet_p2ide_reclaim` reclaim note cycles | 22,871 | 8,280 | -14,591 | 63.80% |
| `counter_contract::test_counter_contract` note cycles | 49,505 | 10,474 | -39,031 | 78.84% |
| `counter_contract_no_auth::test_counter_contract_no_auth` auth procedure cycles | 1,803 | 1,778 | -25 | 1.39% |
| `counter_contract_no_auth::test_counter_contract_no_auth` note cycles | 49,505 | 10,474 | -39,031 | 78.84% |
| `counter_contract_rust_auth::test_counter_contract_rust_auth_blocks_unauthorized_note_creation` auth procedure cycles | 86,895 | 74,561 | -12,334 | 14.19% |
