### PR TITLE
fix(frontend/wasm): interpret `split2` limbs as `I64`

### DIFF
--- a/frontend/wasm/src/code_translator/mod.rs
+++ b/frontend/wasm/src/code_translator/mod.rs
@@ -528,7 +528,7 @@ pub fn translate_operator<B: ?Sized + Builder>(
 
             let res = builder.mul_wrapping(lhs, rhs, span)?;
 
-            let (res_hi, res_lo) = builder.split2(res, Type::U64, span)?;
+            let (res_hi, res_lo) = builder.split2(res, Type::I64, span)?;
             state.pushn(&[res_hi, res_lo]);
         }
         Operator::I64MulWideS => {

--- a/tests/integration/src/end_to_end/arithmetic.rs
+++ b/tests/integration/src/end_to_end/arithmetic.rs
@@ -407,7 +407,6 @@ fn overflowing_mul_u64() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1108"]
 fn overflowing_mul_u128() {
     test_overflowing_arith(u128::overflowing_mul, "overflowing_mul", NumericStrategy::full_range());
 }
@@ -435,7 +434,7 @@ fn overflowing_mul_i64() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1108"]
+#[ignore = "https://github.com/0xMiden/compiler/issues/1111"]
 fn overflowing_mul_i128() {
     test_overflowing_arith(i128::overflowing_mul, "overflowing_mul", NumericStrategy::full_range());
 }


### PR DESCRIPTION
Closes #1108 by casting `split2` limbs to `i64` instead of `u64` to satisfy Wasm type constraints.

With this fix in place `overflowing_mul_i128` hits #1111, so it still needs to be ignored.