### PR TITLE
ci: add shear, workspace inheritance, and zizmor checks, and move heavy GitHub Actions jobs to WarpBuild

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - warp-ubuntu-latest-x64-8x

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,10 +28,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,25 +23,47 @@ env:
   # Set the new value when the cache grows too much and we hit the runner's disk space limit
   # via https://github.com/rust-lang/docs.rs/pull/2433
   RUST_CACHE_KEY: rust-cache-20251212
+  # Reduce cache size by not storing debug info in dev-profile artifacts.
+  CARGO_PROFILE_DEV_DEBUG: 0
 
 jobs:
-  lint:
-    name: lint
+  workspace_inheritance:
+    name: Workspace inheritance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      # Pin install-action to a release and request the tool explicitly; shortcut
+      # tags can trip zizmor's impostor-commit audit when they are later retagged.
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-binstall
+      - name: Install workspace inheritance checker
+        run: cargo binstall --no-confirm cargo-workspace-inheritance-check@1.2.0
+      - name: Check workspace inheritance
+        run: cargo workspace-inheritance-check --promotion-threshold 2 --promotion-failure
+
+  lint:
+    name: lint
+    runs-on: warp-ubuntu-latest-x64-8x
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
           rustc --version
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           # Use a common cache for the basic compilation/formatter/clippy checks
           shared-key: ${{ github.workflow }}-shared
           prefix-key: ${{ env.RUST_CACHE_KEY }}
-          save-if: ${{ github.ref == 'refs/heads/next' }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install cargo-make
         run: |
           if ! cargo make --version 2>/dev/null; then
@@ -53,20 +75,22 @@ jobs:
 
   check_format:
     name: check formatting
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     # Run this job after the linter, so the cache is hot
     needs: [lint]
     # But run this check even if the lint check failed
     if: ${{ always() }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
           rustc --version
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           # Use a common cache for the basic compilation/formatter/clippy checks
           shared-key: ${{ github.workflow }}-shared
@@ -85,52 +109,37 @@ jobs:
   check_unused:
     name: check for unused items/dependencies
     runs-on: ubuntu-latest
-    # Run this job after the linter, so the cache is hot
-    needs: [lint]
-    # But run this check even if the lint check failed
-    if: ${{ always() }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: ./.github/actions/cleanup-runner
-      - name: Install Rust
-        run: |
-          rustup update --no-self-update
-          rustc --version
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          # Use a common cache for the basic compilation/formatter/clippy checks
-          shared-key: ${{ github.workflow }}-shared
-          prefix-key: ${{ env.RUST_CACHE_KEY }}
-          # But do not save this cache, just use it
-          save-if: false
-      - name: Install cargo-make
-        run: |
-          if ! cargo make --version 2>/dev/null; then
-            cargo install cargo-make --force
-          fi
-      - name: Clippy
-        run: |
-          cargo make unused
+          persist-credentials: false
+      - name: Install cargo-shear
+        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-shear@1.11.2
+      - name: Check for unused dependencies
+        run: cargo shear
 
   unit_tests:
     name: midenc unit tests
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
           rustc --version
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           # NOTE: We use a different cache for the tests, so they can be run in parallel, but we
           # also share the cache for the tests for efficiency
           shared-key: ${{ github.workflow }}-shared-tests
           prefix-key: ${{ env.RUST_CACHE_KEY }}
-          save-if: ${{ github.ref == 'refs/heads/next' }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install cargo-make
         run: |
           if ! cargo make --version 2>/dev/null; then
@@ -148,22 +157,24 @@ jobs:
 
   release_profile_tests:
     name: midenc release-profile tests
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
           rustc --version
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           # NOTE: Keep a separate cache because the workspace is rebuilt under
           # the custom test-release profile.
           shared-key: ${{ github.workflow }}-shared-release-tests
           prefix-key: ${{ env.RUST_CACHE_KEY }}
-          save-if: ${{ github.ref == 'refs/heads/next' }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install cargo-make
         run: |
           if ! cargo make --version 2>/dev/null; then
@@ -175,19 +186,21 @@ jobs:
 
   lit_tests:
     name: midenc lit/filecheck tests
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     # We only want to run our lit tests if the unit tests pass, and that has the added
     # benefit that we can re-use the cache from the unit test job
     needs: [unit_tests]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
           rustc --version
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           # NOTE: We use a different cache for the tests, so they can be run in parallel, but we
           # also share the cache for the tests for efficiency
@@ -204,19 +217,21 @@ jobs:
 
   midenc_integration_tests:
     name: midenc integration tests
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     # We only want to run the integration tests if the unit tests pass, and that has the added
     # benefit that we can re-use the cache from the unit test job for all integration tests
     needs: [unit_tests]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
           rustc --version
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           shared-key: ${{ github.workflow }}-shared-tests
           prefix-key: ${{ env.RUST_CACHE_KEY }}
@@ -234,19 +249,21 @@ jobs:
 
   midenc_integration_tests_examples:
     name: midenc integration tests
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     # We only want to run the integration tests if the unit tests pass, and that has the added
     # benefit that we can re-use the cache from the unit test job for all integration tests
     needs: [unit_tests]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
           rustc --version
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           shared-key: ${{ github.workflow }}-shared-tests
           prefix-key: ${{ env.RUST_CACHE_KEY }}
@@ -264,19 +281,21 @@ jobs:
 
   cargo_miden_integration_tests:
     name: cargo-miden integration tests
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     # We only want to run the integration tests if the unit tests pass, and that has the added
     # benefit that we can re-use the cache from the unit test job for all integration tests
     needs: [unit_tests]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
           rustc --version
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           shared-key: ${{ github.workflow }}-shared-tests
           prefix-key: ${{ env.RUST_CACHE_KEY }}
@@ -294,19 +313,21 @@ jobs:
 
   cargo_miden_tests_templates_and_examples:
     name: cargo-miden test new project templates and examples
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     # We only want to run the integration tests if the unit tests pass, and that has the added
     # benefit that we can re-use the cache from the unit test job for all integration tests
     needs: [unit_tests]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
           rustc --version
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           shared-key: ${{ github.workflow }}-shared-tests
           prefix-key: ${{ env.RUST_CACHE_KEY }}
@@ -323,19 +344,21 @@ jobs:
 
   miden_integration_node_tests:
     name: miden integration node tests
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     # We only want to run the integration tests if the unit tests pass, and that has the added
     # benefit that we can re-use the cache from the unit test job for all integration tests
     needs: [unit_tests]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
           rustc --version
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           shared-key: ${{ github.workflow }}-shared-tests
           prefix-key: ${{ env.RUST_CACHE_KEY }}
@@ -352,21 +375,23 @@ jobs:
 
   check_release:
     name: release checks
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
           rustc --version
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           # NOTE: We use a different cache for the these release checks
           shared-key: ${{ github.workflow }}-shared-release-checks
           prefix-key: ${{ env.RUST_CACHE_KEY }}
-          save-if: ${{ github.ref == 'refs/heads/next' }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install cargo-make
         run: |
           if ! cargo make --version 2>/dev/null; then
@@ -385,22 +410,24 @@ jobs:
 
   cargo_publish_dry_run:
     name: cargo publish dry run
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     needs: [unit_tests]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |
           rustup update --no-self-update
           rustc --version
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           # Use a common cache for the basic compilation/formatter/clippy checks
           shared-key: ${{ github.workflow }}-shared
           prefix-key: ${{ env.RUST_CACHE_KEY }}
-          save-if: ${{ github.ref == 'refs/heads/next' }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install cargo-make
         run: |
           if ! cargo make --version 2>/dev/null; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ env:
   # Set the new value when the cache grows too much and we hit the runner's disk space limit
   # via https://github.com/rust-lang/docs.rs/pull/2433
   RUST_CACHE_KEY: rust-cache-20251212
-  # Reduce cache size by not storing debug info in dev-profile artifacts.
-  CARGO_PROFILE_DEV_DEBUG: 0
 
 jobs:
   workspace_inheritance:
@@ -109,16 +107,30 @@ jobs:
   check_unused:
     name: check for unused items/dependencies
     runs-on: ubuntu-latest
+    # Run this job after the linter, so the cache is hot
+    needs: [lint]
+    # But run this check even if the lint check failed
+    if: ${{ always() }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+      - uses: ./.github/actions/cleanup-runner
+      - name: Install Rust
+        run: |
+          rustup update --no-self-update
+          rustc --version
       - name: Install cargo-shear
         uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
           tool: cargo-shear@1.11.2
+      - name: Install cargo-make
+        run: |
+          if ! cargo make --version 2>/dev/null; then
+            cargo install cargo-make --force
+          fi
       - name: Check for unused dependencies
-        run: cargo shear
+        run: cargo make unused
 
   unit_tests:
     name: midenc unit tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       releases_created: ${{ steps.publish.outputs.releases_created }}
     steps:
       - &checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -38,7 +38,7 @@ jobs:
           rustc --version
       - name: Publish
         id: publish
-        uses: release-plz/action@v0.5
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
         with:
           command: release
         env:
@@ -101,9 +101,8 @@ jobs:
         if: ${{ steps.midenc-release.outputs.release_tag != '' }}
         run: |
           set -e
-          ARGS="--release --target ${{ matrix.target }}"
-          cargo make --profile production midenc ${ARGS}
-          cargo make --profile production cargo-miden ${ARGS}
+          cargo make --profile production midenc --release --target "${{ matrix.target }}"
+          cargo make --profile production cargo-miden --release --target "${{ matrix.target }}"
       - name: prepare artifacts
         if: ${{ steps.midenc-release.outputs.release_tag != '' }}
         run: |
@@ -112,12 +111,12 @@ jobs:
           mv bin/cargo-miden cargo-miden-${{ matrix.target }}
       - name: attest midenc
         if: ${{ steps.midenc-release.outputs.release_tag != '' }}
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-path: midenc-${{ matrix.target }}
       - name: attest cargo-miden
         if: ${{ steps.midenc-release.outputs.release_tag != '' }}
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-path: cargo-miden-${{ matrix.target }}
       - name: upload
@@ -127,8 +126,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
-          gh release upload ${RELEASE_TAG} midenc-${{ matrix.target }}
-          gh release upload ${RELEASE_TAG} cargo-miden-${{ matrix.target }}
+          gh release upload "${RELEASE_TAG}" "midenc-${{ matrix.target }}"
+          gh release upload "${RELEASE_TAG}" "cargo-miden-${{ matrix.target }}"
 
   release:
     name: prepare the next release
@@ -152,14 +151,14 @@ jobs:
       - *install-rust
       - name: Create release PR
         id: release-pr
-        uses: release-plz/action@v0.5
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
         with:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Trigger CI for release PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release_old.yml
+++ b/.github/workflows/release_old.yml
@@ -23,9 +23,10 @@ jobs:
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
+          persist-credentials: false
       - uses: ./.github/actions/cleanup-runner
       - name: Install Rust
         run: |

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,39 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: [main, next]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - "zizmor.yml"
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - "zizmor.yml"
+  merge_group:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          advanced-security: false
+          config: zizmor.yml
+          version: 1.23.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,10 @@ cargo-miden = { version = "0.8.1", path = "tools/cargo-miden" }
 midenc-integration-test-support = { path = "tests/support" }
 midenc-expect-test = { path = "tools/expect-test" }
 miden-field = { version = "^0.25" }
+miden-base-sys = { version = "0.12.0", path = "sdk/base-sys" }
+miden-field-repr = { version = "0.12.0", path = "sdk/field-repr/repr" }
+miden-stdlib-sys = { version = "0.12.0", path = "sdk/stdlib-sys" }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
 [patch.crates-io]
 #miden-assembly = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ serde = { version = "1.0", default-features = false, features = [
     "alloc",
     "rc",
 ] }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 heck = "0.5"
 smallvec = { version = "1.15", default-features = false, features = [
     "union",
@@ -161,7 +162,6 @@ miden-field = { version = "^0.25" }
 miden-base-sys = { version = "0.12.0", path = "sdk/base-sys" }
 miden-field-repr = { version = "0.12.0", path = "sdk/field-repr/repr" }
 miden-stdlib-sys = { version = "0.12.0", path = "sdk/stdlib-sys" }
-serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
 [patch.crates-io]
 #miden-assembly = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }

--- a/hir-symbol/Cargo.toml
+++ b/hir-symbol/Cargo.toml
@@ -24,7 +24,7 @@ compact_str = ["dep:compact_str"]
 compact_str = { workspace = true, optional = true }
 lock_api = "0.4"
 miden-formatting.workspace = true
-parking_lot = { version = "0.12", optional = true }
+parking_lot = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
 [build-dependencies]

--- a/hir/Cargo.toml
+++ b/hir/Cargo.toml
@@ -46,7 +46,7 @@ thiserror.workspace = true
 # NOTE: Use local paths for dev-only dependency to avoid relying on crates.io during packaging
 midenc-expect-test = { path = "../tools/expect-test" }
 midenc-log = { path = "../midenc-log" }
-pretty_assertions = "1.0"
+pretty_assertions.workspace = true
 
 [package.metadata.cargo-shear]
 ignored-paths = [

--- a/sdk/base-macros/Cargo.toml
+++ b/sdk/base-macros/Cargo.toml
@@ -32,7 +32,7 @@ wit-bindgen-rust = { version = "0.57", default-features = false }
 # NOTE: Use local paths for dev-only dependency to avoid relying on crates.io during packaging
 miden-protocol = { workspace = true, features = ["std"] }
 miden-field.workspace = true
-miden-field-repr = { version = "0.12.0", path = "../field-repr/repr" }
+miden-field-repr.workspace = true
 
 [package.metadata.docs.rs]
 default-target = "x86_64-unknown-linux-gnu"

--- a/sdk/base-sys/Cargo.toml
+++ b/sdk/base-sys/Cargo.toml
@@ -19,8 +19,8 @@ links = "miden_base_sys_stubs"
 doctest = false
 
 [dependencies]
-miden-stdlib-sys = { version = "0.12.0", path = "../stdlib-sys" }
-miden-field-repr = { version = "0.12.0", path = "../field-repr/repr" }
+miden-stdlib-sys.workspace = true
+miden-field-repr.workspace = true
 
 [features]
 default = []

--- a/sdk/base/Cargo.toml
+++ b/sdk/base/Cargo.toml
@@ -16,8 +16,8 @@ test = false
 doctest = false
 
 [dependencies]
-miden-base-sys = { version = "0.12.0", path = "../base-sys" }
-miden-stdlib-sys = { version = "0.12.0", path = "../stdlib-sys" }
+miden-base-sys.workspace = true
+miden-stdlib-sys.workspace = true
 
 [features]
 default = []

--- a/sdk/field-repr/tests/Cargo.toml
+++ b/sdk/field-repr/tests/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 doctest = false
 
 [dependencies]
-miden-field-repr = { path = "../repr", version = "0.12.0" }
+miden-field-repr.workspace = true
 miden-core.workspace = true
 miden-field.workspace = true
 

--- a/sdk/sdk/Cargo.toml
+++ b/sdk/sdk/Cargo.toml
@@ -18,11 +18,11 @@ doctest = false
 
 [dependencies]
 miden-sdk-alloc = { version = "0.12.0", path = "../alloc" }
-miden-stdlib-sys = { version = "0.12.0", path = "../stdlib-sys" }
+miden-stdlib-sys.workspace = true
 miden-base = { version = "0.12.0", path = "../base" }
 miden-base-macros = { version = "0.12.0", path = "../base-macros" }
-miden-base-sys = { version = "0.12.0", path = "../base-sys" }
-miden-field-repr = { version = "0.12.0", path = "../field-repr/repr" }
+miden-base-sys.workspace = true
+miden-field-repr.workspace = true
 miden-field.workspace = true
 wit-bindgen = { version = "0.57", default-features = false, features = ["macros"] }
 

--- a/sdk/wasm-metadata/Cargo.toml
+++ b/sdk/wasm-metadata/Cargo.toml
@@ -18,4 +18,4 @@ doctest = false
 
 [dependencies]
 serde.workspace = true
-serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+serde_json.workspace = true

--- a/tools/cargo-miden/Cargo.toml
+++ b/tools/cargo-miden/Cargo.toml
@@ -34,7 +34,7 @@ anyhow.workspace = true
 cargo_metadata = "^0.23"
 path-absolutize = "^3.1"
 serde.workspace = true
-serde_json = "1.0"
+serde_json = { workspace = true, features = ["std"] }
 toml_edit = { version = "^0.25", features = ["serde"] }
 semver.workspace = true
 liquid = "0.26"

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  use-trusted-publishing:
+    ignore:
+      - release_old.yml
+  secrets-outside-env:
+    ignore:
+      - release.yml
+      - release_old.yml
+      - trigger-deploy-docs.yml


### PR DESCRIPTION
1. The dependency check now uses [`cargo-shear`](https://github.com/Boshen/cargo-shear), replacing `cargo-machete`. `cargo shear` found unused dependencies that were still present in
  this workspace, and it can also catch dependencies placed in the wrong section.
  2. [`zizmor`](https://github.com/zizmorcore/zizmor) scans GitHub Actions files for risky patterns, like loose action pins or unsafe defaults.
  3. The heavier CI jobs now run on larger [WarpBuild](https://www.warpbuild.com/) runners.
  4. The dependency policy check now also uses `cargo-workspace-inheritance-check`. It makes sure crates shared across the workspace use one workspace-level dependency entry instead of
  repeating versions in many crate manifests.

  The PR also removes the unused dependencies that `shear` found, pins action versions more tightly, and promotes shared dependencies to the workspace table.