### PR TITLE
fix: sign extend small ints for operand stack

### DIFF
--- a/tests/integration/src/end_to_end/arithmetic.rs
+++ b/tests/integration/src/end_to_end/arithmetic.rs
@@ -1,7 +1,7 @@
 use std::{any::type_name, marker::PhantomData};
 
 use miden_core::Felt;
-use miden_debug::{FromMidenRepr, ToMidenRepr};
+use miden_debug::{FromMidenRepr, ToMidenRepr, push_wasm_ty_to_operand_stack};
 use midenc_frontend_wasm::WasmTranslationConfig;
 use num_traits::{PrimInt, ToBytes, Unsigned};
 use proptest::{
@@ -162,8 +162,8 @@ macro_rules! test_func_two_arg {
                     .run(&(0..$a_ty::MAX/2, any::<$b_ty>()), move |(a, b)| {
                         let rust_out = $func(a, b);
                         let mut args = Vec::<midenc_hir::Felt>::default();
-                        a.push_to_operand_stack(&mut args);
-                        b.push_to_operand_stack(&mut args);
+                        push_wasm_ty_to_operand_stack(a, &mut args);
+                        push_wasm_ty_to_operand_stack(b, &mut args);
                         run_masm_vs_rust(rust_out, &package, &args, &test.session)
                     });
                 match res {
@@ -902,8 +902,8 @@ fn test_overflowing_arith<T>(
 
         let mut args = Vec::<midenc_hir::Felt>::default();
         out_addr.push_to_operand_stack(&mut args);
-        a.push_to_operand_stack(&mut args);
-        b.push_to_operand_stack(&mut args);
+        push_wasm_ty_to_operand_stack(a, &mut args);
+        push_wasm_ty_to_operand_stack(b, &mut args);
 
         eval_package::<Felt, _, _>(&package, None, &args, &test.session, |trace| {
             let ty_byte_size = std::mem::size_of::<T>();
@@ -961,8 +961,8 @@ where
         let out_addr = 20u32 * 65536;
         let mut args = Vec::<midenc_hir::Felt>::default();
         out_addr.push_to_operand_stack(&mut args);
-        a.push_to_operand_stack(&mut args);
-        b.push_to_operand_stack(&mut args);
+        push_wasm_ty_to_operand_stack(a, &mut args);
+        push_wasm_ty_to_operand_stack(b, &mut args);
 
         eval_package::<u32, _, _>(&package, None, &args, &test.session, |trace| {
             let ty_byte_size = std::mem::size_of::<T>();
@@ -1022,8 +1022,8 @@ fn test_checked_arith<T>(
 
         let mut args = Vec::<midenc_hir::Felt>::default();
         out_addr.push_to_operand_stack(&mut args);
-        a.push_to_operand_stack(&mut args);
-        b.push_to_operand_stack(&mut args);
+        push_wasm_ty_to_operand_stack(a, &mut args);
+        push_wasm_ty_to_operand_stack(b, &mut args);
 
         eval_package::<Felt, _, _>(&package, None, &args, &test.session, |trace| {
             let ty_byte_size = std::mem::size_of::<T>();

--- a/tests/integration/src/end_to_end/arithmetic.rs
+++ b/tests/integration/src/end_to_end/arithmetic.rs
@@ -308,13 +308,11 @@ fn overflowing_add_u128() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1091"]
 fn overflowing_add_i8() {
     test_overflowing_arith(i8::overflowing_add, "overflowing_add", NumericStrategy::full_range());
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1091"]
 fn overflowing_add_i16() {
     test_overflowing_arith(i16::overflowing_add, "overflowing_add", NumericStrategy::full_range());
 }
@@ -360,13 +358,11 @@ fn overflowing_sub_u128() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1091"]
 fn overflowing_sub_i8() {
     test_overflowing_arith(i8::overflowing_sub, "overflowing_sub", NumericStrategy::full_range());
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1091"]
 fn overflowing_sub_i16() {
     test_overflowing_arith(i16::overflowing_sub, "overflowing_sub", NumericStrategy::full_range());
 }
@@ -412,13 +408,11 @@ fn overflowing_mul_u128() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1091"]
 fn overflowing_mul_i8() {
     test_overflowing_arith(i8::overflowing_mul, "overflowing_mul", NumericStrategy::full_range());
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1091"]
 fn overflowing_mul_i16() {
     test_overflowing_arith(i16::overflowing_mul, "overflowing_mul", NumericStrategy::full_range());
 }
@@ -486,7 +480,6 @@ fn overflowing_div_u128() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/966"]
 fn overflowing_div_i8() {
     test_overflowing_arith(
         i8::overflowing_div,
@@ -496,7 +489,6 @@ fn overflowing_div_i8() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/966"]
 fn overflowing_div_i16() {
     test_overflowing_arith(
         i16::overflowing_div,
@@ -650,13 +642,11 @@ fn checked_add_u64() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1091"]
 fn checked_add_i8() {
     test_checked_arith(i8::checked_add, "checked_add", NumericStrategy::full_range());
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1091"]
 fn checked_add_i16() {
     test_checked_arith(i16::checked_add, "checked_add", NumericStrategy::full_range());
 }
@@ -692,13 +682,11 @@ fn checked_sub_u64() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1091"]
 fn checked_sub_i8() {
     test_checked_arith(i8::checked_sub, "checked_sub", NumericStrategy::full_range());
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1091"]
 fn checked_sub_i16() {
     test_checked_arith(i16::checked_sub, "checked_sub", NumericStrategy::full_range());
 }
@@ -734,13 +722,11 @@ fn checked_mul_u64() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1091"]
 fn checked_mul_i8() {
     test_checked_arith(i8::checked_mul, "checked_mul", NumericStrategy::full_range());
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1091"]
 fn checked_mul_i16() {
     test_checked_arith(i16::checked_mul, "checked_mul", NumericStrategy::full_range());
 }
@@ -779,13 +765,11 @@ fn checked_div_u64() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/966"]
 fn checked_div_i8() {
     test_checked_arith(i8::checked_div, "checked_div", NumericStrategy::full_range());
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/966"]
 fn checked_div_i16() {
     test_checked_arith(i16::checked_div, "checked_div", NumericStrategy::full_range());
 }
@@ -1233,13 +1217,11 @@ fn wrapping_shr_u128() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1110"]
 fn wrapping_shr_i8() {
     test_binary_fn(i8::wrapping_shr, "wrapping_shr", (any::<i8>(), any::<u32>()));
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1110"]
 fn wrapping_shr_i16() {
     test_binary_fn(i16::wrapping_shr, "wrapping_shr", (any::<i16>(), any::<u32>()));
 }


### PR DESCRIPTION
Closes #1091

For Masm compiled from Rust, small ints need to be sign-extended before they are pushed on the operand stack. This unlocks the small int arithmetics tests.

### History

- Started using `push_wasm_ty_to_operand_stack` in #992
- Seems like it got lost during the vm v0.21 migration
- Later on, more tests were added that should have used `push_wasm_ty_to_operand_stack` too