### PR TITLE
test: add regression test for production of invalid bitcast

### DIFF
--- a/examples/auth-component-no-auth/Cargo.lock
+++ b/examples/auth-component-no-auth/Cargo.lock
@@ -1039,7 +1039,6 @@ version = "0.12.0"
 dependencies = [
  "heck",
  "miden-formatting",
- "miden-mast-package",
  "miden-protocol",
  "midenc-frontend-wasm-metadata",
  "proc-macro2",

--- a/examples/auth-component-rpo-falcon512/Cargo.lock
+++ b/examples/auth-component-rpo-falcon512/Cargo.lock
@@ -1039,7 +1039,6 @@ version = "0.12.0"
 dependencies = [
  "heck",
  "miden-formatting",
- "miden-mast-package",
  "miden-protocol",
  "midenc-frontend-wasm-metadata",
  "proc-macro2",

--- a/examples/basic-wallet-tx-script/Cargo.lock
+++ b/examples/basic-wallet-tx-script/Cargo.lock
@@ -1039,7 +1039,6 @@ version = "0.12.0"
 dependencies = [
  "heck",
  "miden-formatting",
- "miden-mast-package",
  "miden-protocol",
  "midenc-frontend-wasm-metadata",
  "proc-macro2",

--- a/examples/basic-wallet/Cargo.lock
+++ b/examples/basic-wallet/Cargo.lock
@@ -1039,7 +1039,6 @@ version = "0.12.0"
 dependencies = [
  "heck",
  "miden-formatting",
- "miden-mast-package",
  "miden-protocol",
  "midenc-frontend-wasm-metadata",
  "proc-macro2",

--- a/examples/counter-contract/Cargo.lock
+++ b/examples/counter-contract/Cargo.lock
@@ -1039,7 +1039,6 @@ version = "0.12.0"
 dependencies = [
  "heck",
  "miden-formatting",
- "miden-mast-package",
  "miden-protocol",
  "midenc-frontend-wasm-metadata",
  "proc-macro2",

--- a/examples/counter-note/Cargo.lock
+++ b/examples/counter-note/Cargo.lock
@@ -1039,7 +1039,6 @@ version = "0.12.0"
 dependencies = [
  "heck",
  "miden-formatting",
- "miden-mast-package",
  "miden-protocol",
  "midenc-frontend-wasm-metadata",
  "proc-macro2",

--- a/examples/p2id-note/Cargo.lock
+++ b/examples/p2id-note/Cargo.lock
@@ -1032,7 +1032,6 @@ version = "0.12.0"
 dependencies = [
  "heck",
  "miden-formatting",
- "miden-mast-package",
  "miden-protocol",
  "midenc-frontend-wasm-metadata",
  "proc-macro2",

--- a/examples/p2ide-note/Cargo.lock
+++ b/examples/p2ide-note/Cargo.lock
@@ -1032,7 +1032,6 @@ version = "0.12.0"
 dependencies = [
  "heck",
  "miden-formatting",
- "miden-mast-package",
  "miden-protocol",
  "midenc-frontend-wasm-metadata",
  "proc-macro2",

--- a/examples/storage-example/Cargo.lock
+++ b/examples/storage-example/Cargo.lock
@@ -1032,7 +1032,6 @@ version = "0.12.0"
 dependencies = [
  "heck",
  "miden-formatting",
- "miden-mast-package",
  "miden-protocol",
  "midenc-frontend-wasm-metadata",
  "proc-macro2",

--- a/tests/lit/regression/width_changing_bitcast.wat
+++ b/tests/lit/regression/width_changing_bitcast.wat
@@ -1,0 +1,25 @@
+;; In this sequence, `i32.wrap_i64` produced an invalid bitcast from `i64` to `i32`.
+;;
+;; TODO stop producing the invalid bitcast + make this test assert valid ops are generated
+;;
+;; RUN: /bin/sh -c "TMPDIR=\$(mktemp -d) && midenc %s --entrypoint=width_changing_bitcast::wrap_i64 --emit=hir=\"\$TMPDIR\" --emit=masm=\"\$TMPDIR\" -o \"\$TMPDIR/width_changing_bitcast.masp\" && cat \"\$TMPDIR/root.hir\"" | filecheck %s
+
+;; CHECK-LABEL: builtin.function public {{.*}}@wrap_i64
+;; CHECK: [[C64:[%v][0-9]+]] = arith.constant 64 : i64;
+;; CHECK-NEXT: {{[%v][0-9]+}} = hir.bitcast [[C64]] <{ ty = #builtin.type<i32> }>;
+
+(module
+  (func $wrap_i64 (export "wrap_i64") (param i64 i64 i64) (result i32)
+    local.get 0
+    i64.clz
+    local.get 1
+    i64.clz
+    i64.const 64
+    i64.add
+    local.get 2
+    i64.const 0
+    i64.ne
+    select
+    i32.wrap_i64
+  )
+)


### PR DESCRIPTION
Adds a test to reproduce #1133 which can be run with

```
cargo make midenc
MIDENC_BIN_DIR="$PWD/bin" \
    litcheck lit run -v tests/lit/regression/width_changing_bitcast.wat
```

Could be added as-is and then updated once the issue was fixed. Or be merged only after the fix. Any preferences?