### PR TITLE
docs: fix grammar errors and typos in compiler documentation

### DIFF
--- a/docs/external/src/guides/develop_miden_in_rust.md
+++ b/docs/external/src/guides/develop_miden_in_rust.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 This chapter will walk through how to develop Miden programs in Rust using the standard library
 provided by the `miden-stdlib-sys` crate (see the
-[README](https://github.com/0xMiden/compiler/blob/main/sdk/stdlib-sys/README.md).
+[README](https://github.com/0xMiden/compiler/blob/main/sdk/stdlib-sys/README.md)).
 
 ## Getting started
 

--- a/docs/external/src/guides/rust_to_wasm.md
+++ b/docs/external/src/guides/rust_to_wasm.md
@@ -131,7 +131,7 @@ All that remains is to compile to WebAssembly:
     cargo build --release --target=wasm32-wasip1
 
 This places a `wasm_fib.wasm` file under the `target/wasm32-wasip1/release/` directory, which
-we can then examine with [wasm2wat](https://github.com/WebAssembly/wabt) to set the code we generated:
+we can then examine with [wasm2wat](https://github.com/WebAssembly/wabt) to see the code we generated:
 
     wasm2wat target/wasm32-wasip1/release/wasm_fib.wasm
 

--- a/docs/external/src/usage/cargo-miden.md
+++ b/docs/external/src/usage/cargo-miden.md
@@ -45,7 +45,7 @@ Your first step will be to create a new Rust project set up for compiling to Mid
 cargo miden new foo
 ```
 
-In this above example, this will create a new directory `foo`, containing a Cargo project for a
+In the above example, this will create a new directory `foo`, containing a Cargo project for a
 crate named `foo`, generated from our Miden project template.
 
 The template we use sets things up so that you can pretty much just build and run. Since the

--- a/docs/external/src/usage/midenc.md
+++ b/docs/external/src/usage/midenc.md
@@ -44,7 +44,7 @@ cargo install --path midenc --locked
 
 ## Usage
 
-Once installed, you should be able to invoke the compiler, you should see output similar to this:
+Once installed, you should be able to invoke the compiler and see output similar to this:
 
 ```bash
 midenc help compile


### PR DESCRIPTION
Fix grammar errors and typos across compiler documentation pages.

Changes:
- midenc.md: `"invoke the compiler, you should see"` → `"invoke the compiler and see"`
- cargo-miden.md: `"In this above example"` → `"In the above example"`
- rust_to_wasm.md: `"to set the code"` → `"to see the code"`
- develop_miden_in_rust.md: `"see the README."` → `"see the README)."`

**Test plan**
Documentation-only change; no code paths affected.