### PR TITLE
fix(frontend/wasm): make some `i64` unary instructions return `i64`

### DIFF
--- a/frontend/wasm/src/code_translator/expected/i64_clz.hir
+++ b/frontend/wasm/src/code_translator/expected/i64_clz.hir
@@ -1,7 +1,8 @@
 builtin.function public extern("C") @test_wrapper() {
     %0 = arith.constant 1 : i64;
     %1 = arith.clz %0;
-    %2 = hir.bitcast %1 <{ ty = #builtin.type<i32> }>;
+    %2 = arith.zext %1 <{ ty = #builtin.type<u64> }>;
+    %3 = hir.bitcast %2 <{ ty = #builtin.type<i64> }>;
     cf.br ^block5;
 ^block5:
     builtin.ret;

--- a/frontend/wasm/src/code_translator/expected/i64_ctz.hir
+++ b/frontend/wasm/src/code_translator/expected/i64_ctz.hir
@@ -1,7 +1,8 @@
 builtin.function public extern("C") @test_wrapper() {
     %0 = arith.constant 1 : i64;
     %1 = arith.ctz %0;
-    %2 = hir.bitcast %1 <{ ty = #builtin.type<i32> }>;
+    %2 = arith.zext %1 <{ ty = #builtin.type<u64> }>;
+    %3 = hir.bitcast %2 <{ ty = #builtin.type<i64> }>;
     cf.br ^block5;
 ^block5:
     builtin.ret;

--- a/frontend/wasm/src/code_translator/expected/i64_popcnt.hir
+++ b/frontend/wasm/src/code_translator/expected/i64_popcnt.hir
@@ -1,0 +1,9 @@
+builtin.function public extern("C") @test_wrapper() {
+    %0 = arith.constant 1 : i64;
+    %1 = arith.popcnt %0;
+    %2 = arith.zext %1 <{ ty = #builtin.type<u64> }>;
+    %3 = hir.bitcast %2 <{ ty = #builtin.type<i64> }>;
+    cf.br ^block5;
+^block5:
+    builtin.ret;
+};

--- a/frontend/wasm/src/code_translator/mod.rs
+++ b/frontend/wasm/src/code_translator/mod.rs
@@ -333,23 +333,44 @@ pub fn translate_operator<B: ?Sized + Builder>(
         Operator::I64Const { value } => state.push1(builder.i64(*value, span)),
 
         /******************************* Unary Operators *************************************/
-        Operator::I32Clz | Operator::I64Clz => {
+        Operator::I32Clz => {
             let val = state.pop1();
             let count = builder.clz(val, span)?;
             // To ensure we match the Wasm semantics, treat the output of clz as an i32
             state.push1(builder.bitcast(count, Type::I32, span)?);
         }
-        Operator::I32Ctz | Operator::I64Ctz => {
+        Operator::I64Clz => {
+            let val = state.pop1();
+            let count_u32 = builder.clz(val, span)?;
+            // To ensure we match the Wasm semantics, treat the output of clz as an i64
+            let count_u64 = builder.zext(count_u32, Type::U64, span)?;
+            state.push1(builder.bitcast(count_u64, Type::I64, span)?);
+        }
+        Operator::I32Ctz => {
             let val = state.pop1();
             let count = builder.ctz(val, span)?;
             // To ensure we match the Wasm semantics, treat the output of ctz as an i32
             state.push1(builder.bitcast(count, Type::I32, span)?);
         }
-        Operator::I32Popcnt | Operator::I64Popcnt => {
+        Operator::I64Ctz => {
+            let val = state.pop1();
+            let count_u32 = builder.ctz(val, span)?;
+            // To ensure we match the Wasm semantics, treat the output of ctz as an i64
+            let count_u64 = builder.zext(count_u32, Type::U64, span)?;
+            state.push1(builder.bitcast(count_u64, Type::I64, span)?);
+        }
+        Operator::I32Popcnt => {
             let val = state.pop1();
             let count = builder.popcnt(val, span)?;
             // To ensure we match the Wasm semantics, treat the output of popcnt as an i32
             state.push1(builder.bitcast(count, Type::I32, span)?);
+        }
+        Operator::I64Popcnt => {
+            let val = state.pop1();
+            let count_u32 = builder.popcnt(val, span)?;
+            // To ensure we match the Wasm semantics, treat the output of popcnt as an i64
+            let count_u64 = builder.zext(count_u32, Type::U64, span)?;
+            state.push1(builder.bitcast(count_u64, Type::I64, span)?);
         }
         Operator::I32Extend8S => {
             let val = state.pop1();

--- a/frontend/wasm/src/code_translator/tests.rs
+++ b/frontend/wasm/src/code_translator/tests.rs
@@ -331,6 +331,18 @@ fn i32_popcnt() {
 }
 
 #[test]
+fn i64_popcnt() {
+    check_op(
+        r#"
+            i64.const 1
+            i64.popcnt
+            drop
+        "#,
+        expect_file!["./expected/i64_popcnt.hir"],
+    )
+}
+
+#[test]
 fn i32_clz() {
     check_op(
         r#"

--- a/tests/integration/src/end_to_end/arithmetic.rs
+++ b/tests/integration/src/end_to_end/arithmetic.rs
@@ -470,7 +470,6 @@ fn overflowing_div_u64() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1121"]
 fn overflowing_div_u128() {
     test_overflowing_arith(
         u128::overflowing_div,
@@ -516,7 +515,6 @@ fn overflowing_div_i64() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1109"]
 fn overflowing_div_i128() {
     test_overflowing_arith(
         i128::overflowing_div,
@@ -562,7 +560,6 @@ fn overflowing_rem_u64() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1122"]
 fn overflowing_rem_u128() {
     test_overflowing_arith(
         u128::overflowing_rem,


### PR DESCRIPTION
Closes #1133
Closes #1121
Closes #1122
Allows unignoring some tests in `arithmetic.rs`

Change Wasm translation such that `i64.clz, i64.ctz, i64.popcnt` return `i64` instead of `i32`.

According to the [Wasm spec](https://webassembly.github.io/profiles/core/syntax/instructions.html#numeric-instructions) they return `i64` because:

> Unary Operations: consume one operand and produce one result of the respective type.

Also the [instruction overview](https://webassembly.github.io/profiles/core/appendix/index-instructions.html) lists them with `[i64] -> [i64]`.

Here's a [compiler explorer showcase](https://godbolt.org/z/1EGGPTjvr): Rust's `leading_zeros()` returns `u32`, so there's a `i32.wrap_i64` to convert `i64.clz` output.

### Performance impact

None in expect tests. Might be that none of the instructions is hit in tests that assert cycle counts. Which aligns with the bug being hidden so far. Recently added overflowing arith tests for 128 bit ints surfaced it.

For some programs the cycle count might slightly increase as now there's an extra `zext`.

### `arith` dialect return types

Currently `arith` ops `Clz, Ctz, Popcnt` all return `UInt32`. Could/should that be changed to `Or<UInt32, UInt64>`? Might avoid the `zext`.