### PR TITLE
fix: edge case handling in `i32::overflowing_mul` intrinsic

### DIFF
--- a/codegen/masm/intrinsics/i32.masm
+++ b/codegen/masm/intrinsics/i32.masm
@@ -174,14 +174,19 @@ pub proc overflowing_mul # [b, a]
         movup.2 cdrop                     # [-a or a, is_b_signed, b, negate_result]
         swap.2 dup.0 exec.unchecked_neg   # [-b, b, is_b_signed, -a or a, negate_result]
         movup.2 cdrop                     # [-b or b, -a or a, negate_result]
-        u32widening_mul swap.1         # [overflowed, result, negate_result]
+        u32widening_mul swap.1            # [hi, lo, negate_result]
 
-        # if the unsigned op overflowed, we definitely overflowed, but overflow
-        # also occurred if the supposedly unsigned result has its sign bit set,
-        # which could only happen if we overflowed the positive i32 range
-        dup.1 exec.is_signed or           # [overflowed, result, negate_result]
-        swap.1 dup.0 exec.unchecked_neg   # [-result, result, overflowed, negate_result]
-        movup.3 cdrop swap.1              # [overflowed, -result or result]
+        # Overflow occurs when the product of |a| and |b| exceeds the signed i32 range.
+        # Since the i32::MIN edge case is handled above, the maximum representable
+        # positive value is i32::MAX = 2^31 - 1. The u32widening_mul result [hi, lo]
+        # is unsigned, so even when hi == 0, if its sign bit is set (lo >= 2^31),
+        # the product has overflowed.
+        dup.1 exec.is_signed              # [is_signed(lo), hi, lo, negate_result]
+        dup.1 eq.0 not                    # [hi != 0, is_signed(lo), hi, lo, negate_result]
+        or                                # [overflowed, hi, lo, negate_result]
+        swap.1 drop                       # [overflowed, lo, negate_result]
+        swap.1 dup.0 exec.unchecked_neg   # [-lo, lo, overflowed, negate_result]
+        movup.3 cdrop swap.1              # [overflowed, -lo or lo]
     end
 end
 

--- a/codegen/masm/intrinsics/i32.masm
+++ b/codegen/masm/intrinsics/i32.masm
@@ -177,16 +177,21 @@ pub proc overflowing_mul # [b, a]
         u32widening_mul swap.1            # [hi, lo, negate_result]
 
         # Overflow occurs when the product of |a| and |b| exceeds the signed i32 range.
-        # Since the i32::MIN edge case is handled above, the maximum representable
-        # positive value is i32::MAX = 2^31 - 1. The u32widening_mul result [hi, lo]
-        # is unsigned, so even when hi == 0, if its sign bit is set (lo >= 2^31),
-        # the product has overflowed.
-        dup.1 exec.is_signed              # [is_signed(lo), hi, lo, negate_result]
-        dup.1 eq.0 not                    # [hi != 0, is_signed(lo), hi, lo, negate_result]
-        or                                # [overflowed, hi, lo, negate_result]
+        # A positive result may be at most i32::MAX = 2^31 - 1, while a negative result
+        # of 2^31 is valid because that equals i32::MIN.
+        dup.0 eq.0 not                    # [hi != 0, hi, lo, negate_result]
+        dup.2 exec.is_signed              # [lo >= 2^31, hi != 0, hi, lo, negate_result]
+        or                                # [magnitude > MAX, hi, lo, negate_result]
+        dup.2 push.MIN eq                 # [lo == MIN, magnitude > MAX, hi, lo, negate_result]
+        dup.4                             # [negate_result, lo == MIN, magnitude > MAX, hi, lo, negate_result]
+        and                               # [negate_result && lo == MIN, magnitude > MAX, hi, lo, negate_result]
+        dup.2 eq.0                        # [hi == 0, negate_result && lo == MIN, magnitude > MAX, hi, lo, negate_result]
+        and                               # [allowed_i32_MIN, magnitude > MAX, hi, lo, negate_result]
+        not                               # [!allowed_i32_MIN, magnitude > MAX, hi, lo, negate_result]
+        and                               # [overflowed, hi, lo, negate_result]
         swap.1 drop                       # [overflowed, lo, negate_result]
         swap.1 dup.0 exec.unchecked_neg   # [-lo, lo, overflowed, negate_result]
-        movup.3 cdrop swap.1              # [overflowed, -lo or lo]
+        movup.3 cdrop swap.1              # [overflowed, result]
     end
 end
 

--- a/tests/integration/src/end_to_end/arithmetic.rs
+++ b/tests/integration/src/end_to_end/arithmetic.rs
@@ -409,26 +409,51 @@ fn overflowing_mul_u128() {
 
 #[test]
 fn overflowing_mul_i8() {
+    test_overflowing_arith(
+        i8::overflowing_mul,
+        "overflowing_mul",
+        NumericStrategy::signed_mul_min(),
+    );
     test_overflowing_arith(i8::overflowing_mul, "overflowing_mul", NumericStrategy::full_range());
 }
 
 #[test]
 fn overflowing_mul_i16() {
+    test_overflowing_arith(
+        i16::overflowing_mul,
+        "overflowing_mul",
+        NumericStrategy::signed_mul_min(),
+    );
     test_overflowing_arith(i16::overflowing_mul, "overflowing_mul", NumericStrategy::full_range());
 }
 
 #[test]
 fn overflowing_mul_i32() {
+    test_overflowing_arith(
+        i32::overflowing_mul,
+        "overflowing_mul",
+        NumericStrategy::signed_mul_min(),
+    );
     test_overflowing_arith(i32::overflowing_mul, "overflowing_mul", NumericStrategy::full_range());
 }
 
 #[test]
 fn overflowing_mul_i64() {
+    test_overflowing_arith(
+        i64::overflowing_mul,
+        "overflowing_mul",
+        NumericStrategy::signed_mul_min(),
+    );
     test_overflowing_arith(i64::overflowing_mul, "overflowing_mul", NumericStrategy::full_range());
 }
 
 #[test]
 fn overflowing_mul_i128() {
+    test_overflowing_arith(
+        i128::overflowing_mul,
+        "overflowing_mul",
+        NumericStrategy::signed_mul_min(),
+    );
     test_overflowing_arith(i128::overflowing_mul, "overflowing_mul", NumericStrategy::full_range());
 }
 
@@ -719,22 +744,32 @@ fn checked_mul_u64() {
 
 #[test]
 fn checked_mul_i8() {
+    test_checked_arith(i8::checked_mul, "checked_mul", NumericStrategy::signed_mul_min());
     test_checked_arith(i8::checked_mul, "checked_mul", NumericStrategy::full_range());
 }
 
 #[test]
 fn checked_mul_i16() {
+    test_checked_arith(i16::checked_mul, "checked_mul", NumericStrategy::signed_mul_min());
     test_checked_arith(i16::checked_mul, "checked_mul", NumericStrategy::full_range());
 }
 
 #[test]
 fn checked_mul_i32() {
+    test_checked_arith(i32::checked_mul, "checked_mul", NumericStrategy::signed_mul_min());
     test_checked_arith(i32::checked_mul, "checked_mul", NumericStrategy::full_range());
 }
 
 #[test]
 fn checked_mul_i64() {
     test_checked_arith(i64::checked_mul, "checked_mul", NumericStrategy::full_range());
+}
+
+#[test]
+#[ignore = "https://github.com/0xMiden/compiler/issues/1144 include this check in \
+            `checked_mul_i64` once the issue is resolved"]
+fn checked_mul_i64_edge_cases() {
+    test_checked_arith(i64::checked_mul, "checked_mul", NumericStrategy::signed_mul_min());
 }
 
 // When dividing by zero, `checked_div` returns `None` and doesn't panic. Therefore the full
@@ -851,6 +886,26 @@ where
         T: num_traits::Signed,
     {
         (any::<T>(), prop_oneof![T::min_value()..=-T::one(), T::one()..=T::max_value(),])
+    }
+
+    /// Returns a strategy with tuples such that `a * b = T::min_value`.
+    ///
+    /// A product with that result can hit edge cases in compiler intrinsics. A strategy covering
+    /// the full range of `T` does not necessarily produce `a * b = T::min_value`.
+    ///
+    /// Whether the Rust code in a test hits a particular intrinsic depends on the compilation
+    /// pipeline. For example, at the time of writing, Rust's `i32::overflowing_mul` does *not*
+    /// lower to the `i32::overflowing_mul` intrinsic. Despite that, using this strategy has helped
+    /// to uncover issues.
+    fn signed_mul_min() -> impl Strategy<Value = (T, T)>
+    where
+        T: num_traits::Signed + 'static,
+    {
+        let two = T::one() + T::one();
+        let four = two + two;
+        let eight = four + four;
+        let min = T::min_value();
+        prop::sample::select(vec![(min / two, two), (min / four, four), (min / eight, eight)])
     }
 }
 

--- a/tests/integration/src/end_to_end/arithmetic.rs
+++ b/tests/integration/src/end_to_end/arithmetic.rs
@@ -428,7 +428,6 @@ fn overflowing_mul_i64() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1110"]
 fn overflowing_mul_i128() {
     test_overflowing_arith(i128::overflowing_mul, "overflowing_mul", NumericStrategy::full_range());
 }

--- a/tests/integration/src/end_to_end/differential/tests.rs
+++ b/tests/integration/src/end_to_end/differential/tests.rs
@@ -56,9 +56,6 @@ fn unreachable_guard() {
 }
 
 #[test]
-#[ignore = "fuzzer found a native/MASM divergence on wrapping_mul; e.g. inputs (530384503, \
-            3296201177) trigger an intrinsic panic in i32.masm — needs investigation before \
-            re-enabling"]
 fn muladd() {
     run_case("muladd", include_str!("cases/case_muladd.rs"));
 }


### PR DESCRIPTION
Closes #1093 and allows unignoring arithmetic test `overflowing_mul_i128`.

### `u32widening_mul` returns `[hi, lo]`

In the compiler intrinsic `i32::overflowing_mul` the result of `u32widening_mul` was misinterpreted:

```
[overflowed, result] // previously
[hi, lo]             // actually
```

Addressed in this PR by converting hi to overflowed.

### `a * b = i32::Min` is not overflow

Currently this is incorrectly interpreted as overflow because it overflows the positive `i32` range:

> [...] the supposedly unsigned result has its sign bit set, which could only happen if we overflowed the positive i32 range

Fixed by handling that edge case.

### Testing compiler intrinsics

Hitting a particular intrinsic in tests can be difficult, which made me think about a way to test intrinsics directly. See #1142.