### PR TITLE
chore: unignore differential test `unreachable_guard`

### DIFF
--- a/tests/integration/src/end_to_end/differential/tests.rs
+++ b/tests/integration/src/end_to_end/differential/tests.rs
@@ -49,8 +49,6 @@ fn sparse_match() {
 
 /// Exercises compile-time translation of an unreachable panic edge.
 #[test]
-#[ignore = "fuzzer found a native/MASM divergence — inputs (363814857, 995348134) trigger a MASM \
-            assertion (eqz) at cycle 67; needs investigation before re-enabling"]
 fn unreachable_guard() {
     run_case("unreachable_guard", include_str!("cases/case_unreachable_guard.rs"));
 }


### PR DESCRIPTION
Closes #1094 

After recent fixes the test passes.