### PR TITLE
feat: enabel load/store of `u128`; extend quadword mem test coverage

### DIFF
--- a/codegen/masm/src/emit/mem.rs
+++ b/codegen/masm/src/emit/mem.rs
@@ -159,7 +159,7 @@ impl OpEmitter<'_> {
                     ptr_ty.pointee()
                 );
                 match &ty {
-                    Type::I128 => self.load_quad_word(None, span),
+                    Type::I128 | Type::U128 => self.load_quad_word(None, span),
                     Type::I64 | Type::U64 => self.load_double_word_int(None, span),
                     Type::Felt => self.load_felt(None, span),
                     Type::I32 | Type::U32 | Type::Ptr(_) => self.load_word(None, span),
@@ -184,7 +184,7 @@ impl OpEmitter<'_> {
     pub fn load_imm(&mut self, addr: u32, ty: Type, span: SourceSpan) {
         let ptr = NativePtr::from_ptr(addr);
         match &ty {
-            Type::I128 => self.load_quad_word(Some(ptr), span),
+            Type::I128 | Type::U128 => self.load_quad_word(Some(ptr), span),
             Type::I64 | Type::U64 => self.load_double_word_int(Some(ptr), span),
             Type::Felt => self.load_felt(Some(ptr), span),
             Type::I32 | Type::U32 | Type::Ptr(_) => self.load_word(Some(ptr), span),
@@ -656,7 +656,7 @@ impl OpEmitter<'_> {
                     ptr_ty.pointee()
                 );
                 match value_ty {
-                    Type::I128 => self.store_quad_word(None, span),
+                    Type::I128 | Type::U128 => self.store_quad_word(None, span),
                     Type::I64 | Type::U64 => self.store_double_word_int(None, span),
                     Type::Felt => self.store_felt(None, span),
                     Type::I32 | Type::U32 | Type::Ptr(_) => self.store_word(None, span),
@@ -684,7 +684,7 @@ impl OpEmitter<'_> {
         assert!(!value_ty.is_zst(), "cannot store a zero-sized type in memory");
         let ptr = NativePtr::from_ptr(addr);
         match value_ty {
-            Type::I128 => self.store_quad_word(Some(ptr), span),
+            Type::I128 | Type::U128 => self.store_quad_word(Some(ptr), span),
             Type::I64 | Type::U64 => self.store_double_word_int(Some(ptr), span),
             Type::Felt => self.store_felt(Some(ptr), span),
             Type::I32 | Type::U32 | Type::Ptr(_) => self.store_word(Some(ptr), span),

--- a/tests/integration/src/codegen/memory/load_qw.rs
+++ b/tests/integration/src/codegen/memory/load_qw.rs
@@ -69,25 +69,30 @@ fn load_qw_with_offset_u128() {
 }
 
 /// Tests the memory load intrinsic for aligned loads of quad-word (i.e. 128-bit) values
-#[test]
-fn load_qw() {
+fn load_qw_impl<T>()
+where
+    T: QuadwordIO + Arbitrary + ToMidenRepr + 'static,
+{
     setup::enable_compiler_instrumentation();
 
     // Generate a `test` module with `main` function that invokes `load_qw` when lowered to MASM
     // Compile once outside the test loop
-    let (package, context) =
-        compile_test_module([Type::from(PointerType::new(Type::I128))], [Type::I128], |builder| {
+    let (package, context) = compile_test_module(
+        [Type::from(PointerType::new(T::hir_type()))],
+        [T::hir_type()],
+        |builder| {
             let block = builder.current_block();
             // Get the input pointer, and load the value at that address
             let ptr = block.borrow().arguments()[0] as ValueRef;
             let loaded = builder.load(ptr, SourceSpan::default()).unwrap();
             // Return the value so we can assert that the output of execution matches
             builder.ret(Some(loaded), SourceSpan::default()).unwrap();
-        });
+        },
+    );
 
     let config = proptest::test_runner::Config::with_cases(10);
     let res = TestRunner::new(config).run(
-        &(any::<i128>(), random_word_aligned_addr()),
+        &(any::<T>(), random_word_aligned_addr()),
         move |(value, write_to)| {
             // Felts must be written in little-endian order: lo at lower address.
             let value_felts = value.to_felts();
@@ -97,7 +102,7 @@ fn load_qw() {
             }];
 
             let args = [Felt::new(write_to as u64)];
-            let output = eval_package::<i128, _, _>(
+            let output = eval_package::<T, _, _>(
                 &package,
                 initializers,
                 &args,
@@ -124,19 +129,18 @@ fn load_qw() {
                     log::trace!(target: "executor", "e2 = {e2} ({e2:0x})");
                     log::trace!(target: "executor", "e3 = {e3} ({e3:0x})");
 
-                    let uvalue = value as u128;
+                    let uvalue = u128::from_le_bytes(value.to_le_bytes());
                     prop_assert_eq!(e0, uvalue as u64 & 0xffffffff);
                     prop_assert_eq!(e1, (uvalue >> 32) as u64 & 0xffffffff);
                     prop_assert_eq!(e2, (uvalue >> 64) as u64 & 0xffffffff);
                     prop_assert_eq!(e3, (uvalue >> 96) as u64 & 0xffffffff);
 
-                    let stored =
-                        trace.read_from_rust_memory::<i128>(write_to).ok_or_else(|| {
-                            TestCaseError::fail(format!(
-                                "expected {value} to have been written to byte address \
-                                 {write_to}, but read from that address failed"
-                            ))
-                        })?;
+                    let stored = trace.read_from_rust_memory::<T>(write_to).ok_or_else(|| {
+                        TestCaseError::fail(format!(
+                            "expected {value} to have been written to byte address {write_to}, \
+                             but read from that address failed"
+                        ))
+                    })?;
 
                     prop_assert_eq!(
                         stored,
@@ -152,7 +156,7 @@ fn load_qw() {
                 },
             )?;
 
-            prop_assert_eq!(output, value, "expected 0x{:x}; found 0x{:x}", value, output,);
+            prop_assert_eq!(output, value, "expected 0x{:x?}; found 0x{:x?}", value, output,);
 
             Ok(())
         },
@@ -165,4 +169,14 @@ fn load_qw() {
         Ok(_) => (),
         _ => panic!("Unexpected test result: {res:?}"),
     }
+}
+
+#[test]
+fn load_qw_i128() {
+    load_qw_impl::<i128>();
+}
+
+#[test]
+fn load_qw_u128() {
+    load_qw_impl::<u128>();
 }

--- a/tests/integration/src/codegen/memory/load_qw.rs
+++ b/tests/integration/src/codegen/memory/load_qw.rs
@@ -37,7 +37,7 @@ fn load_qw_with_offset_impl<T: QuadwordIO>() {
         }];
 
         let start = offs as usize;
-        let expected = T::from_le_bytes_arr(
+        let expected = T::from_le_bytes(
             initial_bytes[start..start + 16].try_into().expect("expected a 16-byte window"),
         );
 

--- a/tests/integration/src/codegen/memory/load_qw.rs
+++ b/tests/integration/src/codegen/memory/load_qw.rs
@@ -1,8 +1,7 @@
 use super::*;
 
 /// Tests the memory load intrinsic for aligned and unaligned loads of quad-word values
-#[test]
-fn load_qw_with_offset() {
+fn load_qw_with_offset_impl<T: QuadwordIO>() {
     setup::enable_compiler_instrumentation();
 
     // Use the start of the 17th page (1 page after the 16 pages reserved for the Rust stack).
@@ -11,14 +10,14 @@ fn load_qw_with_offset() {
     // Generate a `test` module with `main` function that invokes `load_qw` when lowered to MASM.
     // The parameter is the offset to be applied to the base address (`read_from`).
     // Compile once outside the test loop.
-    let (package, context) = compile_test_module([Type::U32], [Type::I128], |builder| {
+    let (package, context) = compile_test_module([Type::U32], [T::hir_type()], |builder| {
         let block = builder.current_block();
 
         let offs = block.borrow().arguments()[0] as ValueRef;
         let base_addr = builder.u32(read_from, SourceSpan::default());
         let read_addr = builder.add(base_addr, offs, SourceSpan::default()).unwrap();
         let ptr = builder
-            .inttoptr(read_addr, Type::from(PointerType::new(Type::I128)), SourceSpan::default())
+            .inttoptr(read_addr, Type::from(PointerType::new(T::hir_type())), SourceSpan::default())
             .unwrap();
         let loaded = builder.load(ptr, SourceSpan::default()).unwrap();
 
@@ -38,11 +37,11 @@ fn load_qw_with_offset() {
         }];
 
         let start = offs as usize;
-        let expected = i128::from_le_bytes(
+        let expected = T::from_le_bytes_arr(
             initial_bytes[start..start + 16].try_into().expect("expected a 16-byte window"),
         );
 
-        let output = eval_package::<i128, _, _>(
+        let output = eval_package::<T, _, _>(
             &package,
             initializers,
             &[Felt::new(offs as u64)],
@@ -57,6 +56,16 @@ fn load_qw_with_offset() {
     for offs in 0..=15 {
         run_test(offs);
     }
+}
+
+#[test]
+fn load_qw_with_offset_i128() {
+    load_qw_with_offset_impl::<i128>();
+}
+
+#[test]
+fn load_qw_with_offset_u128() {
+    load_qw_with_offset_impl::<u128>();
 }
 
 /// Tests the memory load intrinsic for aligned loads of quad-word (i.e. 128-bit) values

--- a/tests/integration/src/codegen/memory/mod.rs
+++ b/tests/integration/src/codegen/memory/mod.rs
@@ -4,7 +4,7 @@ use miden_debug::{FromMidenRepr, ToMidenRepr};
 use midenc_dialect_arith::ArithOpBuilder;
 use midenc_dialect_hir::HirOpBuilder;
 use midenc_hir::{
-    Builder, Felt, PointerType, SourceSpan, Type, ValueRef,
+    Builder, Felt, Immediate, PointerType, SourceSpan, Type, ValueRef,
     dialects::builtin::{BuiltinOpBuilder, attributes::Signature},
 };
 use proptest::{
@@ -23,7 +23,7 @@ mod load_u16;
 mod load_u64_unaligned;
 mod load_u8;
 mod regressions;
-mod store_u128_unaligned;
+mod store_qw;
 mod store_u16;
 mod store_u32_unaligned;
 mod store_u64_unaligned;
@@ -42,7 +42,9 @@ pub fn random_word_aligned_addr() -> impl Strategy<Value = u32> {
 /// Enables test helpers generic over 128 bit integer types.
 pub trait QuadwordIO: FromMidenRepr + PartialEq + Clone + std::fmt::Debug {
     fn hir_type() -> Type;
-    fn from_le_bytes_arr(bytes: [u8; 16]) -> Self;
+    fn from_le_bytes(bytes: [u8; 16]) -> Self;
+    fn to_le_bytes(&self) -> [u8; 16];
+    fn as_immediate(&self) -> Immediate;
 }
 
 impl QuadwordIO for i128 {
@@ -50,8 +52,16 @@ impl QuadwordIO for i128 {
         Type::I128
     }
 
-    fn from_le_bytes_arr(bytes: [u8; 16]) -> Self {
+    fn from_le_bytes(bytes: [u8; 16]) -> Self {
         i128::from_le_bytes(bytes)
+    }
+
+    fn to_le_bytes(&self) -> [u8; 16] {
+        i128::to_le_bytes(*self)
+    }
+
+    fn as_immediate(&self) -> Immediate {
+        Immediate::I128(*self)
     }
 }
 
@@ -60,7 +70,15 @@ impl QuadwordIO for u128 {
         Type::U128
     }
 
-    fn from_le_bytes_arr(bytes: [u8; 16]) -> Self {
+    fn from_le_bytes(bytes: [u8; 16]) -> Self {
         u128::from_le_bytes(bytes)
+    }
+
+    fn to_le_bytes(&self) -> [u8; 16] {
+        u128::to_le_bytes(*self)
+    }
+
+    fn as_immediate(&self) -> Immediate {
+        Immediate::U128(*self)
     }
 }

--- a/tests/integration/src/codegen/memory/mod.rs
+++ b/tests/integration/src/codegen/memory/mod.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use miden_debug::ToMidenRepr;
+use miden_debug::{FromMidenRepr, ToMidenRepr};
 use midenc_dialect_arith::ArithOpBuilder;
 use midenc_dialect_hir::HirOpBuilder;
 use midenc_hir::{
@@ -37,4 +37,30 @@ pub fn random_word_aligned_addr() -> impl Strategy<Value = u32> {
     // Page 17..256, word offset 0..1024 within that page
     (17u32..256, 0u32..1024)
         .prop_map(|(page, word)| ((page * u16::MAX as u32) + (word * 4)).next_multiple_of(16))
+}
+
+/// Enables test helpers generic over 128 bit integer types.
+pub trait QuadwordIO: FromMidenRepr + PartialEq + Clone + std::fmt::Debug {
+    fn hir_type() -> Type;
+    fn from_le_bytes_arr(bytes: [u8; 16]) -> Self;
+}
+
+impl QuadwordIO for i128 {
+    fn hir_type() -> Type {
+        Type::I128
+    }
+
+    fn from_le_bytes_arr(bytes: [u8; 16]) -> Self {
+        i128::from_le_bytes(bytes)
+    }
+}
+
+impl QuadwordIO for u128 {
+    fn hir_type() -> Type {
+        Type::U128
+    }
+
+    fn from_le_bytes_arr(bytes: [u8; 16]) -> Self {
+        u128::from_le_bytes(bytes)
+    }
 }

--- a/tests/integration/src/codegen/memory/mod.rs
+++ b/tests/integration/src/codegen/memory/mod.rs
@@ -8,7 +8,7 @@ use midenc_hir::{
     dialects::builtin::{BuiltinOpBuilder, attributes::Signature},
 };
 use proptest::{
-    prelude::{Strategy, any},
+    prelude::{Arbitrary, Strategy, any},
     prop_assert_eq,
     test_runner::{TestCaseError, TestError, TestRunner},
 };
@@ -40,7 +40,9 @@ pub fn random_word_aligned_addr() -> impl Strategy<Value = u32> {
 }
 
 /// Enables test helpers generic over 128 bit integer types.
-pub trait QuadwordIO: FromMidenRepr + PartialEq + Clone + std::fmt::Debug {
+pub trait QuadwordIO:
+    FromMidenRepr + PartialEq + Clone + Copy + std::fmt::Display + std::fmt::Debug
+{
     fn hir_type() -> Type;
     fn from_le_bytes(bytes: [u8; 16]) -> Self;
     fn to_le_bytes(&self) -> [u8; 16];

--- a/tests/integration/src/codegen/memory/store_qw.rs
+++ b/tests/integration/src/codegen/memory/store_qw.rs
@@ -1,12 +1,8 @@
-use midenc_hir::Immediate;
-
 use super::*;
 
-#[test]
-fn store_u128_unaligned() {
+fn store_qw_unaligned_impl<T: QuadwordIO>(write_val: T) {
     // Use the start of the 17th page (1 page after the 16 pages reserved for the Rust stack).
     let write_to = 17 * 2u32.pow(16);
-    let write_val = 0x00112233_44556677_8899aabb_ccddeeff_i128;
 
     // Signature of the test module:
     //
@@ -19,10 +15,14 @@ fn store_u128_unaligned() {
         let base_addr = builder.u32(write_to, SourceSpan::default());
         let write_addr = builder.add(base_addr, idx_val, SourceSpan::default()).unwrap();
         let ptr = builder
-            .inttoptr(write_addr, Type::from(PointerType::new(Type::I128)), SourceSpan::default())
+            .inttoptr(
+                write_addr,
+                Type::from(PointerType::new(T::hir_type())),
+                SourceSpan::default(),
+            )
             .unwrap();
 
-        let write_val = builder.imm(Immediate::I128(write_val), SourceSpan::default());
+        let write_val = builder.imm(T::as_immediate(&write_val), SourceSpan::default());
         builder.store(ptr, write_val, SourceSpan::default()).unwrap();
 
         let result = builder.u32(1, SourceSpan::default());
@@ -86,4 +86,14 @@ fn store_u128_unaligned() {
     for offs in 0..=3 {
         run_test(offs);
     }
+}
+
+#[test]
+fn store_qw_unaligned_i128() {
+    store_qw_unaligned_impl(0x00112233_44556677_8899aabb_ccddeeff_i128);
+}
+
+#[test]
+fn store_qw_unaligned_u128() {
+    store_qw_unaligned_impl(0x00112233_44556677_8899aabb_ccddeeff_u128);
 }

--- a/tests/integration/src/codegen/memory/store_qw.rs
+++ b/tests/integration/src/codegen/memory/store_qw.rs
@@ -30,12 +30,13 @@ fn store_qw_unaligned_impl<T: QuadwordIO>(write_val: T) {
     });
 
     let run_test = |offs: u32| {
-        // Write known 20 bytes (5xu32) at `addr` before running the module.
+        // Write known 32 bytes (8xu32) at `addr` before running the module.
         // Run the module with different offsets and afterwards verify storing 16 bytes inside the
         // module has modified memory as expected.
         let initial_bytes = [
             0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
-            0x0f, 0x10, 0x11, 0x12, 0x13, 0x14,
+            0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c,
+            0x1d, 0x1e, 0x1f, 0x20,
         ];
         let initializers = [Initializer::MemoryBytes {
             addr: write_to,
@@ -51,6 +52,9 @@ fn store_qw_unaligned_impl<T: QuadwordIO>(write_val: T) {
             u32::from_le_bytes(expected_bytes[8..12].try_into().unwrap()),
             u32::from_le_bytes(expected_bytes[12..16].try_into().unwrap()),
             u32::from_le_bytes(expected_bytes[16..20].try_into().unwrap()),
+            u32::from_le_bytes(expected_bytes[20..24].try_into().unwrap()),
+            u32::from_le_bytes(expected_bytes[24..28].try_into().unwrap()),
+            u32::from_le_bytes(expected_bytes[28..32].try_into().unwrap()),
         ];
 
         let output = eval_package::<u32, _, _>(
@@ -65,6 +69,9 @@ fn store_qw_unaligned_impl<T: QuadwordIO>(write_val: T) {
                     trace.read_from_rust_memory::<u32>(write_to + 8).unwrap(),
                     trace.read_from_rust_memory::<u32>(write_to + 12).unwrap(),
                     trace.read_from_rust_memory::<u32>(write_to + 16).unwrap(),
+                    trace.read_from_rust_memory::<u32>(write_to + 20).unwrap(),
+                    trace.read_from_rust_memory::<u32>(write_to + 24).unwrap(),
+                    trace.read_from_rust_memory::<u32>(write_to + 28).unwrap(),
                 ];
 
                 for (index, (actual, expected)) in actual.iter().zip(expected.iter()).enumerate() {
@@ -83,7 +90,7 @@ fn store_qw_unaligned_impl<T: QuadwordIO>(write_val: T) {
         assert_eq!(output, 1);
     };
 
-    for offs in 0..=3 {
+    for offs in 0..=15 {
         run_test(offs);
     }
 }


### PR DESCRIPTION
Closes #1137

- Enables `load` and `store` for `Type::U128`
- Adds `QuadwordIO` trait to make test helpers generic (`u128`, `128`)
- Extends `quadword` load/store test coverage. See commit messages for details.

Can be reviewed per commit.