### PR TITLE
feat(hir): implement dialect conversion infrastructure

### DIFF
--- a/codegen/masm/src/legalization.rs
+++ b/codegen/masm/src/legalization.rs
@@ -1,0 +1,210 @@
+use alloc::rc::Rc;
+
+use midenc_dialect_arith as arith;
+use midenc_dialect_cf as cf;
+use midenc_dialect_hir as hir;
+use midenc_dialect_scf as scf;
+use midenc_dialect_ub as ub;
+use midenc_dialect_wasm as wasm;
+use midenc_hir::{
+    Context, EntityMut, Operation, OperationName, Report,
+    conversion::{
+        ConversionConfig, ConversionPatternSet, ConversionTarget, DynamicLegalityResult,
+        apply_full_conversion,
+    },
+    dialects::{builtin, debuginfo},
+    pass::{Pass, PassExecutionState, PostPassStatus},
+};
+
+use crate::HirLowering;
+
+midenc_hir::inventory::submit!(::midenc_hir::pass::registry::PassInfo::new::<LegalizeForMasm>(
+    LegalizeForMasm::ARGUMENT,
+    "legalize HIR for MASM codegen"
+));
+
+/// A dialect conversion pass that validates IR against the set of operations MASM codegen can
+/// lower.
+///
+/// This pass is intentionally owned by `midenc-codegen-masm`: it builds the MASM-specific
+/// legalization target, runs full dialect conversion, and fails before `ToMasmComponent` can
+/// encounter unsupported operations.
+#[derive(Default)]
+pub struct LegalizeForMasm;
+
+impl LegalizeForMasm {
+    /// Command-line/pass-pipeline argument for this pass.
+    pub const ARGUMENT: &'static str = "legalize-for-masm";
+}
+
+impl Pass for LegalizeForMasm {
+    type Target = Operation;
+
+    fn name(&self) -> &'static str {
+        "legalize-for-masm"
+    }
+
+    fn argument(&self) -> &'static str {
+        Self::ARGUMENT
+    }
+
+    fn description(&self) -> &'static str {
+        "Legalizes HIR to the set of operations supported by MASM codegen"
+    }
+
+    fn can_schedule_on(&self, _name: &OperationName) -> bool {
+        true
+    }
+
+    fn initialize(&mut self, context: Rc<Context>) -> Result<(), Report> {
+        register_masm_legalization_dialects(&context);
+        Ok(())
+    }
+
+    fn run_on_operation(
+        &mut self,
+        op: EntityMut<'_, Self::Target>,
+        state: &mut PassExecutionState,
+    ) -> Result<(), Report> {
+        let root = op.as_operation_ref();
+        let context = op.context_rc();
+        drop(op);
+
+        let target = masm_legalization_target(context.clone());
+        let patterns = ConversionPatternSet::new(context);
+        let result = apply_full_conversion(root, target, patterns, ConversionConfig::default())?;
+
+        let changed = PostPassStatus::from(result.changed());
+        state.set_post_pass_status(changed);
+        if !changed.ir_changed() {
+            state.preserved_analyses_mut().preserve_all();
+        }
+
+        Ok(())
+    }
+}
+
+/// Build a conversion target that represents the final IR accepted by MASM codegen.
+///
+/// Structural builtin operations such as modules and functions are legal containers, but their
+/// nested operations are still checked. Leaf operations in explicitly supported dialects are legal
+/// only when they implement `HirLowering`. `builtin.unrealized_conversion_cast` is always illegal
+/// as a final operation.
+pub fn masm_legalization_target(context: Rc<Context>) -> ConversionTarget {
+    register_masm_legalization_dialects(&context);
+    let mut target = ConversionTarget::new(context);
+    populate_masm_legalization_target(&mut target);
+    target
+}
+
+/// Populate `target` with MASM codegen legality rules.
+///
+/// This helper is exposed so tests and future codegen passes can extend the MASM target while
+/// keeping the base policy centralized in this crate.
+pub fn populate_masm_legalization_target(target: &mut ConversionTarget) {
+    target
+        .add_legal_op::<builtin::World>()
+        .add_legal_op::<builtin::Component>()
+        .add_legal_op::<builtin::Module>()
+        .add_legal_op::<builtin::Interface>()
+        .add_legal_op::<builtin::Function>()
+        .add_legal_op::<builtin::GlobalVariable>()
+        .add_legal_op::<builtin::Segment>()
+        .add_dynamically_legal_op::<builtin::UnrealizedConversionCast, _>(|op| {
+            DynamicLegalityResult::illegal_with_reason(Report::msg(format!(
+                "operation '{}' is temporary dialect-conversion scaffolding and must be \
+                 reconciled or lowered to a real cast before MASM codegen",
+                op.name()
+            )))
+        })
+        .add_dynamically_legal_dialect::<builtin::BuiltinDialect, _>(masm_lowerable_op)
+        .add_dynamically_legal_dialect::<arith::ArithDialect, _>(masm_lowerable_op)
+        .add_dynamically_legal_dialect::<cf::ControlFlowDialect, _>(masm_lowerable_op)
+        .add_dynamically_legal_dialect::<scf::ScfDialect, _>(masm_lowerable_op)
+        .add_dynamically_legal_dialect::<ub::UndefinedBehaviorDialect, _>(masm_lowerable_op)
+        .add_dynamically_legal_dialect::<hir::HirDialect, _>(masm_lowerable_op)
+        .add_dynamically_legal_dialect::<wasm::WasmDialect, _>(masm_lowerable_op)
+        .add_dynamically_legal_dialect::<debuginfo::DebugInfoDialect, _>(masm_lowerable_op);
+}
+
+fn register_masm_legalization_dialects(context: &Rc<Context>) {
+    context.get_or_register_dialect::<builtin::BuiltinDialect>();
+    context.get_or_register_dialect::<arith::ArithDialect>();
+    context.get_or_register_dialect::<cf::ControlFlowDialect>();
+    context.get_or_register_dialect::<scf::ScfDialect>();
+    context.get_or_register_dialect::<ub::UndefinedBehaviorDialect>();
+    context.get_or_register_dialect::<hir::HirDialect>();
+    context.get_or_register_dialect::<wasm::WasmDialect>();
+    context.get_or_register_dialect::<debuginfo::DebugInfoDialect>();
+}
+
+fn masm_lowerable_op(op: &Operation) -> DynamicLegalityResult {
+    if op.implements::<dyn HirLowering>() {
+        DynamicLegalityResult::legal()
+    } else {
+        DynamicLegalityResult::illegal_with_reason(Report::msg(format!(
+            "operation '{}' is in a MASM-supported dialect but does not implement HirLowering",
+            op.name()
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::format;
+
+    use midenc_dialect_arith::ArithOpBuilder;
+    use midenc_dialect_hir::HirOpBuilder;
+    use midenc_hir::{SourceSpan, Type, dialects::builtin::BuiltinOpBuilder, testing::Test};
+
+    use super::*;
+
+    #[test]
+    fn masm_supported_ops_pass_legalization() {
+        let mut test = Test::new("masm_supported_ops_pass_legalization", &[], &[Type::U32]);
+        {
+            let mut builder = test.function_builder();
+            let value = builder.u32(7, SourceSpan::UNKNOWN);
+            builder.ret([value], SourceSpan::UNKNOWN).unwrap();
+        }
+
+        test.apply_pass::<LegalizeForMasm>(true).unwrap();
+    }
+
+    #[test]
+    fn unsupported_hir_ops_fail_legalization() {
+        let mut test = Test::new("unsupported_hir_ops_fail_legalization", &[], &[]);
+        {
+            let mut builder = test.function_builder();
+            let _bytes = builder.bytes(&[1, 2, 3, 4], SourceSpan::UNKNOWN).unwrap();
+            builder.ret(None, SourceSpan::UNKNOWN).unwrap();
+        }
+
+        let err = test.apply_pass::<LegalizeForMasm>(false).unwrap_err();
+        let message = format!("{err}");
+        assert!(message.contains("hir.bytes"));
+        assert!(message.contains("does not implement HirLowering"));
+    }
+
+    #[test]
+    fn unreconciled_unrealized_conversion_casts_fail_legalization() {
+        let mut test = Test::new(
+            "unreconciled_unrealized_conversion_casts_fail_legalization",
+            &[Type::U32],
+            &[Type::I32],
+        );
+        {
+            let mut builder = test.function_builder();
+            let entry = builder.entry_block();
+            let arg = entry.borrow().arguments()[0].borrow().as_value_ref();
+            let cast =
+                builder.unrealized_conversion_cast(arg, Type::I32, SourceSpan::UNKNOWN).unwrap();
+            builder.ret([cast], SourceSpan::UNKNOWN).unwrap();
+        }
+
+        let err = test.apply_pass::<LegalizeForMasm>(false).unwrap_err();
+        let message = format!("{err}");
+        assert!(message.contains("builtin.unrealized_conversion_cast"));
+        assert!(message.contains("temporary dialect-conversion scaffolding"));
+    }
+}

--- a/codegen/masm/src/lib.rs
+++ b/codegen/masm/src/lib.rs
@@ -10,6 +10,7 @@ mod emit;
 mod emitter;
 mod events;
 pub mod intrinsics;
+mod legalization;
 mod linker;
 mod lower;
 mod opt;
@@ -40,6 +41,7 @@ pub(crate) use self::lower::HirLowering;
 pub use self::{
     artifact::{MasmComponent, Rodata},
     events::{TRACE_FRAME_END, TRACE_FRAME_START, TRACE_PRINT_LN, TraceEvent},
+    legalization::{LegalizeForMasm, masm_legalization_target, populate_masm_legalization_target},
     lower::{NativePtr, ToMasmComponent},
     stack::{Constraint, Operand, OperandStack},
 };

--- a/dialects/hir/src/ops/invoke.rs
+++ b/dialects/hir/src/ops/invoke.rs
@@ -420,6 +420,10 @@ impl CallOpInterface for Syscall {
 mod tests {
     use midenc_hir::{
         CallOpInterface, SourceSpan, Symbol, SymbolTable, Type, Usable,
+        conversion::{
+            TypeConversion, TypeConverter, converted_resolved_call_signature_1_to_1,
+            verify_call_signature_operands_and_results,
+        },
         diagnostics::Uri,
         dialects::builtin::{BuiltinOpBuilder, attributes::Signature},
         parse::{self, ParserConfig},
@@ -450,6 +454,40 @@ builtin.module public @test {
             source,
         )
         .expect("hir.exec parser should type operands from signature params");
+    }
+
+    #[test]
+    fn conversion_helpers_resolve_and_convert_call_signatures() {
+        let mut test =
+            Test::named("conversion_helpers_resolve_and_convert_call_signatures").in_module("test");
+        let callee = test.define_function("callee", &[Type::U32], &[Type::U32]);
+        test.with_function("caller", &[Type::U32], &[]);
+
+        let signature = Signature::new(&test.context_rc(), [Type::U32], [Type::U32]);
+        let call = {
+            let mut builder = test.function_builder();
+            let entry = builder.entry_block();
+            let arg = entry.borrow().arguments()[0].borrow().as_value_ref();
+            builder.call(callee, signature, [arg], SourceSpan::default()).unwrap()
+        };
+
+        verify_call_signature_operands_and_results(call.as_operation_ref()).unwrap();
+
+        let mut converter = TypeConverter::new();
+        converter.add_conversion(|ty| {
+            if ty == &Type::U32 {
+                Some(TypeConversion::One(Type::I32))
+            } else {
+                None
+            }
+        });
+        let converted =
+            converted_resolved_call_signature_1_to_1(call.as_operation_ref(), &converter)
+                .unwrap()
+                .expect("call should resolve to a callable signature");
+
+        assert_eq!(converted.params()[0].ty, Type::I32);
+        assert_eq!(converted.results()[0].ty, Type::I32);
     }
 
     #[test]

--- a/docs/internal/src/dialect_conversion.md
+++ b/docs/internal/src/dialect_conversion.md
@@ -1,0 +1,1043 @@
+# Dialect Conversion
+
+Status: proposed
+
+This document specifies a dialect conversion framework for HIR. The design is
+inspired by MLIR's dialect conversion framework, but is shaped around HIR's Rust
+implementation: typed operation structs, runtime operation trait metadata,
+arena-backed intrusive IR entities, the existing `Rewriter` API, and the pass
+manager.
+
+The immediate use case is making code generation stricter and more extensible:
+frontends and higher-level compiler components should be free to introduce new
+dialects, while code generation should require the IR to be legalized to a known
+target set before lowering to Miden Assembly.
+
+## Goals
+
+- Define a target legality model that can mark whole dialects, individual
+  operations, dynamically legal subsets of operations, and interface-based sets
+  of operations as legal.
+- Support explicit illegal dialects and operations, so high-level dialects can
+  be rejected unless conversion patterns legalize them.
+- Support transitive legalization. If a pattern legalizes `A` to `B`, and
+  another pattern legalizes `B` to `C`, then a target that accepts `C` can
+  legalize `A` without an `A` to `C` pattern.
+- Express op conversion as rewrite patterns that use the same mental model as
+  existing HIR patterns, but with conversion-specific support for remapped
+  operands, type conversion, and legalization diagnostics.
+- Preserve HIR invariants during conversion: SSA dominance, type-correct
+  operands and results, valid block successor operands, symbol table integrity,
+  and verifier success after the pass.
+- Integrate with MASM lowering so unsupported high-level operations fail before
+  codegen, with clear diagnostics.
+
+## Non-Goals
+
+- Do not implement MLIR's rollback mode. Conversion patterns must do all
+  fallible matching before mutation. If mutation starts and later conversion
+  fails, the pass reports a compiler error instead of restoring old IR.
+- Do not require dialect authors to use a TableGen-like declaration language.
+  Registration should use normal Rust traits, derive macros, and inventory-style
+  providers consistent with the rest of HIR.
+- Do not replace canonicalization. Canonicalization remains best-effort
+  simplification. Dialect conversion is target-driven legalization.
+- Do not make MASM lowering itself responsible for discovering conversion paths.
+  MASM lowering should receive already-legal IR.
+
+## Background
+
+MLIR dialect conversion is built around four separable pieces:
+
+- A conversion target that defines legal, dynamically legal, illegal, and
+  unknown operations.
+- Rewrite patterns that legalize illegal operations.
+- An operation legalization graph derived from pattern root operations and
+  generated operations.
+- An optional type converter that maps source types to target types and inserts
+  materializations when converted and unconverted IR must interact.
+
+HIR already has much of the underlying machinery:
+
+- Dialects expose registered operations through `DialectInfo`.
+- Operations carry an `OperationName` with dialect, opcode, properties, and
+  runtime trait metadata.
+- Dialect registration hooks can late-bind traits to operations, as MASM
+  lowering already does for `dyn HirLowering`.
+- Rewrite patterns already have roots, benefits, bounded recursion flags, and
+  generated-op metadata.
+- `Rewriter` already supports operation replacement, erasure, moving blocks and
+  operations, and use replacement.
+- `builtin.unrealized_conversion_cast` already exists and is a natural
+  materialization operation for temporary type bridges.
+
+The proposed framework extends those mechanisms instead of introducing a
+parallel IR transformation system.
+
+## Crate Layout
+
+Core conversion APIs should live in `midenc-hir`:
+
+```text
+hir/src/conversion.rs
+hir/src/conversion/target.rs
+hir/src/conversion/pattern.rs
+hir/src/conversion/pattern_set.rs
+hir/src/conversion/rewriter.rs
+hir/src/conversion/type_converter.rs
+hir/src/conversion/driver.rs
+hir/src/conversion/diagnostics.rs
+```
+
+Reusable pass adapters or test-only plumbing may live in `midenc-hir-transform`,
+beside canonicalization and other reusable transforms:
+
+```text
+hir-transform/src/dialect_conversion.rs
+```
+
+Concrete target conversion passes should live with their target:
+
+```text
+codegen/masm/src/legalization.rs
+```
+
+This keeps the reusable mechanics in HIR and keeps target ownership with the
+backend that knows the legal dialect subset. The production MASM pass should be
+defined in `midenc-codegen-masm`, because it depends on MASM-specific policy and
+on `dyn HirLowering`, which is backend-owned lowering metadata.
+
+## Conversion Target
+
+`ConversionTarget` defines whether an operation instance is acceptable for a
+given conversion.
+
+```rust,ignore
+pub struct ConversionTarget {
+    context: Rc<Context>,
+    unknown_op_policy: UnknownOpPolicy,
+    dialect_actions: FxHashMap<Symbol, LegalityRule>,
+    op_actions: BTreeMap<OperationName, LegalityRule>,
+    interface_actions: Vec<InterfaceLegalityRule>,
+    recursive_legality: BTreeMap<OperationName, RecursiveLegalityRule>,
+}
+
+pub enum Legality {
+    Legal,
+    Illegal,
+    Unknown,
+    DynamicLegal,
+    DynamicIllegal,
+}
+
+pub enum StaticLegality {
+    Legal,
+    Illegal,
+    Unknown,
+    Dynamic,
+}
+
+pub enum UnknownOpPolicy {
+    Legal,
+    Illegal,
+    Dynamic(Rc<dyn Fn(&Operation) -> DynamicLegalityResult>),
+}
+
+pub enum DynamicLegalityResult {
+    Legal,
+    Illegal { reason: Option<Report> },
+}
+```
+
+`LegalityRule` stores the static action and, for dynamic legality, a callback:
+
+```rust,ignore
+pub enum LegalityRule {
+    Legal,
+    Illegal,
+    Dynamic(Rc<dyn Fn(&Operation) -> DynamicLegalityResult>),
+}
+```
+
+The target API should include:
+
+```rust,ignore
+impl ConversionTarget {
+    pub fn new(context: Rc<Context>) -> Self;
+
+    pub fn set_unknown_op_policy(&mut self, policy: UnknownOpPolicy) -> &mut Self;
+
+    pub fn add_legal_dialect<D: DialectRegistration>(&mut self) -> &mut Self;
+    pub fn add_illegal_dialect<D: DialectRegistration>(&mut self) -> &mut Self;
+    pub fn add_dynamically_legal_dialect<D, F>(&mut self, callback: F) -> &mut Self
+    where
+        D: DialectRegistration,
+        F: Fn(&Operation) -> DynamicLegalityResult + 'static;
+    pub fn add_dynamically_legal_dialect_if_op_interface<D, Trait>(&mut self) -> &mut Self
+    where
+        D: DialectRegistration,
+        Trait: ?Sized + Pointee<Metadata = DynMetadata<Trait>> + 'static;
+
+    pub fn add_legal_op<Op: OpRegistration>(&mut self) -> &mut Self;
+    pub fn add_illegal_op<Op: OpRegistration>(&mut self) -> &mut Self;
+    pub fn add_dynamically_legal_op<Op, F>(&mut self, callback: F) -> &mut Self
+    where
+        Op: OpRegistration,
+        F: Fn(&Operation) -> DynamicLegalityResult + 'static;
+
+    pub fn add_legal_op_interface<Trait>(&mut self) -> &mut Self
+    where
+        Trait: ?Sized + Pointee<Metadata = DynMetadata<Trait>> + 'static;
+    pub fn add_dynamically_legal_op_interface<Trait, F>(&mut self, callback: F) -> &mut Self
+    where
+        Trait: ?Sized + Pointee<Metadata = DynMetadata<Trait>> + 'static,
+        F: Fn(&Operation) -> DynamicLegalityResult + 'static;
+
+    pub fn mark_op_recursively_legal<Op: OpRegistration>(&mut self) -> &mut Self;
+    pub fn mark_op_recursively_legal_if<Op, F>(&mut self, callback: F) -> &mut Self
+    where
+        Op: OpRegistration,
+        F: Fn(&Operation) -> DynamicLegalityResult + 'static;
+
+    pub fn legality(&self, op: &Operation) -> Legality;
+    pub fn is_legal(&self, op: &Operation) -> bool;
+    pub fn is_recursively_legal(&self, op: &Operation) -> bool;
+}
+```
+
+Legality precedence:
+
+1. Operation-specific rules.
+2. Dialect-specific rules.
+3. Interface rules.
+4. Unknown operation policy.
+
+Operation-specific rules override dialect rules. Dialect rules override broad
+interface rules. An explicit illegal operation inside an otherwise legal dialect
+must still be converted, and an explicit illegal dialect must not be bypassed by
+a broad interface rule.
+
+Targets that support only part of a dialect should express that as dynamic
+legality on the dialect or operation, using operation metadata as needed. For
+example, a MASM target can mark a dialect dynamically legal only for operations
+whose metadata says they implement `dyn HirLowering`, plus any target-specific
+type or shape restrictions. Broad `add_legal_op_interface::<dyn HirLowering>()`
+is useful for tests and exploratory targets, but final codegen targets should
+prefer explicit dialect/op policy so they do not accidentally accept an excluded
+dialect.
+
+Dynamic legality is checked on operation instances, not just names. This allows
+rules such as:
+
+- `arith.add` is legal only for MASM-supported integer widths.
+- A dialect is legal only for operations that implement `dyn HirLowering`.
+- `cf.cond_br` is legal only in the limited form still accepted by MASM
+  lowering.
+
+### Recursive Legality
+
+If an operation is recursively legal, all nested operations are considered legal
+for the purposes of the current conversion. This is useful for operations that
+encapsulate a region with separate semantics, or for staged conversion when the
+parent operation owns later lowering.
+
+Recursive legality is only valid if the operation itself is legal or dynamically
+legal for the target. The driver should assert this at target construction time
+when possible, and diagnose it during conversion otherwise.
+
+## Conversion Modes
+
+The framework should support three modes, though MASM should use full
+conversion.
+
+```rust,ignore
+pub enum ConversionMode {
+    Full,
+    Partial,
+    Analysis,
+}
+```
+
+Full conversion succeeds only if every operation under the selected roots is
+legal after conversion. Unknown operations are legal only if the target says so.
+
+Partial conversion legalizes every operation explicitly marked illegal and every
+operation that has an available legalizing path, but can leave unknown
+operations in place if they are not explicitly illegal. This is useful for
+incremental compiler development and optional dialect lowering.
+
+Analysis conversion computes what would be legalizable without mutating IR. It
+should report the set of illegal, legal, and legalizable operations. This is a
+debugging and planning aid; it is not required by MASM lowering.
+
+## Conversion Patterns
+
+Conversion patterns are rewrite patterns with target-aware semantics.
+
+```rust,ignore
+pub trait ConversionPattern: Pattern {
+    fn type_converter(&self) -> Option<&TypeConverter> {
+        None
+    }
+
+    fn match_and_rewrite(
+        &self,
+        op: OperationRef,
+        operands: ConvertedOperands<'_>,
+        rewriter: &mut ConversionPatternRewriter,
+    ) -> Result<bool, Report>;
+}
+```
+
+`ConvertedOperands` contains the current replacement values for each original
+operand. When a pattern has a type converter, these operands have already been
+converted or materialized to the types requested by that converter.
+
+```rust,ignore
+pub struct ConvertedOperands<'a> {
+    groups: &'a [SmallVec<[ValueRef; 2]>],
+}
+```
+
+Most typed patterns should use an adapter:
+
+```rust,ignore
+pub trait OpConversionPattern<T: Op>: ConversionPattern {
+    fn match_and_rewrite_typed(
+        &self,
+        op: UnsafeIntrusiveEntityRef<T>,
+        operands: ConvertedOperands<'_>,
+        rewriter: &mut ConversionPatternRewriter,
+    ) -> Result<bool, Report>;
+}
+```
+
+`Ok(false)` means the pattern did not match and no mutation occurred. Patterns
+should report actionable non-match reasons through a conversion equivalent of
+`notify_match_failure`, so diagnostics can explain why each candidate was
+rejected. `Err(report)` remains reserved for internal compiler errors or
+malformed IR, not ordinary match failure.
+
+Pattern metadata must declare generated operations:
+
+```rust,ignore
+let mut info = PatternInfo::new(...);
+info.with_generated_ops([arith::Add::name(), scf::If::name()]);
+```
+
+HIR's existing `PatternInfo` already has `generated_ops` storage; the conversion
+work should add a small builder/helper API for populating it. The legalization
+graph depends on this declaration. If a pattern creates an operation not listed
+in `generated_ops`, debug builds should report an internal compiler error.
+Release builds should still legalize the created operation recursively, but
+diagnostics should make the missing metadata obvious.
+
+### Pattern Mutation Contract
+
+Because v1 has no rollback, conversion patterns must follow a strict contract:
+
+- Do all fallible matching before mutating IR.
+- Once mutation starts, any later failure is a compiler error, not a normal
+  pattern miss.
+- Return `Ok(false)` only before mutation.
+- Use `ConversionPatternRewriter` for all mutation so created, modified, and
+  replaced operations are tracked.
+
+This mirrors how most HIR rewrites should already be written, but conversion
+must enforce it more tightly because failed legalization after mutation leaves
+the IR in an intermediate state.
+
+## Pattern Registration
+
+Canonicalization patterns are attached to operations. Dialect conversion needs a
+target/source-oriented provider mechanism, because conversion patterns are often
+owned by the destination dialect or backend rather than the source operation.
+
+```rust,ignore
+pub trait ConversionPatternProvider {
+    fn name(&self) -> &'static str;
+    fn source_dialect(&self) -> Option<Symbol>;
+    fn target_dialects(&self) -> &'static [&'static str];
+    fn populate(&self, context: Rc<Context>, patterns: &mut ConversionPatternSet);
+}
+```
+
+Providers should be registered through `inventory`, like dialects and passes.
+
+The conversion pass gathers all providers linked into the current binary. The
+legalization graph then filters patterns to those useful for the requested
+target, so registering more providers does not force their use.
+
+Manual population should also be supported for tests and specialized pipelines:
+
+```rust,ignore
+let mut patterns = ConversionPatternSet::new(context.clone());
+populate_cf_to_scf_patterns(context.clone(), &mut patterns);
+apply_full_conversion(root, target, patterns)?;
+```
+
+## Legalization Graph
+
+The driver builds a legalization graph from pattern metadata. The precise graph
+nodes are operation names, because final legality is queried on concrete
+operation instances. A pattern contributes an edge from each possible root
+operation to every operation it may generate.
+
+A root operation is legalizable if:
+
+- It is already legal according to the target, or
+- There exists at least one pattern for that root such that every generated op
+  is legal or legalizable.
+
+HIR patterns may be rooted on a concrete operation, a trait, or `Any`.
+Operation-rooted patterns give the graph the most precision. Trait-rooted
+patterns should be expanded to registered operations that implement the trait
+when the context has enough metadata; otherwise they must be treated like
+conservative any-op patterns.
+
+Dynamic legality is instance-specific, so graph construction cannot prove a
+dynamic operation name is always legal. It should still treat dynamically legal
+operation names as conditional terminal nodes when deciding whether a path might
+exist, then require the concrete generated operation instance to pass dynamic
+legality after the rewrite. This prevents the graph from pruning useful paths
+just because the terminal legality depends on operation attributes or types.
+
+Algorithm sketch:
+
+```text
+for each pattern:
+    if pattern.root is Any:
+        add to any-op patterns
+        continue
+
+    roots = expand operation root or trait root to operation names
+    if roots cannot be expanded:
+        add to any-op patterns
+        continue
+
+    for root in roots:
+        if target says root is statically legal or conditionally legal:
+            skip pattern for this root
+            continue
+
+        invalid[root].insert(pattern)
+        for generated in pattern.generated_ops:
+            parents[generated].insert(root)
+        worklist.insert(pattern)
+
+if any-op patterns exist:
+    conservatively keep all rooted patterns
+else:
+    while worklist not empty:
+        pattern = worklist.pop()
+        if any generated op is statically illegal or unknown and not legalizable:
+            continue
+        if any generated op is conditionally legal:
+            keep pattern, but require runtime legality check after rewrite
+        legalizer_patterns[root].push(pattern)
+        invalid[root].remove(pattern)
+        for parent in parents[root]:
+            worklist.extend(invalid[parent])
+
+for each legalizer pattern list:
+    compute legalization depth recursively
+    sort by smaller depth, then higher PatternBenefit
+```
+
+This matches the behavior we want from MLIR: an `A -> B` pattern becomes useful
+when `B` is itself legalizable, not only when `B` is directly legal.
+
+Patterns with `PatternKind::Trait` and `PatternKind::Any` are useful but reduce
+static pruning precision when they cannot be expanded to concrete root
+operations. They should be allowed, but target-specific conversion libraries
+should prefer operation-specific roots whenever possible.
+
+## Conversion Driver
+
+The core driver is target-driven, not greedy. It walks the IR and legalizes
+operations that are not legal for the target.
+
+```rust,ignore
+pub fn apply_full_conversion(
+    root: OperationRef,
+    target: ConversionTarget,
+    patterns: ConversionPatternSet,
+    config: ConversionConfig,
+) -> Result<ConversionResult, Report>;
+```
+
+`ConversionConfig`:
+
+```rust,ignore
+pub struct ConversionConfig {
+    pub mode: ConversionMode,
+    pub reconcile_unrealized_casts: bool,
+    pub max_iterations: Option<NonZeroU32>,
+    pub listener: Option<Rc<dyn ConversionListener>>,
+    pub verify_after_conversion: bool,
+}
+```
+
+Driver behavior:
+
+1. Freeze pattern set and build the legalization graph.
+2. Walk each root in preorder.
+3. If an op is recursively legal, skip its nested regions.
+4. If an op is legal and needs no type conversion, continue.
+5. If an op is illegal or dynamically illegal, try conversion patterns in
+   computed legalization order.
+6. Before invoking a pattern, build converted operands from the current value
+   mapping and the pattern's type converter.
+7. After a pattern succeeds, recursively legalize created and modified
+   operations.
+8. If no pattern applies, emit a diagnostic explaining the failed target and any
+   known candidate patterns.
+9. Reconcile redundant `builtin.unrealized_conversion_cast` operations if
+   configured.
+10. Run verification if configured.
+
+The driver should use preorder traversal, because parent operations often own
+regions whose signatures or semantics must be converted before nested operations
+can be interpreted correctly.
+
+## Conversion Rewriter
+
+`ConversionPatternRewriter` wraps the existing `Rewriter` and records
+conversion-specific state.
+
+```rust,ignore
+pub struct ConversionPatternRewriter {
+    inner: PatternRewriter<ConversionListenerAdapter>,
+    value_mapping: ValueMapping,
+    created_ops: SmallSet<OperationRef, 8>,
+    modified_ops: SmallSet<OperationRef, 8>,
+    replaced_ops: SmallSet<OperationRef, 8>,
+    current_type_converter: Option<Rc<TypeConverter>>,
+}
+```
+
+Required APIs:
+
+```rust,ignore
+impl ConversionPatternRewriter {
+    pub fn get_remapped_values(&self, value: ValueRef) -> SmallVec<[ValueRef; 2]>;
+
+    pub fn notify_match_failure(
+        &mut self,
+        op: OperationRef,
+        reason: impl Into<Report>,
+    );
+
+    pub fn replace_op(
+        &mut self,
+        op: OperationRef,
+        replacement_values: &[ValueRef],
+    ) -> Result<(), Report>;
+
+    pub fn replace_op_with_new_op<T, Args>(
+        &mut self,
+        op: OperationRef,
+        span: SourceSpan,
+        args: Args,
+    ) -> Result<UnsafeIntrusiveEntityRef<T>, Report>
+    where
+        T: BuildableOp<Args>;
+
+    pub fn erase_op(&mut self, op: OperationRef) -> Result<(), Report>;
+
+    pub fn convert_region_types(
+        &mut self,
+        region: RegionRef,
+        converter: &TypeConverter,
+        entry: Option<SignatureConversion>,
+    ) -> Result<(), Report>;
+
+    pub fn apply_signature_conversion(
+        &mut self,
+        block: BlockRef,
+        converter: &TypeConverter,
+        signature: SignatureConversion,
+    ) -> Result<BlockRef, Report>;
+}
+```
+
+The conversion rewriter must own all IR mutation during conversion. It should
+use the existing rewriter listener hooks to track created, modified, replaced,
+and erased operations, but it should not expose a mutable inner `Rewriter` that
+patterns can use to bypass value mapping or generated-op tracking. If a generic
+rewriter API is needed inside conversion, it should be re-exposed through
+conversion-aware wrappers.
+
+### Value Mapping
+
+The rewriter maps each original value to zero, one, or many replacement values:
+
+```rust,ignore
+pub struct ValueMapping {
+    replacements: FxHashMap<ValueRef, SmallVec<[ValueRef; 2]>>,
+}
+```
+
+Replacement with zero values is valid only when all live uses are also removed
+or remapped. This is required for zero-sized type lowering and dead value
+elimination, but should be diagnosed aggressively when stale uses remain.
+
+When an operation is replaced, the rewriter updates:
+
+- Uses that are already in converted IR.
+- The conversion value mapping.
+- Source materializations for users that remain unconverted and still expect
+  original types.
+
+## Type Conversion
+
+Type conversion is optional per pattern. Patterns that do not need type changes
+can leave the type converter unset and receive the latest remapped values
+without materializations.
+
+```rust,ignore
+pub struct TypeConverter {
+    conversions: Vec<TypeConversionFn>,
+    value_conversions: Vec<ValueConversionFn>,
+    source_materializations: Vec<MaterializationFn>,
+    target_materializations: Vec<MaterializationFn>,
+}
+
+pub enum TypeConversion {
+    One(Type),
+    Many(SmallVec<[Type; 2]>),
+    Drop,
+}
+```
+
+The converter should support both context-free type conversion and
+context-aware value conversion:
+
+```rust,ignore
+pub fn convert_type(&self, ty: &Type) -> Option<SmallVec<[Type; 2]>>;
+pub fn convert_value(&self, value: ValueRef) -> Option<SmallVec<[Type; 2]>>;
+pub fn is_legal_type(&self, ty: &Type) -> bool;
+```
+
+The first production implementation should focus on 1:1 type conversion. The
+API should leave room for 1:N and drop conversions, but those are not required
+for the initial MASM legalization path unless a concrete lowering needs them.
+
+1:N conversion becomes necessary when one source SSA value must be represented
+by multiple target SSA values, such as aggregate flattening, ABI lowering of
+records/tuples/results into scalar components, fat-pointer lowering, or
+multi-limb value lowering. Drop conversion is the 1:0 case, such as removing a
+zero-sized marker value. Until such a use case is implemented, the driver may
+reject `Many` and `Drop` conversions that require boundary materialization.
+
+### Materialization
+
+Materializations bridge converted and unconverted IR.
+
+- Target materialization converts a value to the type expected by a conversion
+  pattern.
+- Source materialization converts a replacement value back to the original type
+  for users that have not been converted.
+
+Materialization callbacks can build real operations. If no callback succeeds,
+the default is to build `builtin.unrealized_conversion_cast` only for 1:1
+materializations. The current builtin cast is unary and single-result; 1:N or
+drop materializations require either target-specific real operations or a future
+variadic/multi-result cast operation. If neither exists, conversion must fail
+with a type materialization diagnostic rather than silently fabricating an
+invalid cast.
+
+`builtin.unrealized_conversion_cast` is an intermediate bridge, not a legal
+final operation for production full conversion. The conversion driver may create
+it temporarily to keep IR type-correct while adjacent operations are being
+converted. After conversion, those casts must be realized or reconciled before
+the final target legality check.
+
+Reconciliation should:
+
+- Erase identity casts.
+- Collapse cast chains when source and final destination types match.
+- Replace uses with the original value when possible.
+- Fail if a cast remains in a full conversion target that does not explicitly
+  permit temporary casts.
+
+For MASM codegen, unreconciled unrealized casts must be illegal. Same VM stack
+shape is not enough to prove semantic compatibility, because it can erase
+value-range or ABI facts such as `felt` versus `u32`. If a conversion needs such
+a bridge, it must be realized as a real checked cast or eliminated before
+`ToMasmComponent`.
+
+## Region and Block Signature Conversion
+
+Block arguments require explicit handling because they participate in CFG edges.
+
+```rust,ignore
+pub struct SignatureConversion {
+    converted_types: SmallVec<[Type; 4]>,
+    mappings: Vec<InputMapping>,
+}
+
+pub enum InputMapping {
+    Keep {
+        old_index: usize,
+        new_index: usize,
+        new_count: usize,
+    },
+    Replace {
+        old_index: usize,
+        values: SmallVec<[ValueRef; 2]>,
+    },
+    Drop {
+        old_index: usize,
+    },
+}
+```
+
+For simple 1:1 type changes, the implementation may update block argument types
+in place if all uses can be safely remapped.
+
+When future 1:N or drop argument conversion support is added, the
+implementation should create a replacement block with the converted signature,
+move operations into it, replace block uses, and erase the old block once all
+argument uses have been replaced. This mirrors MLIR's conservative approach and
+fits HIR's existing block move APIs.
+
+Successor operands must be rewritten with the same signature conversion. This
+requires using `BranchOpInterface` for unstructured branches and
+`RegionBranchOpInterface`/`RegionBranchTerminatorOpInterface` for structured
+region control flow.
+
+The conversion driver must not assume that generic branch helpers can handle
+changed argument counts. For each terminator or region branch operation whose
+successor signature changes, conversion must either use an operation-specific
+rewrite that rebuilds the successor operand list, or call a trait method that is
+explicitly capable of changing successor operand arity. The driver should run
+independent structural checks after signature conversion:
+
+- Every successor operand list has the same arity as the destination block
+  arguments after conversion.
+- Forwarded and produced successor operands still match the operation's
+  interface contract.
+- Region-return operands match the parent operation result or continuation
+  signature.
+
+Function-like operations need dialect-specific conversion patterns because the
+function signature attribute, entry block arguments, symbol uses, and call sites
+must agree. The framework should provide utilities, but not assume every
+callable has the same signature representation.
+
+Function-like conversion utilities should cover:
+
+- Updating the function type/signature attribute.
+- Applying entry block argument conversion.
+- Rewriting direct call operands and result uses.
+- Updating declarations and external ABI metadata.
+- Preserving or updating symbol table entries and callee symbol references.
+- Diagnosing unresolved indirect-call or function-pointer cases that the target
+  does not support.
+
+## MASM Legalization Target
+
+MASM lowering should run a full conversion before `ToMasmComponent`.
+
+The target should be stricter than "these dialects are allowed". It should
+accept only operations that are supported by MASM lowering and satisfy any
+dynamic type/shape restrictions.
+
+Recommended policy:
+
+```rust,ignore
+pub fn populate_masm_conversion_target(target: &mut ConversionTarget) {
+    target.add_dynamically_legal_dialect::<arith::ArithDialect>(is_masm_lowerable);
+    target.add_dynamically_legal_dialect::<builtin::BuiltinDialect>(is_masm_lowerable);
+    target.add_dynamically_legal_dialect::<hir::HirDialect>(is_masm_lowerable);
+    target.add_dynamically_legal_dialect::<scf::ScfDialect>(is_masm_lowerable);
+
+    target.add_dynamically_legal_dialect::<cf::ControlFlowDialect>(|op| {
+        legal_if(op.implements::<dyn HirLowering>() && is_intentionally_supported_cf_form(op))
+    });
+
+    target.add_illegal_op::<builtin::UnrealizedConversionCast>();
+    target.add_illegal_dialect::<wasm::WasmDialect>();
+}
+
+fn is_masm_lowerable(op: &Operation) -> DynamicLegalityResult {
+    legal_if(op.implements::<dyn HirLowering>() && satisfies_masm_dynamic_constraints(op))
+}
+
+fn legal_if(condition: bool) -> DynamicLegalityResult {
+    if condition {
+        DynamicLegalityResult::Legal
+    } else {
+        DynamicLegalityResult::Illegal { reason: None }
+    }
+}
+```
+
+The exact dialect and operation lists should be explicit. `dyn HirLowering`
+guards codegen support, but only as a predicate inside MASM's dialect/op
+legality rules. It should not be installed as a blanket interface legality rule
+for the final MASM target, because that would allow excluded dialects to reach
+codegen just because they happen to have lowering code registered.
+
+`cf` should become illegal once control-flow lifting has run, except for any
+temporary edge cases that MASM lowering still intentionally supports. Those edge
+cases should be operation-specific dynamic legality rules, not blanket dialect
+legality.
+
+`builtin.unrealized_conversion_cast` should be illegal for the final MASM
+target. Existing lowering support for it should be treated as a defensive
+diagnostic path while the legalizer is being introduced, not as evidence that
+unrealized casts are acceptable after full conversion.
+
+## Diagnostics
+
+Conversion errors must identify both the illegal operation and the missing path.
+
+Diagnostics should include:
+
+- Operation name and source span.
+- Whether the operation is explicitly illegal, dynamically illegal, or unknown.
+- The reason returned by dynamic legality callbacks, when present.
+- Candidate patterns considered for the operation.
+- For each candidate that failed before mutation, the match failure reason when
+  available.
+- For graph-level rejection, the generated operation that blocks legalization.
+- For type conversion failures, the original type and the converter/pattern that
+  requested conversion.
+
+Dynamic legality callbacks and conversion patterns should be able to report
+structured failure reasons. A boolean-only predicate is acceptable as a
+convenience adapter, but the core driver should preserve richer reasons so
+failed full conversion does not degrade into "pattern did not match" without
+actionable context.
+
+Example:
+
+```text
+error: failed to legalize operation `foo.matmul`
+  reason: target `masm` marks dialect `foo` illegal
+  candidate patterns:
+    foo.matmul-to-linalg.matmul rejected: generated op `linalg.matmul` has no path to target
+    foo.matmul-to-hir-loop rejected: operand #2 type `tensor<4x4xfelt>` cannot be converted
+```
+
+The debug log should mirror the conversion tree:
+
+```text
+legalizing foo.matmul
+  pattern foo.matmul-to-hir-loop
+    created scf.for
+    created arith.add
+    legalizing scf.for: legal
+    legalizing arith.add: legal
+  success
+```
+
+## Safety and Invariants
+
+After successful full conversion:
+
+- Every operation under the converted root is legal or nested under a
+  recursively legal operation.
+- No operation explicitly marked illegal remains.
+- All operation operands have values with the expected types.
+- All block successor operands match destination block argument lists.
+- All value replacements dominate their uses.
+- No unreconciled `builtin.unrealized_conversion_cast` remains in production
+  full conversion.
+- The standard verifier succeeds.
+
+Debug builds should add additional checks:
+
+- A successful pattern must replace, erase, or mark the root operation modified
+  in place.
+- Created operations must be listed in the pattern's `generated_ops`.
+- Patterns must not return `Ok(false)` after mutation begins.
+- `replace_op` replacement arity must match converted result mapping.
+- Signature conversions must account for every original block argument.
+
+## Testing Strategy
+
+Unit tests in `midenc-hir`:
+
+- Static legal dialect, op, interface, illegal override, unknown policy.
+- Dynamic legality for specific operation instances.
+- Recursive legality skips nested illegal operations.
+- Legalization graph resolves `A -> B -> C`.
+- Legalization graph rejects `A -> B` when `B` has no legal path.
+- Any-op pattern behavior is conservative but usable.
+- Generated-op metadata checking catches undeclared created ops in debug tests.
+
+Conversion driver tests:
+
+- Full conversion succeeds when all illegal ops are replaced.
+- Full conversion fails on unknown/illegal ops with no path.
+- Partial conversion leaves unknown ops but converts explicit illegal ops.
+- Analysis conversion reports legalizable and non-legalizable ops without
+  mutation.
+- Pattern ordering prefers shorter legalization depth before pattern benefit.
+
+Type conversion tests:
+
+- 1:1 type conversion remaps operands.
+- 1:N and drop conversions are rejected cleanly when they would require
+  unsupported default materialization.
+- Target materialization is inserted for converted operands.
+- Source materialization is inserted for unconverted users.
+- Unrealized conversion casts are reconciled.
+- Future 1:N/drop support replaces operation results with multiple values and
+  fails if stale live uses remain.
+
+Region/signature tests:
+
+- Entry block argument type conversion.
+- Non-entry block argument conversion.
+- Successor operand rewriting for `cf.br` and `cf.cond_br`.
+- Region branch operation conversion for `scf.if`/`scf.while` where needed.
+
+MASM integration tests:
+
+- A high-level test dialect op fails before codegen without a conversion path.
+- A high-level test dialect op legalizes transitively to MASM-supported ops.
+- Unsupported `wasm` ops fail before codegen unless converted.
+- Any unreconciled unrealized cast fails before codegen.
+
+## Implementation Plan
+
+### Phase 1: Core Legality Model
+
+- Add `hir::conversion` module skeleton and public re-exports.
+- Implement `ConversionTarget`, `LegalityRule`, `Legality`, and
+  `UnknownOpPolicy`.
+- Add tests for dialect/op/interface/dynamic legality and override precedence.
+- Add recursive legality bookkeeping and tests.
+
+Deliverable: legality can be queried for operation instances without running
+rewrites.
+
+### Phase 2: Conversion Pattern Infrastructure
+
+- Add `ConversionPattern`, `OpConversionPattern<T>`,
+  `ConversionPatternSet`, and `FrozenConversionPatternSet`.
+- Reuse or extend existing `PatternInfo` for generated-op metadata.
+- Normalize root inspection around `Pattern::kind()`/`PatternInfo::root_trait`;
+  fix any existing helper mismatch before relying on trait-rooted conversion
+  patterns.
+- Add inventory-based `ConversionPatternProvider`.
+- Add tests for provider population and frozen pattern indexing.
+
+Deliverable: conversion patterns can be registered and grouped by root
+operation.
+
+### Phase 3: Legalization Graph
+
+- Implement graph construction from target and frozen pattern set.
+- Compute legalizable roots and pattern legalization depth.
+- Apply cost model: shorter legalization depth, then higher pattern benefit.
+- Add graph-only tests for direct, transitive, missing, and cyclic paths.
+
+Deliverable: the framework can decide which patterns can lead to the target
+before mutating IR.
+
+### Phase 4: Basic Conversion Driver Without Type Conversion
+
+- Implement `ConversionPatternRewriter` as a wrapper around existing
+  `PatternRewriter`.
+- Track created, modified, replaced, and erased operations.
+- Implement full conversion for same-type replacements.
+- Enforce no-rollback mutation contract in debug builds.
+- Add driver tests with a small test dialect converting `test_a` to `test_b` to
+  a target-legal op.
+
+Deliverable: full conversion works for op-to-op and op-to-sequence rewrites
+where value types do not change.
+
+### Phase 5: Type Converter and Materialization
+
+- Add `TypeConverter`, conversion callbacks, value mapping, and converted
+  operand adaptors.
+- Implement target/source materialization with
+  `builtin.unrealized_conversion_cast` fallback for 1:1 conversions only.
+- Implement cast reconciliation.
+- Add tests for 1:1 conversions, rejected unsupported 1:N/drop
+  materializations, and failed type conversions.
+
+Deliverable: conversion patterns can safely consume operands and produce
+results with 1:1 changed types. 1:N/drop support is reserved for a later phase
+unless a concrete MASM legalization use case requires it.
+
+### Phase 6: Region and Signature Conversion
+
+- Implement `SignatureConversion`.
+- Implement block signature conversion for 1:1 argument type changes.
+- Add utilities for rewriting branch successor operands through
+  `BranchOpInterface`.
+- Add hooks/utilities for region branch operations where required.
+- Add function-like conversion helpers, but keep callable dialect semantics in
+  dialect-specific patterns.
+
+Deliverable: conversions can change block argument and region signatures.
+
+### Phase 7: Reusable Driver Integration
+
+- Add helper APIs:
+
+```rust,ignore
+apply_full_conversion(root, target, patterns, config)
+apply_partial_conversion(root, target, patterns, config)
+analyze_conversion(root, target, patterns, config)
+```
+
+- Add optional reusable pass adapter support in `midenc-hir-transform` only for
+  callers that provide a concrete `ConversionTarget` and pattern population
+  function directly.
+- Do not require a global target-name registry for production use in v1.
+- Wire verifier execution after successful conversion.
+
+Deliverable: conversion is usable from concrete passes, pipelines, and tests
+without baking target policy into the generic infrastructure.
+
+### Phase 8: MASM Legalization
+
+- Add MASM conversion target construction in `codegen/masm`.
+- Add a MASM-owned `LegalizeForMasm` pass in `midenc-codegen-masm`.
+- Populate MASM-specific dynamic legality rules.
+- Add `LegalizeForMasm` immediately before MASM lowering in the compiler
+  pipeline. It should be the final legalization gate before `ToMasmComponent`,
+  after higher-level canonicalization and dialect-lowering passes have run.
+- Convert existing ad hoc pre-codegen legality assumptions into target rules.
+- Replace lowering panics/assertions for unsupported IR with legalization
+  diagnostics where possible.
+- Add integration tests for successful and failing legalization.
+
+Deliverable: MASM lowering receives legal IR or a conversion diagnostic.
+
+### Phase 9: Developer Experience
+
+- Improve diagnostics with conversion trace output.
+- Add debug logging target, likely `dialect-conversion`.
+- Document how dialect authors register conversion providers.
+- Add examples using a test dialect and a realistic `cf`/`scf` or `wasm`/HIR
+  conversion.
+
+Deliverable: new dialect authors can define and debug conversions without
+reading the driver implementation.
+
+## Review Points
+
+- Full conversion should be the first production mode. Partial and analysis
+  modes are useful enough to include in the API, but can land after the full
+  conversion path if implementation needs to be staged.
+- Interface-based predicates should be supported, but MASM should use them
+  inside explicit dialect/op policy rather than blanket interface legality.
+- 1:N/drop type conversion is not required for v1 MASM legalization unless a
+  concrete lowering needs it. The API may reserve space for it, but default
+  materialization is 1:1 until a variadic/multi-result bridge exists.
+- `builtin.unrealized_conversion_cast` is temporary conversion scaffolding and
+  should be illegal after production full conversion.
+- The MASM legalization pass is owned by `midenc-codegen-masm`; generic
+  dialect conversion infrastructure should not depend on MASM target policy.
+- The no-rollback contract is accepted for v1. If a future conversion use case
+  needs speculative mutation, it should be designed as a separate transaction
+  layer rather than retrofitted into the initial driver.

--- a/docs/internal/src/index.md
+++ b/docs/internal/src/index.md
@@ -7,5 +7,6 @@ This document provides an index of the various design documents for the compiler
 - [Data Layout](data_layout.md)
 - [Analyses](analyses.md)
 - [Rewrites](rewrites.md)
+- [Dialect Conversion](dialect_conversion.md)
 - [Code Generation](codegen.md)
 - [Packaging](packaging.md)

--- a/hir/src/conversion.rs
+++ b/hir/src/conversion.rs
@@ -1,0 +1,12 @@
+mod diagnostics;
+mod legalization_graph;
+mod pattern;
+mod pattern_set;
+mod rewriter;
+mod target;
+mod type_converter;
+
+pub use self::{
+    diagnostics::*, legalization_graph::*, pattern::*, pattern_set::*, rewriter::*, target::*,
+    type_converter::*,
+};

--- a/hir/src/conversion.rs
+++ b/hir/src/conversion.rs
@@ -4,10 +4,11 @@ mod legalization_graph;
 mod pattern;
 mod pattern_set;
 mod rewriter;
+mod signature_conversion;
 mod target;
 mod type_converter;
 
 pub use self::{
     diagnostics::*, driver::*, legalization_graph::*, pattern::*, pattern_set::*, rewriter::*,
-    target::*, type_converter::*,
+    signature_conversion::*, target::*, type_converter::*,
 };

--- a/hir/src/conversion.rs
+++ b/hir/src/conversion.rs
@@ -1,3 +1,15 @@
+//! Target-driven dialect conversion infrastructure.
+//!
+//! This module provides the generic pieces used to legalize HIR from one set of dialects to
+//! another: conversion targets, conversion patterns, type conversion, signature helpers, and the
+//! full-conversion driver. Concrete lowering pipelines own their target definitions and pattern
+//! population, while this module owns the common legality and rewrite orchestration.
+//!
+//! The initial driver intentionally does not provide rollback. Conversion patterns must separate
+//! matching from mutation: returning `Ok(false)` means no IR mutation occurred, returning
+//! `Ok(true)` means the pattern rewrote the IR, and returning `Err` aborts conversion without
+//! relying on the framework to undo partial changes.
+
 mod diagnostics;
 mod driver;
 mod legalization_graph;

--- a/hir/src/conversion.rs
+++ b/hir/src/conversion.rs
@@ -1,4 +1,5 @@
 mod diagnostics;
+mod driver;
 mod legalization_graph;
 mod pattern;
 mod pattern_set;
@@ -7,6 +8,6 @@ mod target;
 mod type_converter;
 
 pub use self::{
-    diagnostics::*, legalization_graph::*, pattern::*, pattern_set::*, rewriter::*, target::*,
-    type_converter::*,
+    diagnostics::*, driver::*, legalization_graph::*, pattern::*, pattern_set::*, rewriter::*,
+    target::*, type_converter::*,
 };

--- a/hir/src/conversion/diagnostics.rs
+++ b/hir/src/conversion/diagnostics.rs
@@ -1,0 +1,47 @@
+use crate::Report;
+
+/// The result of evaluating a dynamic legality predicate.
+pub enum DynamicLegalityResult {
+    Legal,
+    Illegal { reason: Option<Report> },
+}
+
+impl DynamicLegalityResult {
+    #[inline]
+    pub const fn legal() -> Self {
+        Self::Legal
+    }
+
+    #[inline]
+    pub const fn illegal() -> Self {
+        Self::Illegal { reason: None }
+    }
+
+    #[inline]
+    pub fn illegal_with_reason(reason: Report) -> Self {
+        Self::Illegal {
+            reason: Some(reason),
+        }
+    }
+
+    #[inline]
+    pub const fn legal_if(condition: bool) -> Self {
+        if condition {
+            Self::Legal
+        } else {
+            Self::Illegal { reason: None }
+        }
+    }
+
+    #[inline]
+    pub const fn is_legal(&self) -> bool {
+        matches!(self, Self::Legal)
+    }
+}
+
+impl From<bool> for DynamicLegalityResult {
+    #[inline]
+    fn from(condition: bool) -> Self {
+        Self::legal_if(condition)
+    }
+}

--- a/hir/src/conversion/diagnostics.rs
+++ b/hir/src/conversion/diagnostics.rs
@@ -2,21 +2,29 @@ use crate::Report;
 
 /// The result of evaluating a dynamic legality predicate.
 pub enum DynamicLegalityResult {
+    /// The operation instance is legal for the target.
     Legal,
+    /// The operation instance is illegal for the target.
+    ///
+    /// `reason`, when present, is reported to callers as the explanation for the dynamic legality
+    /// failure.
     Illegal { reason: Option<Report> },
 }
 
 impl DynamicLegalityResult {
+    /// Return a legal dynamic legality result.
     #[inline]
     pub const fn legal() -> Self {
         Self::Legal
     }
 
+    /// Return an illegal dynamic legality result without an explanatory diagnostic.
     #[inline]
     pub const fn illegal() -> Self {
         Self::Illegal { reason: None }
     }
 
+    /// Return an illegal dynamic legality result with an explanatory diagnostic.
     #[inline]
     pub fn illegal_with_reason(reason: Report) -> Self {
         Self::Illegal {
@@ -24,6 +32,7 @@ impl DynamicLegalityResult {
         }
     }
 
+    /// Return `Legal` when `condition` is true, otherwise return an illegal result.
     #[inline]
     pub const fn legal_if(condition: bool) -> Self {
         if condition {
@@ -33,6 +42,7 @@ impl DynamicLegalityResult {
         }
     }
 
+    /// Return true when this result is legal.
     #[inline]
     pub const fn is_legal(&self) -> bool {
         matches!(self, Self::Legal)

--- a/hir/src/conversion/driver.rs
+++ b/hir/src/conversion/driver.rs
@@ -5,8 +5,12 @@ use smallvec::SmallVec;
 use super::{
     ConversionPattern, ConversionPatternRewriter, ConversionPatternSet, ConversionTarget,
     ConvertedOperands, FrozenConversionPatternSet, Legality, LegalizationGraph, TrackedMutations,
+    TypeConverter,
 };
-use crate::{OperationName, OperationRef, Report, ValueRef, WalkResult};
+use crate::{
+    OperationName, OperationRef, Report, Spanned, ValueRef, WalkResult,
+    dialects::builtin::UnrealizedConversionCast,
+};
 
 /// Dialect conversion mode.
 ///
@@ -23,6 +27,7 @@ pub enum ConversionMode {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct ConversionConfig {
     mode: ConversionMode,
+    reconcile_unrealized_casts: bool,
     verify_after_conversion: bool,
     max_iterations: usize,
 }
@@ -36,6 +41,11 @@ impl ConversionConfig {
     #[inline]
     pub const fn verify_after_conversion(&self) -> bool {
         self.verify_after_conversion
+    }
+
+    #[inline]
+    pub const fn reconcile_unrealized_casts(&self) -> bool {
+        self.reconcile_unrealized_casts
     }
 
     #[inline]
@@ -53,6 +63,11 @@ impl ConversionConfig {
         self
     }
 
+    pub fn with_reconcile_unrealized_casts(&mut self, yes: bool) -> &mut Self {
+        self.reconcile_unrealized_casts = yes;
+        self
+    }
+
     pub fn with_max_iterations(&mut self, max_iterations: usize) -> &mut Self {
         self.max_iterations = max_iterations;
         self
@@ -63,6 +78,7 @@ impl Default for ConversionConfig {
     fn default() -> Self {
         Self {
             mode: ConversionMode::Full,
+            reconcile_unrealized_casts: true,
             verify_after_conversion: true,
             max_iterations: 1024,
         }
@@ -138,6 +154,11 @@ impl FullConversionDriver<'_> {
             }
         }
 
+        if self.config.reconcile_unrealized_casts() {
+            self.result.changed |= self.reconcile_unrealized_conversion_casts()?;
+        }
+        self.verify_full_conversion_legality()?;
+
         if self.config.verify_after_conversion() {
             self.root.borrow().recursively_verify()?;
         }
@@ -162,6 +183,9 @@ impl FullConversionDriver<'_> {
     }
 
     fn legalize_operation(&mut self, op: OperationRef) -> Result<(), Report> {
+        if self.config.reconcile_unrealized_casts() && is_unrealized_conversion_cast(op) {
+            return Ok(());
+        }
         if self.target.is_recursively_legal(&op.borrow()) || self.target.is_legal(&op.borrow()) {
             return Ok(());
         }
@@ -178,20 +202,25 @@ impl FullConversionDriver<'_> {
 
         let mut match_failures = vec![];
         for pattern in candidates {
-            let operand_groups = converted_operands_for(op);
-            let operands = ConvertedOperands::new(&operand_groups);
-            let mut rewriter = ConversionPatternRewriter::new(Rc::clone(&self.context));
+            let type_converter = pattern.type_converter().cloned();
+            let mut rewriter = ConversionPatternRewriter::new_with_type_converter(
+                Rc::clone(&self.context),
+                type_converter.clone(),
+            );
             if op.parent().is_some() {
                 rewriter.set_insertion_point_before(op);
             }
 
+            let operand_groups =
+                converted_operands_for(op, type_converter.as_ref(), &mut rewriter)?;
+            let mutation_count_before_pattern = rewriter.mutation_count();
+            let operands = ConvertedOperands::new(&operand_groups);
             let applied = pattern.match_and_rewrite(op, operands, &mut rewriter);
             let mutation_count = rewriter.mutation_count();
-            let mutations = rewriter.take_tracked_mutations();
 
             match applied {
                 Err(err) => {
-                    if mutations.has_mutations() {
+                    if mutation_count > mutation_count_before_pattern {
                         return Err(pattern_mutated_then_failed_error(
                             pattern.as_ref(),
                             op,
@@ -199,22 +228,25 @@ impl FullConversionDriver<'_> {
                             err,
                         ));
                     }
+                    rewriter.erase_unused_materializations()?;
                     return Err(err);
                 }
                 Ok(false) => {
-                    if mutations.has_mutations() {
+                    if mutation_count > mutation_count_before_pattern {
                         return Err(pattern_mutated_without_success_error(
                             pattern.as_ref(),
                             op,
                             mutation_count,
                         ));
                     }
+                    rewriter.erase_unused_materializations()?;
                     collect_match_failures(&mut match_failures, &mut rewriter);
                 }
                 Ok(true) => {
-                    if !mutations.has_mutations() {
+                    if mutation_count == mutation_count_before_pattern {
                         return Err(pattern_succeeded_without_mutation_error(pattern.as_ref(), op));
                     }
+                    let mutations = rewriter.take_tracked_mutations();
                     self.note_pattern_application(pattern.as_ref())?;
                     self.validate_generated_ops(pattern.as_ref(), &mutations)?;
                     self.result.changed = true;
@@ -260,6 +292,9 @@ impl FullConversionDriver<'_> {
         mutations: &TrackedMutations,
     ) -> Result<(), Report> {
         for op in mutations.inserted_ops() {
+            if mutations.materialized_ops().iter().any(|materialized| materialized == op) {
+                continue;
+            }
             let name = op.borrow().name();
             if !pattern.generated_ops().iter().any(|generated| generated == &name) {
                 return Err(Report::msg(format!(
@@ -276,10 +311,105 @@ impl FullConversionDriver<'_> {
     fn legalize_tracked_ops(&mut self, mutations: &TrackedMutations) -> Result<(), Report> {
         for op in mutations.inserted_ops().iter().chain(mutations.modified_ops().iter()).copied() {
             if self.is_live(op) {
+                if self.config.reconcile_unrealized_casts() && is_unrealized_conversion_cast(op) {
+                    continue;
+                }
                 self.legalize_operation(op)?;
             }
         }
         Ok(())
+    }
+
+    fn reconcile_unrealized_conversion_casts(&mut self) -> Result<bool, Report> {
+        let mut reconciled = false;
+        loop {
+            let mut changed = false;
+            let casts = self.collect_unrealized_conversion_casts()?;
+            if casts.is_empty() {
+                return Ok(reconciled);
+            }
+
+            let mut rewriter = ConversionPatternRewriter::new(Rc::clone(&self.context));
+            for cast in casts {
+                if !self.is_live(cast) {
+                    continue;
+                }
+                if !cast.borrow().is_used() {
+                    rewriter.erase_op(cast)?;
+                    reconciled = true;
+                    changed = true;
+                    continue;
+                }
+
+                let Some((input, result)) = unrealized_conversion_cast_values(cast) else {
+                    continue;
+                };
+                let input_ty = input.borrow().ty().clone();
+                let result_ty = result.borrow().ty().clone();
+                if input_ty == result_ty {
+                    rewriter.replace_op(cast, &[input])?;
+                    reconciled = true;
+                    changed = true;
+                    continue;
+                }
+
+                let Some(previous_cast) = input
+                    .borrow()
+                    .get_defining_op()
+                    .filter(|op| is_unrealized_conversion_cast(*op))
+                else {
+                    continue;
+                };
+                let Some((previous_input, _)) = unrealized_conversion_cast_values(previous_cast)
+                else {
+                    continue;
+                };
+                if *previous_input.borrow().ty() == result_ty {
+                    rewriter.replace_op(cast, &[previous_input])?;
+                    if self.is_live(previous_cast) && !previous_cast.borrow().is_used() {
+                        rewriter.erase_op(previous_cast)?;
+                    }
+                    reconciled = true;
+                    changed = true;
+                }
+            }
+
+            if !changed {
+                return Ok(reconciled);
+            }
+        }
+    }
+
+    fn collect_unrealized_conversion_casts(&self) -> Result<Vec<OperationRef>, Report> {
+        let mut casts = vec![];
+        self.root
+            .borrow()
+            .prewalk(|op| {
+                if is_unrealized_conversion_cast(op.as_operation_ref()) {
+                    casts.push(op.as_operation_ref());
+                }
+                WalkResult::<Report>::Continue(())
+            })
+            .into_result()?;
+        Ok(casts)
+    }
+
+    fn verify_full_conversion_legality(&self) -> Result<(), Report> {
+        self.root
+            .borrow()
+            .prewalk(|op| {
+                if self.target.is_recursively_legal(op) {
+                    return WalkResult::<Report>::Skip;
+                }
+
+                if self.target.is_legal(op) {
+                    WalkResult::<Report>::Continue(())
+                } else {
+                    let op_ref = op.as_operation_ref();
+                    WalkResult::Break(self.no_legalization_path_error(op_ref))
+                }
+            })
+            .into_result()
     }
 
     fn no_legalization_path_error(&self, op: OperationRef) -> Report {
@@ -303,12 +433,46 @@ impl FullConversionDriver<'_> {
     }
 }
 
-fn converted_operands_for(op: OperationRef) -> Vec<SmallVec<[ValueRef; 2]>> {
-    op.borrow()
-        .operands()
-        .groups()
-        .map(|group| group.iter().map(|operand| operand.borrow().as_value_ref()).collect())
-        .collect()
+fn converted_operands_for(
+    op: OperationRef,
+    type_converter: Option<&TypeConverter>,
+    rewriter: &mut ConversionPatternRewriter,
+) -> Result<Vec<SmallVec<[ValueRef; 2]>>, Report> {
+    let (span, operand_groups) = {
+        let op = op.borrow();
+        let span = op.span();
+        let operand_groups = op
+            .operands()
+            .groups()
+            .map(|group| {
+                group
+                    .iter()
+                    .map(|operand| operand.borrow().as_value_ref())
+                    .collect::<SmallVec<[ValueRef; 2]>>()
+            })
+            .collect::<Vec<_>>();
+        (span, operand_groups)
+    };
+
+    let mut converted = vec![];
+    for group in operand_groups {
+        let mut converted_group = SmallVec::<[ValueRef; 2]>::new();
+        for value in group {
+            let Some(type_converter) = type_converter else {
+                converted_group.push(value);
+                continue;
+            };
+            let converted_ty = type_converter.convert_value_1_to_1(value)?;
+            converted_group.push(type_converter.materialize_target_conversion(
+                rewriter,
+                value,
+                converted_ty,
+                span,
+            )?);
+        }
+        converted.push(converted_group);
+    }
+    Ok(converted)
 }
 
 fn collect_match_failures(failures: &mut Vec<String>, rewriter: &mut ConversionPatternRewriter) {
@@ -318,6 +482,16 @@ fn collect_match_failures(failures: &mut Vec<String>, rewriter: &mut ConversionP
             .into_iter()
             .map(|failure| format!("{}: {}", failure.op().borrow().name(), failure.reason())),
     );
+}
+
+fn is_unrealized_conversion_cast(op: OperationRef) -> bool {
+    op.try_downcast_op::<UnrealizedConversionCast>().is_ok()
+}
+
+fn unrealized_conversion_cast_values(op: OperationRef) -> Option<(ValueRef, ValueRef)> {
+    let cast = op.try_downcast_op::<UnrealizedConversionCast>().ok()?;
+    let cast = cast.borrow();
+    Some((cast.operand().as_value_ref(), cast.result().as_value_ref()))
 }
 
 fn legality_failure_reason(target: &ConversionTarget, op: &crate::Operation) -> Option<String> {
@@ -399,9 +573,12 @@ mod tests {
     use crate::{
         Context, Immediate, Op, OperationRef, Overflow, Report, SourceSpan, Spanned, Type,
         ValueRef,
-        conversion::{ConvertedOperands, DynamicLegalityResult, UnknownOpPolicy},
+        conversion::{
+            ConvertedOperands, DynamicLegalityResult, TypeConversion, TypeConverter,
+            UnknownOpPolicy,
+        },
         dialects::{
-            builtin::BuiltinOpBuilder,
+            builtin::{BuiltinOpBuilder, UnrealizedConversionCast},
             test::{Add, Constant, Mul, Shl, TestDialect, TestOpBuilder},
         },
         patterns::{Pattern, PatternBenefit, PatternInfo, PatternKind},
@@ -441,6 +618,54 @@ mod tests {
         ) -> Result<bool, Report> {
             let Some((span, lhs, rhs)) = add_parts(op, operands) else {
                 rewriter.notify_match_failure(op, Report::msg("expected test.add"));
+                return Ok(false);
+            };
+
+            rewriter.replace_op_with_new_op::<Mul, _>(op, span, (lhs, rhs, Overflow::Checked))?;
+            Ok(true)
+        }
+    }
+
+    struct AddToMulWithTypeConversion {
+        info: PatternInfo,
+        type_converter: TypeConverter,
+    }
+
+    impl AddToMulWithTypeConversion {
+        fn new(context: Rc<Context>, type_converter: TypeConverter) -> Self {
+            let dialect = context.get_or_register_dialect::<TestDialect>();
+            let mut info = PatternInfo::new(
+                context,
+                "add-to-mul-with-type-conversion",
+                PatternKind::Operation(dialect.expect_registered_name::<Add>()),
+                PatternBenefit::new(1),
+            );
+            info.with_generated_ops([dialect.expect_registered_name::<Mul>()]);
+            Self {
+                info,
+                type_converter,
+            }
+        }
+    }
+
+    impl Pattern for AddToMulWithTypeConversion {
+        fn info(&self) -> &PatternInfo {
+            &self.info
+        }
+    }
+
+    impl ConversionPattern for AddToMulWithTypeConversion {
+        fn type_converter(&self) -> Option<&TypeConverter> {
+            Some(&self.type_converter)
+        }
+
+        fn match_and_rewrite(
+            &self,
+            op: OperationRef,
+            operands: ConvertedOperands<'_>,
+            rewriter: &mut ConversionPatternRewriter,
+        ) -> Result<bool, Report> {
+            let Some((span, lhs, rhs)) = add_parts(op, operands) else {
                 return Ok(false);
             };
 
@@ -669,6 +894,37 @@ mod tests {
         target
     }
 
+    fn u32_to_i32_converter() -> TypeConverter {
+        let mut converter = TypeConverter::new();
+        converter.add_conversion(|ty| {
+            if ty == &Type::U32 {
+                Some(TypeConversion::One(Type::I32))
+            } else {
+                None
+            }
+        });
+        converter
+    }
+
+    fn cast_chain_function(name: &'static str, middle: Type, result: Type) -> Test {
+        let mut test = Test::new(name, &[Type::U32], core::slice::from_ref(&result));
+        {
+            let mut builder = test.function_builder();
+            let block = builder.current_block();
+            let arg = block.borrow().arguments()[0] as ValueRef;
+            let first = builder
+                .builder_mut()
+                .unrealized_conversion_cast(arg, middle, SourceSpan::default())
+                .unwrap();
+            let second = builder
+                .builder_mut()
+                .unrealized_conversion_cast(first, result, SourceSpan::default())
+                .unwrap();
+            builder.ret(Some(second), SourceSpan::default()).unwrap();
+        }
+        test
+    }
+
     #[test]
     fn full_conversion_rewrites_illegal_op_to_legal_op() {
         let test = add_function("full_conversion_rewrites_illegal_op_to_legal_op");
@@ -763,6 +1019,110 @@ builtin.function public extern(\"C\") @full_conversion_rewrites_illegal_op_to_le
         let output = test.function().borrow().as_operation().to_string();
         assert!(output.contains("test.mul"));
         assert!(!output.contains("test.add"));
+    }
+
+    #[test]
+    fn full_conversion_materializes_1_to_1_type_conversions() {
+        let test = add_function("full_conversion_materializes_1_to_1_type_conversions");
+        let target = target_with_test_ops(test.context_rc(), |target| {
+            target.add_legal_op::<Mul>().add_legal_op::<UnrealizedConversionCast>();
+        });
+        let mut patterns = ConversionPatternSet::new(test.context_rc());
+        patterns.push(AddToMulWithTypeConversion::new(test.context_rc(), u32_to_i32_converter()));
+
+        let result = apply_full_conversion(
+            test.function().as_operation_ref(),
+            target,
+            patterns,
+            ConversionConfig::default(),
+        )
+        .unwrap();
+
+        assert_eq!(result.converted_ops(), 1);
+        let output = test.function().borrow().as_operation().to_string();
+        assert!(output.contains("builtin.unrealized_conversion_cast"));
+        assert!(output.contains("#builtin.type<i32>"));
+        assert!(output.contains("#builtin.type<u32>"));
+        assert!(output.contains("test.mul"));
+        assert!(!output.contains("test.add"));
+    }
+
+    #[test]
+    fn full_conversion_rejects_non_1_to_1_operand_materialization() {
+        let test = add_function("full_conversion_rejects_non_1_to_1_operand_materialization");
+        let target = target_with_test_ops(test.context_rc(), |target| {
+            target.add_legal_op::<Mul>();
+        });
+        let mut converter = TypeConverter::new();
+        converter.add_conversion(|ty| {
+            if ty == &Type::U32 {
+                Some(TypeConversion::Many(smallvec::smallvec![Type::I32, Type::I32]))
+            } else {
+                None
+            }
+        });
+        let mut patterns = ConversionPatternSet::new(test.context_rc());
+        patterns.push(AddToMulWithTypeConversion::new(test.context_rc(), converter));
+
+        let err = apply_full_conversion(
+            test.function().as_operation_ref(),
+            target,
+            patterns,
+            ConversionConfig::default(),
+        )
+        .unwrap_err();
+
+        assert!(format!("{err}").contains("1:1"));
+    }
+
+    #[test]
+    fn full_conversion_reconciles_identity_unrealized_casts() {
+        let test = cast_chain_function(
+            "full_conversion_reconciles_identity_unrealized_casts",
+            Type::U32,
+            Type::U32,
+        );
+        let mut target = ConversionTarget::new(test.context_rc());
+        target
+            .set_unknown_op_policy(UnknownOpPolicy::Legal)
+            .add_illegal_op::<UnrealizedConversionCast>();
+
+        let result = apply_full_conversion(
+            test.function().as_operation_ref(),
+            target,
+            ConversionPatternSet::new(test.context_rc()),
+            ConversionConfig::default(),
+        )
+        .unwrap();
+
+        assert!(result.changed());
+        let output = test.function().borrow().as_operation().to_string();
+        assert!(!output.contains("builtin.unrealized_conversion_cast"));
+    }
+
+    #[test]
+    fn full_conversion_reconciles_reversible_unrealized_cast_chains() {
+        let test = cast_chain_function(
+            "full_conversion_reconciles_reversible_unrealized_cast_chains",
+            Type::I32,
+            Type::U32,
+        );
+        let mut target = ConversionTarget::new(test.context_rc());
+        target
+            .set_unknown_op_policy(UnknownOpPolicy::Legal)
+            .add_illegal_op::<UnrealizedConversionCast>();
+
+        let result = apply_full_conversion(
+            test.function().as_operation_ref(),
+            target,
+            ConversionPatternSet::new(test.context_rc()),
+            ConversionConfig::default(),
+        )
+        .unwrap();
+
+        assert!(result.changed());
+        let output = test.function().borrow().as_operation().to_string();
+        assert!(!output.contains("builtin.unrealized_conversion_cast"));
     }
 
     #[test]

--- a/hir/src/conversion/driver.rs
+++ b/hir/src/conversion/driver.rs
@@ -1,0 +1,831 @@
+use alloc::{format, rc::Rc, string::String, vec, vec::Vec};
+
+use smallvec::SmallVec;
+
+use super::{
+    ConversionPattern, ConversionPatternRewriter, ConversionPatternSet, ConversionTarget,
+    ConvertedOperands, FrozenConversionPatternSet, Legality, LegalizationGraph, TrackedMutations,
+};
+use crate::{OperationName, OperationRef, Report, ValueRef, WalkResult};
+
+/// Dialect conversion mode.
+///
+/// Only full conversion is implemented in Phase 4. The additional variants reserve the API shape
+/// for the partial and analysis modes described by the design document.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum ConversionMode {
+    Full,
+    Partial,
+    Analysis,
+}
+
+/// Configuration for the dialect conversion driver.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct ConversionConfig {
+    mode: ConversionMode,
+    verify_after_conversion: bool,
+    max_iterations: usize,
+}
+
+impl ConversionConfig {
+    #[inline]
+    pub const fn mode(&self) -> ConversionMode {
+        self.mode
+    }
+
+    #[inline]
+    pub const fn verify_after_conversion(&self) -> bool {
+        self.verify_after_conversion
+    }
+
+    #[inline]
+    pub const fn max_iterations(&self) -> usize {
+        self.max_iterations
+    }
+
+    pub fn with_mode(&mut self, mode: ConversionMode) -> &mut Self {
+        self.mode = mode;
+        self
+    }
+
+    pub fn with_verify_after_conversion(&mut self, yes: bool) -> &mut Self {
+        self.verify_after_conversion = yes;
+        self
+    }
+
+    pub fn with_max_iterations(&mut self, max_iterations: usize) -> &mut Self {
+        self.max_iterations = max_iterations;
+        self
+    }
+}
+
+impl Default for ConversionConfig {
+    fn default() -> Self {
+        Self {
+            mode: ConversionMode::Full,
+            verify_after_conversion: true,
+            max_iterations: 1024,
+        }
+    }
+}
+
+/// Result of a conversion driver run.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct ConversionResult {
+    changed: bool,
+    converted_ops: usize,
+}
+
+impl ConversionResult {
+    #[inline]
+    pub const fn changed(&self) -> bool {
+        self.changed
+    }
+
+    #[inline]
+    pub const fn converted_ops(&self) -> usize {
+        self.converted_ops
+    }
+}
+
+/// Apply full dialect conversion to `root`.
+///
+/// Full conversion requires every operation under `root` to be legal for `target`, except for
+/// operations nested under recursively legal operations.
+pub fn apply_full_conversion(
+    root: OperationRef,
+    target: ConversionTarget,
+    patterns: ConversionPatternSet,
+    config: ConversionConfig,
+) -> Result<ConversionResult, Report> {
+    if config.mode() != ConversionMode::Full {
+        return Err(Report::msg("apply_full_conversion requires ConversionMode::Full"));
+    }
+
+    let frozen_patterns = FrozenConversionPatternSet::new(patterns);
+    let graph = LegalizationGraph::new(&target, &frozen_patterns);
+    let mut driver = FullConversionDriver {
+        root,
+        target: &target,
+        graph,
+        context: target.context(),
+        config,
+        result: ConversionResult {
+            changed: false,
+            converted_ops: 0,
+        },
+    };
+
+    driver.run()?;
+    Ok(driver.result)
+}
+
+struct FullConversionDriver<'a> {
+    root: OperationRef,
+    target: &'a ConversionTarget,
+    graph: LegalizationGraph<'a>,
+    context: Rc<crate::Context>,
+    config: ConversionConfig,
+    result: ConversionResult,
+}
+
+impl FullConversionDriver<'_> {
+    fn run(&mut self) -> Result<(), Report> {
+        let ops = self.collect_conversion_order()?;
+        for op in ops {
+            if self.is_live(op) {
+                self.legalize_operation(op)?;
+            }
+        }
+
+        if self.config.verify_after_conversion() {
+            self.root.borrow().recursively_verify()?;
+        }
+
+        Ok(())
+    }
+
+    fn collect_conversion_order(&self) -> Result<Vec<OperationRef>, Report> {
+        let mut ops = vec![];
+        self.root
+            .borrow()
+            .prewalk(|op| {
+                if self.target.is_recursively_legal(op) {
+                    WalkResult::<Report>::Skip
+                } else {
+                    ops.push(op.as_operation_ref());
+                    WalkResult::<Report>::Continue(())
+                }
+            })
+            .into_result()?;
+        Ok(ops)
+    }
+
+    fn legalize_operation(&mut self, op: OperationRef) -> Result<(), Report> {
+        if self.target.is_recursively_legal(&op.borrow()) || self.target.is_legal(&op.borrow()) {
+            return Ok(());
+        }
+
+        let op_name = op.borrow().name();
+        if !self.graph.is_legalizable(&op_name) {
+            return Err(self.no_legalization_path_error(op));
+        }
+
+        let candidates = self.candidate_patterns(&op_name);
+        if candidates.is_empty() {
+            return Err(self.no_legalization_path_error(op));
+        }
+
+        let mut match_failures = vec![];
+        for pattern in candidates {
+            let operand_groups = converted_operands_for(op);
+            let operands = ConvertedOperands::new(&operand_groups);
+            let mut rewriter = ConversionPatternRewriter::new(Rc::clone(&self.context));
+            if op.parent().is_some() {
+                rewriter.set_insertion_point_before(op);
+            }
+
+            let applied = pattern.match_and_rewrite(op, operands, &mut rewriter);
+            let mutation_count = rewriter.mutation_count();
+            let mutations = rewriter.take_tracked_mutations();
+
+            match applied {
+                Err(err) => {
+                    if mutations.has_mutations() {
+                        return Err(pattern_mutated_then_failed_error(
+                            pattern.as_ref(),
+                            op,
+                            mutation_count,
+                            err,
+                        ));
+                    }
+                    return Err(err);
+                }
+                Ok(false) => {
+                    if mutations.has_mutations() {
+                        return Err(pattern_mutated_without_success_error(
+                            pattern.as_ref(),
+                            op,
+                            mutation_count,
+                        ));
+                    }
+                    collect_match_failures(&mut match_failures, &mut rewriter);
+                }
+                Ok(true) => {
+                    if !mutations.has_mutations() {
+                        return Err(pattern_succeeded_without_mutation_error(pattern.as_ref(), op));
+                    }
+                    self.note_pattern_application(pattern.as_ref())?;
+                    self.validate_generated_ops(pattern.as_ref(), &mutations)?;
+                    self.result.changed = true;
+
+                    self.legalize_tracked_ops(&mutations)?;
+                    if self.is_live(op) {
+                        self.legalize_operation(op)?;
+                    }
+                    return Ok(());
+                }
+            }
+        }
+
+        Err(no_matching_pattern_error(op, match_failures))
+    }
+
+    fn candidate_patterns(&self, op_name: &OperationName) -> Vec<Rc<dyn ConversionPattern>> {
+        self.graph
+            .legalizer_patterns(op_name)
+            .iter()
+            .chain(self.graph.any_op_patterns().iter())
+            .cloned()
+            .collect()
+    }
+
+    fn note_pattern_application(&mut self, pattern: &dyn ConversionPattern) -> Result<(), Report> {
+        if self.result.converted_ops >= self.config.max_iterations() {
+            return Err(Report::msg(format!(
+                "dialect conversion exceeded the configured rewrite limit of {} while applying \
+                 pattern '{}'",
+                self.config.max_iterations(),
+                pattern.name()
+            )));
+        }
+
+        self.result.converted_ops += 1;
+        Ok(())
+    }
+
+    fn validate_generated_ops(
+        &self,
+        pattern: &dyn ConversionPattern,
+        mutations: &TrackedMutations,
+    ) -> Result<(), Report> {
+        for op in mutations.inserted_ops() {
+            let name = op.borrow().name();
+            if !pattern.generated_ops().iter().any(|generated| generated == &name) {
+                return Err(Report::msg(format!(
+                    "conversion pattern '{}' generated undeclared operation '{}'; add it to the \
+                     pattern's generated operation metadata",
+                    pattern.name(),
+                    name
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn legalize_tracked_ops(&mut self, mutations: &TrackedMutations) -> Result<(), Report> {
+        for op in mutations.inserted_ops().iter().chain(mutations.modified_ops().iter()).copied() {
+            if self.is_live(op) {
+                self.legalize_operation(op)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn no_legalization_path_error(&self, op: OperationRef) -> Report {
+        let op = op.borrow();
+        let reason = legality_failure_reason(self.target, &op);
+        if let Some(reason) = reason {
+            Report::msg(format!(
+                "failed to legalize operation '{}': no legalization path to target; {reason}",
+                op.name()
+            ))
+        } else {
+            Report::msg(format!(
+                "failed to legalize operation '{}': no legalization path to target",
+                op.name()
+            ))
+        }
+    }
+
+    fn is_live(&self, op: OperationRef) -> bool {
+        op == self.root || op.parent().is_some()
+    }
+}
+
+fn converted_operands_for(op: OperationRef) -> Vec<SmallVec<[ValueRef; 2]>> {
+    op.borrow()
+        .operands()
+        .groups()
+        .map(|group| group.iter().map(|operand| operand.borrow().as_value_ref()).collect())
+        .collect()
+}
+
+fn collect_match_failures(failures: &mut Vec<String>, rewriter: &mut ConversionPatternRewriter) {
+    failures.extend(
+        rewriter
+            .take_match_failures()
+            .into_iter()
+            .map(|failure| format!("{}: {}", failure.op().borrow().name(), failure.reason())),
+    );
+}
+
+fn legality_failure_reason(target: &ConversionTarget, op: &crate::Operation) -> Option<String> {
+    match target.legality(op) {
+        Legality::DynamicIllegal {
+            reason: Some(reason),
+        } => Some(format!("{reason}")),
+        Legality::DynamicIllegal { reason: None } => {
+            Some(String::from("dynamic legality predicate returned illegal"))
+        }
+        Legality::Illegal => Some(String::from("operation is explicitly illegal")),
+        Legality::Unknown => Some(String::from("operation is unknown to the conversion target")),
+        Legality::Legal | Legality::DynamicLegal => None,
+    }
+}
+
+fn pattern_mutated_then_failed_error(
+    pattern: &dyn ConversionPattern,
+    op: OperationRef,
+    mutation_count: usize,
+    err: Report,
+) -> Report {
+    Report::msg(format!(
+        "conversion pattern '{}' failed after mutating operation '{}' ({} mutations observed): {}",
+        pattern.name(),
+        op.borrow().name(),
+        mutation_count,
+        err
+    ))
+}
+
+fn pattern_mutated_without_success_error(
+    pattern: &dyn ConversionPattern,
+    op: OperationRef,
+    mutation_count: usize,
+) -> Report {
+    Report::msg(format!(
+        "conversion pattern '{}' mutated operation '{}' but returned no match ({} mutations \
+         observed)",
+        pattern.name(),
+        op.borrow().name(),
+        mutation_count
+    ))
+}
+
+fn pattern_succeeded_without_mutation_error(
+    pattern: &dyn ConversionPattern,
+    op: OperationRef,
+) -> Report {
+    Report::msg(format!(
+        "conversion pattern '{}' reported success for operation '{}' without mutating IR",
+        pattern.name(),
+        op.borrow().name()
+    ))
+}
+
+fn no_matching_pattern_error(op: OperationRef, failures: Vec<String>) -> Report {
+    if failures.is_empty() {
+        return Report::msg(format!(
+            "failed to legalize operation '{}': no conversion pattern matched",
+            op.borrow().name()
+        ));
+    }
+
+    Report::msg(format!(
+        "failed to legalize operation '{}': no conversion pattern matched ({})",
+        op.borrow().name(),
+        failures.join("; ")
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{rc::Rc, string::ToString};
+
+    use pretty_assertions::assert_str_eq;
+
+    use super::*;
+    use crate::{
+        Context, Immediate, Op, OperationRef, Overflow, Report, SourceSpan, Spanned, Type,
+        ValueRef,
+        conversion::{ConvertedOperands, DynamicLegalityResult, UnknownOpPolicy},
+        dialects::{
+            builtin::BuiltinOpBuilder,
+            test::{Add, Constant, Mul, Shl, TestDialect, TestOpBuilder},
+        },
+        patterns::{Pattern, PatternBenefit, PatternInfo, PatternKind},
+        testing::Test,
+    };
+
+    struct AddToMul {
+        info: PatternInfo,
+    }
+
+    impl AddToMul {
+        fn new(context: Rc<Context>) -> Self {
+            let dialect = context.get_or_register_dialect::<TestDialect>();
+            let mut info = PatternInfo::new(
+                context,
+                "add-to-mul",
+                PatternKind::Operation(dialect.expect_registered_name::<Add>()),
+                PatternBenefit::new(1),
+            );
+            info.with_generated_ops([dialect.expect_registered_name::<Mul>()]);
+            Self { info }
+        }
+    }
+
+    impl Pattern for AddToMul {
+        fn info(&self) -> &PatternInfo {
+            &self.info
+        }
+    }
+
+    impl ConversionPattern for AddToMul {
+        fn match_and_rewrite(
+            &self,
+            op: OperationRef,
+            operands: ConvertedOperands<'_>,
+            rewriter: &mut ConversionPatternRewriter,
+        ) -> Result<bool, Report> {
+            let Some((span, lhs, rhs)) = add_parts(op, operands) else {
+                rewriter.notify_match_failure(op, Report::msg("expected test.add"));
+                return Ok(false);
+            };
+
+            rewriter.replace_op_with_new_op::<Mul, _>(op, span, (lhs, rhs, Overflow::Checked))?;
+            Ok(true)
+        }
+    }
+
+    struct MulToShl {
+        info: PatternInfo,
+    }
+
+    impl MulToShl {
+        fn new(context: Rc<Context>) -> Self {
+            let dialect = context.get_or_register_dialect::<TestDialect>();
+            let mut info = PatternInfo::new(
+                context,
+                "mul-to-shl",
+                PatternKind::Operation(dialect.expect_registered_name::<Mul>()),
+                PatternBenefit::new(1),
+            );
+            info.with_generated_ops([dialect.expect_registered_name::<Shl>()]);
+            Self { info }
+        }
+    }
+
+    impl Pattern for MulToShl {
+        fn info(&self) -> &PatternInfo {
+            &self.info
+        }
+    }
+
+    impl ConversionPattern for MulToShl {
+        fn match_and_rewrite(
+            &self,
+            op: OperationRef,
+            operands: ConvertedOperands<'_>,
+            rewriter: &mut ConversionPatternRewriter,
+        ) -> Result<bool, Report> {
+            if op.try_downcast_op::<Mul>().is_err() {
+                rewriter.notify_match_failure(op, Report::msg("expected test.mul"));
+                return Ok(false);
+            }
+
+            let Some(values) = operands.get(0) else {
+                return Ok(false);
+            };
+            let Some(lhs) = values.first().copied() else {
+                return Ok(false);
+            };
+            let Some(rhs) = values.get(1).copied() else {
+                return Ok(false);
+            };
+            let span = op.borrow().span();
+
+            rewriter.replace_op_with_new_op::<Shl, _>(op, span, (lhs, rhs))?;
+            Ok(true)
+        }
+    }
+
+    struct AddToMulByTwo {
+        info: PatternInfo,
+    }
+
+    impl AddToMulByTwo {
+        fn new(context: Rc<Context>) -> Self {
+            let dialect = context.get_or_register_dialect::<TestDialect>();
+            let mut info = PatternInfo::new(
+                context,
+                "add-to-mul-by-two",
+                PatternKind::Operation(dialect.expect_registered_name::<Add>()),
+                PatternBenefit::new(1),
+            );
+            info.with_generated_ops([
+                dialect.expect_registered_name::<Constant>(),
+                dialect.expect_registered_name::<Mul>(),
+            ]);
+            Self { info }
+        }
+    }
+
+    impl Pattern for AddToMulByTwo {
+        fn info(&self) -> &PatternInfo {
+            &self.info
+        }
+    }
+
+    impl ConversionPattern for AddToMulByTwo {
+        fn match_and_rewrite(
+            &self,
+            op: OperationRef,
+            operands: ConvertedOperands<'_>,
+            rewriter: &mut ConversionPatternRewriter,
+        ) -> Result<bool, Report> {
+            if op.try_downcast_op::<Add>().is_err() {
+                return Ok(false);
+            }
+
+            let span = op.borrow().span();
+            let Some(values) = operands.get(0) else {
+                return Ok(false);
+            };
+            let Some(lhs) = values.first().copied() else {
+                return Ok(false);
+            };
+            let Some(_rhs) = values.get(1).copied() else {
+                return Ok(false);
+            };
+            let constant = rewriter.create_op::<Constant, _>(span, (Immediate::U32(2),))?;
+            let rhs = constant.borrow().result().as_value_ref();
+            let mul = rewriter.create_op::<Mul, _>(span, (lhs, rhs, Overflow::Checked))?;
+            let result = mul.borrow().result().as_value_ref();
+            rewriter.replace_op(op, &[result])?;
+            Ok(true)
+        }
+    }
+
+    struct UndeclaredAddToMul {
+        info: PatternInfo,
+    }
+
+    impl UndeclaredAddToMul {
+        fn new(context: Rc<Context>) -> Self {
+            let dialect = context.get_or_register_dialect::<TestDialect>();
+            Self {
+                info: PatternInfo::new(
+                    context,
+                    "undeclared-add-to-mul",
+                    PatternKind::Operation(dialect.expect_registered_name::<Add>()),
+                    PatternBenefit::new(1),
+                ),
+            }
+        }
+    }
+
+    impl Pattern for UndeclaredAddToMul {
+        fn info(&self) -> &PatternInfo {
+            &self.info
+        }
+    }
+
+    impl ConversionPattern for UndeclaredAddToMul {
+        fn match_and_rewrite(
+            &self,
+            op: OperationRef,
+            operands: ConvertedOperands<'_>,
+            rewriter: &mut ConversionPatternRewriter,
+        ) -> Result<bool, Report> {
+            let Some((span, lhs, rhs)) = add_parts(op, operands) else {
+                return Ok(false);
+            };
+            rewriter.replace_op_with_new_op::<Mul, _>(op, span, (lhs, rhs, Overflow::Checked))?;
+            Ok(true)
+        }
+    }
+
+    struct MutatesButFails {
+        info: PatternInfo,
+    }
+
+    impl MutatesButFails {
+        fn new(context: Rc<Context>) -> Self {
+            let dialect = context.get_or_register_dialect::<TestDialect>();
+            let mut info = PatternInfo::new(
+                context,
+                "mutates-but-fails",
+                PatternKind::Operation(dialect.expect_registered_name::<Add>()),
+                PatternBenefit::new(1),
+            );
+            info.with_generated_ops([dialect.expect_registered_name::<Constant>()]);
+            Self { info }
+        }
+    }
+
+    impl Pattern for MutatesButFails {
+        fn info(&self) -> &PatternInfo {
+            &self.info
+        }
+    }
+
+    impl ConversionPattern for MutatesButFails {
+        fn match_and_rewrite(
+            &self,
+            op: OperationRef,
+            _operands: ConvertedOperands<'_>,
+            rewriter: &mut ConversionPatternRewriter,
+        ) -> Result<bool, Report> {
+            let span = op.borrow().span();
+            let _ = rewriter.create_op::<Constant, _>(span, (Immediate::U32(1),))?;
+            Ok(false)
+        }
+    }
+
+    fn add_parts(
+        op: OperationRef,
+        operands: ConvertedOperands<'_>,
+    ) -> Option<(SourceSpan, ValueRef, ValueRef)> {
+        op.try_downcast_op::<Add>().ok()?;
+        let values = operands.get(0)?;
+        let lhs = values.first().copied()?;
+        let rhs = values.get(1).copied()?;
+        Some((op.borrow().span(), lhs, rhs))
+    }
+
+    fn add_function(name: &'static str) -> Test {
+        let mut test = Test::new(name, &[Type::U32, Type::U32], &[Type::U32]);
+        {
+            let mut builder = test.function_builder();
+            let block = builder.current_block();
+            let lhs = block.borrow().arguments()[0] as ValueRef;
+            let rhs = block.borrow().arguments()[1] as ValueRef;
+            let result = builder.add(lhs, rhs, SourceSpan::default()).unwrap();
+            builder.ret(Some(result), SourceSpan::default()).unwrap();
+        }
+        test
+    }
+
+    fn target_with_test_ops(
+        context: Rc<Context>,
+        legal_ops: impl FnOnce(&mut ConversionTarget),
+    ) -> ConversionTarget {
+        let mut target = ConversionTarget::new(context);
+        target.set_unknown_op_policy(UnknownOpPolicy::Legal);
+        target.add_illegal_op::<Add>();
+        legal_ops(&mut target);
+        target
+    }
+
+    #[test]
+    fn full_conversion_rewrites_illegal_op_to_legal_op() {
+        let test = add_function("full_conversion_rewrites_illegal_op_to_legal_op");
+        let target = target_with_test_ops(test.context_rc(), |target| {
+            target.add_legal_op::<Mul>();
+        });
+        let mut patterns = ConversionPatternSet::new(test.context_rc());
+        patterns.push(AddToMul::new(test.context_rc()));
+
+        let result = apply_full_conversion(
+            test.function().as_operation_ref(),
+            target,
+            patterns,
+            ConversionConfig::default(),
+        )
+        .unwrap();
+
+        assert!(result.changed());
+        assert_eq!(result.converted_ops(), 1);
+        let output = test.function().borrow().as_operation().to_string();
+        let expected = "\
+builtin.function public extern(\"C\") @full_conversion_rewrites_illegal_op_to_legal_op(%0: u32, \
+                        %1: u32) -> u32 {
+    %3 = test.mul %0, %1 <{ overflow = #builtin.overflow<checked> }>;
+    builtin.ret %3 : (u32);
+};";
+        assert_str_eq!(output.as_str(), expected);
+    }
+
+    #[test]
+    fn full_conversion_reports_missing_legalization_path() {
+        let test = add_function("full_conversion_reports_missing_legalization_path");
+        let target = target_with_test_ops(test.context_rc(), |_| {});
+        let patterns = ConversionPatternSet::new(test.context_rc());
+
+        let err = apply_full_conversion(
+            test.function().as_operation_ref(),
+            target,
+            patterns,
+            ConversionConfig::default(),
+        )
+        .unwrap_err();
+
+        assert!(format!("{err}").contains("no legalization path"));
+    }
+
+    #[test]
+    fn full_conversion_legalizes_transitive_rewrites() {
+        let test = add_function("full_conversion_legalizes_transitive_rewrites");
+        let target = target_with_test_ops(test.context_rc(), |target| {
+            target.add_illegal_op::<Mul>().add_legal_op::<Shl>();
+        });
+        let mut patterns = ConversionPatternSet::new(test.context_rc());
+        patterns.push(AddToMul::new(test.context_rc()));
+        patterns.push(MulToShl::new(test.context_rc()));
+
+        let result = apply_full_conversion(
+            test.function().as_operation_ref(),
+            target,
+            patterns,
+            ConversionConfig::default(),
+        )
+        .unwrap();
+
+        assert_eq!(result.converted_ops(), 2);
+        let output = test.function().borrow().as_operation().to_string();
+        assert!(output.contains("test.shl"));
+        assert!(!output.contains("test.add"));
+        assert!(!output.contains("test.mul"));
+    }
+
+    #[test]
+    fn full_conversion_rewrites_dynamically_illegal_ops() {
+        let test = add_function("full_conversion_rewrites_dynamically_illegal_ops");
+        let target = target_with_test_ops(test.context_rc(), |target| {
+            target
+                .add_dynamically_legal_op::<Add, _>(|_| DynamicLegalityResult::illegal())
+                .add_legal_op::<Mul>();
+        });
+        let mut patterns = ConversionPatternSet::new(test.context_rc());
+        patterns.push(AddToMul::new(test.context_rc()));
+
+        let result = apply_full_conversion(
+            test.function().as_operation_ref(),
+            target,
+            patterns,
+            ConversionConfig::default(),
+        )
+        .unwrap();
+
+        assert_eq!(result.converted_ops(), 1);
+        let output = test.function().borrow().as_operation().to_string();
+        assert!(output.contains("test.mul"));
+        assert!(!output.contains("test.add"));
+    }
+
+    #[test]
+    fn full_conversion_supports_op_to_sequence_rewrites() {
+        let test = add_function("full_conversion_supports_op_to_sequence_rewrites");
+        let target = target_with_test_ops(test.context_rc(), |target| {
+            target.add_legal_op::<Constant>().add_legal_op::<Mul>();
+        });
+        let mut patterns = ConversionPatternSet::new(test.context_rc());
+        patterns.push(AddToMulByTwo::new(test.context_rc()));
+
+        let result = apply_full_conversion(
+            test.function().as_operation_ref(),
+            target,
+            patterns,
+            ConversionConfig::default(),
+        )
+        .unwrap();
+
+        assert_eq!(result.converted_ops(), 1);
+        let output = test.function().borrow().as_operation().to_string();
+        assert!(output.contains("test.constant 2"));
+        assert!(output.contains("test.mul"));
+        assert!(!output.contains("test.add"));
+    }
+
+    #[test]
+    fn full_conversion_rejects_undeclared_generated_ops() {
+        let test = add_function("full_conversion_rejects_undeclared_generated_ops");
+        let target = target_with_test_ops(test.context_rc(), |target| {
+            target.add_legal_op::<Mul>();
+        });
+        let mut patterns = ConversionPatternSet::new(test.context_rc());
+        patterns.push(UndeclaredAddToMul::new(test.context_rc()));
+
+        let err = apply_full_conversion(
+            test.function().as_operation_ref(),
+            target,
+            patterns,
+            ConversionConfig::default(),
+        )
+        .unwrap_err();
+
+        assert!(format!("{err}").contains("generated undeclared operation"));
+    }
+
+    #[test]
+    fn full_conversion_rejects_mutation_contract_violations() {
+        let test = add_function("full_conversion_rejects_mutation_contract_violations");
+        let target = target_with_test_ops(test.context_rc(), |target| {
+            target.add_legal_op::<Constant>();
+        });
+        let mut patterns = ConversionPatternSet::new(test.context_rc());
+        patterns.push(MutatesButFails::new(test.context_rc()));
+
+        let err = apply_full_conversion(
+            test.function().as_operation_ref(),
+            target,
+            patterns,
+            ConversionConfig::default(),
+        )
+        .unwrap_err();
+
+        assert!(format!("{err}").contains("mutated operation"));
+    }
+}

--- a/hir/src/conversion/driver.rs
+++ b/hir/src/conversion/driver.rs
@@ -14,12 +14,17 @@ use crate::{
 
 /// Dialect conversion mode.
 ///
-/// Only full conversion is implemented in Phase 4. The additional variants reserve the API shape
-/// for the partial and analysis modes described by the design document.
+/// Only full conversion is implemented today. The additional variants reserve the API shape for
+/// the partial and analysis modes described by the design document.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ConversionMode {
+    /// Require every operation under the root to be legal after conversion.
     Full,
+    /// Reserved for MLIR-style partial conversion, where already-legal operations may remain
+    /// without forcing every unknown operation to legalize.
     Partial,
+    /// Reserved for analysis-only conversion that reports whether conversion could succeed without
+    /// mutating IR.
     Analysis,
 }
 
@@ -33,41 +38,57 @@ pub struct ConversionConfig {
 }
 
 impl ConversionConfig {
+    /// Return the configured conversion mode.
     #[inline]
     pub const fn mode(&self) -> ConversionMode {
         self.mode
     }
 
+    /// Return whether the converted root is recursively verified after legality succeeds.
     #[inline]
     pub const fn verify_after_conversion(&self) -> bool {
         self.verify_after_conversion
     }
 
+    /// Return whether temporary `builtin.unrealized_conversion_cast` operations are reconciled.
     #[inline]
     pub const fn reconcile_unrealized_casts(&self) -> bool {
         self.reconcile_unrealized_casts
     }
 
+    /// Return the maximum number of pattern applications allowed during conversion.
     #[inline]
     pub const fn max_iterations(&self) -> usize {
         self.max_iterations
     }
 
+    /// Set the conversion mode.
+    ///
+    /// The current driver accepts only [`ConversionMode::Full`]; other modes are reserved API.
     pub fn with_mode(&mut self, mode: ConversionMode) -> &mut Self {
         self.mode = mode;
         self
     }
 
+    /// Enable or disable recursive IR verification after conversion.
     pub fn with_verify_after_conversion(&mut self, yes: bool) -> &mut Self {
         self.verify_after_conversion = yes;
         self
     }
 
+    /// Enable or disable reconciliation of temporary unrealized conversion casts.
+    ///
+    /// When enabled, the driver may leave these casts in the IR during pattern application to keep
+    /// operands/results type-correct, but unreconciled casts must still be legal according to the
+    /// final conversion target.
     pub fn with_reconcile_unrealized_casts(&mut self, yes: bool) -> &mut Self {
         self.reconcile_unrealized_casts = yes;
         self
     }
 
+    /// Set the maximum number of successful pattern applications.
+    ///
+    /// This guards against rewrite cycles in conversion patterns.
     pub fn with_max_iterations(&mut self, max_iterations: usize) -> &mut Self {
         self.max_iterations = max_iterations;
         self
@@ -93,11 +114,13 @@ pub struct ConversionResult {
 }
 
 impl ConversionResult {
+    /// Return true when at least one pattern application or cast reconciliation changed the IR.
     #[inline]
     pub const fn changed(&self) -> bool {
         self.changed
     }
 
+    /// Return the number of successful conversion pattern applications.
     #[inline]
     pub const fn converted_ops(&self) -> usize {
         self.converted_ops
@@ -108,6 +131,11 @@ impl ConversionResult {
 ///
 /// Full conversion requires every operation under `root` to be legal for `target`, except for
 /// operations nested under recursively legal operations.
+///
+/// Patterns are tried according to the legalization graph derived from the target and each
+/// pattern's generated-op metadata. A pattern that returns `Ok(false)` must not mutate IR, and a
+/// pattern that returns `Ok(true)` must mutate IR. Violating either contract is reported as a
+/// conversion error because this driver intentionally does not roll changes back.
 pub fn apply_full_conversion(
     root: OperationRef,
     target: ConversionTarget,

--- a/hir/src/conversion/legalization_graph.rs
+++ b/hir/src/conversion/legalization_graph.rs
@@ -1,0 +1,380 @@
+use alloc::{collections::BTreeMap, rc::Rc, vec::Vec};
+
+use smallvec::SmallVec;
+
+use super::{ConversionPattern, ConversionTarget, FrozenConversionPatternSet, StaticLegality};
+use crate::OperationName;
+
+/// Pattern graph used to decide which conversions may reach a target.
+pub struct LegalizationGraph<'a> {
+    target: &'a ConversionTarget,
+    legalizer_patterns: BTreeMap<OperationName, SmallVec<[Rc<dyn ConversionPattern>; 2]>>,
+    any_op_patterns: SmallVec<[Rc<dyn ConversionPattern>; 1]>,
+}
+
+impl<'a> LegalizationGraph<'a> {
+    pub fn new(target: &'a ConversionTarget, patterns: &FrozenConversionPatternSet) -> Self {
+        let any_op_patterns = patterns.any_op_patterns().iter().cloned().collect();
+        let mut this = Self {
+            target,
+            legalizer_patterns: Default::default(),
+            any_op_patterns,
+        };
+
+        if !this.any_op_patterns.is_empty() {
+            for (root, patterns) in patterns.op_specific_patterns().iter() {
+                this.legalizer_patterns.insert(root.clone(), patterns.iter().cloned().collect());
+            }
+            this.sort_legalizer_patterns();
+            return this;
+        }
+
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for (root, patterns) in patterns.op_specific_patterns().iter() {
+                if target_is_terminal(target, root) {
+                    continue;
+                }
+
+                for pattern in patterns {
+                    if this.has_pattern(root, pattern) {
+                        continue;
+                    }
+                    if this.pattern_may_legalize(pattern.as_ref()) {
+                        this.legalizer_patterns
+                            .entry(root.clone())
+                            .or_default()
+                            .push(Rc::clone(pattern));
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        this.sort_legalizer_patterns();
+        this
+    }
+
+    #[inline]
+    pub fn is_legalizable(&self, name: &OperationName) -> bool {
+        target_is_terminal(self.target, name)
+            || self.legalizer_patterns.contains_key(name)
+            || !self.any_op_patterns.is_empty()
+    }
+
+    #[inline]
+    pub fn legalizer_patterns(&self, name: &OperationName) -> &[Rc<dyn ConversionPattern>] {
+        self.legalizer_patterns
+            .get(name)
+            .map(|patterns| patterns.as_slice())
+            .unwrap_or(&[])
+    }
+
+    #[inline]
+    pub fn any_op_patterns(&self) -> &[Rc<dyn ConversionPattern>] {
+        &self.any_op_patterns
+    }
+
+    fn has_pattern(&self, root: &OperationName, pattern: &Rc<dyn ConversionPattern>) -> bool {
+        self.legalizer_patterns
+            .get(root)
+            .is_some_and(|patterns| patterns.iter().any(|existing| Rc::ptr_eq(existing, pattern)))
+    }
+
+    fn pattern_may_legalize(&self, pattern: &dyn ConversionPattern) -> bool {
+        pattern.generated_ops().iter().all(|generated| self.is_legalizable(generated))
+    }
+
+    fn sort_legalizer_patterns(&mut self) {
+        let roots = self.legalizer_patterns.keys().cloned().collect::<Vec<_>>();
+        for root in roots {
+            let mut patterns = self.legalizer_patterns.remove(&root).unwrap();
+            patterns.sort_by(|lhs, rhs| {
+                let lhs_depth = self.pattern_depth(lhs.as_ref());
+                let rhs_depth = self.pattern_depth(rhs.as_ref());
+                lhs_depth.cmp(&rhs_depth).then_with(|| lhs.benefit().cmp(rhs.benefit()))
+            });
+            self.legalizer_patterns.insert(root, patterns);
+        }
+    }
+
+    fn pattern_depth(&self, pattern: &dyn ConversionPattern) -> u32 {
+        pattern
+            .generated_ops()
+            .iter()
+            .map(|generated| self.legalization_depth(generated, &mut Vec::new()))
+            .max()
+            .unwrap_or(0)
+            .saturating_add(1)
+    }
+
+    fn legalization_depth(&self, name: &OperationName, stack: &mut Vec<OperationName>) -> u32 {
+        if target_is_terminal(self.target, name) {
+            return 0;
+        }
+        if stack.iter().any(|active| active == name) {
+            return u32::MAX / 2;
+        }
+
+        let Some(patterns) = self.legalizer_patterns.get(name) else {
+            return u32::MAX / 2;
+        };
+
+        stack.push(name.clone());
+        let depth = patterns
+            .iter()
+            .map(|pattern| {
+                pattern
+                    .generated_ops()
+                    .iter()
+                    .map(|generated| self.legalization_depth(generated, stack))
+                    .max()
+                    .unwrap_or(0)
+                    .saturating_add(1)
+            })
+            .min()
+            .unwrap_or(u32::MAX / 2);
+        stack.pop();
+        depth
+    }
+}
+
+fn target_is_terminal(target: &ConversionTarget, name: &OperationName) -> bool {
+    matches!(target.static_legality(name), StaticLegality::Legal | StaticLegality::Dynamic)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::rc::Rc;
+
+    use super::*;
+    use crate::{
+        Context, OperationRef, Report,
+        conversion::{
+            ConversionPatternRewriter, ConversionPatternSet, ConvertedOperands,
+            DynamicLegalityResult,
+        },
+        dialects::test::{Add, Constant, Mul, TestDialect},
+        patterns::{Pattern, PatternBenefit, PatternInfo, PatternKind},
+    };
+
+    struct TestConversionPattern {
+        info: PatternInfo,
+    }
+
+    impl TestConversionPattern {
+        fn new(
+            context: Rc<Context>,
+            name: &'static str,
+            root: OperationName,
+            generated_ops: impl IntoIterator<Item = OperationName>,
+            benefit: u16,
+        ) -> Self {
+            let mut info = PatternInfo::new(
+                context,
+                name,
+                PatternKind::Operation(root),
+                PatternBenefit::new(benefit),
+            );
+            info.with_generated_ops(generated_ops);
+            Self { info }
+        }
+
+        fn any(context: Rc<Context>) -> Self {
+            Self {
+                info: PatternInfo::new(
+                    context,
+                    "any-conversion",
+                    PatternKind::Any,
+                    PatternBenefit::new(1),
+                ),
+            }
+        }
+    }
+
+    impl Pattern for TestConversionPattern {
+        fn info(&self) -> &PatternInfo {
+            &self.info
+        }
+    }
+
+    impl ConversionPattern for TestConversionPattern {
+        fn match_and_rewrite(
+            &self,
+            _op: OperationRef,
+            _operands: ConvertedOperands<'_>,
+            _rewriter: &mut ConversionPatternRewriter,
+        ) -> Result<bool, Report> {
+            Ok(false)
+        }
+    }
+
+    fn names(context: &Rc<Context>) -> (OperationName, OperationName, OperationName) {
+        let dialect = context.get_or_register_dialect::<TestDialect>();
+        (
+            dialect.expect_registered_name::<Constant>(),
+            dialect.expect_registered_name::<Add>(),
+            dialect.expect_registered_name::<Mul>(),
+        )
+    }
+
+    #[test]
+    fn resolves_transitive_legalization_paths() {
+        let context = Rc::new(Context::default());
+        let (constant, add, mul) = names(&context);
+        let mut target = ConversionTarget::new(context.clone());
+        target.add_legal_op::<Mul>();
+
+        let mut patterns = ConversionPatternSet::new(context.clone());
+        patterns.push(TestConversionPattern::new(
+            context.clone(),
+            "constant-to-add",
+            constant.clone(),
+            [add.clone()],
+            1,
+        ));
+        patterns.push(TestConversionPattern::new(
+            context.clone(),
+            "add-to-mul",
+            add.clone(),
+            [mul],
+            1,
+        ));
+        let frozen = FrozenConversionPatternSet::new(patterns);
+
+        let graph = LegalizationGraph::new(&target, &frozen);
+
+        assert!(graph.is_legalizable(&constant));
+        assert!(graph.is_legalizable(&add));
+        assert_eq!(graph.legalizer_patterns(&constant).len(), 1);
+    }
+
+    #[test]
+    fn rejects_paths_with_no_terminal_target() {
+        let context = Rc::new(Context::default());
+        let (constant, add, _) = names(&context);
+        let target = ConversionTarget::new(context.clone());
+
+        let mut patterns = ConversionPatternSet::new(context.clone());
+        patterns.push(TestConversionPattern::new(
+            context.clone(),
+            "constant-to-add",
+            constant.clone(),
+            [add],
+            1,
+        ));
+        let frozen = FrozenConversionPatternSet::new(patterns);
+
+        let graph = LegalizationGraph::new(&target, &frozen);
+
+        assert!(!graph.is_legalizable(&constant));
+        assert!(graph.legalizer_patterns(&constant).is_empty());
+    }
+
+    #[test]
+    fn rejects_cycles_without_a_terminal_target() {
+        let context = Rc::new(Context::default());
+        let (constant, add, _) = names(&context);
+        let target = ConversionTarget::new(context.clone());
+
+        let mut patterns = ConversionPatternSet::new(context.clone());
+        patterns.push(TestConversionPattern::new(
+            context.clone(),
+            "constant-to-add",
+            constant.clone(),
+            [add.clone()],
+            1,
+        ));
+        patterns.push(TestConversionPattern::new(
+            context.clone(),
+            "add-to-constant",
+            add,
+            [constant.clone()],
+            1,
+        ));
+        let frozen = FrozenConversionPatternSet::new(patterns);
+
+        let graph = LegalizationGraph::new(&target, &frozen);
+
+        assert!(!graph.is_legalizable(&constant));
+    }
+
+    #[test]
+    fn treats_dynamic_legality_as_conditional_terminal() {
+        let context = Rc::new(Context::default());
+        let (constant, add, _) = names(&context);
+        let mut target = ConversionTarget::new(context.clone());
+        target.add_dynamically_legal_op::<Add, _>(|_| DynamicLegalityResult::legal());
+
+        let mut patterns = ConversionPatternSet::new(context.clone());
+        patterns.push(TestConversionPattern::new(
+            context.clone(),
+            "constant-to-add",
+            constant.clone(),
+            [add],
+            1,
+        ));
+        let frozen = FrozenConversionPatternSet::new(patterns);
+
+        let graph = LegalizationGraph::new(&target, &frozen);
+
+        assert!(graph.is_legalizable(&constant));
+    }
+
+    #[test]
+    fn any_op_patterns_keep_rooted_patterns_conservatively() {
+        let context = Rc::new(Context::default());
+        let (constant, add, _) = names(&context);
+        let target = ConversionTarget::new(context.clone());
+
+        let mut patterns = ConversionPatternSet::new(context.clone());
+        patterns.push(TestConversionPattern::any(context.clone()));
+        patterns.push(TestConversionPattern::new(
+            context.clone(),
+            "constant-to-add",
+            constant.clone(),
+            [add],
+            1,
+        ));
+        let frozen = FrozenConversionPatternSet::new(patterns);
+
+        let graph = LegalizationGraph::new(&target, &frozen);
+
+        assert!(graph.is_legalizable(&constant));
+        assert_eq!(graph.any_op_patterns().len(), 1);
+        assert_eq!(graph.legalizer_patterns(&constant).len(), 1);
+    }
+
+    #[test]
+    fn orders_by_depth_before_benefit() {
+        let context = Rc::new(Context::default());
+        let (constant, add, mul) = names(&context);
+        let mut target = ConversionTarget::new(context.clone());
+        target.add_legal_op::<Mul>();
+
+        let mut patterns = ConversionPatternSet::new(context.clone());
+        patterns.push(TestConversionPattern::new(
+            context.clone(),
+            "constant-to-add-high-benefit",
+            constant.clone(),
+            [add.clone()],
+            10,
+        ));
+        patterns.push(TestConversionPattern::new(
+            context.clone(),
+            "constant-to-mul-low-benefit",
+            constant.clone(),
+            [mul.clone()],
+            1,
+        ));
+        patterns.push(TestConversionPattern::new(context.clone(), "add-to-mul", add, [mul], 1));
+        let frozen = FrozenConversionPatternSet::new(patterns);
+
+        let graph = LegalizationGraph::new(&target, &frozen);
+        let candidates = graph.legalizer_patterns(&constant);
+
+        assert_eq!(candidates[0].name(), "constant-to-mul-low-benefit");
+        assert_eq!(candidates[1].name(), "constant-to-add-high-benefit");
+    }
+}

--- a/hir/src/conversion/legalization_graph.rs
+++ b/hir/src/conversion/legalization_graph.rs
@@ -6,6 +6,13 @@ use super::{ConversionPattern, ConversionTarget, FrozenConversionPatternSet, Sta
 use crate::OperationName;
 
 /// Pattern graph used to decide which conversions may reach a target.
+///
+/// The graph is built from a conversion target and a frozen pattern set. It keeps only patterns
+/// whose declared generated operations can themselves reach terminal legal operations, which lets
+/// the driver orchestrate transitive conversion such as A -> B -> C when only C is legal.
+///
+/// This is primarily driver infrastructure, but it is public so tests, diagnostics, and future
+/// tooling can inspect legalization reachability.
 pub struct LegalizationGraph<'a> {
     target: &'a ConversionTarget,
     legalizer_patterns: BTreeMap<OperationName, SmallVec<[Rc<dyn ConversionPattern>; 2]>>,
@@ -13,6 +20,11 @@ pub struct LegalizationGraph<'a> {
 }
 
 impl<'a> LegalizationGraph<'a> {
+    /// Build a legalization graph for `target` using the already-frozen `patterns`.
+    ///
+    /// Any-op patterns are conservatively retained for all roots because their generated
+    /// operation set is not root-specific. Operation-specific patterns are retained only when all
+    /// declared generated operations are legalizable.
     pub fn new(target: &'a ConversionTarget, patterns: &FrozenConversionPatternSet) -> Self {
         let any_op_patterns = patterns.any_op_patterns().iter().cloned().collect();
         let mut this = Self {
@@ -56,6 +68,8 @@ impl<'a> LegalizationGraph<'a> {
         this
     }
 
+    /// Return true when `name` is legal, dynamically legal, or has at least one possible
+    /// legalization pattern.
     #[inline]
     pub fn is_legalizable(&self, name: &OperationName) -> bool {
         target_is_terminal(self.target, name)
@@ -63,6 +77,9 @@ impl<'a> LegalizationGraph<'a> {
             || !self.any_op_patterns.is_empty()
     }
 
+    /// Return operation-specific legalizer patterns for `name`.
+    ///
+    /// The returned patterns are sorted by estimated legalization depth and then pattern benefit.
     #[inline]
     pub fn legalizer_patterns(&self, name: &OperationName) -> &[Rc<dyn ConversionPattern>] {
         self.legalizer_patterns
@@ -71,6 +88,7 @@ impl<'a> LegalizationGraph<'a> {
             .unwrap_or(&[])
     }
 
+    /// Return any-op conversion patterns retained by the graph.
     #[inline]
     pub fn any_op_patterns(&self) -> &[Rc<dyn ConversionPattern>] {
         &self.any_op_patterns

--- a/hir/src/conversion/legalization_graph.rs
+++ b/hir/src/conversion/legalization_graph.rs
@@ -33,7 +33,7 @@ impl<'a> LegalizationGraph<'a> {
         while changed {
             changed = false;
             for (root, patterns) in patterns.op_specific_patterns().iter() {
-                if target_is_terminal(target, root) {
+                if matches!(target.static_legality(root), StaticLegality::Legal) {
                     continue;
                 }
 
@@ -320,6 +320,31 @@ mod tests {
         let graph = LegalizationGraph::new(&target, &frozen);
 
         assert!(graph.is_legalizable(&constant));
+    }
+
+    #[test]
+    fn retains_patterns_rooted_on_dynamic_legality() {
+        let context = Rc::new(Context::default());
+        let (_, add, mul) = names(&context);
+        let mut target = ConversionTarget::new(context.clone());
+        target
+            .add_dynamically_legal_op::<Add, _>(|_| DynamicLegalityResult::illegal())
+            .add_legal_op::<Mul>();
+
+        let mut patterns = ConversionPatternSet::new(context.clone());
+        patterns.push(TestConversionPattern::new(
+            context.clone(),
+            "add-to-mul",
+            add.clone(),
+            [mul],
+            1,
+        ));
+        let frozen = FrozenConversionPatternSet::new(patterns);
+
+        let graph = LegalizationGraph::new(&target, &frozen);
+
+        assert!(graph.is_legalizable(&add));
+        assert_eq!(graph.legalizer_patterns(&add).len(), 1);
     }
 
     #[test]

--- a/hir/src/conversion/pattern.rs
+++ b/hir/src/conversion/pattern.rs
@@ -1,0 +1,60 @@
+use super::{ConversionPatternRewriter, TypeConverter};
+use crate::{
+    Op, OperationRef, Report, SmallVec, UnsafeIntrusiveEntityRef, ValueRef, patterns::Pattern,
+};
+
+/// Operands remapped through the current conversion value mapping.
+pub struct ConvertedOperands<'a> {
+    groups: &'a [SmallVec<[ValueRef; 2]>],
+}
+
+impl<'a> ConvertedOperands<'a> {
+    #[inline]
+    pub const fn new(groups: &'a [SmallVec<[ValueRef; 2]>]) -> Self {
+        Self { groups }
+    }
+
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.groups.is_empty()
+    }
+
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.groups.len()
+    }
+
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&'a [ValueRef]> {
+        self.groups.get(index).map(|group| group.as_slice())
+    }
+
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = &'a [ValueRef]> {
+        self.groups.iter().map(|group| group.as_slice())
+    }
+}
+
+/// A rewrite pattern that participates in target-driven dialect conversion.
+pub trait ConversionPattern: Pattern {
+    fn type_converter(&self) -> Option<&TypeConverter> {
+        None
+    }
+
+    fn match_and_rewrite(
+        &self,
+        op: OperationRef,
+        operands: ConvertedOperands<'_>,
+        rewriter: &mut ConversionPatternRewriter,
+    ) -> Result<bool, Report>;
+}
+
+/// Typed adapter trait for conversion patterns rooted on a concrete operation.
+pub trait OpConversionPattern<T: Op>: ConversionPattern {
+    fn match_and_rewrite_typed(
+        &self,
+        op: UnsafeIntrusiveEntityRef<T>,
+        operands: ConvertedOperands<'_>,
+        rewriter: &mut ConversionPatternRewriter,
+    ) -> Result<bool, Report>;
+}

--- a/hir/src/conversion/pattern.rs
+++ b/hir/src/conversion/pattern.rs
@@ -4,31 +4,40 @@ use crate::{
 };
 
 /// Operands remapped through the current conversion value mapping.
+///
+/// Each source operand maps to a group of converted values. The initial driver supports 1:1 type
+/// conversion for boundary materialization, but this view is shaped for future 1:N conversions so
+/// pattern code does not need another API break when that support is added.
 pub struct ConvertedOperands<'a> {
     groups: &'a [SmallVec<[ValueRef; 2]>],
 }
 
 impl<'a> ConvertedOperands<'a> {
+    /// Create a converted operand view over precomputed operand groups.
     #[inline]
     pub const fn new(groups: &'a [SmallVec<[ValueRef; 2]>]) -> Self {
         Self { groups }
     }
 
+    /// Return true when the root operation has no operands.
     #[inline]
     pub const fn is_empty(&self) -> bool {
         self.groups.is_empty()
     }
 
+    /// Return the number of source operands represented by this view.
     #[inline]
     pub const fn len(&self) -> usize {
         self.groups.len()
     }
 
+    /// Return the converted value group for source operand `index`.
     #[inline]
     pub fn get(&self, index: usize) -> Option<&'a [ValueRef]> {
         self.groups.get(index).map(|group| group.as_slice())
     }
 
+    /// Iterate over converted value groups in source operand order.
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = &'a [ValueRef]> {
         self.groups.iter().map(|group| group.as_slice())
@@ -37,10 +46,22 @@ impl<'a> ConvertedOperands<'a> {
 
 /// A rewrite pattern that participates in target-driven dialect conversion.
 pub trait ConversionPattern: Pattern {
+    /// Return the type converter used to remap operands before this pattern runs.
+    ///
+    /// Patterns that rewrite type-changing operations should return the same converter they use
+    /// when building replacement IR. Patterns that do not need type remapping can use the default
+    /// `None`, which passes original operands through unchanged.
     fn type_converter(&self) -> Option<&TypeConverter> {
         None
     }
 
+    /// Try to rewrite `op` using converted operands and the conversion rewriter.
+    ///
+    /// Return `Ok(true)` after successfully mutating IR. Return `Ok(false)` when the pattern does
+    /// not match; in that case the pattern must not mutate IR, but may call
+    /// [`ConversionPatternRewriter::notify_match_failure`] to leave a diagnostic breadcrumb. Return
+    /// `Err` for a fatal failure that should abort conversion. The full-conversion driver checks
+    /// this mutation contract because it does not provide rollback.
     fn match_and_rewrite(
         &self,
         op: OperationRef,
@@ -51,6 +72,11 @@ pub trait ConversionPattern: Pattern {
 
 /// Typed adapter trait for conversion patterns rooted on a concrete operation.
 pub trait OpConversionPattern<T: Op>: ConversionPattern {
+    /// Try to rewrite a statically typed root operation.
+    ///
+    /// This has the same mutation and result contract as
+    /// [`ConversionPattern::match_and_rewrite`], but lets pattern implementations work with their
+    /// concrete operation type after the caller has performed the root-type check.
     fn match_and_rewrite_typed(
         &self,
         op: UnsafeIntrusiveEntityRef<T>,

--- a/hir/src/conversion/pattern_set.rs
+++ b/hir/src/conversion/pattern_set.rs
@@ -6,12 +6,17 @@ use super::ConversionPattern;
 use crate::{Context, OperationName, patterns::PatternKind};
 
 /// Mutable collection of conversion patterns.
+///
+/// Build one of these in a concrete legalization pass, populate it with source-to-target
+/// conversion patterns, then pass it to the conversion driver. The driver freezes the set before
+/// use so it can index patterns by root operation name.
 pub struct ConversionPatternSet {
     context: Rc<Context>,
     patterns: Vec<Box<dyn ConversionPattern>>,
 }
 
 impl ConversionPatternSet {
+    /// Create an empty pattern set for `context`.
     pub fn new(context: Rc<Context>) -> Self {
         Self {
             context,
@@ -19,6 +24,7 @@ impl ConversionPatternSet {
         }
     }
 
+    /// Create a pattern set from boxed conversion patterns.
     pub fn from_iter<P>(context: Rc<Context>, patterns: P) -> Self
     where
         P: IntoIterator<Item = Box<dyn ConversionPattern>>,
@@ -29,20 +35,24 @@ impl ConversionPatternSet {
         }
     }
 
+    /// Return the context associated with this pattern set.
     #[inline]
     pub fn context(&self) -> Rc<Context> {
         Rc::clone(&self.context)
     }
 
+    /// Return the mutable set's patterns in insertion order.
     #[inline]
     pub fn patterns(&self) -> &[Box<dyn ConversionPattern>] {
         &self.patterns
     }
 
+    /// Add one conversion pattern to this set.
     pub fn push(&mut self, pattern: impl ConversionPattern + 'static) {
         self.patterns.push(Box::new(pattern));
     }
 
+    /// Extend this set with boxed conversion patterns.
     pub fn extend<P>(&mut self, patterns: P)
     where
         P: IntoIterator<Item = Box<dyn ConversionPattern>>,
@@ -52,6 +62,10 @@ impl ConversionPatternSet {
 }
 
 /// Immutable conversion pattern set indexed by root kind.
+///
+/// Freezing expands trait-rooted patterns to the operations that are registered in the context at
+/// freeze time. Callers that rely on trait-rooted conversion patterns must register the relevant
+/// dialects before freezing the set.
 pub struct FrozenConversionPatternSet {
     context: Rc<Context>,
     patterns: Vec<Rc<dyn ConversionPattern>>,
@@ -60,6 +74,7 @@ pub struct FrozenConversionPatternSet {
 }
 
 impl FrozenConversionPatternSet {
+    /// Freeze and index a mutable conversion pattern set.
     pub fn new(patterns: ConversionPatternSet) -> Self {
         let ConversionPatternSet { context, patterns } = patterns;
         let mut this = Self {
@@ -102,16 +117,22 @@ impl FrozenConversionPatternSet {
         this
     }
 
+    /// Return the context used to freeze this set.
     #[inline]
     pub fn context(&self) -> Rc<Context> {
         Rc::clone(&self.context)
     }
 
+    /// Return all frozen patterns in insertion order.
     #[inline]
     pub fn patterns(&self) -> &[Rc<dyn ConversionPattern>] {
         &self.patterns
     }
 
+    /// Return patterns indexed by concrete root operation name.
+    ///
+    /// This includes operation-rooted patterns and trait-rooted patterns expanded against
+    /// registered operation metadata.
     #[inline]
     pub fn op_specific_patterns(
         &self,
@@ -119,15 +140,21 @@ impl FrozenConversionPatternSet {
         &self.op_specific_patterns
     }
 
+    /// Return patterns that may match any operation.
     #[inline]
     pub fn any_op_patterns(&self) -> &[Rc<dyn ConversionPattern>] {
         &self.any_op_patterns
     }
 }
 
+/// Callback type used by conversion providers to populate a pattern set.
 pub type PopulateConversionPatternsFn = fn(Rc<Context>, &mut ConversionPatternSet);
 
 /// Inventory-friendly description of a conversion pattern provider.
+///
+/// Providers are lightweight metadata records. Concrete passes may discover registered providers,
+/// filter them by source/target dialect metadata, and invoke [`Self::populate`] to add their
+/// patterns to a pass-owned [`ConversionPatternSet`].
 pub struct ConversionPatternProviderInfo {
     name: &'static str,
     source_dialect: Option<&'static str>,
@@ -136,6 +163,11 @@ pub struct ConversionPatternProviderInfo {
 }
 
 impl ConversionPatternProviderInfo {
+    /// Create provider metadata for inventory registration.
+    ///
+    /// `source_dialect` may be `None` for generic providers. `target_dialects` is descriptive
+    /// metadata for pass-level filtering and diagnostics; it does not by itself make any dialect
+    /// legal.
     pub const fn new(
         name: &'static str,
         source_dialect: Option<&'static str>,
@@ -150,26 +182,31 @@ impl ConversionPatternProviderInfo {
         }
     }
 
+    /// Return the provider's human-readable name.
     #[inline]
     pub const fn name(&self) -> &'static str {
         self.name
     }
 
+    /// Return the provider's source dialect, if it is specific to one dialect.
     #[inline]
     pub const fn source_dialect(&self) -> Option<&'static str> {
         self.source_dialect
     }
 
+    /// Return the provider's declared target dialect namespaces.
     #[inline]
     pub const fn target_dialects(&self) -> &'static [&'static str] {
         self.target_dialects
     }
 
+    /// Populate `patterns` with this provider's conversion patterns.
     #[inline]
     pub fn populate(&self, context: Rc<Context>, patterns: &mut ConversionPatternSet) {
         (self.populate)(context, patterns);
     }
 
+    /// Iterate over provider metadata registered with `inventory`.
     #[inline]
     pub fn registered() -> impl Iterator<Item = &'static ConversionPatternProviderInfo> {
         inventory::iter::<ConversionPatternProviderInfo>()

--- a/hir/src/conversion/pattern_set.rs
+++ b/hir/src/conversion/pattern_set.rs
@@ -1,0 +1,354 @@
+use alloc::{boxed::Box, collections::BTreeMap, rc::Rc, vec, vec::Vec};
+
+use smallvec::SmallVec;
+
+use super::ConversionPattern;
+use crate::{Context, OperationName, patterns::PatternKind};
+
+/// Mutable collection of conversion patterns.
+pub struct ConversionPatternSet {
+    context: Rc<Context>,
+    patterns: Vec<Box<dyn ConversionPattern>>,
+}
+
+impl ConversionPatternSet {
+    pub fn new(context: Rc<Context>) -> Self {
+        Self {
+            context,
+            patterns: vec![],
+        }
+    }
+
+    pub fn from_iter<P>(context: Rc<Context>, patterns: P) -> Self
+    where
+        P: IntoIterator<Item = Box<dyn ConversionPattern>>,
+    {
+        Self {
+            context,
+            patterns: patterns.into_iter().collect(),
+        }
+    }
+
+    #[inline]
+    pub fn context(&self) -> Rc<Context> {
+        Rc::clone(&self.context)
+    }
+
+    #[inline]
+    pub fn patterns(&self) -> &[Box<dyn ConversionPattern>] {
+        &self.patterns
+    }
+
+    pub fn push(&mut self, pattern: impl ConversionPattern + 'static) {
+        self.patterns.push(Box::new(pattern));
+    }
+
+    pub fn extend<P>(&mut self, patterns: P)
+    where
+        P: IntoIterator<Item = Box<dyn ConversionPattern>>,
+    {
+        self.patterns.extend(patterns);
+    }
+}
+
+/// Immutable conversion pattern set indexed by root kind.
+pub struct FrozenConversionPatternSet {
+    context: Rc<Context>,
+    patterns: Vec<Rc<dyn ConversionPattern>>,
+    op_specific_patterns: BTreeMap<OperationName, SmallVec<[Rc<dyn ConversionPattern>; 2]>>,
+    any_op_patterns: SmallVec<[Rc<dyn ConversionPattern>; 1]>,
+}
+
+impl FrozenConversionPatternSet {
+    pub fn new(patterns: ConversionPatternSet) -> Self {
+        let ConversionPatternSet { context, patterns } = patterns;
+        let mut this = Self {
+            context,
+            patterns: Default::default(),
+            op_specific_patterns: Default::default(),
+            any_op_patterns: Default::default(),
+        };
+
+        for pattern in patterns {
+            let pattern = Rc::<dyn ConversionPattern>::from(pattern);
+            match pattern.kind() {
+                PatternKind::Operation(name) => {
+                    this.op_specific_patterns
+                        .entry(name.clone())
+                        .or_default()
+                        .push(Rc::clone(&pattern));
+                    this.patterns.push(pattern);
+                }
+                PatternKind::Trait(trait_id) => {
+                    for dialect in this.context.registered_dialects().values() {
+                        for op in dialect.registered_ops().iter() {
+                            if op.implements_trait_id(trait_id) {
+                                this.op_specific_patterns
+                                    .entry(op.clone())
+                                    .or_default()
+                                    .push(Rc::clone(&pattern));
+                            }
+                        }
+                    }
+                    this.patterns.push(pattern);
+                }
+                PatternKind::Any => {
+                    this.any_op_patterns.push(Rc::clone(&pattern));
+                    this.patterns.push(pattern);
+                }
+            }
+        }
+
+        this
+    }
+
+    #[inline]
+    pub fn context(&self) -> Rc<Context> {
+        Rc::clone(&self.context)
+    }
+
+    #[inline]
+    pub fn patterns(&self) -> &[Rc<dyn ConversionPattern>] {
+        &self.patterns
+    }
+
+    #[inline]
+    pub fn op_specific_patterns(
+        &self,
+    ) -> &BTreeMap<OperationName, SmallVec<[Rc<dyn ConversionPattern>; 2]>> {
+        &self.op_specific_patterns
+    }
+
+    #[inline]
+    pub fn any_op_patterns(&self) -> &[Rc<dyn ConversionPattern>] {
+        &self.any_op_patterns
+    }
+}
+
+pub type PopulateConversionPatternsFn = fn(Rc<Context>, &mut ConversionPatternSet);
+
+/// Inventory-friendly description of a conversion pattern provider.
+pub struct ConversionPatternProviderInfo {
+    name: &'static str,
+    source_dialect: Option<&'static str>,
+    target_dialects: &'static [&'static str],
+    populate: PopulateConversionPatternsFn,
+}
+
+impl ConversionPatternProviderInfo {
+    pub const fn new(
+        name: &'static str,
+        source_dialect: Option<&'static str>,
+        target_dialects: &'static [&'static str],
+        populate: PopulateConversionPatternsFn,
+    ) -> Self {
+        Self {
+            name,
+            source_dialect,
+            target_dialects,
+            populate,
+        }
+    }
+
+    #[inline]
+    pub const fn name(&self) -> &'static str {
+        self.name
+    }
+
+    #[inline]
+    pub const fn source_dialect(&self) -> Option<&'static str> {
+        self.source_dialect
+    }
+
+    #[inline]
+    pub const fn target_dialects(&self) -> &'static [&'static str] {
+        self.target_dialects
+    }
+
+    #[inline]
+    pub fn populate(&self, context: Rc<Context>, patterns: &mut ConversionPatternSet) {
+        (self.populate)(context, patterns);
+    }
+
+    #[inline]
+    pub fn registered() -> impl Iterator<Item = &'static ConversionPatternProviderInfo> {
+        inventory::iter::<ConversionPatternProviderInfo>()
+    }
+}
+
+inventory::collect!(ConversionPatternProviderInfo);
+
+#[cfg(test)]
+mod tests {
+    use alloc::rc::Rc;
+    use core::any::TypeId;
+
+    use crate::{
+        Context, DialectRegistration, OperationName, OperationRef, Report, SmallVec, ValueRef,
+        conversion::{
+            ConversionPattern, ConversionPatternProviderInfo, ConversionPatternRewriter,
+            ConversionPatternSet, ConvertedOperands, FrozenConversionPatternSet,
+        },
+        dialects::test::{Add, Constant, TestDialect},
+        patterns::{Pattern, PatternBenefit, PatternInfo, PatternKind},
+        traits::ConstantLike,
+    };
+
+    struct TestConversionPattern {
+        info: PatternInfo,
+    }
+
+    impl TestConversionPattern {
+        fn new(context: Rc<Context>, name: &'static str, kind: PatternKind) -> Self {
+            Self {
+                info: PatternInfo::new(context, name, kind, PatternBenefit::new(1)),
+            }
+        }
+
+        fn with_generated_ops(
+            mut self,
+            generated_ops: impl IntoIterator<Item = OperationName>,
+        ) -> Self {
+            self.info.with_generated_ops(generated_ops);
+            self
+        }
+    }
+
+    impl Pattern for TestConversionPattern {
+        fn info(&self) -> &PatternInfo {
+            &self.info
+        }
+    }
+
+    impl ConversionPattern for TestConversionPattern {
+        fn match_and_rewrite(
+            &self,
+            _op: OperationRef,
+            _operands: ConvertedOperands<'_>,
+            _rewriter: &mut ConversionPatternRewriter,
+        ) -> Result<bool, Report> {
+            Ok(false)
+        }
+    }
+
+    #[test]
+    fn freezes_operation_rooted_patterns() {
+        let context = Rc::new(Context::default());
+        let root = context
+            .get_or_register_dialect::<TestDialect>()
+            .expect_registered_name::<Constant>();
+
+        let mut patterns = ConversionPatternSet::new(context.clone());
+        patterns.push(TestConversionPattern::new(
+            context.clone(),
+            "constant-conversion",
+            PatternKind::Operation(root.clone()),
+        ));
+
+        let frozen = FrozenConversionPatternSet::new(patterns);
+        assert_eq!(frozen.patterns().len(), 1);
+        assert_eq!(frozen.op_specific_patterns()[&root].len(), 1);
+        assert!(frozen.any_op_patterns().is_empty());
+    }
+
+    #[test]
+    fn expands_trait_rooted_patterns_to_registered_ops() {
+        let context = Rc::new(Context::default());
+        let dialect = context.get_or_register_dialect::<TestDialect>();
+        let constant = dialect.expect_registered_name::<Constant>();
+        let add = dialect.expect_registered_name::<Add>();
+
+        let mut patterns = ConversionPatternSet::new(context.clone());
+        patterns.push(TestConversionPattern::new(
+            context.clone(),
+            "constant-like-conversion",
+            PatternKind::Trait(TypeId::of::<dyn ConstantLike>()),
+        ));
+
+        let frozen = FrozenConversionPatternSet::new(patterns);
+        assert_eq!(frozen.op_specific_patterns()[&constant].len(), 1);
+        assert!(!frozen.op_specific_patterns().contains_key(&add));
+    }
+
+    #[test]
+    fn keeps_any_op_patterns_separate() {
+        let context = Rc::new(Context::default());
+        let mut patterns = ConversionPatternSet::new(context.clone());
+        patterns.push(TestConversionPattern::new(context, "any-conversion", PatternKind::Any));
+
+        let frozen = FrozenConversionPatternSet::new(patterns);
+        assert_eq!(frozen.patterns().len(), 1);
+        assert_eq!(frozen.any_op_patterns().len(), 1);
+        assert!(frozen.op_specific_patterns().is_empty());
+    }
+
+    #[test]
+    fn preserves_generated_op_metadata() {
+        let context = Rc::new(Context::default());
+        let dialect = context.get_or_register_dialect::<TestDialect>();
+        let root = dialect.expect_registered_name::<Constant>();
+        let generated = dialect.expect_registered_name::<Add>();
+        let pattern =
+            TestConversionPattern::new(context, "constant-to-add", PatternKind::Operation(root))
+                .with_generated_ops([generated.clone()]);
+
+        assert_eq!(pattern.generated_ops(), &[generated]);
+    }
+
+    fn populate_test_patterns(context: Rc<Context>, patterns: &mut ConversionPatternSet) {
+        let root = context
+            .get_or_register_dialect::<TestDialect>()
+            .expect_registered_name::<Constant>();
+        patterns.push(TestConversionPattern::new(
+            context,
+            "provider-pattern",
+            PatternKind::Operation(root),
+        ));
+    }
+
+    #[test]
+    fn provider_info_populates_pattern_set() {
+        let context = Rc::new(Context::default());
+        let info = ConversionPatternProviderInfo::new(
+            "test-provider",
+            Some(TestDialect::NAMESPACE),
+            &["test-target"],
+            populate_test_patterns,
+        );
+        let mut patterns = ConversionPatternSet::new(context.clone());
+
+        info.populate(context, &mut patterns);
+
+        assert_eq!(info.name(), "test-provider");
+        assert_eq!(info.source_dialect(), Some(TestDialect::NAMESPACE));
+        assert_eq!(info.target_dialects(), &["test-target"]);
+        assert_eq!(patterns.patterns().len(), 1);
+    }
+
+    #[test]
+    fn converted_operands_exposes_groups() {
+        let groups: [SmallVec<[ValueRef; 2]>; 1] = [SmallVec::new()];
+        let operands = ConvertedOperands::new(&groups);
+
+        assert_eq!(operands.len(), 1);
+        assert!(operands.get(0).is_some_and(|group| group.is_empty()));
+    }
+
+    #[test]
+    fn pattern_info_generated_ops_helper_appends() {
+        let context = Rc::new(Context::default());
+        let dialect = context.get_or_register_dialect::<TestDialect>();
+        let root = dialect.expect_registered_name::<Constant>();
+        let generated = dialect.expect_registered_name::<Add>();
+        let mut info = PatternInfo::new(
+            context,
+            "generated-op-helper",
+            PatternKind::Operation(root),
+            PatternBenefit::new(1),
+        );
+
+        info.with_generated_ops([generated.clone()]);
+
+        assert_eq!(info.generated_ops(), &[generated]);
+    }
+}

--- a/hir/src/conversion/rewriter.rs
+++ b/hir/src/conversion/rewriter.rs
@@ -1,6 +1,13 @@
-use alloc::vec::Vec;
+use alloc::{rc::Rc, vec::Vec};
+use core::cell::RefCell;
 
-use crate::{OperationRef, Report};
+use smallvec::SmallVec;
+
+use crate::{
+    BlockRef, BuildableOp, Builder, BuilderExt, Context, Listener, ListenerType, OperationRef,
+    ProgramPoint, RegionRef, Report, SourceSpan, UnsafeIntrusiveEntityRef, ValueRef,
+    patterns::{PatternRewriter, Rewriter, RewriterListener},
+};
 
 /// A recorded reason that a conversion pattern did not match.
 pub struct MatchFailure {
@@ -20,20 +27,241 @@ impl MatchFailure {
     }
 }
 
+/// Mutations observed while applying a conversion pattern.
+#[derive(Default)]
+pub struct TrackedMutations {
+    inserted_ops: Vec<OperationRef>,
+    modified_ops: Vec<OperationRef>,
+    replaced_ops: Vec<OperationRef>,
+    erased_ops: Vec<OperationRef>,
+    block_mutations: usize,
+    mutation_count: usize,
+}
+
+impl TrackedMutations {
+    #[inline]
+    pub fn inserted_ops(&self) -> &[OperationRef] {
+        &self.inserted_ops
+    }
+
+    #[inline]
+    pub fn modified_ops(&self) -> &[OperationRef] {
+        &self.modified_ops
+    }
+
+    #[inline]
+    pub fn replaced_ops(&self) -> &[OperationRef] {
+        &self.replaced_ops
+    }
+
+    #[inline]
+    pub fn erased_ops(&self) -> &[OperationRef] {
+        &self.erased_ops
+    }
+
+    #[inline]
+    pub const fn block_mutations(&self) -> usize {
+        self.block_mutations
+    }
+
+    #[inline]
+    pub const fn mutation_count(&self) -> usize {
+        self.mutation_count
+    }
+
+    #[inline]
+    pub const fn has_mutations(&self) -> bool {
+        self.mutation_count > 0
+    }
+}
+
+struct ConversionTrackingListener {
+    mutations: RefCell<TrackedMutations>,
+}
+
+impl ConversionTrackingListener {
+    fn new() -> Self {
+        Self {
+            mutations: RefCell::new(TrackedMutations::default()),
+        }
+    }
+
+    fn mutation_count(&self) -> usize {
+        self.mutations.borrow().mutation_count()
+    }
+
+    fn take_mutations(&self) -> TrackedMutations {
+        core::mem::take(&mut *self.mutations.borrow_mut())
+    }
+
+    fn record_inserted_op(&self, op: OperationRef) {
+        let mut mutations = self.mutations.borrow_mut();
+        push_unique(&mut mutations.inserted_ops, op);
+        mutations.mutation_count += 1;
+    }
+
+    fn record_modified_op(&self, op: OperationRef) {
+        let mut mutations = self.mutations.borrow_mut();
+        push_unique(&mut mutations.modified_ops, op);
+        mutations.mutation_count += 1;
+    }
+
+    fn record_replaced_op(&self, op: OperationRef) {
+        let mut mutations = self.mutations.borrow_mut();
+        push_unique(&mut mutations.replaced_ops, op);
+        mutations.mutation_count += 1;
+    }
+
+    fn record_erased_op(&self, op: OperationRef) {
+        let mut mutations = self.mutations.borrow_mut();
+        push_unique(&mut mutations.erased_ops, op);
+        mutations.mutation_count += 1;
+    }
+
+    fn record_block_mutation(&self) {
+        let mut mutations = self.mutations.borrow_mut();
+        mutations.block_mutations += 1;
+        mutations.mutation_count += 1;
+    }
+}
+
+impl Listener for ConversionTrackingListener {
+    fn kind(&self) -> ListenerType {
+        ListenerType::Rewriter
+    }
+
+    fn notify_operation_inserted(&self, op: OperationRef, _prev: ProgramPoint) {
+        self.record_inserted_op(op);
+    }
+
+    fn notify_block_inserted(
+        &self,
+        _block: BlockRef,
+        _prev: Option<RegionRef>,
+        _ip: Option<BlockRef>,
+    ) {
+        self.record_block_mutation();
+    }
+}
+
+impl RewriterListener for ConversionTrackingListener {
+    fn notify_block_erased(&self, _block: BlockRef) {
+        self.record_block_mutation();
+    }
+
+    fn notify_operation_modified(&self, op: OperationRef) {
+        self.record_modified_op(op);
+    }
+
+    fn notify_operation_replaced(&self, op: OperationRef, _replacement: OperationRef) {
+        self.record_replaced_op(op);
+    }
+
+    fn notify_operation_replaced_with_values(
+        &self,
+        op: OperationRef,
+        _replacement: &[Option<ValueRef>],
+    ) {
+        self.record_replaced_op(op);
+    }
+
+    fn notify_operation_erased(&self, op: OperationRef) {
+        self.record_erased_op(op);
+    }
+}
+
+fn push_unique(ops: &mut Vec<OperationRef>, op: OperationRef) {
+    if !ops.contains(&op) {
+        ops.push(op);
+    }
+}
+
 /// Rewriter used by conversion patterns.
-///
-/// The Phase 4 driver will extend this with a listener-backed wrapper around
-/// the existing pattern rewriter.
 pub struct ConversionPatternRewriter {
+    inner: PatternRewriter<Rc<ConversionTrackingListener>>,
+    tracking: Rc<ConversionTrackingListener>,
     match_failures: Vec<MatchFailure>,
 }
 
 impl ConversionPatternRewriter {
     #[inline]
-    pub const fn new() -> Self {
+    pub fn new(context: Rc<Context>) -> Self {
+        let tracking = Rc::new(ConversionTrackingListener::new());
+        let inner = PatternRewriter::new_with_listener(context, Rc::clone(&tracking));
         Self {
+            inner,
+            tracking,
             match_failures: Vec::new(),
         }
+    }
+
+    /// Set the insertion point before `op`.
+    #[inline]
+    pub fn set_insertion_point_before(&mut self, op: OperationRef) {
+        self.inner.set_insertion_point_before(op);
+    }
+
+    /// Set the insertion point after `op`.
+    #[inline]
+    pub fn set_insertion_point_after(&mut self, op: OperationRef) {
+        self.inner.set_insertion_point_after(op);
+    }
+
+    /// Create a new operation at the current insertion point.
+    pub fn create_op<T, Args>(
+        &mut self,
+        span: SourceSpan,
+        args: Args,
+    ) -> Result<UnsafeIntrusiveEntityRef<T>, Report>
+    where
+        Args: core::marker::Tuple,
+        T: BuildableOp<Args>,
+    {
+        let builder = self.inner.create::<T, Args>(span);
+        core::ops::FnOnce::call_once(builder, args)
+    }
+
+    /// Replace `op` with the provided same-type replacement values.
+    pub fn replace_op(
+        &mut self,
+        op: OperationRef,
+        replacement_values: &[ValueRef],
+    ) -> Result<(), Report> {
+        if op.borrow().num_results() != replacement_values.len() {
+            return Err(Report::msg("replacement value count does not match operation results"));
+        }
+
+        let values = replacement_values
+            .iter()
+            .copied()
+            .map(Some)
+            .collect::<SmallVec<[Option<ValueRef>; 2]>>();
+        self.inner.replace_op_with_values(op, &values);
+        Ok(())
+    }
+
+    /// Create a new operation before `op`, then replace `op` with the new operation's results.
+    pub fn replace_op_with_new_op<T, Args>(
+        &mut self,
+        op: OperationRef,
+        span: SourceSpan,
+        args: Args,
+    ) -> Result<UnsafeIntrusiveEntityRef<T>, Report>
+    where
+        Args: core::marker::Tuple,
+        T: BuildableOp<Args>,
+    {
+        self.set_insertion_point_before(op);
+        let replacement = self.create_op::<T, Args>(span, args)?;
+        self.inner.replace_op(op, replacement.as_operation_ref());
+        Ok(replacement)
+    }
+
+    /// Erase an operation with no remaining uses.
+    #[inline]
+    pub fn erase_op(&mut self, op: OperationRef) -> Result<(), Report> {
+        self.inner.erase_op(op);
+        Ok(())
     }
 
     pub fn notify_match_failure(&mut self, op: OperationRef, reason: Report) {
@@ -49,12 +277,18 @@ impl ConversionPatternRewriter {
     pub fn clear_match_failures(&mut self) {
         self.match_failures.clear();
     }
-}
 
-impl Default for ConversionPatternRewriter {
+    pub fn take_match_failures(&mut self) -> Vec<MatchFailure> {
+        core::mem::take(&mut self.match_failures)
+    }
+
     #[inline]
-    fn default() -> Self {
-        Self::new()
+    pub fn mutation_count(&self) -> usize {
+        self.tracking.mutation_count()
+    }
+
+    pub fn take_tracked_mutations(&mut self) -> TrackedMutations {
+        self.tracking.take_mutations()
     }
 }
 
@@ -73,8 +307,8 @@ mod tests {
         let op = context
             .get_or_register_dialect::<<Constant as OpRegistration>::Dialect>()
             .expect_registered_name::<Constant>()
-            .alloc_default(context);
-        let mut rewriter = ConversionPatternRewriter::new();
+            .alloc_default(context.clone());
+        let mut rewriter = ConversionPatternRewriter::new(context);
 
         rewriter.notify_match_failure(op, Report::msg("no match"));
 

--- a/hir/src/conversion/rewriter.rs
+++ b/hir/src/conversion/rewriter.rs
@@ -1,0 +1,85 @@
+use alloc::vec::Vec;
+
+use crate::{OperationRef, Report};
+
+/// A recorded reason that a conversion pattern did not match.
+pub struct MatchFailure {
+    op: OperationRef,
+    reason: Report,
+}
+
+impl MatchFailure {
+    #[inline]
+    pub const fn op(&self) -> OperationRef {
+        self.op
+    }
+
+    #[inline]
+    pub const fn reason(&self) -> &Report {
+        &self.reason
+    }
+}
+
+/// Rewriter used by conversion patterns.
+///
+/// The Phase 4 driver will extend this with a listener-backed wrapper around
+/// the existing pattern rewriter.
+pub struct ConversionPatternRewriter {
+    match_failures: Vec<MatchFailure>,
+}
+
+impl ConversionPatternRewriter {
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            match_failures: Vec::new(),
+        }
+    }
+
+    pub fn notify_match_failure(&mut self, op: OperationRef, reason: Report) {
+        self.match_failures.push(MatchFailure { op, reason });
+    }
+
+    #[inline]
+    pub fn match_failures(&self) -> &[MatchFailure] {
+        &self.match_failures
+    }
+
+    #[inline]
+    pub fn clear_match_failures(&mut self) {
+        self.match_failures.clear();
+    }
+}
+
+impl Default for ConversionPatternRewriter {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::rc::Rc;
+
+    use crate::{
+        Context, OpRegistration, Report, conversion::ConversionPatternRewriter,
+        dialects::test::Constant,
+    };
+
+    #[test]
+    fn records_match_failures() {
+        let context = Rc::new(Context::default());
+        let op = context
+            .get_or_register_dialect::<<Constant as OpRegistration>::Dialect>()
+            .expect_registered_name::<Constant>()
+            .alloc_default(context);
+        let mut rewriter = ConversionPatternRewriter::new();
+
+        rewriter.notify_match_failure(op, Report::msg("no match"));
+
+        assert_eq!(rewriter.match_failures().len(), 1);
+        rewriter.clear_match_failures();
+        assert!(rewriter.match_failures().is_empty());
+    }
+}

--- a/hir/src/conversion/rewriter.rs
+++ b/hir/src/conversion/rewriter.rs
@@ -1,11 +1,12 @@
-use alloc::{rc::Rc, vec::Vec};
+use alloc::{format, rc::Rc, vec::Vec};
 use core::cell::RefCell;
 
 use smallvec::SmallVec;
 
+use super::TypeConverter;
 use crate::{
     BlockRef, BuildableOp, Builder, BuilderExt, Context, Listener, ListenerType, OperationRef,
-    ProgramPoint, RegionRef, Report, SourceSpan, UnsafeIntrusiveEntityRef, ValueRef,
+    ProgramPoint, RegionRef, Report, SourceSpan, Spanned, Type, UnsafeIntrusiveEntityRef, ValueRef,
     patterns::{PatternRewriter, Rewriter, RewriterListener},
 };
 
@@ -34,6 +35,7 @@ pub struct TrackedMutations {
     modified_ops: Vec<OperationRef>,
     replaced_ops: Vec<OperationRef>,
     erased_ops: Vec<OperationRef>,
+    materialized_ops: Vec<OperationRef>,
     block_mutations: usize,
     mutation_count: usize,
 }
@@ -57,6 +59,11 @@ impl TrackedMutations {
     #[inline]
     pub fn erased_ops(&self) -> &[OperationRef] {
         &self.erased_ops
+    }
+
+    #[inline]
+    pub fn materialized_ops(&self) -> &[OperationRef] {
+        &self.materialized_ops
     }
 
     #[inline]
@@ -116,6 +123,11 @@ impl ConversionTrackingListener {
         let mut mutations = self.mutations.borrow_mut();
         push_unique(&mut mutations.erased_ops, op);
         mutations.mutation_count += 1;
+    }
+
+    fn record_materialized_op(&self, op: OperationRef) {
+        let mut mutations = self.mutations.borrow_mut();
+        push_unique(&mut mutations.materialized_ops, op);
     }
 
     fn record_block_mutation(&self) {
@@ -180,17 +192,27 @@ fn push_unique(ops: &mut Vec<OperationRef>, op: OperationRef) {
 pub struct ConversionPatternRewriter {
     inner: PatternRewriter<Rc<ConversionTrackingListener>>,
     tracking: Rc<ConversionTrackingListener>,
+    type_converter: Option<TypeConverter>,
     match_failures: Vec<MatchFailure>,
 }
 
 impl ConversionPatternRewriter {
     #[inline]
     pub fn new(context: Rc<Context>) -> Self {
+        Self::new_with_type_converter(context, None)
+    }
+
+    #[inline]
+    pub fn new_with_type_converter(
+        context: Rc<Context>,
+        type_converter: Option<TypeConverter>,
+    ) -> Self {
         let tracking = Rc::new(ConversionTrackingListener::new());
         let inner = PatternRewriter::new_with_listener(context, Rc::clone(&tracking));
         Self {
             inner,
             tracking,
+            type_converter,
             match_failures: Vec::new(),
         }
     }
@@ -221,6 +243,23 @@ impl ConversionPatternRewriter {
         core::ops::FnOnce::call_once(builder, args)
     }
 
+    /// Mark `op` as a framework-owned materialization operation.
+    #[inline]
+    pub fn mark_materialization_op(&mut self, op: OperationRef) {
+        self.tracking.record_materialized_op(op);
+    }
+
+    /// Erase framework materializations that are still unused.
+    pub fn erase_unused_materializations(&mut self) -> Result<(), Report> {
+        let materialized_ops = self.tracking.mutations.borrow().materialized_ops.clone();
+        for op in materialized_ops.into_iter().rev() {
+            if op.parent().is_some() && !op.borrow().is_used() {
+                self.inner.erase_op(op);
+            }
+        }
+        Ok(())
+    }
+
     /// Replace `op` with the provided same-type replacement values.
     pub fn replace_op(
         &mut self,
@@ -231,6 +270,7 @@ impl ConversionPatternRewriter {
             return Err(Report::msg("replacement value count does not match operation results"));
         }
 
+        let replacement_values = self.materialize_source_replacements(op, replacement_values)?;
         let values = replacement_values
             .iter()
             .copied()
@@ -253,7 +293,14 @@ impl ConversionPatternRewriter {
     {
         self.set_insertion_point_before(op);
         let replacement = self.create_op::<T, Args>(span, args)?;
-        self.inner.replace_op(op, replacement.as_operation_ref());
+        let replacement_values = replacement
+            .borrow()
+            .results()
+            .all()
+            .iter()
+            .map(|result| result.borrow().as_value_ref())
+            .collect::<SmallVec<[ValueRef; 2]>>();
+        self.replace_op(op, &replacement_values)?;
         Ok(replacement)
     }
 
@@ -289,6 +336,62 @@ impl ConversionPatternRewriter {
 
     pub fn take_tracked_mutations(&mut self) -> TrackedMutations {
         self.tracking.take_mutations()
+    }
+
+    fn materialize_source_replacements(
+        &mut self,
+        op: OperationRef,
+        replacement_values: &[ValueRef],
+    ) -> Result<SmallVec<[ValueRef; 2]>, Report> {
+        let original_results = op
+            .borrow()
+            .results()
+            .all()
+            .iter()
+            .map(|result| {
+                let value = result.borrow().as_value_ref();
+                let value_ref = value.borrow();
+                let ty = value_ref.ty().clone();
+                let is_used = value_ref.is_used();
+                drop(value_ref);
+                (value, ty, is_used)
+            })
+            .collect::<SmallVec<[(ValueRef, Type, bool); 2]>>();
+
+        let mut replacements = SmallVec::<[ValueRef; 2]>::new();
+        for ((original, original_ty, is_used), replacement) in
+            original_results.into_iter().zip(replacement_values.iter().copied())
+        {
+            let replacement_ty = replacement.borrow().ty().clone();
+            if replacement_ty == original_ty || !is_used {
+                replacements.push(replacement);
+                continue;
+            }
+
+            let Some(type_converter) = self.type_converter.clone() else {
+                return Err(Report::msg(
+                    "replacement value type does not match original result type and no type \
+                     converter is available",
+                ));
+            };
+            let expected_ty = type_converter.convert_value_1_to_1(original)?;
+            if expected_ty != replacement_ty {
+                return Err(Report::msg(format!(
+                    "replacement value type '{}' does not match converted result type '{}'",
+                    replacement_ty, expected_ty
+                )));
+            }
+
+            self.set_insertion_point_before(op);
+            replacements.push(type_converter.materialize_source_conversion(
+                self,
+                replacement,
+                original_ty,
+                op.borrow().span(),
+            )?);
+        }
+
+        Ok(replacements)
     }
 }
 

--- a/hir/src/conversion/rewriter.rs
+++ b/hir/src/conversion/rewriter.rs
@@ -17,11 +17,13 @@ pub struct MatchFailure {
 }
 
 impl MatchFailure {
+    /// Return the operation that failed to match a conversion pattern.
     #[inline]
     pub const fn op(&self) -> OperationRef {
         self.op
     }
 
+    /// Return the diagnostic reason recorded by the pattern.
     #[inline]
     pub const fn reason(&self) -> &Report {
         &self.reason
@@ -29,6 +31,10 @@ impl MatchFailure {
 }
 
 /// Mutations observed while applying a conversion pattern.
+///
+/// The conversion driver uses this summary to legalize newly inserted or modified operations after
+/// a pattern succeeds. The lists contain each operation at most once, while `mutation_count`
+/// counts all listener notifications.
 #[derive(Default)]
 pub struct TrackedMutations {
     inserted_ops: Vec<OperationRef>,
@@ -41,41 +47,49 @@ pub struct TrackedMutations {
 }
 
 impl TrackedMutations {
+    /// Return operations inserted while the pattern ran.
     #[inline]
     pub fn inserted_ops(&self) -> &[OperationRef] {
         &self.inserted_ops
     }
 
+    /// Return operations modified while the pattern ran.
     #[inline]
     pub fn modified_ops(&self) -> &[OperationRef] {
         &self.modified_ops
     }
 
+    /// Return operations replaced while the pattern ran.
     #[inline]
     pub fn replaced_ops(&self) -> &[OperationRef] {
         &self.replaced_ops
     }
 
+    /// Return operations erased while the pattern ran.
     #[inline]
     pub fn erased_ops(&self) -> &[OperationRef] {
         &self.erased_ops
     }
 
+    /// Return framework-owned materialization operations created while the pattern ran.
     #[inline]
     pub fn materialized_ops(&self) -> &[OperationRef] {
         &self.materialized_ops
     }
 
+    /// Return the number of block insertion/erasure notifications observed.
     #[inline]
     pub const fn block_mutations(&self) -> usize {
         self.block_mutations
     }
 
+    /// Return the total number of mutation notifications observed.
     #[inline]
     pub const fn mutation_count(&self) -> usize {
         self.mutation_count
     }
 
+    /// Return true when any IR mutation notification was observed.
     #[inline]
     pub const fn has_mutations(&self) -> bool {
         self.mutation_count > 0
@@ -189,6 +203,10 @@ fn push_unique(ops: &mut Vec<OperationRef>, op: OperationRef) {
 }
 
 /// Rewriter used by conversion patterns.
+///
+/// This wraps the normal [`PatternRewriter`] with mutation tracking and type-conversion
+/// materialization support. Conversion patterns should perform all IR changes through this
+/// rewriter so the driver can validate the pattern contract and legalize generated operations.
 pub struct ConversionPatternRewriter {
     inner: PatternRewriter<Rc<ConversionTrackingListener>>,
     tracking: Rc<ConversionTrackingListener>,
@@ -197,11 +215,17 @@ pub struct ConversionPatternRewriter {
 }
 
 impl ConversionPatternRewriter {
+    /// Create a conversion rewriter without type-conversion support.
     #[inline]
     pub fn new(context: Rc<Context>) -> Self {
         Self::new_with_type_converter(context, None)
     }
 
+    /// Create a conversion rewriter with an optional type converter.
+    ///
+    /// The type converter is used by helpers such as [`Self::replace_op`] to insert source
+    /// materializations when replacement values have converted result types but existing users
+    /// still expect the original result types.
     #[inline]
     pub fn new_with_type_converter(
         context: Rc<Context>,
@@ -250,6 +274,9 @@ impl ConversionPatternRewriter {
     }
 
     /// Erase framework materializations that are still unused.
+    ///
+    /// Drivers call this after a pattern fails to match so temporary casts inserted while building
+    /// converted operands do not remain in the IR.
     pub fn erase_unused_materializations(&mut self) -> Result<(), Report> {
         let materialized_ops = self.tracking.mutations.borrow().materialized_ops.clone();
         for op in materialized_ops.into_iter().rev() {
@@ -261,6 +288,10 @@ impl ConversionPatternRewriter {
     }
 
     /// Replace `op` with the provided same-type replacement values.
+    ///
+    /// The number of replacement values must match `op`'s result count. If a replacement value has
+    /// the converted result type while existing uses require the original result type, this method
+    /// asks the configured [`TypeConverter`] to materialize a source conversion.
     pub fn replace_op(
         &mut self,
         op: OperationRef,
@@ -281,6 +312,9 @@ impl ConversionPatternRewriter {
     }
 
     /// Create a new operation before `op`, then replace `op` with the new operation's results.
+    ///
+    /// This is a convenience for the common single-operation legalization case. It uses
+    /// [`Self::replace_op`] for result replacement, so the same materialization behavior applies.
     pub fn replace_op_with_new_op<T, Args>(
         &mut self,
         op: OperationRef,
@@ -305,35 +339,47 @@ impl ConversionPatternRewriter {
     }
 
     /// Erase an operation with no remaining uses.
+    ///
+    /// Callers are responsible for ensuring the operation can be erased without leaving dangling
+    /// uses or invalid control-flow edges.
     #[inline]
     pub fn erase_op(&mut self, op: OperationRef) -> Result<(), Report> {
         self.inner.erase_op(op);
         Ok(())
     }
 
+    /// Record a non-fatal reason why the current pattern did not match `op`.
+    ///
+    /// A pattern can call this before returning `Ok(false)`. The driver includes collected match
+    /// failures in diagnostics when no candidate pattern can legalize an operation.
     pub fn notify_match_failure(&mut self, op: OperationRef, reason: Report) {
         self.match_failures.push(MatchFailure { op, reason });
     }
 
+    /// Return match failures recorded since the last clear/take.
     #[inline]
     pub fn match_failures(&self) -> &[MatchFailure] {
         &self.match_failures
     }
 
+    /// Remove all recorded match failures.
     #[inline]
     pub fn clear_match_failures(&mut self) {
         self.match_failures.clear();
     }
 
+    /// Take and clear all recorded match failures.
     pub fn take_match_failures(&mut self) -> Vec<MatchFailure> {
         core::mem::take(&mut self.match_failures)
     }
 
+    /// Return the total number of mutation notifications observed by this rewriter.
     #[inline]
     pub fn mutation_count(&self) -> usize {
         self.tracking.mutation_count()
     }
 
+    /// Take and clear tracked mutation state.
     pub fn take_tracked_mutations(&mut self) -> TrackedMutations {
         self.tracking.take_mutations()
     }

--- a/hir/src/conversion/signature_conversion.rs
+++ b/hir/src/conversion/signature_conversion.rs
@@ -11,6 +11,11 @@ use crate::{
 };
 
 /// Describes how a block/callable signature maps original inputs to converted inputs.
+///
+/// The current utilities support applying 1:1 block argument type updates in place. The mapping
+/// model also records replace/drop decisions for future or dialect-specific signature rewrites,
+/// but callers using those mappings must rewrite the affected block predecessors, call operands,
+/// and region successor operands themselves.
 #[derive(Debug)]
 pub struct SignatureConversion {
     converted_types: SmallVec<[Type; 4]>,
@@ -18,6 +23,7 @@ pub struct SignatureConversion {
 }
 
 impl SignatureConversion {
+    /// Create an empty signature conversion.
     pub fn new() -> Self {
         Self {
             converted_types: SmallVec::new(),
@@ -25,6 +31,10 @@ impl SignatureConversion {
         }
     }
 
+    /// Build a 1:1 signature conversion for a block's current arguments.
+    ///
+    /// Each block argument is converted with [`TypeConverter::convert_value_1_to_1`]. The result
+    /// can be applied in place with [`Self::apply_to_block_arguments_1_to_1`].
     pub fn for_block_1_to_1(
         block: BlockRef,
         type_converter: &TypeConverter,
@@ -44,16 +54,19 @@ impl SignatureConversion {
         Ok(conversion)
     }
 
+    /// Return the converted input types in new signature order.
     #[inline]
     pub fn converted_types(&self) -> &[Type] {
         &self.converted_types
     }
 
+    /// Return mappings from old inputs to the converted signature.
     #[inline]
     pub fn mappings(&self) -> &[InputMapping] {
         &self.mappings
     }
 
+    /// Keep old input `old_index` as one converted input with `new_type`.
     pub fn keep_input(&mut self, old_index: usize, new_type: Type) -> &mut Self {
         let new_index = self.converted_types.len();
         self.converted_types.push(new_type);
@@ -65,6 +78,11 @@ impl SignatureConversion {
         self
     }
 
+    /// Replace old input `old_index` with existing values.
+    ///
+    /// This records the mapping only. Generic in-place block argument conversion does not support
+    /// replacement mappings, so dialect-specific rewrites must update uses and control-flow
+    /// operands consistently before relying on this mapping.
     pub fn replace_input(
         &mut self,
         old_index: usize,
@@ -77,6 +95,10 @@ impl SignatureConversion {
         self
     }
 
+    /// Drop old input `old_index` from the converted signature.
+    ///
+    /// This records the mapping only. Dropping a live block argument or callable parameter also
+    /// requires updating all branch/call/region successor operands that feed it.
     pub fn drop_input(&mut self, old_index: usize) -> &mut Self {
         self.mappings.push(InputMapping::Drop { old_index });
         self
@@ -148,21 +170,33 @@ impl Default for SignatureConversion {
 /// Mapping from one original input to the converted signature.
 #[derive(Clone, Debug)]
 pub enum InputMapping {
+    /// Preserve one original input as one converted input.
     Keep {
+        /// Index of the original input.
         old_index: usize,
+        /// First index of this input in the converted signature.
         new_index: usize,
+        /// Number of converted inputs produced for this original input.
         new_count: usize,
     },
+    /// Replace an original input with existing values.
     Replace {
+        /// Index of the original input.
         old_index: usize,
+        /// Values that replace the original input.
         values: SmallVec<[ValueRef; 2]>,
     },
+    /// Remove an original input from the converted signature.
     Drop {
+        /// Index of the original input.
         old_index: usize,
     },
 }
 
 /// Convert a builtin ABI signature 1:1, preserving ABI metadata on each parameter/result.
+///
+/// This updates only parameter and result types. Calling convention and other ABI metadata remain
+/// unchanged.
 pub fn convert_signature_1_to_1(
     signature: &Signature,
     type_converter: &TypeConverter,
@@ -178,6 +212,9 @@ pub fn convert_signature_1_to_1(
 }
 
 /// Return the converted callable signature for `op`, if it implements `CallableOpInterface`.
+///
+/// The operation is not mutated. Concrete conversion patterns can use the returned signature to
+/// rewrite dialect-specific callable storage.
 pub fn converted_callable_signature_1_to_1(
     op: OperationRef,
     type_converter: &TypeConverter,
@@ -207,6 +244,9 @@ pub fn converted_resolved_call_signature_1_to_1(
 }
 
 /// Verify that a call-like operation's operands/results match its resolved callable signature.
+///
+/// Non-call operations are accepted. This helper is intended for conversion patterns or post-pass
+/// checks that need interface-level validation without knowing the concrete call dialect.
 pub fn verify_call_signature_operands_and_results(op: OperationRef) -> Result<(), Report> {
     let op = op.borrow();
     let Some(call) = op.as_trait::<dyn CallOpInterface>() else {
@@ -258,6 +298,8 @@ pub fn verify_call_signature_operands_and_results(op: OperationRef) -> Result<()
 }
 
 /// Verify that a branch operation's successor operand lists still match destination block arity.
+///
+/// Non-branch operations are accepted. Type compatibility is delegated to the branch interface.
 pub fn verify_branch_successor_operand_arities(op: OperationRef) -> Result<(), Report> {
     let op = op.borrow();
     let Some(branch) = op.as_trait::<dyn BranchOpInterface>() else {
@@ -288,6 +330,9 @@ pub fn verify_branch_successor_operand_arities(op: OperationRef) -> Result<(), R
 }
 
 /// Verify entry successor operands for a region-branching operation.
+///
+/// Non-region-branch operations are accepted. This checks only the structural entry successor
+/// operand lists exposed through the interface.
 pub fn verify_region_branch_successor_operand_arities(op: OperationRef) -> Result<(), Report> {
     let op = op.borrow();
     let Some(region_branch) = op.as_trait::<dyn RegionBranchOpInterface>() else {
@@ -311,6 +356,9 @@ pub fn verify_region_branch_successor_operand_arities(op: OperationRef) -> Resul
 }
 
 /// Verify region successor operands forwarded by a region-branch terminator operation.
+///
+/// Non-region-branch terminators are accepted. For matching terminators, the parent operation must
+/// implement [`RegionBranchOpInterface`] so successor type compatibility can be checked.
 pub fn verify_region_branch_terminator_successor_operand_arities(
     op: OperationRef,
 ) -> Result<(), Report> {

--- a/hir/src/conversion/signature_conversion.rs
+++ b/hir/src/conversion/signature_conversion.rs
@@ -1,0 +1,716 @@
+use alloc::{format, string::ToString, vec::Vec};
+
+use smallvec::SmallVec;
+
+use super::TypeConverter;
+use crate::{
+    BlockRef, CallOpInterface, CallableOpInterface, OperationRef, RegionBranchOpInterface,
+    RegionBranchTerminatorOpInterface, RegionSuccessorInfo, Report, SuccessorOperand,
+    SuccessorOperands, Type, Value, ValueRef, dialects::builtin::attributes::Signature,
+    traits::BranchOpInterface,
+};
+
+/// Describes how a block/callable signature maps original inputs to converted inputs.
+#[derive(Debug)]
+pub struct SignatureConversion {
+    converted_types: SmallVec<[Type; 4]>,
+    mappings: Vec<InputMapping>,
+}
+
+impl SignatureConversion {
+    pub fn new() -> Self {
+        Self {
+            converted_types: SmallVec::new(),
+            mappings: Vec::new(),
+        }
+    }
+
+    pub fn for_block_1_to_1(
+        block: BlockRef,
+        type_converter: &TypeConverter,
+    ) -> Result<Self, Report> {
+        let arguments = block
+            .borrow()
+            .arguments()
+            .iter()
+            .copied()
+            .map(|arg| arg as ValueRef)
+            .collect::<SmallVec<[ValueRef; 4]>>();
+
+        let mut conversion = Self::new();
+        for (index, argument) in arguments.into_iter().enumerate() {
+            conversion.keep_input(index, type_converter.convert_value_1_to_1(argument)?);
+        }
+        Ok(conversion)
+    }
+
+    #[inline]
+    pub fn converted_types(&self) -> &[Type] {
+        &self.converted_types
+    }
+
+    #[inline]
+    pub fn mappings(&self) -> &[InputMapping] {
+        &self.mappings
+    }
+
+    pub fn keep_input(&mut self, old_index: usize, new_type: Type) -> &mut Self {
+        let new_index = self.converted_types.len();
+        self.converted_types.push(new_type);
+        self.mappings.push(InputMapping::Keep {
+            old_index,
+            new_index,
+            new_count: 1,
+        });
+        self
+    }
+
+    pub fn replace_input(
+        &mut self,
+        old_index: usize,
+        values: impl IntoIterator<Item = ValueRef>,
+    ) -> &mut Self {
+        self.mappings.push(InputMapping::Replace {
+            old_index,
+            values: values.into_iter().collect(),
+        });
+        self
+    }
+
+    pub fn drop_input(&mut self, old_index: usize) -> &mut Self {
+        self.mappings.push(InputMapping::Drop { old_index });
+        self
+    }
+
+    /// Apply this conversion to block argument types in place.
+    ///
+    /// This is intentionally limited to 1:1 conversions. 1:N and drop conversions need a
+    /// replacement block plus successor rewrites, which should be implemented when a concrete
+    /// lowering needs it.
+    pub fn apply_to_block_arguments_1_to_1(&self, block: BlockRef) -> Result<bool, Report> {
+        let arguments = block.borrow().arguments().iter().copied().collect::<SmallVec<[_; 4]>>();
+        if arguments.len() != self.mappings.len() {
+            return Err(Report::msg(format!(
+                "cannot apply signature conversion to block: expected {} input mappings for the \
+                 block arguments, got {}",
+                arguments.len(),
+                self.mappings.len()
+            )));
+        }
+        if arguments.len() != self.converted_types.len() {
+            return Err(Report::msg(format!(
+                "cannot apply signature conversion to block: expected {} converted inputs for the \
+                 block arguments, got {}",
+                arguments.len(),
+                self.converted_types.len()
+            )));
+        }
+
+        for (expected_old_index, mapping) in self.mappings.iter().enumerate() {
+            match mapping {
+                InputMapping::Keep {
+                    old_index,
+                    new_index,
+                    new_count,
+                } if *old_index == expected_old_index
+                    && *new_index == expected_old_index
+                    && *new_count == 1 => {}
+                InputMapping::Keep { .. } => {
+                    return Err(Report::msg(
+                        "cannot apply non-identity input ordering to block arguments in place",
+                    ));
+                }
+                InputMapping::Replace { .. } | InputMapping::Drop { .. } => {
+                    return Err(Report::msg(
+                        "cannot apply replace/drop input mapping to block arguments in place",
+                    ));
+                }
+            }
+        }
+
+        let mut changed = false;
+        for (mut argument, ty) in arguments.into_iter().zip(self.converted_types.iter()) {
+            if argument.borrow().ty() != ty {
+                argument.borrow_mut().set_type(ty.clone());
+                changed = true;
+            }
+        }
+        Ok(changed)
+    }
+}
+
+impl Default for SignatureConversion {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Mapping from one original input to the converted signature.
+#[derive(Clone, Debug)]
+pub enum InputMapping {
+    Keep {
+        old_index: usize,
+        new_index: usize,
+        new_count: usize,
+    },
+    Replace {
+        old_index: usize,
+        values: SmallVec<[ValueRef; 2]>,
+    },
+    Drop {
+        old_index: usize,
+    },
+}
+
+/// Convert a builtin ABI signature 1:1, preserving ABI metadata on each parameter/result.
+pub fn convert_signature_1_to_1(
+    signature: &Signature,
+    type_converter: &TypeConverter,
+) -> Result<Signature, Report> {
+    let mut converted = signature.clone();
+    for param in converted.params.iter_mut() {
+        param.ty = type_converter.convert_type_1_to_1(&param.ty)?;
+    }
+    for result in converted.results.iter_mut() {
+        result.ty = type_converter.convert_type_1_to_1(&result.ty)?;
+    }
+    Ok(converted)
+}
+
+/// Return the converted callable signature for `op`, if it implements `CallableOpInterface`.
+pub fn converted_callable_signature_1_to_1(
+    op: OperationRef,
+    type_converter: &TypeConverter,
+) -> Result<Option<Signature>, Report> {
+    let op = op.borrow();
+    let Some(callable) = op.as_trait::<dyn CallableOpInterface>() else {
+        return Ok(None);
+    };
+    convert_signature_1_to_1(&callable.signature(), type_converter).map(Some)
+}
+
+/// Resolve a call-like operation and return the converted callee signature.
+///
+/// This helper intentionally does not rewrite call operands, result values, or callee attributes.
+/// Different dialects store those pieces differently, so concrete conversion patterns should use
+/// this to drive operation-specific rewrites.
+pub fn converted_resolved_call_signature_1_to_1(
+    op: OperationRef,
+    type_converter: &TypeConverter,
+) -> Result<Option<Signature>, Report> {
+    let op = op.borrow();
+    let Some(call) = op.as_trait::<dyn CallOpInterface>() else {
+        return Ok(None);
+    };
+    let signature = resolve_call_signature(op.name().to_string(), call)?;
+    convert_signature_1_to_1(&signature, type_converter).map(Some)
+}
+
+/// Verify that a call-like operation's operands/results match its resolved callable signature.
+pub fn verify_call_signature_operands_and_results(op: OperationRef) -> Result<(), Report> {
+    let op = op.borrow();
+    let Some(call) = op.as_trait::<dyn CallOpInterface>() else {
+        return Ok(());
+    };
+
+    let op_name = op.name().to_string();
+    let signature = resolve_call_signature(op_name.clone(), call)?;
+
+    let arguments = call.arguments();
+    if arguments.len() != signature.params().len() {
+        return Err(Report::msg(format!(
+            "operation '{op_name}' has {} call operands, but the resolved callee expects {}",
+            arguments.len(),
+            signature.params().len()
+        )));
+    }
+    for (index, (argument, param)) in arguments.iter().zip(signature.params()).enumerate() {
+        let argument_ty = argument.borrow().ty();
+        if argument_ty != param.ty {
+            return Err(Report::msg(format!(
+                "operation '{op_name}' passes operand {index} of type '{argument_ty}', but the \
+                 resolved callee expects '{}'",
+                param.ty
+            )));
+        }
+    }
+
+    let results = signature.results();
+    if op.num_results() != results.len() {
+        return Err(Report::msg(format!(
+            "operation '{op_name}' has {} results, but the resolved callee returns {}",
+            op.num_results(),
+            results.len()
+        )));
+    }
+    for (index, (result, expected)) in op.results().iter().zip(results.iter()).enumerate() {
+        let result_ty = result.borrow().ty().clone();
+        if result_ty != expected.ty {
+            return Err(Report::msg(format!(
+                "operation '{op_name}' result {index} has type '{result_ty}', but the resolved \
+                 callee returns '{}'",
+                expected.ty
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Verify that a branch operation's successor operand lists still match destination block arity.
+pub fn verify_branch_successor_operand_arities(op: OperationRef) -> Result<(), Report> {
+    let op = op.borrow();
+    let Some(branch) = op.as_trait::<dyn BranchOpInterface>() else {
+        return Ok(());
+    };
+
+    for successor_index in 0..op.num_successors() {
+        let successor = op.successor(successor_index);
+        let destination = successor.successor();
+        let destination_arguments = destination
+            .borrow()
+            .arguments()
+            .iter()
+            .copied()
+            .map(|arg| arg as ValueRef)
+            .collect::<SmallVec<[ValueRef; 4]>>();
+        let operands = branch.get_successor_operands(successor_index);
+        verify_successor_operands_against_inputs(
+            op.name().to_string(),
+            format!("successor {successor_index}"),
+            &operands,
+            destination_arguments.iter().copied(),
+            |lhs, rhs| branch.are_types_compatible(lhs, rhs),
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Verify entry successor operands for a region-branching operation.
+pub fn verify_region_branch_successor_operand_arities(op: OperationRef) -> Result<(), Report> {
+    let op = op.borrow();
+    let Some(region_branch) = op.as_trait::<dyn RegionBranchOpInterface>() else {
+        return Ok(());
+    };
+
+    let operand_constants = unknown_operand_constants(op.num_operands());
+    for successor in region_branch.get_entry_successor_regions(&operand_constants) {
+        let point = *successor.branch_point();
+        let operands = region_branch.get_entry_successor_operands(point);
+        verify_successor_operands_against_inputs(
+            op.name().to_string(),
+            format!("region successor {point}"),
+            &operands,
+            successor.successor_inputs().iter(),
+            |lhs, rhs| region_branch.are_types_compatible(lhs, rhs),
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Verify region successor operands forwarded by a region-branch terminator operation.
+pub fn verify_region_branch_terminator_successor_operand_arities(
+    op: OperationRef,
+) -> Result<(), Report> {
+    let op = op.borrow();
+    let Some(terminator) = op.as_trait::<dyn RegionBranchTerminatorOpInterface>() else {
+        return Ok(());
+    };
+
+    let parent_op_ref = op.parent_region().and_then(|region| region.parent()).ok_or_else(|| {
+        Report::msg(format!(
+            "operation '{}' implements RegionBranchTerminatorOpInterface but has no parent region \
+             branch operation",
+            op.name()
+        ))
+    })?;
+
+    let op_name = op.name().to_string();
+    let operand_constants = unknown_operand_constants(op.num_operands());
+    for successor in terminator.get_successor_regions(&operand_constants) {
+        let point = successor.successor();
+        let inputs = region_successor_inputs(&successor)?;
+        let operands = terminator.get_successor_operands(point);
+        let parent = parent_op_ref.borrow();
+        let region_branch = parent.as_trait::<dyn RegionBranchOpInterface>().ok_or_else(|| {
+            Report::msg(format!(
+                "operation '{op_name}' has parent operation '{}' that does not implement \
+                 RegionBranchOpInterface",
+                parent.name()
+            ))
+        })?;
+        verify_successor_operands_against_inputs(
+            op_name.clone(),
+            format!("region terminator successor {point}"),
+            &operands,
+            inputs.iter().copied(),
+            |lhs, rhs| region_branch.are_types_compatible(lhs, rhs),
+        )?;
+    }
+
+    Ok(())
+}
+
+fn unknown_operand_constants(num_operands: usize) -> Vec<Option<crate::AttributeRef>> {
+    core::iter::repeat_with(|| None).take(num_operands).collect()
+}
+
+fn resolve_call_signature(
+    op_name: alloc::string::String,
+    call: &dyn CallOpInterface,
+) -> Result<Signature, Report> {
+    let callee = call.callable_for_callee();
+    let Some(resolved) = call.resolve() else {
+        return Err(Report::msg(format!(
+            "operation '{op_name}' references unresolved callee '{callee}'"
+        )));
+    };
+    let Some(callable) = resolved.as_trait_ref::<dyn CallableOpInterface>() else {
+        return Err(Report::msg(format!(
+            "operation '{op_name}' resolved callee '{callee}', but it is not callable"
+        )));
+    };
+    Ok(callable.borrow().signature())
+}
+
+fn region_successor_inputs(
+    successor: &RegionSuccessorInfo,
+) -> Result<SmallVec<[ValueRef; 4]>, Report> {
+    match successor {
+        RegionSuccessorInfo::Entering(region) => {
+            let region = region.borrow();
+            let Some(entry) = region.entry_block_ref() else {
+                return Err(Report::msg(
+                    "region branch successor points to an empty region with no entry block",
+                ));
+            };
+            Ok(entry
+                .borrow()
+                .arguments()
+                .iter()
+                .map(|arg| arg.borrow().as_value_ref())
+                .collect())
+        }
+        RegionSuccessorInfo::Returning(values) => Ok(values.iter().copied().collect()),
+    }
+}
+
+fn verify_successor_operands_against_inputs(
+    op_name: alloc::string::String,
+    edge: alloc::string::String,
+    operands: &impl SuccessorOperands,
+    inputs: impl IntoIterator<Item = ValueRef>,
+    are_types_compatible: impl Fn(&Type, &Type) -> bool,
+) -> Result<(), Report> {
+    let inputs = inputs.into_iter().collect::<SmallVec<[ValueRef; 4]>>();
+    if operands.len() != inputs.len() {
+        return Err(Report::msg(format!(
+            "operation '{op_name}' has {} operands for {edge}, but the destination expects {}",
+            operands.len(),
+            inputs.len()
+        )));
+    }
+
+    let forwarded = operands.forwarded();
+    for (index, input) in inputs.into_iter().enumerate() {
+        let successor_operand = if index < operands.num_produced() {
+            SuccessorOperand::Produced
+        } else {
+            let forwarded_index = index - operands.num_produced();
+            let Some(operand) = forwarded.get(forwarded_index) else {
+                return Err(Report::msg(format!(
+                    "operation '{op_name}' is missing forwarded operand {forwarded_index} for \
+                     {edge}"
+                )));
+            };
+            SuccessorOperand::Forwarded(operand.borrow().as_value_ref())
+        };
+
+        let SuccessorOperand::Forwarded(value) = successor_operand else {
+            continue;
+        };
+        let value_ty = value.borrow().ty().clone();
+        let input_ty = input.borrow().ty().clone();
+        if !are_types_compatible(&value_ty, &input_ty) {
+            return Err(Report::msg(format!(
+                "operation '{op_name}' forwards operand {index} of type '{value_ty}' to {edge}, \
+                 but the destination expects '{input_ty}'"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{format, vec};
+
+    use super::*;
+    use crate::{
+        AttributeRef, BlockRef, Builder, BuilderExt, Context, Op, RegionBranchPoint, RegionKind,
+        RegionKindInterface, RegionSuccessorIter, SourceSpan, SuccessorOperandRange,
+        SuccessorOperandRangeMut, Type,
+        derive::{EffectOpInterface, operation},
+        dialects::{builtin::attributes::Signature, test::TestDialect},
+        effects::MemoryEffectOpInterface,
+        smallvec,
+        testing::Test,
+        traits::{AnyType, Terminator},
+    };
+
+    #[derive(EffectOpInterface)]
+    #[operation(
+        dialect = TestDialect,
+        traits(Terminator),
+        implements(BranchOpInterface, MemoryEffectOpInterface)
+    )]
+    pub struct SignatureTestBr {
+        #[successor]
+        target: Successor,
+    }
+
+    impl BranchOpInterface for SignatureTestBr {}
+
+    #[derive(EffectOpInterface)]
+    #[operation(
+        dialect = TestDialect,
+        implements(RegionBranchOpInterface, RegionKindInterface, MemoryEffectOpInterface)
+    )]
+    pub struct SignatureTestRegionBranch {
+        #[region]
+        body: Region,
+    }
+
+    impl RegionBranchOpInterface for SignatureTestRegionBranch {
+        fn get_successor_regions(&self, point: RegionBranchPoint) -> RegionSuccessorIter<'_> {
+            match point {
+                RegionBranchPoint::Parent => RegionSuccessorIter::new(
+                    self.as_operation(),
+                    [RegionSuccessorInfo::Entering(self.body().as_region_ref())],
+                ),
+                RegionBranchPoint::Child(_) => RegionSuccessorIter::new(
+                    self.as_operation(),
+                    [RegionSuccessorInfo::Returning(SmallVec::new())],
+                ),
+            }
+        }
+    }
+
+    impl RegionKindInterface for SignatureTestRegionBranch {
+        fn kind(&self) -> RegionKind {
+            RegionKind::SSA
+        }
+    }
+
+    #[derive(EffectOpInterface)]
+    #[operation(
+        dialect = TestDialect,
+        traits(Terminator),
+        implements(RegionBranchTerminatorOpInterface, MemoryEffectOpInterface)
+    )]
+    pub struct SignatureTestRegionYield {
+        #[operands]
+        yielded: AnyType,
+    }
+
+    impl RegionBranchTerminatorOpInterface for SignatureTestRegionYield {
+        fn get_successor_operands(&self, _point: RegionBranchPoint) -> SuccessorOperandRange<'_> {
+            SuccessorOperandRange::forward(self.yielded())
+        }
+
+        fn get_mutable_successor_operands(
+            &mut self,
+            _point: RegionBranchPoint,
+        ) -> SuccessorOperandRangeMut<'_> {
+            SuccessorOperandRangeMut::forward(self.yielded_mut())
+        }
+
+        fn get_successor_regions(
+            &self,
+            _operands: &[Option<AttributeRef>],
+        ) -> SmallVec<[RegionSuccessorInfo; 2]> {
+            smallvec![RegionSuccessorInfo::Returning(SmallVec::new())]
+        }
+    }
+
+    fn u32_to_i32_converter() -> TypeConverter {
+        let mut converter = TypeConverter::new();
+        converter.add_conversion(|ty| {
+            if ty == &Type::U32 {
+                Some(super::super::TypeConversion::One(Type::I32))
+            } else {
+                None
+            }
+        });
+        converter
+    }
+
+    #[test]
+    fn applies_1_to_1_block_argument_conversion_in_place() {
+        let test = Test::new(
+            "applies_1_to_1_block_argument_conversion_in_place",
+            &[Type::U32, Type::I32],
+            &[],
+        );
+        let block = test.entry_block();
+
+        let conversion = SignatureConversion::for_block_1_to_1(block, &u32_to_i32_converter())
+            .expect("signature conversion failed");
+
+        assert!(conversion.apply_to_block_arguments_1_to_1(block).unwrap());
+        let types = block.borrow().argument_types().collect::<Vec<_>>();
+        assert_eq!(types, vec![Type::I32, Type::I32]);
+    }
+
+    #[test]
+    fn applies_1_to_1_non_entry_block_argument_conversion_in_place() {
+        let mut test =
+            Test::new("applies_1_to_1_non_entry_block_argument_conversion_in_place", &[], &[]);
+        let block = {
+            let mut builder = test.function_builder();
+            let block = builder.create_block();
+            builder.append_block_param(block, Type::U32, SourceSpan::UNKNOWN);
+            block
+        };
+
+        let conversion = SignatureConversion::for_block_1_to_1(block, &u32_to_i32_converter())
+            .expect("signature conversion failed");
+
+        assert!(conversion.apply_to_block_arguments_1_to_1(block).unwrap());
+        let types = block.borrow().argument_types().collect::<Vec<_>>();
+        assert_eq!(types, vec![Type::I32]);
+    }
+
+    #[test]
+    fn rejects_non_1_to_1_block_argument_conversion() {
+        let test = Test::new("rejects_non_1_to_1_block_argument_conversion", &[Type::U32], &[]);
+        let block = test.entry_block();
+        let mut converter = TypeConverter::new();
+        converter.add_conversion(|ty| {
+            if ty == &Type::U32 {
+                Some(super::super::TypeConversion::Drop)
+            } else {
+                None
+            }
+        });
+
+        let err = SignatureConversion::for_block_1_to_1(block, &converter).unwrap_err();
+        assert!(format!("{err}").contains("1:1"));
+    }
+
+    #[test]
+    fn converts_builtin_signature_1_to_1() {
+        let context = alloc::rc::Rc::new(Context::default());
+        let signature = Signature::new(&context, [Type::U32], [Type::U32]);
+
+        let converted = convert_signature_1_to_1(&signature, &u32_to_i32_converter()).unwrap();
+
+        assert_eq!(converted.params()[0].ty, Type::I32);
+        assert_eq!(converted.results()[0].ty, Type::I32);
+        assert_eq!(converted.calling_convention(), signature.calling_convention());
+    }
+
+    #[test]
+    fn converts_callable_signature_1_to_1() {
+        let test = Test::new("converts_callable_signature_1_to_1", &[Type::U32], &[Type::U32]);
+
+        let converted = converted_callable_signature_1_to_1(
+            test.function().as_operation_ref(),
+            &u32_to_i32_converter(),
+        )
+        .unwrap()
+        .expect("function should implement CallableOpInterface");
+
+        assert_eq!(converted.params()[0].ty, Type::I32);
+        assert_eq!(converted.results()[0].ty, Type::I32);
+    }
+
+    #[test]
+    fn reports_branch_successor_operand_arity_mismatch() {
+        let mut test =
+            Test::new("reports_branch_successor_operand_arity_mismatch", &[Type::U32], &[]);
+        let op = {
+            let mut builder = test.function_builder();
+            let dest = builder.create_block();
+            builder.append_block_param(dest, Type::U32, SourceSpan::UNKNOWN);
+            let op_builder = builder
+                .builder_mut()
+                .create::<SignatureTestBr, (BlockRef, Vec<ValueRef>)>(SourceSpan::UNKNOWN);
+            op_builder(dest, Vec::new()).unwrap()
+        };
+
+        let err = verify_branch_successor_operand_arities(op.as_operation_ref()).unwrap_err();
+        assert!(format!("{err}").contains("destination expects 1"));
+    }
+
+    #[test]
+    fn accepts_matching_branch_successor_operands() {
+        let mut test = Test::new("accepts_matching_branch_successor_operands", &[Type::U32], &[]);
+        let op = {
+            let mut builder = test.function_builder();
+            let entry = builder.entry_block();
+            let arg = entry.borrow().arguments()[0] as ValueRef;
+            let dest: BlockRef = builder.create_block();
+            builder.append_block_param(dest, Type::U32, SourceSpan::UNKNOWN);
+            let op_builder = builder
+                .builder_mut()
+                .create::<SignatureTestBr, (BlockRef, [ValueRef; 1])>(SourceSpan::UNKNOWN);
+            op_builder(dest, [arg]).unwrap()
+        };
+
+        verify_branch_successor_operand_arities(op.as_operation_ref()).unwrap();
+    }
+
+    #[test]
+    fn reports_region_branch_entry_successor_arity_mismatch() {
+        let mut test = Test::new("reports_region_branch_entry_successor_arity_mismatch", &[], &[]);
+        let op = {
+            let mut builder = test.function_builder();
+            let op_builder = builder
+                .builder_mut()
+                .create::<SignatureTestRegionBranch, ()>(SourceSpan::UNKNOWN);
+            let op = op_builder().unwrap();
+            let region = op.borrow().body().as_region_ref();
+            builder.builder_mut().create_block(region, None, &[Type::U32]);
+            op
+        };
+
+        let err =
+            verify_region_branch_successor_operand_arities(op.as_operation_ref()).unwrap_err();
+        assert!(format!("{err}").contains("destination expects 1"));
+    }
+
+    #[test]
+    fn reports_region_branch_terminator_successor_arity_mismatch() {
+        let mut test = Test::new(
+            "reports_region_branch_terminator_successor_arity_mismatch",
+            &[Type::U32],
+            &[],
+        );
+        let terminator = {
+            let mut builder = test.function_builder();
+            let entry = builder.entry_block();
+            let arg = entry.borrow().arguments()[0] as ValueRef;
+            let op_builder = builder
+                .builder_mut()
+                .create::<SignatureTestRegionBranch, ()>(SourceSpan::UNKNOWN);
+            let op = op_builder().unwrap();
+            let region = op.borrow().body().as_region_ref();
+            let body = builder.builder_mut().create_block(region, None, &[]);
+            builder.builder_mut().set_insertion_point_to_end(body);
+            let yield_builder = builder
+                .builder_mut()
+                .create::<SignatureTestRegionYield, ([ValueRef; 1],)>(SourceSpan::UNKNOWN);
+            yield_builder([arg]).unwrap()
+        };
+
+        let err = verify_region_branch_terminator_successor_operand_arities(
+            terminator.as_operation_ref(),
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("destination expects 0"));
+    }
+}

--- a/hir/src/conversion/target.rs
+++ b/hir/src/conversion/target.rs
@@ -1,0 +1,466 @@
+use alloc::{collections::BTreeMap, rc::Rc, vec::Vec};
+use core::{
+    any::TypeId,
+    ptr::{DynMetadata, Pointee},
+};
+
+use super::DynamicLegalityResult;
+use crate::{
+    Context, DialectRegistration, FxHashMap, OpRegistration, Operation, OperationName, Report,
+    interner::Symbol,
+};
+
+type DynamicLegalityFn = Rc<dyn Fn(&Operation) -> DynamicLegalityResult>;
+
+/// Describes whether an operation instance is legal for a conversion target.
+pub enum Legality {
+    Legal,
+    Illegal,
+    Unknown,
+    DynamicLegal,
+    DynamicIllegal { reason: Option<Report> },
+}
+
+impl Legality {
+    #[inline]
+    pub const fn is_legal(&self) -> bool {
+        matches!(self, Self::Legal | Self::DynamicLegal)
+    }
+
+    #[inline]
+    pub const fn is_illegal(&self) -> bool {
+        matches!(self, Self::Illegal | Self::DynamicIllegal { .. })
+    }
+
+    #[inline]
+    pub const fn is_unknown(&self) -> bool {
+        matches!(self, Self::Unknown)
+    }
+}
+
+/// Describes the best legality answer available from operation metadata alone.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum StaticLegality {
+    Legal,
+    Illegal,
+    Unknown,
+    Dynamic,
+}
+
+/// Policy used when an operation has no op, dialect, or interface rule.
+#[derive(Clone)]
+pub enum UnknownOpPolicy {
+    Legal,
+    Illegal,
+    Dynamic(DynamicLegalityFn),
+}
+
+impl UnknownOpPolicy {
+    #[inline]
+    fn static_legality(&self) -> StaticLegality {
+        match self {
+            Self::Legal => StaticLegality::Legal,
+            Self::Illegal => StaticLegality::Illegal,
+            Self::Dynamic(_) => StaticLegality::Dynamic,
+        }
+    }
+
+    #[inline]
+    fn evaluate(&self, op: &Operation) -> Legality {
+        match self {
+            Self::Legal => Legality::Legal,
+            Self::Illegal => Legality::Illegal,
+            Self::Dynamic(callback) => evaluate_dynamic(callback(op)),
+        }
+    }
+}
+
+/// A legality rule for a dialect, operation, or interface.
+#[derive(Clone)]
+pub enum LegalityRule {
+    Legal,
+    Illegal,
+    Dynamic(DynamicLegalityFn),
+}
+
+impl LegalityRule {
+    #[inline]
+    fn static_legality(&self) -> StaticLegality {
+        match self {
+            Self::Legal => StaticLegality::Legal,
+            Self::Illegal => StaticLegality::Illegal,
+            Self::Dynamic(_) => StaticLegality::Dynamic,
+        }
+    }
+
+    #[inline]
+    fn evaluate(&self, op: &Operation) -> Legality {
+        match self {
+            Self::Legal => Legality::Legal,
+            Self::Illegal => Legality::Illegal,
+            Self::Dynamic(callback) => evaluate_dynamic(callback(op)),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct InterfaceLegalityRule {
+    trait_id: TypeId,
+    rule: LegalityRule,
+}
+
+#[derive(Clone)]
+pub enum RecursiveLegalityRule {
+    Legal,
+    Dynamic(DynamicLegalityFn),
+}
+
+impl RecursiveLegalityRule {
+    #[inline]
+    fn evaluate(&self, op: &Operation) -> bool {
+        match self {
+            Self::Legal => true,
+            Self::Dynamic(callback) => callback(op).is_legal(),
+        }
+    }
+}
+
+/// Defines the set of operations accepted by a dialect conversion.
+pub struct ConversionTarget {
+    context: Rc<Context>,
+    unknown_op_policy: UnknownOpPolicy,
+    dialect_actions: FxHashMap<Symbol, LegalityRule>,
+    op_actions: BTreeMap<OperationName, LegalityRule>,
+    interface_actions: Vec<InterfaceLegalityRule>,
+    recursive_legality: BTreeMap<OperationName, RecursiveLegalityRule>,
+}
+
+impl ConversionTarget {
+    pub fn new(context: Rc<Context>) -> Self {
+        Self {
+            context,
+            unknown_op_policy: UnknownOpPolicy::Illegal,
+            dialect_actions: Default::default(),
+            op_actions: Default::default(),
+            interface_actions: Default::default(),
+            recursive_legality: Default::default(),
+        }
+    }
+
+    #[inline]
+    pub fn context(&self) -> Rc<Context> {
+        Rc::clone(&self.context)
+    }
+
+    pub fn set_unknown_op_policy(&mut self, policy: UnknownOpPolicy) -> &mut Self {
+        self.unknown_op_policy = policy;
+        self
+    }
+
+    pub fn add_legal_dialect<D: DialectRegistration>(&mut self) -> &mut Self {
+        self.set_dialect_rule::<D>(LegalityRule::Legal)
+    }
+
+    pub fn add_illegal_dialect<D: DialectRegistration>(&mut self) -> &mut Self {
+        self.set_dialect_rule::<D>(LegalityRule::Illegal)
+    }
+
+    pub fn add_dynamically_legal_dialect<D, F>(&mut self, callback: F) -> &mut Self
+    where
+        D: DialectRegistration,
+        F: Fn(&Operation) -> DynamicLegalityResult + 'static,
+    {
+        self.set_dialect_rule::<D>(LegalityRule::Dynamic(Rc::new(callback)))
+    }
+
+    pub fn add_dynamically_legal_dialect_if_op_interface<D, Trait>(&mut self) -> &mut Self
+    where
+        D: DialectRegistration,
+        Trait: ?Sized + Pointee<Metadata = DynMetadata<Trait>> + 'static,
+    {
+        self.add_dynamically_legal_dialect::<D, _>(|op| {
+            DynamicLegalityResult::legal_if(op.implements::<Trait>())
+        })
+    }
+
+    pub fn add_legal_op<Op: OpRegistration>(&mut self) -> &mut Self {
+        self.set_op_rule::<Op>(LegalityRule::Legal)
+    }
+
+    pub fn add_illegal_op<Op: OpRegistration>(&mut self) -> &mut Self {
+        self.set_op_rule::<Op>(LegalityRule::Illegal)
+    }
+
+    pub fn add_dynamically_legal_op<Op, F>(&mut self, callback: F) -> &mut Self
+    where
+        Op: OpRegistration,
+        F: Fn(&Operation) -> DynamicLegalityResult + 'static,
+    {
+        self.set_op_rule::<Op>(LegalityRule::Dynamic(Rc::new(callback)))
+    }
+
+    pub fn add_legal_op_interface<Trait>(&mut self) -> &mut Self
+    where
+        Trait: ?Sized + Pointee<Metadata = DynMetadata<Trait>> + 'static,
+    {
+        self.set_interface_rule::<Trait>(LegalityRule::Legal)
+    }
+
+    pub fn add_dynamically_legal_op_interface<Trait, F>(&mut self, callback: F) -> &mut Self
+    where
+        Trait: ?Sized + Pointee<Metadata = DynMetadata<Trait>> + 'static,
+        F: Fn(&Operation) -> DynamicLegalityResult + 'static,
+    {
+        self.set_interface_rule::<Trait>(LegalityRule::Dynamic(Rc::new(callback)))
+    }
+
+    pub fn mark_op_recursively_legal<Op: OpRegistration>(&mut self) -> &mut Self {
+        let name = self.registered_op_name::<Op>();
+        self.recursive_legality.insert(name, RecursiveLegalityRule::Legal);
+        self
+    }
+
+    pub fn mark_op_recursively_legal_if<Op, F>(&mut self, callback: F) -> &mut Self
+    where
+        Op: OpRegistration,
+        F: Fn(&Operation) -> DynamicLegalityResult + 'static,
+    {
+        let name = self.registered_op_name::<Op>();
+        self.recursive_legality
+            .insert(name, RecursiveLegalityRule::Dynamic(Rc::new(callback)));
+        self
+    }
+
+    pub fn legality(&self, op: &Operation) -> Legality {
+        let name = op.name();
+        if let Some(rule) = self.op_actions.get(&name) {
+            return rule.evaluate(op);
+        }
+
+        if let Some(rule) = self.dialect_actions.get(&name.dialect()) {
+            return rule.evaluate(op);
+        }
+
+        for interface in self.interface_actions.iter() {
+            if name.implements_trait_id(&interface.trait_id) {
+                return interface.rule.evaluate(op);
+            }
+        }
+
+        self.unknown_op_policy.evaluate(op)
+    }
+
+    pub fn static_legality(&self, name: &OperationName) -> StaticLegality {
+        if let Some(rule) = self.op_actions.get(name) {
+            return rule.static_legality();
+        }
+
+        if let Some(rule) = self.dialect_actions.get(&name.dialect()) {
+            return rule.static_legality();
+        }
+
+        for interface in self.interface_actions.iter() {
+            if name.implements_trait_id(&interface.trait_id) {
+                return interface.rule.static_legality();
+            }
+        }
+
+        self.unknown_op_policy.static_legality()
+    }
+
+    #[inline]
+    pub fn is_legal(&self, op: &Operation) -> bool {
+        self.legality(op).is_legal()
+    }
+
+    pub fn is_recursively_legal(&self, op: &Operation) -> bool {
+        let name = op.name();
+        let Some(rule) = self.recursive_legality.get(&name) else {
+            return false;
+        };
+        self.is_legal(op) && rule.evaluate(op)
+    }
+
+    fn set_dialect_rule<D: DialectRegistration>(&mut self, rule: LegalityRule) -> &mut Self {
+        self.context.get_or_register_dialect::<D>();
+        self.dialect_actions.insert(Symbol::intern(D::NAMESPACE), rule);
+        self
+    }
+
+    fn set_op_rule<Op: OpRegistration>(&mut self, rule: LegalityRule) -> &mut Self {
+        let name = self.registered_op_name::<Op>();
+        self.op_actions.insert(name, rule);
+        self
+    }
+
+    fn set_interface_rule<Trait>(&mut self, rule: LegalityRule) -> &mut Self
+    where
+        Trait: ?Sized + Pointee<Metadata = DynMetadata<Trait>> + 'static,
+    {
+        let trait_id = TypeId::of::<Trait>();
+        if let Some(interface) = self
+            .interface_actions
+            .iter_mut()
+            .find(|interface| interface.trait_id == trait_id)
+        {
+            interface.rule = rule;
+        } else {
+            self.interface_actions.push(InterfaceLegalityRule { trait_id, rule });
+        }
+        self
+    }
+
+    fn registered_op_name<Op: OpRegistration>(&self) -> OperationName {
+        self.context
+            .get_or_register_dialect::<<Op as OpRegistration>::Dialect>()
+            .expect_registered_name::<Op>()
+    }
+}
+
+fn evaluate_dynamic(result: DynamicLegalityResult) -> Legality {
+    match result {
+        DynamicLegalityResult::Legal => Legality::DynamicLegal,
+        DynamicLegalityResult::Illegal { reason } => Legality::DynamicIllegal { reason },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::rc::Rc;
+
+    use crate::{
+        Context, OpRegistration, OperationRef, Report,
+        conversion::{
+            ConversionTarget, DynamicLegalityResult, Legality, StaticLegality, UnknownOpPolicy,
+        },
+        dialects::test::{Add, Constant, TestDialect},
+        traits::{Commutative, ConstantLike},
+    };
+
+    fn detached_op<Op>(context: &Rc<Context>) -> OperationRef
+    where
+        Op: OpRegistration,
+    {
+        context
+            .get_or_register_dialect::<<Op as OpRegistration>::Dialect>()
+            .expect_registered_name::<Op>()
+            .alloc_default(context.clone())
+    }
+
+    #[test]
+    fn default_unknown_policy_is_illegal() {
+        let context = Rc::new(Context::default());
+        let target = ConversionTarget::new(context.clone());
+        let op = detached_op::<Constant>(&context);
+
+        assert!(matches!(target.legality(&op.borrow()), Legality::Illegal));
+    }
+
+    #[test]
+    fn unknown_policy_can_mark_unknown_ops_legal_or_dynamic() {
+        let context = Rc::new(Context::default());
+        let op = detached_op::<Constant>(&context);
+
+        let mut target = ConversionTarget::new(context.clone());
+        target.set_unknown_op_policy(UnknownOpPolicy::Legal);
+        assert!(target.is_legal(&op.borrow()));
+
+        target.set_unknown_op_policy(UnknownOpPolicy::Dynamic(Rc::new(|_| {
+            DynamicLegalityResult::illegal_with_reason(Report::msg("not legal"))
+        })));
+        assert!(matches!(
+            target.legality(&op.borrow()),
+            Legality::DynamicIllegal { reason: Some(_) }
+        ));
+    }
+
+    #[test]
+    fn operation_rule_overrides_dialect_rule() {
+        let context = Rc::new(Context::default());
+        let mut target = ConversionTarget::new(context.clone());
+        target.add_legal_dialect::<TestDialect>().add_illegal_op::<Constant>();
+
+        let constant = detached_op::<Constant>(&context);
+        let add = detached_op::<Add>(&context);
+
+        assert!(matches!(target.legality(&constant.borrow()), Legality::Illegal));
+        assert!(matches!(target.legality(&add.borrow()), Legality::Legal));
+    }
+
+    #[test]
+    fn dialect_rule_overrides_interface_rule() {
+        let context = Rc::new(Context::default());
+        let mut target = ConversionTarget::new(context.clone());
+        target
+            .add_legal_op_interface::<dyn ConstantLike>()
+            .add_illegal_dialect::<TestDialect>();
+
+        let constant = detached_op::<Constant>(&context);
+
+        assert!(matches!(target.legality(&constant.borrow()), Legality::Illegal));
+    }
+
+    #[test]
+    fn dialect_can_be_dynamic_by_operation_interface() {
+        let context = Rc::new(Context::default());
+        let mut target = ConversionTarget::new(context.clone());
+        target.add_dynamically_legal_dialect_if_op_interface::<TestDialect, dyn ConstantLike>();
+
+        let constant = detached_op::<Constant>(&context);
+        let add = detached_op::<Add>(&context);
+
+        assert!(matches!(target.legality(&constant.borrow()), Legality::DynamicLegal));
+        assert!(matches!(target.legality(&add.borrow()), Legality::DynamicIllegal { .. }));
+    }
+
+    #[test]
+    fn interface_rule_applies_when_no_op_or_dialect_rule_exists() {
+        let context = Rc::new(Context::default());
+        let mut target = ConversionTarget::new(context.clone());
+        target.add_legal_op_interface::<dyn Commutative>();
+
+        let add = detached_op::<Add>(&context);
+        let constant = detached_op::<Constant>(&context);
+
+        assert!(matches!(target.legality(&add.borrow()), Legality::Legal));
+        assert!(matches!(target.legality(&constant.borrow()), Legality::Illegal));
+    }
+
+    #[test]
+    fn static_legality_reports_metadata_only_result() {
+        let context = Rc::new(Context::default());
+        let mut target = ConversionTarget::new(context.clone());
+        target.add_dynamically_legal_op::<Constant, _>(|_| DynamicLegalityResult::legal());
+
+        let constant = context
+            .get_or_register_dialect::<TestDialect>()
+            .expect_registered_name::<Constant>();
+
+        assert_eq!(target.static_legality(&constant), StaticLegality::Dynamic);
+    }
+
+    #[test]
+    fn recursive_legality_requires_operation_legality() {
+        let context = Rc::new(Context::default());
+        let mut target = ConversionTarget::new(context.clone());
+        target.mark_op_recursively_legal::<Constant>();
+
+        let constant = detached_op::<Constant>(&context);
+        assert!(!target.is_recursively_legal(&constant.borrow()));
+
+        target.add_legal_op::<Constant>();
+        assert!(target.is_recursively_legal(&constant.borrow()));
+    }
+
+    #[test]
+    fn dynamic_recursive_legality_uses_callback() {
+        let context = Rc::new(Context::default());
+        let mut target = ConversionTarget::new(context.clone());
+        target
+            .add_legal_op::<Constant>()
+            .mark_op_recursively_legal_if::<Constant, _>(|_| DynamicLegalityResult::illegal());
+
+        let constant = detached_op::<Constant>(&context);
+        assert!(!target.is_recursively_legal(&constant.borrow()));
+    }
+}

--- a/hir/src/conversion/target.rs
+++ b/hir/src/conversion/target.rs
@@ -14,24 +14,34 @@ type DynamicLegalityFn = Rc<dyn Fn(&Operation) -> DynamicLegalityResult>;
 
 /// Describes whether an operation instance is legal for a conversion target.
 pub enum Legality {
+    /// The operation is statically legal.
     Legal,
+    /// The operation is statically illegal.
     Illegal,
+    /// The target has no rule for the operation.
     Unknown,
+    /// A dynamic legality predicate accepted this operation instance.
     DynamicLegal,
+    /// A dynamic legality predicate rejected this operation instance.
+    ///
+    /// The optional reason is intended for user-facing conversion diagnostics.
     DynamicIllegal { reason: Option<Report> },
 }
 
 impl Legality {
+    /// Return true when this result permits the operation to remain in converted IR.
     #[inline]
     pub const fn is_legal(&self) -> bool {
         matches!(self, Self::Legal | Self::DynamicLegal)
     }
 
+    /// Return true when this result explicitly rejects the operation.
     #[inline]
     pub const fn is_illegal(&self) -> bool {
         matches!(self, Self::Illegal | Self::DynamicIllegal { .. })
     }
 
+    /// Return true when no target rule matched the operation.
     #[inline]
     pub const fn is_unknown(&self) -> bool {
         matches!(self, Self::Unknown)
@@ -41,17 +51,24 @@ impl Legality {
 /// Describes the best legality answer available from operation metadata alone.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum StaticLegality {
+    /// The operation name is accepted without inspecting a concrete operation instance.
     Legal,
+    /// The operation name is rejected without inspecting a concrete operation instance.
     Illegal,
+    /// No matching rule is known for the operation name.
     Unknown,
+    /// A dynamic predicate must inspect each operation instance to decide legality.
     Dynamic,
 }
 
 /// Policy used when an operation has no op, dialect, or interface rule.
 #[derive(Clone)]
 pub enum UnknownOpPolicy {
+    /// Treat otherwise-unmatched operations as legal.
     Legal,
+    /// Treat otherwise-unmatched operations as illegal.
     Illegal,
+    /// Decide legality for otherwise-unmatched operations with a callback.
     Dynamic(DynamicLegalityFn),
 }
 
@@ -78,8 +95,11 @@ impl UnknownOpPolicy {
 /// A legality rule for a dialect, operation, or interface.
 #[derive(Clone)]
 pub enum LegalityRule {
+    /// Matching operations are legal.
     Legal,
+    /// Matching operations are illegal.
     Illegal,
+    /// Matching operations are checked by a callback.
     Dynamic(DynamicLegalityFn),
 }
 
@@ -103,15 +123,25 @@ impl LegalityRule {
     }
 }
 
+/// Legality rule attached to an operation interface.
+///
+/// Interface rules are evaluated after exact operation rules and dialect rules. They are useful
+/// for broad predicates such as "all operations implementing this lowering interface are legal",
+/// but targets that need exceptions should use explicit operation or dialect rules for those
+/// exceptions because those rules take precedence.
 #[derive(Clone)]
 pub struct InterfaceLegalityRule {
     trait_id: TypeId,
     rule: LegalityRule,
 }
 
+/// Rule controlling whether an operation's nested regions are skipped by conversion.
 #[derive(Clone)]
 pub enum RecursiveLegalityRule {
+    /// If the operation itself is legal, all nested operations are considered legal.
     Legal,
+    /// If the operation itself is legal, the callback decides whether nested operations are
+    /// considered legal for this instance.
     Dynamic(DynamicLegalityFn),
 }
 
@@ -126,6 +156,17 @@ impl RecursiveLegalityRule {
 }
 
 /// Defines the set of operations accepted by a dialect conversion.
+///
+/// A target answers legality queries using this precedence:
+///
+/// 1. Exact operation rule.
+/// 2. Dialect rule.
+/// 3. Interface rule, in registration order.
+/// 4. Unknown operation policy.
+///
+/// Conversion targets are owned by concrete passes. The generic driver consumes a target together
+/// with a set of conversion patterns and requires every visited operation to become legal, except
+/// for operations nested under recursively legal operations.
 pub struct ConversionTarget {
     context: Rc<Context>,
     unknown_op_policy: UnknownOpPolicy,
@@ -136,6 +177,7 @@ pub struct ConversionTarget {
 }
 
 impl ConversionTarget {
+    /// Create a target whose default unknown-operation policy is illegal.
     pub fn new(context: Rc<Context>) -> Self {
         Self {
             context,
@@ -147,24 +189,34 @@ impl ConversionTarget {
         }
     }
 
+    /// Return the context used to resolve dialect and operation registrations.
     #[inline]
     pub fn context(&self) -> Rc<Context> {
         Rc::clone(&self.context)
     }
 
+    /// Set the fallback policy used when no operation, dialect, or interface rule matches.
     pub fn set_unknown_op_policy(&mut self, policy: UnknownOpPolicy) -> &mut Self {
         self.unknown_op_policy = policy;
         self
     }
 
+    /// Mark every operation in dialect `D` legal unless a more-specific operation rule overrides
+    /// it.
     pub fn add_legal_dialect<D: DialectRegistration>(&mut self) -> &mut Self {
         self.set_dialect_rule::<D>(LegalityRule::Legal)
     }
 
+    /// Mark every operation in dialect `D` illegal unless a more-specific operation rule overrides
+    /// it.
     pub fn add_illegal_dialect<D: DialectRegistration>(&mut self) -> &mut Self {
         self.set_dialect_rule::<D>(LegalityRule::Illegal)
     }
 
+    /// Mark operations in dialect `D` legal or illegal according to `callback`.
+    ///
+    /// The callback is evaluated for each matching operation instance, so it may inspect traits,
+    /// attributes, operand/result types, regions, or any other operation metadata.
     pub fn add_dynamically_legal_dialect<D, F>(&mut self, callback: F) -> &mut Self
     where
         D: DialectRegistration,
@@ -173,6 +225,8 @@ impl ConversionTarget {
         self.set_dialect_rule::<D>(LegalityRule::Dynamic(Rc::new(callback)))
     }
 
+    /// Mark operations in dialect `D` dynamically legal when their operation registration
+    /// implements `Trait`.
     pub fn add_dynamically_legal_dialect_if_op_interface<D, Trait>(&mut self) -> &mut Self
     where
         D: DialectRegistration,
@@ -183,14 +237,20 @@ impl ConversionTarget {
         })
     }
 
+    /// Mark operation `Op` legal.
     pub fn add_legal_op<Op: OpRegistration>(&mut self) -> &mut Self {
         self.set_op_rule::<Op>(LegalityRule::Legal)
     }
 
+    /// Mark operation `Op` illegal.
     pub fn add_illegal_op<Op: OpRegistration>(&mut self) -> &mut Self {
         self.set_op_rule::<Op>(LegalityRule::Illegal)
     }
 
+    /// Mark operation `Op` legal or illegal according to `callback`.
+    ///
+    /// This is the most precise legality hook and takes precedence over dialect and interface
+    /// rules.
     pub fn add_dynamically_legal_op<Op, F>(&mut self, callback: F) -> &mut Self
     where
         Op: OpRegistration,
@@ -199,6 +259,10 @@ impl ConversionTarget {
         self.set_op_rule::<Op>(LegalityRule::Dynamic(Rc::new(callback)))
     }
 
+    /// Mark all operations whose registration implements `Trait` legal.
+    ///
+    /// This is intentionally broad. Prefer operation or dialect rules when the target needs
+    /// explicit exceptions.
     pub fn add_legal_op_interface<Trait>(&mut self) -> &mut Self
     where
         Trait: ?Sized + Pointee<Metadata = DynMetadata<Trait>> + 'static,
@@ -206,6 +270,8 @@ impl ConversionTarget {
         self.set_interface_rule::<Trait>(LegalityRule::Legal)
     }
 
+    /// Mark all operations whose registration implements `Trait` dynamically legal according to
+    /// `callback`.
     pub fn add_dynamically_legal_op_interface<Trait, F>(&mut self, callback: F) -> &mut Self
     where
         Trait: ?Sized + Pointee<Metadata = DynMetadata<Trait>> + 'static,
@@ -214,12 +280,19 @@ impl ConversionTarget {
         self.set_interface_rule::<Trait>(LegalityRule::Dynamic(Rc::new(callback)))
     }
 
+    /// Mark operation `Op` recursively legal.
+    ///
+    /// Recursive legality only applies when `Op` itself is legal. When it applies, conversion
+    /// skips all nested operations under that operation.
     pub fn mark_op_recursively_legal<Op: OpRegistration>(&mut self) -> &mut Self {
         let name = self.registered_op_name::<Op>();
         self.recursive_legality.insert(name, RecursiveLegalityRule::Legal);
         self
     }
 
+    /// Mark operation `Op` recursively legal when `callback` accepts a concrete instance.
+    ///
+    /// The operation itself must still be legal for recursive legality to apply.
     pub fn mark_op_recursively_legal_if<Op, F>(&mut self, callback: F) -> &mut Self
     where
         Op: OpRegistration,
@@ -231,6 +304,7 @@ impl ConversionTarget {
         self
     }
 
+    /// Evaluate operation-instance legality using the target precedence rules.
     pub fn legality(&self, op: &Operation) -> Legality {
         let name = op.name();
         if let Some(rule) = self.op_actions.get(&name) {
@@ -250,6 +324,10 @@ impl ConversionTarget {
         self.unknown_op_policy.evaluate(op)
     }
 
+    /// Evaluate operation-name legality without inspecting a concrete operation instance.
+    ///
+    /// Dynamic rules return [`StaticLegality::Dynamic`]. This is used by legalization path
+    /// discovery to decide which generated operations may be terminal targets.
     pub fn static_legality(&self, name: &OperationName) -> StaticLegality {
         if let Some(rule) = self.op_actions.get(name) {
             return rule.static_legality();
@@ -268,11 +346,13 @@ impl ConversionTarget {
         self.unknown_op_policy.static_legality()
     }
 
+    /// Return true when `op` is legal for this target.
     #[inline]
     pub fn is_legal(&self, op: &Operation) -> bool {
         self.legality(op).is_legal()
     }
 
+    /// Return true when `op` is legal and its nested operations may be skipped.
     pub fn is_recursively_legal(&self, op: &Operation) -> bool {
         let name = op.name();
         let Some(rule) = self.recursive_legality.get(&name) else {

--- a/hir/src/conversion/type_converter.rs
+++ b/hir/src/conversion/type_converter.rs
@@ -1,22 +1,290 @@
+use alloc::{format, rc::Rc, vec::Vec};
+
+use smallvec::SmallVec;
+
+use super::rewriter::ConversionPatternRewriter;
+use crate::{Report, SourceSpan, Type, ValueRef, dialects::builtin::UnrealizedConversionCast};
+
+type TypeConversionFn = Rc<dyn Fn(&Type) -> Option<TypeConversion>>;
+type ValueConversionFn = Rc<dyn Fn(ValueRef) -> Option<TypeConversion>>;
+type MaterializationFn = Rc<
+    dyn Fn(
+        &mut ConversionPatternRewriter,
+        ValueRef,
+        Type,
+        SourceSpan,
+    ) -> Result<Option<ValueRef>, Report>,
+>;
+
+/// The result of converting one source type.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TypeConversion {
+    /// The source value is represented by one target value.
+    One(Type),
+    /// The source value is represented by multiple target values.
+    ///
+    /// This is reserved by the API, but the Phase 5 driver rejects it when default boundary
+    /// materialization would be required.
+    Many(SmallVec<[Type; 2]>),
+    /// The source value is removed.
+    ///
+    /// This is reserved by the API, but the Phase 5 driver rejects it when default boundary
+    /// materialization would be required.
+    Drop,
+}
+
+impl TypeConversion {
+    #[inline]
+    pub fn one(ty: Type) -> Self {
+        Self::One(ty)
+    }
+
+    #[inline]
+    pub fn many(types: impl IntoIterator<Item = Type>) -> Self {
+        Self::Many(types.into_iter().collect())
+    }
+
+    #[inline]
+    pub const fn drop() -> Self {
+        Self::Drop
+    }
+}
+
 /// Converts source IR types and values to target IR types and values.
-///
-/// This is a placeholder for the Phase 5 implementation. It is introduced now
-/// so conversion pattern APIs can be typed without pulling type conversion into
-/// the initial pattern-registration work.
+#[derive(Clone, Default)]
 pub struct TypeConverter {
-    _private: (),
+    conversions: Vec<TypeConversionFn>,
+    value_conversions: Vec<ValueConversionFn>,
+    source_materializations: Vec<MaterializationFn>,
+    target_materializations: Vec<MaterializationFn>,
 }
 
 impl TypeConverter {
     #[inline]
-    pub const fn new() -> Self {
-        Self { _private: () }
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[inline]
+    pub fn add_conversion<F>(&mut self, callback: F) -> &mut Self
+    where
+        F: Fn(&Type) -> Option<TypeConversion> + 'static,
+    {
+        self.conversions.push(Rc::new(callback));
+        self
+    }
+
+    #[inline]
+    pub fn add_value_conversion<F>(&mut self, callback: F) -> &mut Self
+    where
+        F: Fn(ValueRef) -> Option<TypeConversion> + 'static,
+    {
+        self.value_conversions.push(Rc::new(callback));
+        self
+    }
+
+    #[inline]
+    pub fn add_source_materialization<F>(&mut self, callback: F) -> &mut Self
+    where
+        F: Fn(
+                &mut ConversionPatternRewriter,
+                ValueRef,
+                Type,
+                SourceSpan,
+            ) -> Result<Option<ValueRef>, Report>
+            + 'static,
+    {
+        self.source_materializations.push(Rc::new(callback));
+        self
+    }
+
+    #[inline]
+    pub fn add_target_materialization<F>(&mut self, callback: F) -> &mut Self
+    where
+        F: Fn(
+                &mut ConversionPatternRewriter,
+                ValueRef,
+                Type,
+                SourceSpan,
+            ) -> Result<Option<ValueRef>, Report>
+            + 'static,
+    {
+        self.target_materializations.push(Rc::new(callback));
+        self
+    }
+
+    /// Convert a type.
+    ///
+    /// If no callback handles `ty`, it is treated as an identity conversion.
+    pub fn convert_type(&self, ty: &Type) -> Option<TypeConversion> {
+        self.conversions
+            .iter()
+            .find_map(|convert| convert(ty))
+            .or_else(|| Some(TypeConversion::One(ty.clone())))
+    }
+
+    /// Convert a value, allowing value-specific callbacks to override type-only conversion.
+    pub fn convert_value(&self, value: ValueRef) -> Option<TypeConversion> {
+        self.value_conversions
+            .iter()
+            .find_map(|convert| convert(value))
+            .or_else(|| self.convert_type(value.borrow().ty()))
+    }
+
+    #[inline]
+    pub fn is_legal_type(&self, ty: &Type) -> bool {
+        matches!(self.convert_type(ty), Some(TypeConversion::One(converted)) if converted == *ty)
+    }
+
+    pub fn convert_type_1_to_1(&self, ty: &Type) -> Result<Type, Report> {
+        self.require_1_to_1(self.convert_type(ty), || format!("type '{ty}'"))
+    }
+
+    pub fn convert_value_1_to_1(&self, value: ValueRef) -> Result<Type, Report> {
+        self.require_1_to_1(self.convert_value(value), || {
+            format!("value '{}' of type '{}'", value.borrow(), value.borrow().ty())
+        })
+    }
+
+    pub fn materialize_source_conversion(
+        &self,
+        rewriter: &mut ConversionPatternRewriter,
+        value: ValueRef,
+        ty: Type,
+        span: SourceSpan,
+    ) -> Result<ValueRef, Report> {
+        self.materialize_conversion(
+            &self.source_materializations,
+            rewriter,
+            value,
+            ty,
+            span,
+            "source",
+        )
+    }
+
+    pub fn materialize_target_conversion(
+        &self,
+        rewriter: &mut ConversionPatternRewriter,
+        value: ValueRef,
+        ty: Type,
+        span: SourceSpan,
+    ) -> Result<ValueRef, Report> {
+        self.materialize_conversion(
+            &self.target_materializations,
+            rewriter,
+            value,
+            ty,
+            span,
+            "target",
+        )
+    }
+
+    fn materialize_conversion(
+        &self,
+        callbacks: &[MaterializationFn],
+        rewriter: &mut ConversionPatternRewriter,
+        value: ValueRef,
+        ty: Type,
+        span: SourceSpan,
+        kind: &'static str,
+    ) -> Result<ValueRef, Report> {
+        if *value.borrow().ty() == ty {
+            return Ok(value);
+        }
+
+        for materialize in callbacks {
+            if let Some(materialized) = materialize(rewriter, value, ty.clone(), span)? {
+                return Ok(materialized);
+            }
+        }
+
+        let op = rewriter.create_op::<UnrealizedConversionCast, _>(span, (value, ty.clone()))?;
+        rewriter.mark_materialization_op(op.as_operation_ref());
+        let result = op.borrow().result().as_value_ref();
+        if *result.borrow().ty() != ty {
+            return Err(Report::msg(format!(
+                "{kind} materialization produced type '{}', expected '{ty}'",
+                result.borrow().ty()
+            )));
+        }
+        Ok(result)
+    }
+
+    fn require_1_to_1<F>(
+        &self,
+        conversion: Option<TypeConversion>,
+        describe_source: F,
+    ) -> Result<Type, Report>
+    where
+        F: FnOnce() -> alloc::string::String,
+    {
+        match conversion {
+            Some(TypeConversion::One(ty)) => Ok(ty),
+            Some(TypeConversion::Many(types)) => Err(Report::msg(format!(
+                "only 1:1 type conversion is supported here; {} converted to {} values",
+                describe_source(),
+                types.len()
+            ))),
+            Some(TypeConversion::Drop) => Err(Report::msg(format!(
+                "only 1:1 type conversion is supported here; {} was dropped",
+                describe_source()
+            ))),
+            None => Err(Report::msg(format!("failed to convert {}", describe_source()))),
+        }
     }
 }
 
-impl Default for TypeConverter {
-    #[inline]
-    fn default() -> Self {
-        Self::new()
+#[cfg(test)]
+mod tests {
+    use smallvec::smallvec;
+
+    use super::*;
+    use crate::Type;
+
+    #[test]
+    fn defaults_to_identity_conversion() {
+        let converter = TypeConverter::new();
+
+        assert_eq!(converter.convert_type_1_to_1(&Type::U32).unwrap(), Type::U32);
+        assert!(converter.is_legal_type(&Type::U32));
+    }
+
+    #[test]
+    fn applies_registered_type_conversion() {
+        let mut converter = TypeConverter::new();
+        converter.add_conversion(|ty| {
+            if ty == &Type::U32 {
+                Some(TypeConversion::One(Type::I32))
+            } else {
+                None
+            }
+        });
+
+        assert_eq!(converter.convert_type_1_to_1(&Type::U32).unwrap(), Type::I32);
+        assert!(!converter.is_legal_type(&Type::U32));
+    }
+
+    #[test]
+    fn rejects_many_and_drop_for_1_to_1_queries() {
+        let mut many = TypeConverter::new();
+        many.add_conversion(|ty| {
+            if ty == &Type::U32 {
+                Some(TypeConversion::Many(smallvec![Type::I32, Type::I32]))
+            } else {
+                None
+            }
+        });
+        assert!(format!("{}", many.convert_type_1_to_1(&Type::U32).unwrap_err()).contains("1:1"));
+
+        let mut drop = TypeConverter::new();
+        drop.add_conversion(|ty| {
+            if ty == &Type::U32 {
+                Some(TypeConversion::Drop)
+            } else {
+                None
+            }
+        });
+        assert!(format!("{}", drop.convert_type_1_to_1(&Type::U32).unwrap_err()).contains("1:1"));
     }
 }

--- a/hir/src/conversion/type_converter.rs
+++ b/hir/src/conversion/type_converter.rs
@@ -23,27 +23,36 @@ pub enum TypeConversion {
     One(Type),
     /// The source value is represented by multiple target values.
     ///
-    /// This is reserved by the API, but the Phase 5 driver rejects it when default boundary
+    /// This is reserved by the API, but current driver helpers reject it when default boundary
     /// materialization would be required.
     Many(SmallVec<[Type; 2]>),
     /// The source value is removed.
     ///
-    /// This is reserved by the API, but the Phase 5 driver rejects it when default boundary
+    /// This is reserved by the API, but current driver helpers reject it when default boundary
     /// materialization would be required.
     Drop,
 }
 
 impl TypeConversion {
+    /// Build a 1:1 type conversion result.
     #[inline]
     pub fn one(ty: Type) -> Self {
         Self::One(ty)
     }
 
+    /// Build a 1:N type conversion result.
+    ///
+    /// The current production driver reserves this shape but rejects it in helpers that require
+    /// 1:1 conversion.
     #[inline]
     pub fn many(types: impl IntoIterator<Item = Type>) -> Self {
         Self::Many(types.into_iter().collect())
     }
 
+    /// Build a conversion result that drops the source value.
+    ///
+    /// The current production driver reserves this shape but rejects it in helpers that require
+    /// 1:1 conversion.
     #[inline]
     pub const fn drop() -> Self {
         Self::Drop
@@ -51,6 +60,14 @@ impl TypeConversion {
 }
 
 /// Converts source IR types and values to target IR types and values.
+///
+/// A type converter is attached to conversion patterns that need operand/result type remapping.
+/// Conversion callbacks are tried in registration order. If no type callback handles a type, the
+/// converter treats it as an identity conversion.
+///
+/// The initial driver supports 1:1 boundary materialization. `Many` and `Drop` results are
+/// accepted by the data model for future ABI/aggregate-lowering work, but callers must use the
+/// explicit `*_1_to_1` helpers when they need current driver compatibility.
 #[derive(Clone, Default)]
 pub struct TypeConverter {
     conversions: Vec<TypeConversionFn>,
@@ -60,11 +77,16 @@ pub struct TypeConverter {
 }
 
 impl TypeConverter {
+    /// Create an empty converter that defaults to identity conversion.
     #[inline]
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Add a type conversion callback.
+    ///
+    /// Return `Some` to handle the source type, or `None` to let later callbacks try. Callbacks are
+    /// evaluated in insertion order.
     #[inline]
     pub fn add_conversion<F>(&mut self, callback: F) -> &mut Self
     where
@@ -74,6 +96,10 @@ impl TypeConverter {
         self
     }
 
+    /// Add a value-specific conversion callback.
+    ///
+    /// Value callbacks are checked before type-only callbacks and may inspect the value's defining
+    /// operation, uses, attributes, or type.
     #[inline]
     pub fn add_value_conversion<F>(&mut self, callback: F) -> &mut Self
     where
@@ -83,6 +109,10 @@ impl TypeConverter {
         self
     }
 
+    /// Add a source materialization callback.
+    ///
+    /// Source materializations convert a replacement value back to the original source type when
+    /// replacing an operation whose old result still has live users expecting that source type.
     #[inline]
     pub fn add_source_materialization<F>(&mut self, callback: F) -> &mut Self
     where
@@ -98,6 +128,11 @@ impl TypeConverter {
         self
     }
 
+    /// Add a target materialization callback.
+    ///
+    /// Target materializations convert an existing operand value to the type expected by a
+    /// conversion pattern. If no callback handles the request, the converter creates
+    /// `builtin.unrealized_conversion_cast`.
     #[inline]
     pub fn add_target_materialization<F>(&mut self, callback: F) -> &mut Self
     where
@@ -131,21 +166,32 @@ impl TypeConverter {
             .or_else(|| self.convert_type(value.borrow().ty()))
     }
 
+    /// Return true when `ty` converts to itself.
     #[inline]
     pub fn is_legal_type(&self, ty: &Type) -> bool {
         matches!(self.convert_type(ty), Some(TypeConversion::One(converted)) if converted == *ty)
     }
 
+    /// Convert `ty` and require a 1:1 result.
+    ///
+    /// This returns an error for `Many`, `Drop`, or an unhandled conversion.
     pub fn convert_type_1_to_1(&self, ty: &Type) -> Result<Type, Report> {
         self.require_1_to_1(self.convert_type(ty), || format!("type '{ty}'"))
     }
 
+    /// Convert `value` and require a 1:1 result.
+    ///
+    /// Value-specific callbacks are considered before type callbacks.
     pub fn convert_value_1_to_1(&self, value: ValueRef) -> Result<Type, Report> {
         self.require_1_to_1(self.convert_value(value), || {
             format!("value '{}' of type '{}'", value.borrow(), value.borrow().ty())
         })
     }
 
+    /// Materialize a conversion from target IR back to a source type.
+    ///
+    /// Registered source materializers are tried first. If none applies, an
+    /// `builtin.unrealized_conversion_cast` is inserted and marked as framework-owned.
     pub fn materialize_source_conversion(
         &self,
         rewriter: &mut ConversionPatternRewriter,
@@ -163,6 +209,10 @@ impl TypeConverter {
         )
     }
 
+    /// Materialize a conversion from source IR to a target type.
+    ///
+    /// Registered target materializers are tried first. If none applies, an
+    /// `builtin.unrealized_conversion_cast` is inserted and marked as framework-owned.
     pub fn materialize_target_conversion(
         &self,
         rewriter: &mut ConversionPatternRewriter,

--- a/hir/src/conversion/type_converter.rs
+++ b/hir/src/conversion/type_converter.rs
@@ -1,0 +1,22 @@
+/// Converts source IR types and values to target IR types and values.
+///
+/// This is a placeholder for the Phase 5 implementation. It is introduced now
+/// so conversion pattern APIs can be typed without pulling type conversion into
+/// the initial pattern-registration work.
+pub struct TypeConverter {
+    _private: (),
+}
+
+impl TypeConverter {
+    #[inline]
+    pub const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl Default for TypeConverter {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/hir/src/lib.rs
+++ b/hir/src/lib.rs
@@ -63,6 +63,7 @@ pub mod adt;
 pub mod any;
 pub mod attributes;
 pub mod constants;
+pub mod conversion;
 pub mod demangle;
 pub mod derive;
 pub mod dialects;

--- a/hir/src/patterns/pattern.rs
+++ b/hir/src/patterns/pattern.rs
@@ -127,7 +127,7 @@ pub trait Pattern {
     /// If the pattern does not use a trait id for deciding the root match, this returns `None`
     #[inline(always)]
     fn get_root_trait(&self) -> Option<TypeId> {
-        self.info().get_root_trait()
+        self.info().root_trait()
     }
 }
 
@@ -168,6 +168,15 @@ impl PatternInfo {
     #[inline(always)]
     pub fn with_bounded_rewrite_recursion(&mut self, yes: bool) -> &mut Self {
         self.has_bounded_recursion = yes;
+        self
+    }
+
+    /// Add the set of operations that may be generated when this pattern is applied.
+    pub fn with_generated_ops<I>(&mut self, generated_ops: I) -> &mut Self
+    where
+        I: IntoIterator<Item = OperationName>,
+    {
+        self.generated_ops.extend(generated_ops);
         self
     }
 

--- a/midenc-compile/src/stages/codegen.rs
+++ b/midenc-compile/src/stages/codegen.rs
@@ -2,13 +2,13 @@ use alloc::{boxed::Box, sync::Arc, vec::Vec};
 
 use miden_assembly::ast::Module;
 use midenc_codegen_masm::{
-    self as masm, MasmComponent, ToMasmComponent,
+    self as masm, LegalizeForMasm, MasmComponent, ToMasmComponent,
     intrinsics::{
         ADVICE_INTRINSICS_MODULE_NAME, I32_INTRINSICS_MODULE_NAME, I64_INTRINSICS_MODULE_NAME,
         MEM_INTRINSICS_MODULE_NAME,
     },
 };
-use midenc_hir::pass::AnalysisManager;
+use midenc_hir::pass::{AnalysisManager, IRPrintingConfig, Nesting, OpPassManager, PassManager};
 use midenc_session::OutputType;
 
 use super::*;
@@ -40,6 +40,8 @@ impl Stage for CodegenStage {
         log::debug!("lowering miden component to masm");
 
         let anchor = component.map(|c| c.as_operation_ref()).unwrap_or(world.as_operation_ref());
+        legalize_for_masm(anchor, context.clone())?;
+
         let analysis_manager = AnalysisManager::new(anchor, None);
         let mut masm_component = match component {
             Some(component) => {
@@ -73,6 +75,16 @@ impl Stage for CodegenStage {
             account_component_metadata_bytes,
         })
     }
+}
+
+fn legalize_for_masm(anchor: midenc_hir::OperationRef, context: Rc<Context>) -> CompilerResult<()> {
+    let ir_print_config = IRPrintingConfig::try_from(context.session().options.as_ref())?;
+    let mut pm = PassManager::new(context, OpPassManager::ANY, Nesting::Implicit)
+        .enable_ir_printing(ir_print_config);
+    pm.add_pass(Box::new(LegalizeForMasm));
+    pm.run(anchor)?;
+
+    Ok(())
 }
 
 fn required_intrinsics_modules(session: &Session) -> impl IntoIterator<Item = Arc<Module>> {

--- a/midenc-compile/tests/codegen_legalization.rs
+++ b/midenc-compile/tests/codegen_legalization.rs
@@ -1,0 +1,76 @@
+use std::rc::Rc;
+
+use midenc_compile::{MidenComponent, Stage, stages::CodegenStage};
+use midenc_dialect_hir::HirOpBuilder;
+use midenc_hir::{
+    BuilderExt, Context, Ident, OpBuilder, SourceSpan, Visibility,
+    dialects::builtin::{
+        self, BuiltinOpBuilder, ComponentBuilder, FunctionBuilder, ModuleBuilder, WorldBuilder,
+        attributes::Signature,
+    },
+    version::Version,
+};
+
+#[test]
+fn codegen_stage_accepts_ops_legal_for_masm() {
+    let context = Rc::new(Context::default());
+    let component = build_test_component(context.clone(), |function_builder| {
+        function_builder.ret(None, SourceSpan::UNKNOWN).unwrap();
+    });
+
+    if let Err(err) = CodegenStage.run(component, context) {
+        panic!("codegen unexpectedly rejected legal MASM IR: {err}");
+    }
+}
+
+#[test]
+fn codegen_stage_fails_on_ops_not_legal_for_masm() {
+    let context = Rc::new(Context::default());
+    let component = build_test_component(context.clone(), |function_builder| {
+        let _bytes = function_builder.bytes(&[1, 2, 3, 4], SourceSpan::UNKNOWN).unwrap();
+        function_builder.ret(None, SourceSpan::UNKNOWN).unwrap();
+    });
+
+    let err = match CodegenStage.run(component, context) {
+        Ok(_) => panic!("codegen unexpectedly accepted an unsupported HIR op"),
+        Err(err) => err,
+    };
+    let message = format!("{err}");
+
+    assert!(message.contains("hir.bytes"));
+    assert!(message.contains("does not implement HirLowering"));
+}
+
+fn build_test_component(
+    context: Rc<Context>,
+    build: impl FnOnce(&mut FunctionBuilder<'_, OpBuilder>),
+) -> MidenComponent {
+    let mut builder = OpBuilder::new(context.clone());
+    let world = builder.create::<builtin::World, ()>(SourceSpan::UNKNOWN)().unwrap();
+    let mut world_builder = WorldBuilder::new(world);
+    let component = world_builder
+        .define_component(
+            Ident::with_empty_span("test_ns".into()),
+            Ident::with_empty_span("test".into()),
+            Version::new(1, 0, 0),
+        )
+        .unwrap();
+
+    let mut component_builder = ComponentBuilder::new(component);
+    let module = component_builder.define_module(Ident::with_empty_span("test".into())).unwrap();
+    let signature = Signature::new(&context, [], []);
+    let mut module_builder = ModuleBuilder::new(module);
+    let function = module_builder
+        .define_function(Ident::with_empty_span("main".into()), Visibility::Public, signature)
+        .unwrap();
+
+    let mut builder = OpBuilder::new(context);
+    let mut function_builder = FunctionBuilder::new(function, &mut builder);
+    build(&mut function_builder);
+
+    MidenComponent {
+        world,
+        component: Some(component),
+        account_component_metadata_bytes: None,
+    }
+}


### PR DESCRIPTION
This introduces dialect conversion infrastructure similar to MLIR, so that higher-level dialects can be introduced and then converted via legalization to dialects that the codegen backend understands.

Today, we rely on the compiler pipeline to only produce ops which implement `HirLowering` when passing IR to the backend. If an illegal/unlowerable op reaches the backend, we currently just panic with an error explaining that we expected the op to implement `HirLowering`.

With this change, we now define what dialects (and in some cases, a subset of ops in a dialect) are legal for codegen, and predicate this on those ops implementing `HirLowering`. If a new dialect or op is added, we now get a legalization diagnostic if there is no path to legalizing that dialect (or op). Not only will this catch ops that we haven't explicitly legalized, it will also catch ops we've stated are legal but which don't implement `HirLowering`. If we add a new dialect `A`, and define how to convert it to dialect `B`, and there is a conversion path from `B` to `C`, where `C` is legal for codegen - then `A` can be implicitly legalized by conversion to `C` through `B` - this is handled by the dialect conversion framework.

My main motivation for implementing this, aside from it being in the backlog for a long time, is that it allows my new experimental programming language to use a new HIR dialect as its intermediate representation, and then lower through our existing dialects using this dialect conversion infrastructure.