### PR TITLE
feat: preserve ABI types

### DIFF
--- a/codegen/masm/src/artifact.rs
+++ b/codegen/masm/src/artifact.rs
@@ -214,10 +214,12 @@ impl MasmComponent {
 
         let mut exe = Box::new(masm::Module::new_executable());
         let span = SourceSpan::default();
+        let mut invoked = Vec::new();
         let body = {
             let mut block = masm::Block::new(span, Vec::with_capacity(64));
             // Invoke component initializer, if present
             if let Some(init) = self.init.as_ref() {
+                invoked.push(masm::Invoke::new(masm::InvokeKind::Exec, init.clone()));
                 block.push(Op::Inst(Span::new(span, Inst::Exec(init.clone()))));
             }
 
@@ -231,6 +233,7 @@ impl MasmComponent {
                 span,
                 Inst::Trace(TraceEvent::FrameStart.as_u32().into()),
             )));
+            invoked.push(masm::Invoke::new(masm::InvokeKind::Exec, entrypoint.clone()));
             block.push(Op::Inst(Span::new(span, Inst::Exec(entrypoint.clone()))));
             block
                 .push(Op::Inst(Span::new(span, Inst::Trace(TraceEvent::FrameEnd.as_u32().into()))));
@@ -242,16 +245,18 @@ impl MasmComponent {
                 let qualified = masm::QualifiedProcedureName::new(module.as_path(), name);
                 InvocationTarget::Path(Span::new(span, qualified.into_inner()))
             };
+            invoked.push(masm::Invoke::new(masm::InvokeKind::Exec, truncate_stack.clone()));
             block.push(Op::Inst(Span::new(span, Inst::Exec(truncate_stack))));
             block
         };
-        let start = masm::Procedure::new(
+        let mut start = masm::Procedure::new(
             span,
             masm::Visibility::Public,
             masm::ProcedureName::main(),
             0,
             body,
         );
+        start.extend_invoked(invoked);
         exe.define_procedure(start, source_manager)
             .into_diagnostic()
             .wrap_err("failed to define executable `main` procedure")?;

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -739,6 +739,7 @@ impl MasmFunctionBuilder {
             };
             let span = SourceSpan::default();
             // Add init call to the emitter's target before emitting the function body
+            emitter.invoked.insert(masm::Invoke::new(masm::InvokeKind::Exec, init.clone()));
             emitter
                 .target
                 .push(masm::Op::Inst(Span::new(span, masm::Instruction::Exec(init))));
@@ -761,6 +762,7 @@ impl MasmFunctionBuilder {
                 InvocationTarget::Path(Span::new(SourceSpan::default(), qualified.into_inner()))
             };
             let span = SourceSpan::default();
+            invoked.insert(masm::Invoke::new(masm::InvokeKind::Exec, truncate_stack.clone()));
             body.push(masm::Op::Inst(Span::new(span, masm::Instruction::Exec(truncate_stack))));
         }
         let Self {
@@ -862,9 +864,10 @@ fn masm_component_type_expr_from_hir(ty: &Type) -> masm::TypeExpr {
                     .with_span(SourceSpan::UNKNOWN),
             )
         }
-        Type::Ptr(ptr) => masm::TypeExpr::Ptr(masm::PointerType::new(
-            masm_component_type_expr_from_hir(ptr.pointee()),
-        )),
+        Type::Ptr(ptr) => masm::TypeExpr::Ptr(
+            masm::PointerType::new(masm_component_type_expr_from_hir(ptr.pointee()))
+                .with_address_space(ptr.addrspace()),
+        ),
         Type::Function(_) => masm::TypeExpr::Ptr(masm::PointerType::new(
             masm::TypeExpr::Primitive(Span::unknown(Type::Felt)),
         )),
@@ -904,9 +907,10 @@ fn masm_type_expr_from_hir(ty: &Type) -> masm::TypeExpr {
                     .with_span(SourceSpan::UNKNOWN),
             )
         }
-        Type::Ptr(ptr) => {
-            masm::TypeExpr::Ptr(masm::PointerType::new(masm_type_expr_from_hir(ptr.pointee())))
-        }
+        Type::Ptr(ptr) => masm::TypeExpr::Ptr(
+            masm::PointerType::new(masm_type_expr_from_hir(ptr.pointee()))
+                .with_address_space(ptr.addrspace()),
+        ),
         Type::Function(_) => masm::TypeExpr::Ptr(masm::PointerType::new(
             masm::TypeExpr::Primitive(Span::unknown(Type::Felt)),
         )),
@@ -1010,6 +1014,30 @@ fn patch_debug_var_locals_in_block(
                     stack_pointer_addr,
                 );
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use midenc_hir::PointerType;
+
+    use super::*;
+
+    #[test]
+    fn hir_to_masm_pointer_conversion_preserves_address_space() {
+        for addrspace in [masm::types::AddressSpace::Byte, masm::types::AddressSpace::Element] {
+            let ty = Type::from(PointerType::new_with_address_space(Type::U32, addrspace));
+
+            let masm::TypeExpr::Ptr(ptr) = masm_component_type_expr_from_hir(&ty) else {
+                panic!("expected pointer type expression");
+            };
+            assert_eq!(ptr.address_space(), addrspace);
+
+            let masm::TypeExpr::Ptr(ptr) = masm_type_expr_from_hir(&ty) else {
+                panic!("expected pointer type expression");
+            };
+            assert_eq!(ptr.address_space(), addrspace);
         }
     }
 }

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -816,8 +816,12 @@ impl MasmFunctionBuilder {
 
 fn lowered_signature(function: &builtin::Function) -> masm::FunctionType {
     let sig = function.signature();
-    let args = sig.params.iter().map(|param| masm_type_expr_from_hir(&param.ty)).collect();
-    let results = sig.results.iter().map(|result| masm_type_expr_from_hir(&result.ty)).collect();
+    let args = sig.params.iter().map(|param| masm::TypeExpr::from(param.ty.clone())).collect();
+    let results = sig
+        .results
+        .iter()
+        .map(|result| masm::TypeExpr::from(result.ty.clone()))
+        .collect();
     masm::FunctionType::new(sig.cc, args, results)
 }
 
@@ -832,15 +836,21 @@ fn semantic_debug_signature(function: &builtin::Function) -> Option<masm::Functi
         return None;
     };
 
-    let args = ty.params().iter().map(masm_component_type_expr_from_hir).collect();
-    let results = ty.results().iter().map(masm_component_type_expr_from_hir).collect();
+    let args = ty.params().iter().map(component_abi_type_expr_from_hir).collect();
+    let results = ty.results().iter().map(component_abi_type_expr_from_hir).collect();
     Some(masm::FunctionType::new(ty.calling_convention(), args, results))
 }
 
-fn masm_component_type_expr_from_hir(ty: &Type) -> masm::TypeExpr {
+/// Convert HIR types from a Component Model/WIT signature into MASM syntax types.
+///
+/// This intentionally differs from `From<Type> for TypeExpr`, which describes the lowered MASM
+/// representation and expands wide integer primitives like `u64`/`u128` into 32-bit limb arrays.
+/// Component export metadata should preserve the Component ABI shape instead, including nominal
+/// struct and field names used by debuggers and typed clients.
+fn component_abi_type_expr_from_hir(ty: &Type) -> masm::TypeExpr {
     match ty {
         Type::Array(array) => masm::TypeExpr::Array(masm::ArrayType::new(
-            masm_component_type_expr_from_hir(array.element_type()),
+            component_abi_type_expr_from_hir(array.element_type()),
             array.len(),
         )),
         Type::Struct(struct_ty) => {
@@ -855,7 +865,7 @@ fn masm_component_type_expr_from_hir(ty: &Type) -> masm::TypeExpr {
                 masm::StructField {
                     span: SourceSpan::UNKNOWN,
                     name,
-                    ty: masm_component_type_expr_from_hir(&field.ty),
+                    ty: component_abi_type_expr_from_hir(&field.ty),
                 }
             });
             masm::TypeExpr::Struct(
@@ -865,61 +875,16 @@ fn masm_component_type_expr_from_hir(ty: &Type) -> masm::TypeExpr {
             )
         }
         Type::Ptr(ptr) => masm::TypeExpr::Ptr(
-            masm::PointerType::new(masm_component_type_expr_from_hir(ptr.pointee()))
+            masm::PointerType::new(component_abi_type_expr_from_hir(ptr.pointee()))
                 .with_address_space(ptr.addrspace()),
         ),
         Type::Function(_) => masm::TypeExpr::Ptr(masm::PointerType::new(
             masm::TypeExpr::Primitive(Span::unknown(Type::Felt)),
         )),
         Type::List(element_ty) => masm::TypeExpr::Ptr(
-            masm::PointerType::new(masm_component_type_expr_from_hir(element_ty))
+            masm::PointerType::new(component_abi_type_expr_from_hir(element_ty))
                 .with_address_space(masm::types::AddressSpace::Byte),
         ),
-        Type::Unknown | Type::Never | Type::F64 => panic!("unrepresentable type value: {ty}"),
-        ty => masm::TypeExpr::Primitive(Span::unknown(ty.clone())),
-    }
-}
-
-fn masm_type_expr_from_hir(ty: &Type) -> masm::TypeExpr {
-    match ty {
-        Type::Array(array) => masm::TypeExpr::Array(masm::ArrayType::new(
-            masm_type_expr_from_hir(array.element_type()),
-            array.len(),
-        )),
-        Type::Struct(struct_ty) => {
-            let name = struct_ty.name().and_then(|name| masm::Ident::new(name.as_ref()).ok());
-            let fields = struct_ty.fields().iter().enumerate().map(|(index, field)| {
-                let name = field
-                    .name
-                    .as_deref()
-                    .map(masm::Ident::new)
-                    .and_then(Result::ok)
-                    .unwrap_or_else(|| masm::Ident::new(format!("field{index}")).unwrap());
-                masm::StructField {
-                    span: SourceSpan::UNKNOWN,
-                    name,
-                    ty: masm_type_expr_from_hir(&field.ty),
-                }
-            });
-            masm::TypeExpr::Struct(
-                masm::StructType::new(name, fields)
-                    .with_repr(Span::unknown(struct_ty.repr()))
-                    .with_span(SourceSpan::UNKNOWN),
-            )
-        }
-        Type::Ptr(ptr) => masm::TypeExpr::Ptr(
-            masm::PointerType::new(masm_type_expr_from_hir(ptr.pointee()))
-                .with_address_space(ptr.addrspace()),
-        ),
-        Type::Function(_) => masm::TypeExpr::Ptr(masm::PointerType::new(
-            masm::TypeExpr::Primitive(Span::unknown(Type::Felt)),
-        )),
-        Type::List(element_ty) => masm::TypeExpr::Ptr(
-            masm::PointerType::new(masm_type_expr_from_hir(element_ty))
-                .with_address_space(masm::types::AddressSpace::Byte),
-        ),
-        Type::I128 | Type::U128 => masm::TypeExpr::Array(masm::ArrayType::new(Type::U32.into(), 4)),
-        Type::I64 | Type::U64 => masm::TypeExpr::Array(masm::ArrayType::new(Type::U32.into(), 2)),
         Type::Unknown | Type::Never | Type::F64 => panic!("unrepresentable type value: {ty}"),
         ty => masm::TypeExpr::Primitive(Span::unknown(ty.clone())),
     }
@@ -1020,24 +985,72 @@ fn patch_debug_var_locals_in_block(
 
 #[cfg(test)]
 mod tests {
-    use midenc_hir::PointerType;
+    use alloc::sync::Arc;
+
+    use midenc_hir::{PointerType, StructType, TypeRepr};
 
     use super::*;
 
     #[test]
-    fn hir_to_masm_pointer_conversion_preserves_address_space() {
+    fn type_expr_from_hir_pointer_conversion_preserves_address_space() {
         for addrspace in [masm::types::AddressSpace::Byte, masm::types::AddressSpace::Element] {
             let ty = Type::from(PointerType::new_with_address_space(Type::U32, addrspace));
 
-            let masm::TypeExpr::Ptr(ptr) = masm_component_type_expr_from_hir(&ty) else {
+            let masm::TypeExpr::Ptr(ptr) = component_abi_type_expr_from_hir(&ty) else {
                 panic!("expected pointer type expression");
             };
             assert_eq!(ptr.address_space(), addrspace);
 
-            let masm::TypeExpr::Ptr(ptr) = masm_type_expr_from_hir(&ty) else {
+            let masm::TypeExpr::Ptr(ptr) = masm::TypeExpr::from(ty) else {
                 panic!("expected pointer type expression");
             };
             assert_eq!(ptr.address_space(), addrspace);
         }
+    }
+
+    #[test]
+    fn component_abi_type_conversion_preserves_wide_primitives() {
+        let masm::TypeExpr::Primitive(ty) = component_abi_type_expr_from_hir(&Type::U64) else {
+            panic!("expected primitive component ABI type");
+        };
+        assert_eq!(ty.inner(), &Type::U64);
+
+        let masm::TypeExpr::Array(ty) = masm::TypeExpr::from(Type::U64) else {
+            panic!("expected lowered MASM type");
+        };
+        assert_eq!(ty.arity, 2);
+        let masm::TypeExpr::Primitive(element_ty) = ty.elem.as_ref() else {
+            panic!("expected primitive array element type");
+        };
+        assert_eq!(element_ty.inner(), &Type::U32);
+    }
+
+    #[test]
+    fn component_abi_type_conversion_preserves_nominal_struct_metadata() {
+        let ty = Type::Struct(Arc::new(StructType::from_parts(
+            Some(Arc::from("miden:base/core-types@1.0.0/account-id")),
+            TypeRepr::Default,
+            [
+                (Arc::<str>::from("prefix"), Type::Felt),
+                (Arc::<str>::from("suffix"), Type::Felt),
+            ],
+        )));
+
+        let masm::TypeExpr::Struct(struct_ty) = component_abi_type_expr_from_hir(&ty) else {
+            panic!("expected struct component ABI type");
+        };
+        assert_eq!(
+            struct_ty.name.as_ref().map(|name| name.as_str()),
+            Some("miden:base/core-types@1.0.0/account-id"),
+        );
+        assert_eq!(struct_ty.fields[0].name.as_str(), "prefix");
+        assert_eq!(struct_ty.fields[1].name.as_str(), "suffix");
+
+        let masm::TypeExpr::Struct(struct_ty) = masm::TypeExpr::from(ty) else {
+            panic!("expected lowered struct type");
+        };
+        assert!(struct_ty.name.is_none());
+        assert_eq!(struct_ty.fields[0].name.as_str(), "field0");
+        assert_eq!(struct_ty.fields[1].name.as_str(), "field1");
     }
 }

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -847,6 +847,9 @@ fn semantic_debug_signature(function: &builtin::Function) -> Option<masm::Functi
 /// representation and expands wide integer primitives like `u64`/`u128` into 32-bit limb arrays.
 /// Component export metadata should preserve the Component ABI shape instead, including nominal
 /// struct and field names used by debuggers and typed clients.
+///
+/// TODO(pauls): Remove once miden-vm#XXXX is merged and ships in the next stable release,
+/// expected to be v0.24.
 fn component_abi_type_expr_from_hir(ty: &Type) -> masm::TypeExpr {
     match ty {
         Type::Array(array) => masm::TypeExpr::Array(masm::ArrayType::new(

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -830,9 +830,51 @@ fn semantic_debug_signature(function: &builtin::Function) -> Option<masm::Functi
         return None;
     };
 
-    let args = ty.params().iter().map(masm_type_expr_from_hir).collect();
-    let results = ty.results().iter().map(masm_type_expr_from_hir).collect();
+    let args = ty.params().iter().map(masm_component_type_expr_from_hir).collect();
+    let results = ty.results().iter().map(masm_component_type_expr_from_hir).collect();
     Some(masm::FunctionType::new(ty.calling_convention(), args, results))
+}
+
+fn masm_component_type_expr_from_hir(ty: &Type) -> masm::TypeExpr {
+    match ty {
+        Type::Array(array) => masm::TypeExpr::Array(masm::ArrayType::new(
+            masm_component_type_expr_from_hir(array.element_type()),
+            array.len(),
+        )),
+        Type::Struct(struct_ty) => {
+            let name = struct_ty.name().and_then(|name| masm::Ident::new(name.as_ref()).ok());
+            let fields = struct_ty.fields().iter().enumerate().map(|(index, field)| {
+                let name = field
+                    .name
+                    .as_deref()
+                    .map(masm::Ident::new)
+                    .and_then(Result::ok)
+                    .unwrap_or_else(|| masm::Ident::new(format!("field{index}")).unwrap());
+                masm::StructField {
+                    span: SourceSpan::UNKNOWN,
+                    name,
+                    ty: masm_component_type_expr_from_hir(&field.ty),
+                }
+            });
+            masm::TypeExpr::Struct(
+                masm::StructType::new(name, fields)
+                    .with_repr(Span::unknown(struct_ty.repr()))
+                    .with_span(SourceSpan::UNKNOWN),
+            )
+        }
+        Type::Ptr(ptr) => masm::TypeExpr::Ptr(masm::PointerType::new(
+            masm_component_type_expr_from_hir(ptr.pointee()),
+        )),
+        Type::Function(_) => masm::TypeExpr::Ptr(masm::PointerType::new(
+            masm::TypeExpr::Primitive(Span::unknown(Type::Felt)),
+        )),
+        Type::List(element_ty) => masm::TypeExpr::Ptr(
+            masm::PointerType::new(masm_component_type_expr_from_hir(element_ty))
+                .with_address_space(masm::types::AddressSpace::Byte),
+        ),
+        Type::Unknown | Type::Never | Type::F64 => panic!("unrepresentable type value: {ty}"),
+        ty => masm::TypeExpr::Primitive(Span::unknown(ty.clone())),
+    }
 }
 
 fn masm_type_expr_from_hir(ty: &Type) -> masm::TypeExpr {

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -4,11 +4,13 @@ use miden_assembly::{PathBuf as LibraryPath, ast::InvocationTarget};
 use miden_assembly_syntax::{ast::Attribute, parser::WordValue};
 use miden_core::operations::DebugVarLocation;
 use midenc_hir::{
-    FunctionIdent, Op, OpExt, SourceSpan, Span, Symbol, TraceTarget, ValueRef,
+    FunctionIdent, Op, OpExt, SourceSpan, Span, Symbol, TraceTarget, Type, ValueRef,
     diagnostics::IntoDiagnostic,
     dialects::{
         builtin,
-        debuginfo::attributes::{decode_frame_base_local_index, encode_frame_base_local_offset},
+        debuginfo::attributes::{
+            SubprogramAttr, decode_frame_base_local_index, encode_frame_base_local_offset,
+        },
     },
     interner,
     pass::AnalysisManager,
@@ -671,14 +673,8 @@ impl MasmFunctionBuilder {
                 .into_report()
         })?;
 
-        let sig = function.signature();
-        let args = sig.params.iter().map(|param| masm::TypeExpr::from(param.ty.clone())).collect();
-        let results = sig
-            .results
-            .iter()
-            .map(|result| masm::TypeExpr::from(result.ty.clone()))
-            .collect();
-        let signature = masm::FunctionType::new(sig.cc, args, results);
+        let signature =
+            semantic_debug_signature(function).unwrap_or_else(|| lowered_signature(function));
 
         Ok(Self {
             span: function.span(),
@@ -813,6 +809,73 @@ impl MasmFunctionBuilder {
         procedure.extend_invoked(invoked);
 
         Ok(procedure)
+    }
+}
+
+fn lowered_signature(function: &builtin::Function) -> masm::FunctionType {
+    let sig = function.signature();
+    let args = sig.params.iter().map(|param| masm_type_expr_from_hir(&param.ty)).collect();
+    let results = sig.results.iter().map(|result| masm_type_expr_from_hir(&result.ty)).collect();
+    masm::FunctionType::new(sig.cc, args, results)
+}
+
+fn semantic_debug_signature(function: &builtin::Function) -> Option<masm::FunctionType> {
+    let subprogram = function
+        .as_operation()
+        .get_attribute("di.subprogram")?
+        .try_downcast_attr::<SubprogramAttr>()
+        .ok()?;
+    let subprogram = subprogram.borrow();
+    let Type::Function(ty) = subprogram.ty.as_ref()? else {
+        return None;
+    };
+
+    let args = ty.params().iter().map(masm_type_expr_from_hir).collect();
+    let results = ty.results().iter().map(masm_type_expr_from_hir).collect();
+    Some(masm::FunctionType::new(ty.calling_convention(), args, results))
+}
+
+fn masm_type_expr_from_hir(ty: &Type) -> masm::TypeExpr {
+    match ty {
+        Type::Array(array) => masm::TypeExpr::Array(masm::ArrayType::new(
+            masm_type_expr_from_hir(array.element_type()),
+            array.len(),
+        )),
+        Type::Struct(struct_ty) => {
+            let name = struct_ty.name().and_then(|name| masm::Ident::new(name.as_ref()).ok());
+            let fields = struct_ty.fields().iter().enumerate().map(|(index, field)| {
+                let name = field
+                    .name
+                    .as_deref()
+                    .map(masm::Ident::new)
+                    .and_then(Result::ok)
+                    .unwrap_or_else(|| masm::Ident::new(format!("field{index}")).unwrap());
+                masm::StructField {
+                    span: SourceSpan::UNKNOWN,
+                    name,
+                    ty: masm_type_expr_from_hir(&field.ty),
+                }
+            });
+            masm::TypeExpr::Struct(
+                masm::StructType::new(name, fields)
+                    .with_repr(Span::unknown(struct_ty.repr()))
+                    .with_span(SourceSpan::UNKNOWN),
+            )
+        }
+        Type::Ptr(ptr) => {
+            masm::TypeExpr::Ptr(masm::PointerType::new(masm_type_expr_from_hir(ptr.pointee())))
+        }
+        Type::Function(_) => masm::TypeExpr::Ptr(masm::PointerType::new(
+            masm::TypeExpr::Primitive(Span::unknown(Type::Felt)),
+        )),
+        Type::List(element_ty) => masm::TypeExpr::Ptr(
+            masm::PointerType::new(masm_type_expr_from_hir(element_ty))
+                .with_address_space(masm::types::AddressSpace::Byte),
+        ),
+        Type::I128 | Type::U128 => masm::TypeExpr::Array(masm::ArrayType::new(Type::U32.into(), 4)),
+        Type::I64 | Type::U64 => masm::TypeExpr::Array(masm::ArrayType::new(Type::U32.into(), 2)),
+        Type::Unknown | Type::Never | Type::F64 => panic!("unrepresentable type value: {ty}"),
+        ty => masm::TypeExpr::Primitive(Span::unknown(ty.clone())),
     }
 }
 

--- a/frontend/wasm/src/component/lift_exports.rs
+++ b/frontend/wasm/src/component/lift_exports.rs
@@ -5,7 +5,7 @@ use midenc_dialect_cf::ControlFlowOpBuilder;
 use midenc_dialect_hir::HirOpBuilder;
 use midenc_frontend_wasm_metadata::ProtocolExportKind;
 use midenc_hir::{
-    FunctionType, Ident, Op, OpExt, SmallVec, SourceSpan, SymbolPath, ValueRange, ValueRef,
+    FunctionType, Ident, Op, OpExt, SmallVec, Spanned, SymbolPath, ValueRange, ValueRef,
     Visibility,
     dialects::{
         builtin::{
@@ -64,7 +64,6 @@ pub fn generate_export_lifting_function(
         return Err(diagnostics.diagnostic(Severity::Error).with_message(message).into_report());
     }
 
-    let export_func_ident = Ident::new(export_func_name.to_string().into(), SourceSpan::default());
     let export_metadata = ComponentExportMetadata {
         ty: &export_func_ty,
         param_names: export_param_names,
@@ -80,6 +79,9 @@ pub fn generate_export_lifting_function(
     let core_export_func_ref = core_module_builder
         .get_function(core_export_func_path.name().as_str())
         .expect("failed to find the core module export function");
+    let export_func_span = core_export_func_ref.borrow().span();
+    let export_func_ident =
+        Ident::new(midenc_hir::interner::Symbol::intern(export_func_name), export_func_span);
     // Make the lowered core WASM export internal so only the lifted wrapper is
     // publicly exported from the component, while still allowing the wrapper to
     // call across the nested core module symbol table boundary.

--- a/frontend/wasm/src/component/lift_exports.rs
+++ b/frontend/wasm/src/component/lift_exports.rs
@@ -382,6 +382,10 @@ fn annotate_component_export_debug_signature(
     export_func_ty: &FunctionType,
     export_param_names: &[String],
 ) {
+    assert!(
+        export_func_ty.abi.is_wasm_canonical_abi(),
+        "component export debug signatures must be derived from Component Model ABI function types",
+    );
     let context = {
         let export_func = export_func_ref.borrow();
         export_func.as_operation().context_rc()

--- a/frontend/wasm/src/module/func_translator.rs
+++ b/frontend/wasm/src/module/func_translator.rs
@@ -276,6 +276,7 @@ fn parse_function_body<B: ?Sized + Builder>(
         } else {
             span
         };
+        builder.record_debug_span(effective_span);
 
         if state.reachable && !builder.is_unreachable() {
             builder.apply_location_schedule(code_offset, effective_span, &state.stack);

--- a/frontend/wasm/src/module/function_builder_ext.rs
+++ b/frontend/wasm/src/module/function_builder_ext.rs
@@ -11,7 +11,8 @@ use midenc_dialect_ub::UndefinedBehaviorOpBuilder;
 use midenc_dialect_wasm::WasmOpBuilder;
 use midenc_hir::{
     BlockRef, Builder, Context, EntityRef, FxHashMap, FxHashSet, Ident, Listener, ListenerType, Op,
-    OpBuilder, OperationRef, ProgramPoint, RegionRef, SmallVec, SourceSpan, Type, ValueRef,
+    OpBuilder, OperationRef, ProgramPoint, RegionRef, SmallVec, SourceSpan, Spanned, Type,
+    ValueRef,
     dialects::{
         builtin::{
             BuiltinOpBuilder, FunctionBuilder, FunctionRef,
@@ -244,6 +245,13 @@ impl<B: ?Sized + Builder> FunctionBuilderExt<'_, B> {
                 info.subprogram.line = line;
                 info.subprogram.column = column;
                 info.function_span.get_or_insert(span);
+            }
+            let current_span = self.inner.func.borrow().span();
+            if current_span.is_unknown()
+                || current_span.is_synthetic()
+                || current_span == SourceSpan::default()
+            {
+                self.inner.func.borrow_mut().set_span(span);
             }
             self.refresh_function_debug_attrs();
             self.emit_parameter_dbg_if_needed(span);

--- a/tests/integration/src/sdk/mod.rs
+++ b/tests/integration/src/sdk/mod.rs
@@ -1,9 +1,11 @@
 use std::{collections::BTreeSet, path::Path};
 
+use miden_assembly::ast::types::{FunctionType, Type};
 use miden_core::{
     program::Program,
     serde::{Deserializable, Serializable},
 };
+use miden_mast_package::{PackageExport, ProcedureExport};
 use miden_protocol::note::NoteScript;
 use midenc_frontend_wasm::WasmTranslationConfig;
 
@@ -52,6 +54,110 @@ fn persist_cargo_miden_dependency(
     package
         .write_masp_file(project_path.as_ref().join("target").join("miden").join("release"))
         .expect("failed to persist compiled Miden dependency package");
+}
+
+fn find_manifest_procedure<'a>(
+    package: &'a miden_mast_package::Package,
+    description: &str,
+    mut predicate: impl FnMut(&str) -> bool,
+) -> &'a ProcedureExport {
+    let matches = package
+        .manifest
+        .exports()
+        .filter_map(|export| match export {
+            PackageExport::Procedure(export) => Some(export),
+            PackageExport::Constant(_) | PackageExport::Type(_) => None,
+        })
+        .filter(|export| predicate(export.path.as_ref().as_str()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one manifest procedure matching {description}, got {:?}",
+        package
+            .manifest
+            .exports()
+            .filter_map(|export| match export {
+                PackageExport::Procedure(export) => Some(export.path.as_ref().as_str().to_string()),
+                PackageExport::Constant(_) | PackageExport::Type(_) => None,
+            })
+            .collect::<Vec<_>>(),
+    );
+    matches[0]
+}
+
+fn assert_export_signature<'a>(
+    function: &'a ProcedureExport,
+    expected_params: &[&str],
+    expected_result: &str,
+) -> &'a FunctionType {
+    let signature = function.signature.as_ref().expect("procedure export should have a signature");
+    let params = signature.params.iter().map(ToString::to_string).collect::<Vec<_>>();
+    let expected_params = expected_params.iter().map(|param| param.to_string()).collect::<Vec<_>>();
+    assert_eq!(params, expected_params);
+
+    let result = match signature.results.as_slice() {
+        [] => "void".to_string(),
+        [result] => result.to_string(),
+        results => {
+            format!("({})", results.iter().map(ToString::to_string).collect::<Vec<_>>().join(", "))
+        }
+    };
+    assert_eq!(result, expected_result);
+    signature
+}
+
+fn assert_struct_field_types(ty: &Type, expected_fields: &[&str]) {
+    let Type::Struct(struct_ty) = ty else {
+        panic!("expected struct type, got {ty:?}");
+    };
+    let actual_fields =
+        struct_ty.fields().iter().map(|field| field.ty.to_string()).collect::<Vec<_>>();
+    let expected_fields = expected_fields.iter().map(|ty| ty.to_string()).collect::<Vec<_>>();
+    assert_eq!(actual_fields, expected_fields);
+}
+
+fn assert_component_export_signatures_match_wit(package: &miden_mast_package::Package) {
+    let component_export =
+        find_manifest_procedure(package, "component export process-mixed", |name| {
+            name.ends_with("::\"process-mixed\"") && !name.contains("#process-mixed")
+        });
+    assert_eq!(
+        component_export
+            .signature
+            .as_ref()
+            .expect("component export should have a signature")
+            .calling_convention()
+            .as_str(),
+        "component-model",
+    );
+    let mixed_struct = "struct {u64, struct miden:base/core-types@1.0.0/felt {\n    felt}, u32, \
+                        struct miden:base/core-types@1.0.0/felt {felt}, u8, i1, u16}";
+    let signature = assert_export_signature(component_export, &[mixed_struct], mixed_struct);
+    assert_struct_field_types(
+        &signature.params[0],
+        &[
+            "u64",
+            "struct miden:base/core-types@1.0.0/felt {felt}",
+            "u32",
+            "struct miden:base/core-types@1.0.0/felt {felt}",
+            "u8",
+            "i1",
+            "u16",
+        ],
+    );
+    assert_struct_field_types(
+        &signature.results[0],
+        &[
+            "u64",
+            "struct miden:base/core-types@1.0.0/felt {felt}",
+            "u32",
+            "struct miden:base/core-types@1.0.0/felt {felt}",
+            "u8",
+            "i1",
+            "u16",
+        ],
+    );
 }
 
 fn component_namespace(name: &str) -> String {
@@ -237,6 +343,7 @@ fn rust_sdk_cross_ctx_account_and_note_word() {
     );
     assert!(account_package.is_library());
     let lib = account_package.mast.clone();
+    assert_component_export_signatures_match_wit(account_package.as_ref());
     let expected_module_prefix = "::\"miden:cross-ctx-account-word/";
     let expected_function_suffix = "\"process-word\"";
     let exports = lib

--- a/tests/integration/src/sdk/mod.rs
+++ b/tests/integration/src/sdk/mod.rs
@@ -120,7 +120,8 @@ fn assert_struct_field_types(ty: &Type, expected_fields: &[&str]) {
 fn assert_component_export_signatures_match_wit(package: &miden_mast_package::Package) {
     let component_export =
         find_manifest_procedure(package, "component export process-mixed", |name| {
-            name.ends_with("::\"process-mixed\"") && !name.contains("#process-mixed")
+            name.starts_with("::\"miden:cross-ctx-account-word/foo@1.0.0\"::")
+                && name.ends_with("::\"process-mixed\"")
         });
     assert_eq!(
         component_export


### PR DESCRIPTION
Typed ABI/debug consumers need to distinguish the lowered execution ABI from the source-level/component ABI. Without preserving the semantic signature, tools only see flattened `felt` parameters/results and cannot recover types like `account-id`, `word`, or `asset`.