### PR TITLE
Differential fuzzing: concrete-input harness mode, area-scoped fuzza-agent, and new coverage cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,11 @@ book/
 tests/**/Cargo.lock
 !tests/fixtures/components/**/Cargo.lock
 
+# fuzza-agent working notes — survive `cargo make fuzza-cov-clean` (which wipes
+# target/fuzza-coverage), but are local scratch and not committed. The
+# directory itself is kept (via .gitkeep) so it exists on a fresh checkout.
+tools/fuzza-agent/scratch/*
+!tools/fuzza-agent/scratch/.gitkeep
+tools/fuzza-agent/__pycache__/
+
 *.lit_test_times.txt*

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -575,10 +575,16 @@ cargo llvm-cov --package midenc-integration-tests --no-report -- differential --
 cargo llvm-cov report --json --output-path "${OUT}/report.json"
 cargo llvm-cov report --html --output-dir "${OUT}/html"
 
-python3 "${WORKSPACE}/tools/fuzza-agent/cov.py" \
-    "${OUT}/report.json" "${WORKSPACE}" \
-    --prev "${OUT}/report.prev.json" \
-    > "${OUT}/report.md"
+# Optionally scope the report to a target area. Set FUZZA_AREA to a
+# comma-separated list of workspace-relative path prefixes (e.g.
+# `codegen/masm/src/emit/mem.rs`) to add an area-focused section. The args
+# array is always non-empty, so expansion is safe under `set -u`.
+COV_ARGS=("${OUT}/report.json" "${WORKSPACE}" --prev "${OUT}/report.prev.json")
+if [[ -n "${FUZZA_AREA:-}" ]]; then
+    COV_ARGS+=(--area "${FUZZA_AREA}")
+fi
+
+python3 "${WORKSPACE}/tools/fuzza-agent/cov.py" "${COV_ARGS[@]}" > "${OUT}/report.md"
 
 echo ""
 echo "Coverage report written to:"
@@ -614,10 +620,16 @@ cargo llvm-cov --no-clean --package midenc-integration-tests -- differential --t
 cargo llvm-cov report --json --output-path "${OUT}/report.json"
 cargo llvm-cov report --html --output-dir "${OUT}/html"
 
-python3 "${WORKSPACE}/tools/fuzza-agent/cov.py" \
-    "${OUT}/report.json" "${WORKSPACE}" \
-    --prev "${OUT}/report.prev.json" \
-    > "${OUT}/report.md"
+# Optionally scope the report to a target area. Set FUZZA_AREA to a
+# comma-separated list of workspace-relative path prefixes (e.g.
+# `codegen/masm/src/emit/mem.rs`) to add an area-focused section. The args
+# array is always non-empty, so expansion is safe under `set -u`.
+COV_ARGS=("${OUT}/report.json" "${WORKSPACE}" --prev "${OUT}/report.prev.json")
+if [[ -n "${FUZZA_AREA:-}" ]]; then
+    COV_ARGS+=(--area "${FUZZA_AREA}")
+fi
+
+python3 "${WORKSPACE}/tools/fuzza-agent/cov.py" "${COV_ARGS[@]}" > "${OUT}/report.md"
 
 echo ""
 if [[ "${test_status}" -ne 0 ]]; then

--- a/tests/integration/src/end_to_end/differential/cases/case_calls_selects.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_calls_selects.rs
@@ -1,0 +1,31 @@
+// Non-inlined helper calls with varied signatures (multi-arg u32, u64
+// params/results, bool) plus select-heavy code with reused results.
+// Exercises `translate_call`, `hir::invoke::Exec` lowering,
+// `OpEmitter::process_call_signature`, and the `select`/`dup_select`/
+// `mov_select` emitter variants.
+
+#[inline(never)]
+fn mix(a: u32, b: u32, c: u32, d: u32) -> u32 {
+    a.wrapping_mul(31).wrapping_add(b.rotate_left(c & 31)) ^ d
+}
+
+#[inline(never)]
+fn wide(a: u64, b: u64) -> u64 {
+    a.wrapping_mul(b | 1) ^ (a >> 7)
+}
+
+#[inline(never)]
+fn pick(c: bool, x: u32, y: u32) -> u32 {
+    if c { x } else { y }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let m = mix(input1, input2, input1 >> 3, input2 ^ 0xa5a5_a5a5);
+    let w = wide(((input1 as u64) << 32) | input2 as u64, input2 as u64 | 1);
+    let p = pick(m & 1 == 0, m, input2);
+    let q = pick(w as u32 & 2 == 0, w as u32, (w >> 32) as u32);
+    // Reuse the selected values several times so the emitter has to dup/move
+    // them on the operand stack.
+    p.wrapping_add(q) ^ (p & q) ^ m
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_continue_paths.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_continue_paths.rs
@@ -1,0 +1,28 @@
+// Loop with several `continue` sites (multiple CFG backedges) plus a
+// mid-body `break` (extra exit). cfg-to-scf must funnel all backedges
+// through a single latch and thread the exit discriminator through paths
+// that don't define it, exercising the latch multiplexing and undef/poison
+// threading in `transform_to_reduce_loop`.
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let mut x = input1;
+    let mut acc = 0u32;
+    let mut i = 0u32;
+    let n = input2 % 127;
+    while i < n {
+        i = i.wrapping_add(1);
+        x = x.wrapping_mul(0x0101_0101) ^ i;
+        if x & 3 == 0 {
+            acc = acc.wrapping_add(x >> 7);
+            continue; // backedge 1
+        }
+        if x & 0xc0 == 0x40 {
+            continue; // backedge 2
+        }
+        if x & 0xff00 == 0x3700 {
+            break; // mid-body exit
+        }
+        acc ^= x.rotate_left(5); // falls through to backedge 3
+    }
+    acc ^ x ^ i
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_loop_results.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_loop_results.rs
@@ -1,0 +1,29 @@
+// Loop whose carried values exercise the scf.while canonicalization
+// patterns: two variables converging to the same yielded value
+// (`while_remove_duplicated_results`), carried values dead after the loop
+// (`while_unused_result`), and a loop-invariant value used in the body
+// (`remove_loop_invariant_args_from_before_block`).
+//
+// NB: the trip count is `input2 % 97` — a bound LLVM will not fully
+// unroll/peel (masking with a small power-of-two gets the loop peeled away
+// entirely at opt-level 3).
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let k = input1 | 1; // loop-invariant multiplier (odd, opaque to LLVM)
+    let mut a = input1;
+    let mut b = input2;
+    let mut scratch = input2 ^ 0x9e37_79b9; // live in the loop, dead after it
+    let mut i = 0u32;
+    let n = input2 % 97;
+    while i < n {
+        let t = a.wrapping_add(b).wrapping_mul(k) ^ (scratch & 0xff);
+        // Both `a` and `b` are assigned the same value, so the loop yields
+        // the same SSA value in two result positions.
+        a = t;
+        b = t;
+        scratch = scratch.rotate_left(5).wrapping_add(i);
+        i = i.wrapping_add(1);
+    }
+    // `scratch` and `i` are dead here, leaving unused scf.while results.
+    a.wrapping_add(b)
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_mem_bytes.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_mem_bytes.rs
@@ -1,0 +1,41 @@
+// Sub-word and unaligned memory access. Signed table reads produce
+// i32.load8_s/load16_s and i64.load8_s/load16_s (sext_smallint, both the
+// 32-bit and >32-bit extension paths); `from_le_bytes`/`to_le_bytes` on
+// byte slices at runtime-odd offsets become single unaligned
+// i32/i64.load/store, exercising the cross-element load/store arms in
+// `codegen/masm/src/emit/mem.rs`.
+static SBYTES: [i8; 16] = [-128, -7, 13, -1, 0, 127, -64, 5, -100, 99, -2, 33, -77, 8, -31, 64];
+
+static SHORTS: [i16; 8] = [-32768, -1, 257, 32767, -12345, 513, -300, 1000];
+
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    // Sign-extending sub-word loads, widened to both i32 and i64.
+    let a = SBYTES[(input1 % 16) as usize] as i32;
+    let b = SHORTS[(input2 % 8) as usize] as i32;
+    let c = SBYTES[(input2 % 16) as usize] as i64;
+    let d = SHORTS[(input1 % 8) as usize] as i64;
+
+    let mut buf = [0u8; 40];
+    let mut i = 0u32;
+    while i < 40 {
+        buf[i as usize] = (input1.wrapping_mul(i).wrapping_add(input2 >> (i % 8))) as u8;
+        i += 1;
+    }
+
+    // Unaligned loads at offset 1..=4.
+    let off = ((input2 % 4) + 1) as usize;
+    let w = u32::from_le_bytes(buf[off..off + 4].try_into().unwrap());
+    let h = u16::from_le_bytes(buf[off + 5..off + 7].try_into().unwrap()) as u32;
+    let q = u64::from_le_bytes(buf[off + 8..off + 16].try_into().unwrap());
+
+    // Unaligned stores at the same odd offsets.
+    let x = w ^ input1.rotate_left(7);
+    buf[off + 17..off + 21].copy_from_slice(&x.to_le_bytes());
+    buf[off + 22..off + 24].copy_from_slice(&(h as u16 ^ 0x5a5a).to_le_bytes());
+    buf[off + 24..off + 32].copy_from_slice(&q.wrapping_mul(0x9e3779b97f4a7c15).to_le_bytes());
+    let r = buf[(input1 % 40) as usize] as u32;
+
+    let s = (a.wrapping_add(b) as i64).wrapping_add(c.wrapping_mul(d)) as u32;
+    s ^ w ^ (h << 8) ^ (q as u32) ^ r
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_mem_copy.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_mem_copy.rs
@@ -1,0 +1,40 @@
+// Runtime-length slice copies. `copy_from_slice`/`copy_within` with a
+// length LLVM cannot constant-fold become wasm `memory.copy`, which lowers
+// to the HIR MemCpy op — exercising `OpEmitter::memcpy` (element-aligned
+// fast path + byte fallback loop, both emitted at compile time) and the
+// MemoryCopy translation arm. The u8 copy at odd offsets also takes the
+// fallback loop at runtime; the u32 copies take the element fast path.
+// All copies are between disjoint ranges — overlapping copies diverge
+// (see case_mem_overlap) and are tracked as a separate ignored case.
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let mut a = [0u32; 16];
+    let mut i = 0u32;
+    while i < 16 {
+        a[i as usize] = input1.wrapping_mul(i).wrapping_add(input2);
+        i += 1;
+    }
+
+    // Aligned u32 copy, runtime length 4..=11 elements.
+    let n = ((input2 % 8) + 4) as usize;
+    let mut b = [0u32; 16];
+    b[..n].copy_from_slice(&a[..n]);
+
+    // Second in-buffer copy, disjoint ranges (src 0..=5, dst 10..).
+    let m2 = (n % 4) + 2;
+    a.copy_within(0..m2, 10);
+
+    // Byte copy at odd offsets / odd length — defeats the element-aligned
+    // fast path at runtime.
+    let mut bytes = [0u8; 32];
+    let mut j = 0u32;
+    while j < 16 {
+        bytes[j as usize] = (input1 >> (j % 24)) as u8;
+        j += 1;
+    }
+    let m = ((input1 % 8) + 3) as usize;
+    bytes.copy_within(1..1 + m, 17);
+
+    let k = (input2 % 16) as usize;
+    b[k].wrapping_add(a[(input1 % 16) as usize]) ^ (bytes[17 + m - 1] as u32)
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_mem_globals.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_mem_globals.rs
@@ -1,0 +1,38 @@
+// Mutable statics via atomics (safe Rust, no `static mut`). Non-zero
+// atomic initializers land in the wasm `.data` section, giving a second
+// data segment next to `.rodata` — exercising multi-segment layout:
+// DataSegmentLayout::insert, merge_data_segments, validate_no_overlaps,
+// and word-alignment padding. Atomic load/store lowers to plain
+// i32/i64/i32.load8 memory ops at absolute (constant) addresses.
+//
+// The initial values are restored before returning: the native cdylib is
+// loaded once for all proptest runs, so statics must not carry state.
+use core::sync::atomic::{AtomicU8, AtomicU32, AtomicU64, Ordering::Relaxed};
+
+static A: AtomicU32 = AtomicU32::new(0x1234_5678);
+static B: AtomicU64 = AtomicU64::new(0x9abc_def0_1122_3344);
+static C: AtomicU8 = AtomicU8::new(0x5a);
+
+static RO: [u32; 8] = [11, 222, 3333, 44444, 555_555, 6_666_666, 77_777_777, 888_888_888];
+
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let a0 = A.load(Relaxed);
+    let b0 = B.load(Relaxed);
+    let c0 = C.load(Relaxed);
+
+    A.store(a0.wrapping_add(input1), Relaxed);
+    B.store(b0 ^ ((input2 as u64) << 13), Relaxed);
+    C.store(c0 ^ (input1 as u8), Relaxed);
+
+    let a1 = A.load(Relaxed);
+    let b1 = B.load(Relaxed);
+    let c1 = C.load(Relaxed);
+
+    // Restore the original values to keep the native side stateless.
+    A.store(a0, Relaxed);
+    B.store(b0, Relaxed);
+    C.store(c0, Relaxed);
+
+    a1 ^ (b1 as u32) ^ ((b1 >> 32) as u32) ^ ((c1 as u32) << 24) ^ RO[(input1 % 8) as usize]
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_mem_grow.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_mem_grow.rs
@@ -1,0 +1,22 @@
+// wasm `memory.grow` lowering. `memory_grow(0, 0)` is a side-effecting op
+// LLVM cannot fold, so both calls survive; growing by zero pages returns
+// the current size twice, making the difference deterministically zero on
+// the MASM side, which the native build mirrors with a constant. Exercises
+// the MemoryGrow translation arm and `OpEmitter::mem_grow`.
+#[cfg(target_arch = "wasm32")]
+fn grow_diff() -> u32 {
+    let a = core::arch::wasm32::memory_grow(0, 0) as u32;
+    let b = core::arch::wasm32::memory_grow(0, 0) as u32;
+    a.wrapping_sub(b)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn grow_diff() -> u32 {
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let d = grow_diff();
+    input1.wrapping_mul(3).wrapping_add(input2 ^ d).rotate_left(d.wrapping_add(5) & 31)
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_mem_indexed.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_mem_indexed.rs
@@ -1,0 +1,21 @@
+// Runtime-indexed u32 array on the shadow stack. Dynamic indices prevent
+// SROA from promoting the buffer to registers, so every access survives as
+// a wasm i32.load/i32.store with a computed address — exercising wasm->HIR
+// pointer preparation (`prepare_addr`) and the word-sized load/store paths
+// in `codegen/masm/src/emit/mem.rs`.
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let mut buf = [0u32; 16];
+    let mut acc = input1 | 1;
+    let mut i = 0u32;
+    while i < 16 {
+        buf[(acc % 16) as usize] = acc ^ input2;
+        acc = acc.wrapping_mul(1664525).wrapping_add(1013904223);
+        i += 1;
+    }
+    let j = (input2 % 16) as usize;
+    let a = buf[j];
+    let b = buf[(j + 5) % 16];
+    let c = buf[(input1 % 16) as usize];
+    a.wrapping_add(b).rotate_left(c & 31) ^ acc
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_mem_overlap.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_mem_overlap.rs
@@ -1,0 +1,24 @@
+// Overlapping `copy_within` with dst > src. LLVM emits wasm `memory.copy`,
+// which has memmove semantics (overlap must behave as-if buffered), but the
+// MASM memcpy lowering appears to copy forward, overwriting source elements
+// before they are read. The whole-array sum makes any corruption visible
+// for every input pair (n >= 4, so the ranges always overlap).
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let mut a = [0u32; 16];
+    let mut i = 0u32;
+    while i < 16 {
+        a[i as usize] = input1.wrapping_add(i.wrapping_mul(0x9e37_79b9));
+        i += 1;
+    }
+    // src 2..2+n overlaps dst 4..4+n for all n in 4..=11.
+    let n = ((input2 % 8) + 4) as usize;
+    a.copy_within(2..2 + n, 4);
+    let mut sum = 0u32;
+    let mut j = 0;
+    while j < 16 {
+        sum = sum.wrapping_add(a[j] ^ (j as u32));
+        j += 1;
+    }
+    sum
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_mem_size.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_mem_size.rs
@@ -1,0 +1,28 @@
+// wasm `memory.size` lowering. memory.size is only clobbered by
+// memory.grow, so two bare calls get CSE'd and folded away; a `memory_grow`
+// call behind a dynamically-impossible condition (h % 6 == 5 implies
+// h % 3 == 2, so it can never also be 0 — a cross-modulus contradiction
+// LLVM does not fold) keeps both calls alive without ever executing the
+// grow at runtime. The page-count difference is then deterministically
+// zero, mirrored by the native build's constant. Exercises the MemorySize
+// translation arm and `OpEmitter::mem_size`.
+#[cfg(target_arch = "wasm32")]
+fn size_diff(h: u32) -> u32 {
+    let a = core::arch::wasm32::memory_size(0) as u32;
+    if h % 6 == 5 && h % 3 == 0 {
+        core::arch::wasm32::memory_grow(0, 1);
+    }
+    let b = core::arch::wasm32::memory_size(0) as u32;
+    a.wrapping_sub(b)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn size_diff(_h: u32) -> u32 {
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let d = size_diff(input1 ^ (input2 >> 3));
+    input2.wrapping_add(input1.rotate_right(d.wrapping_add(11) & 31)) ^ d
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_mem_static.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_mem_static.rs
@@ -1,0 +1,20 @@
+// Reads from `static` lookup tables. Non-trivial initializers become wasm
+// data segments, exercising the rodata pipeline: DataSegmentLayout::insert
+// in the frontend, merge/validate/copy/pad in codegen data_segments.rs, and
+// emit_data_segment_initialization. The odd-length byte table forces
+// word-alignment padding; runtime indices keep the loads from folding.
+static SBOX: [u32; 16] = [
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+];
+
+static BYTES: [u8; 13] = *b"miden-fuzzing";
+
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let a = SBOX[(input1 % 16) as usize];
+    let b = SBOX[(input2 % 16) as usize];
+    let c = BYTES[(input1 % 13) as usize] as u32;
+    let d = BYTES[(input2 % 13) as usize] as u32;
+    a.wrapping_add(b).rotate_left(c & 31) ^ d.wrapping_mul(0x0101_0101)
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_midloop_exit.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_midloop_exit.rs
@@ -1,0 +1,29 @@
+// `loop { big_a; if c { break } b; }` — the exit test sits in the middle of
+// the body, and `big_a` is bulky enough that LLVM loop rotation (which
+// would duplicate it) is not profitable. cfg-to-scf then produces an
+// scf.while whose `before` region is `big_a` + check and whose `after`
+// region is non-empty (`b`), exercising the after-region emission paths of
+// the scf.while lowering.
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let mut x = input1 | 1;
+    let mut y = input2;
+    let mut i = 0u32;
+    loop {
+        // big_a: several mixing rounds (too big to duplicate for rotation).
+        x = x.wrapping_mul(0x0808_8405).wrapping_add(y.rotate_left(7));
+        y = y.wrapping_mul(0x9e37_79b9) ^ (x >> 5);
+        x = x.rotate_left(13).wrapping_sub(y & 0xffff);
+        y = y.rotate_right(9).wrapping_add(x | 1);
+        x ^= y.wrapping_mul(31);
+        i = i.wrapping_add(1);
+        // mid-loop exit check
+        if i >= (input2 % 89).wrapping_add(1) || (x & 0xfff) == 0x123 {
+            break;
+        }
+        // b: post-check tail, runs only when the loop continues.
+        y = y.wrapping_add(i.rotate_left(3));
+        x = x.wrapping_add(y >> 11);
+    }
+    x ^ y ^ i
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_multi_exit_loop.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_multi_exit_loop.rs
@@ -1,0 +1,25 @@
+// Loop with multiple distinct exit edges (header exit, conditional break,
+// early return). cfg-to-scf must multiplex the exits through a discriminator
+// carried by the scf.while, exercising `transform_to_reduce_loop` and the
+// post-lift scf.while/index_switch canonicalization patterns.
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let n = input2 % 211;
+    let mut x = input1;
+    let mut i = 0u32;
+    while i < n {
+        x = x.wrapping_mul(0x0100_0193) ^ i;
+        // Exit 2: early return with its own computation.
+        if x & 0x8000_0007 == 0x8000_0003 {
+            return x.rotate_left(9).wrapping_add(input2);
+        }
+        // Exit 3: break with a different live-out shape.
+        if x & 0x8000_000f == 0x8000_000d {
+            x = x.wrapping_sub(i);
+            break;
+        }
+        i = i.wrapping_add(1);
+    }
+    // Exit 1 (header) and exit 3 merge here with different `x`/`i` states.
+    x ^ i.wrapping_mul(0x9e37_79b9)
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_ret_args.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_ret_args.rs
@@ -1,0 +1,18 @@
+// Two return paths that LLVM tail-merges into one exit block carrying the
+// return value as a block argument, plus an impossible trap exit that keeps
+// the branch between exits alive through cfg-to-scf (mixed return-like
+// kinds). The surviving cf.cond_br then has a successor with block
+// arguments, exercising the successor-operand scheduling/renaming loops in
+// the cf.cond_br MASM lowering.
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let h = input1.wrapping_mul(0x0101_0101) ^ input2;
+    if h & 0xf == 3 {
+        return h.rotate_left(5).wrapping_add(input2);
+    }
+    // Impossible: h % 6 == 1 implies h is odd, h % 4 == 0 implies h is even.
+    if h % 6 == 1 && h % 4 == 0 {
+        panic!();
+    }
+    h.rotate_right(7).wrapping_sub(input1)
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_select_sched.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_select_sched.rs
@@ -1,0 +1,17 @@
+// Select-heavy code: one condition feeding two selects with swapped
+// operands, operands kept live past the selects, and a u64 select. Forces
+// the MASM select emitter to copy/move operands on the operand stack
+// (`dup_select`/`mov_select` variants) instead of consuming them.
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let c = (input1 ^ input2) & 1 == 0;
+    let a = input1 | 3;
+    let b = input2.rotate_left(4);
+    let s1 = if c { a } else { b };
+    let s2 = if c { b } else { a };
+    let t = a.wrapping_add(b); // keeps `a` and `b` live past the selects
+    let wa = ((input1 as u64) << 17) | input2 as u64;
+    let wb = (input2 as u64).wrapping_mul(0x9e37_79b9);
+    let s3 = if wa & 1 == 0 { wa } else { wb }; // 64-bit select
+    s1.wrapping_mul(3) ^ s2 ^ t ^ (s3 as u32) ^ ((s3 >> 32) as u32)
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_stack_pressure.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_stack_pressure.rs
@@ -1,0 +1,39 @@
+// A right-leaning, non-reassociable expression tree. Every intermediate is
+// used exactly once, so LLVM stackifies the whole tree onto the wasm operand
+// stack; at the innermost point ~20 values are simultaneously live, pushing
+// the MASM operand stack past its 16-slot limit and exercising the spill
+// analysis/transform and deep operand-scheduling paths.
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let x = input1 | 1;
+    let y = input2 ^ 0x9e37_79b9;
+    x.wrapping_sub(
+        (y ^ x.rotate_left(1).wrapping_sub(
+            (x ^ y.rotate_left(2).wrapping_sub(
+                (y ^ x.rotate_left(3).wrapping_sub(
+                    (x ^ y.rotate_left(4).wrapping_sub(
+                        (y ^ x.rotate_left(5).wrapping_sub(
+                            (x ^ y.rotate_left(6).wrapping_sub(
+                                (y ^ x.rotate_left(7).wrapping_sub(
+                                    (x ^ y.rotate_left(8).wrapping_sub(
+                                        (y ^ x.rotate_left(9)
+                                            .wrapping_sub(x.wrapping_mul(y | 3)))
+                                        .rotate_right(3),
+                                    ))
+                                    .rotate_right(5),
+                                ))
+                                .rotate_right(7),
+                            ))
+                            .rotate_right(9),
+                        ))
+                        .rotate_right(11),
+                    ))
+                    .rotate_right(13),
+                ))
+                .rotate_right(15),
+            ))
+            .rotate_right(17),
+        ))
+        .rotate_right(19),
+    )
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_switch_shapes.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_switch_shapes.rs
@@ -1,0 +1,52 @@
+// Switch-lowering shapes. A four-exit loop produces a contiguous exit
+// discriminator (scf.index_switch dispatch with results), and two
+// equality-comparison chains over a hashed value are re-fused by the
+// `SimplifyCondBrLikeSwitch` canonicalization into cf.switch ops: one with
+// contiguous non-zero cases {7,8,9} (binary-search lowering behind an
+// interval guard) and one with sparse cases {21,77,200} (linear search).
+// LLVM keeps the chains as br_ifs since they are too sparse for br_table.
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let mut x = input1 | 1;
+    let mut i = 0u32;
+    let n = input2 % 173;
+    let tag = loop {
+        if i >= n {
+            break 0u32;
+        }
+        x = x.wrapping_mul(0x0808_8405).wrapping_add(i);
+        if x & 0xf000_0000 == 0x9000_0000 {
+            break 1;
+        }
+        if x & 0x0f00_0000 == 0x0600_0000 {
+            break 2;
+        }
+        if x & 0x00f0_0000 == 0x0030_0000 {
+            break 3;
+        }
+        i = i.wrapping_add(1);
+    };
+
+    let h = x.wrapping_mul(0x9e37_79b9) % 251;
+    // Contiguous non-zero constants — fused into a switch over {7,8,9}.
+    let a = if h == 7 {
+        x ^ 0x1111
+    } else if h == 8 {
+        x.rotate_left(3).wrapping_add(i)
+    } else if h == 9 {
+        x.wrapping_sub(i).rotate_right(2)
+    } else {
+        x >> 3
+    };
+    // Sparse constants — fused into a switch over {21,77,200}.
+    let b = if h == 21 {
+        a.wrapping_add(0x2222)
+    } else if h == 77 {
+        a ^ tag
+    } else if h == 200 {
+        a.rotate_left(9)
+    } else {
+        a.wrapping_mul(5)
+    };
+    b ^ tag.wrapping_mul(0x0101_0101)
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_switch_trap_arm.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_switch_trap_arm.rs
@@ -1,0 +1,24 @@
+// A br_table dispatch where one arm ends in a dynamically-impossible panic
+// (cross-modulus contradiction). The switch then has successor regions with
+// mixed return-like terminators (yield/ret vs unreachable), exercising
+// cfg-to-scf structuring of branch regions that cannot share an exit block
+// (`create_unreachable_terminator`) and index_switch regions ending in traps.
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let h = input1 ^ input2.rotate_left(11);
+    let sel = h % 5;
+    match sel {
+        0 => h.wrapping_mul(3) ^ input2,
+        1 => h.rotate_left(7).wrapping_add(input1),
+        2 => {
+            // Impossible: h % 10 == 7 implies h % 5 == 2 is fine, but
+            // h % 10 == 4 implies h % 5 == 4, contradicting sel == 2.
+            if h % 10 == 4 {
+                panic!();
+            }
+            h >> 2
+        }
+        3 => h.wrapping_sub(input1).rotate_right(3),
+        _ => h ^ 0x5555_aaaa,
+    }
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_trap_branch.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_trap_branch.rs
@@ -1,0 +1,14 @@
+// A dynamically-impossible panic path that LLVM cannot prove away:
+// `h % 6 == 5` implies `h % 3 == 2`, so the conjunction below is never true,
+// but relating remainders by different moduli is beyond known-bits analysis.
+// The surviving `unreachable` exercises `translate_unreachable_operator`,
+// `ub::Unreachable` lowering, and the cfg-to-scf handling of branch regions
+// that end in different return-like ops (ret vs unreachable).
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let h = input1 ^ input2.rotate_left(7);
+    if h % 6 == 5 && h % 3 == 0 {
+        panic!();
+    }
+    h ^ input2
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_u128_mix.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_u128_mix.rs
@@ -1,0 +1,16 @@
+// u128 arithmetic mixed into branchy code — exercises the wide-arithmetic
+// wasm ops (`i64.add128`/`i64.sub128`/`i64.mul_wide_u`) in the frontend and
+// their MASM lowering, with results feeding branch conditions.
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let a = ((input1 as u128) << 64) | ((input2 as u128) << 17) | input1 as u128;
+    let b = (input2 as u128).wrapping_mul(0x9e37_79b9_7f4a_7c15) | 1;
+    let mut acc = a.wrapping_add(b);
+    if acc & 1 == 0 {
+        acc = acc.wrapping_sub(b.rotate_left(13));
+    } else {
+        acc = acc.wrapping_mul(b | 0x10);
+    }
+    let folded = (acc as u64) ^ ((acc >> 64) as u64);
+    (folded as u32) ^ ((folded >> 32) as u32)
+}

--- a/tests/integration/src/end_to_end/differential/cases/case_u64_exits.rs
+++ b/tests/integration/src/end_to_end/differential/cases/case_u64_exits.rs
@@ -1,0 +1,34 @@
+// A non-inlined helper returning u64 whose tail-merged return paths give
+// the function-end block a 2-word (i64) block argument, plus an impossible
+// trap exit and a multi-exit loop inside the helper. Branch successor
+// operands are then multi-word values, exercising the word-count-aware
+// operand scheduling in the cf/scf MASM lowerings.
+#[inline(never)]
+fn churn(a: u32, b: u32) -> u64 {
+    let mut x = ((a as u64) << 32) | b as u64;
+    if b & 0xf == 5 {
+        return x.rotate_left(9) ^ 0x9e37_79b9_7f4a_7c15;
+    }
+    // Impossible: h % 6 == 1 implies h odd; h % 4 == 0 implies h even.
+    let h = a ^ b.rotate_left(3);
+    if h % 6 == 1 && h % 4 == 0 {
+        panic!();
+    }
+    let mut i = 0u32;
+    while i < (b % 37).wrapping_add(1) {
+        x = x.wrapping_mul(0x0808_8405_0101_0193).wrapping_add(i as u64);
+        if (x >> 60) == 0xa {
+            return x ^ ((i as u64) << 17); // exit from inside the loop
+        }
+        i = i.wrapping_add(1);
+    }
+    x.rotate_right(23)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn entrypoint(input1: u32, input2: u32) -> u32 {
+    let r = churn(input1, input2);
+    let s = churn(input2, input1.wrapping_add(0x55aa));
+    let t = r ^ s.rotate_left(31);
+    (t as u32) ^ ((t >> 32) as u32)
+}

--- a/tests/integration/src/end_to_end/differential/harness.rs
+++ b/tests/integration/src/end_to_end/differential/harness.rs
@@ -6,7 +6,8 @@
 //! (`#![no_std]` + `#[panic_handler]`) before writing the case as `src/lib.rs`
 //! of a generated cargo project, builds it twice — natively as a host `cdylib`
 //! and via `cargo-miden` to a MASM package — and compares outputs across
-//! random `(u32, u32)` inputs.
+//! random `(u32, u32)` inputs. [`run_case_with_inputs`] does the same but
+//! against an explicit list of inputs, for pinning a known divergence.
 
 use std::{
     path::PathBuf,
@@ -22,11 +23,38 @@ use proptest::{
 
 use crate::{CompilerTest, project, testing::executor_with_std};
 
+/// How [`run_case_inner`] supplies the `(input1, input2)` pairs to compare.
+enum Inputs<'a> {
+    /// 16 random pairs via proptest — the default fuzzing mode.
+    Random16,
+    /// A fixed list of pairs — deterministic regression inputs, e.g. for
+    /// pinning a known divergence independently of the fuzzer.
+    Explicit(&'a [(u32, u32)]),
+}
+
 /// Compiles `source` for the host and for MASM, then compares the
 /// `entrypoint(u32, u32) -> u32` outputs across 16 random input pairs.
 ///
 /// `name` must be unique per case; it is used as the generated package name.
 pub(super) fn run_case(name: &str, source: &str) {
+    run_case_inner(name, source, Inputs::Random16);
+}
+
+/// Like [`run_case`], but compares against an explicit, deterministic list of
+/// `(input1, input2)` pairs instead of random fuzzing.
+///
+/// Use this to pin a specific divergence (e.g. an input that a fuzzed case
+/// flagged) as its own reproducer, so it fails reliably on exactly that input
+/// rather than only when proptest happens to draw it.
+pub(super) fn run_case_with_inputs(name: &str, source: &str, inputs: &[(u32, u32)]) {
+    assert!(!inputs.is_empty(), "run_case_with_inputs requires at least one input pair");
+    run_case_inner(name, source, Inputs::Explicit(inputs));
+}
+
+/// Shared body of [`run_case`] / [`run_case_with_inputs`]: build the case both
+/// natively and to MASM, then compare `entrypoint` outputs for the requested
+/// inputs.
+fn run_case_inner(name: &str, source: &str, inputs: Inputs<'_>) {
     let pkg_name = format!("differential_{name}");
     let manifest = cargo_toml(&pkg_name);
     let miden_project_manifest = miden_project_toml(&pkg_name);
@@ -56,36 +84,55 @@ pub(super) fn run_case(name: &str, source: &str) {
     let entry: libloading::Symbol<EntryFn> = unsafe { lib.get(b"entrypoint\0") }
         .unwrap_or_else(|e| panic!("missing `entrypoint` in {}: {e}", dylib_path.display()));
 
-    // Proptest: 16 cases, shrinking disabled — the whole case file IS the
-    // reduced reproducer, so shrinking individual inputs adds no value.
-    // The shrinking generates a lot of noise that messes up the feedback for the agent. We want
-    // to capture the exact inputs that triggered the miscompilation. Shrunk inputs might
-    // trigger another code path (another miscompilation?).
-    let cfg = Config {
-        cases: 16,
-        max_shrink_iters: 0,
-        failure_persistence: Some(Box::new(FileFailurePersistence::Off)),
-        ..Config::default()
+    // Run the case for one input pair and return `(native_out, masm_out)`.
+    let eval = |a: u32, b: u32| -> (u32, u32) {
+        let native_out = unsafe { entry(a, b) };
+        let exec = executor_with_std(
+            vec![Felt::new_unchecked(a as u64), Felt::new_unchecked(b as u64)],
+            Some(&package),
+        );
+        let masm_out: u32 =
+            exec.execute_into(&package.unwrap_program(), test.session.source_manager.clone());
+        (native_out, masm_out)
     };
-    TestRunner::new(cfg)
-        .run(&(any::<u32>(), any::<u32>()), |(a, b)| {
-            let native_out = unsafe { entry(a, b) };
-            let exec = executor_with_std(
-                vec![Felt::new_unchecked(a as u64), Felt::new_unchecked(b as u64)],
-                Some(&package),
-            );
-            let masm_out: u32 =
-                exec.execute_into(&package.unwrap_program(), test.session.source_manager.clone());
-            prop_assert_eq!(
-                native_out,
-                masm_out,
-                "native vs masm mismatch for inputs ({}, {})",
-                a,
-                b
-            );
-            Ok(())
-        })
-        .unwrap_or_else(|err| panic!("{name}: {err}"));
+
+    match inputs {
+        // Proptest: 16 cases, shrinking disabled — the whole case file IS the
+        // reduced reproducer, so shrinking individual inputs adds no value.
+        // The shrinking generates a lot of noise that messes up the feedback for the agent. We
+        // want to capture the exact inputs that triggered the miscompilation. Shrunk inputs might
+        // trigger another code path (another miscompilation?).
+        Inputs::Random16 => {
+            let cfg = Config {
+                cases: 16,
+                max_shrink_iters: 0,
+                failure_persistence: Some(Box::new(FileFailurePersistence::Off)),
+                ..Config::default()
+            };
+            TestRunner::new(cfg)
+                .run(&(any::<u32>(), any::<u32>()), |(a, b)| {
+                    let (native_out, masm_out) = eval(a, b);
+                    prop_assert_eq!(
+                        native_out,
+                        masm_out,
+                        "native vs masm mismatch for inputs ({}, {})",
+                        a,
+                        b
+                    );
+                    Ok(())
+                })
+                .unwrap_or_else(|err| panic!("{name}: {err}"));
+        }
+        Inputs::Explicit(pairs) => {
+            for &(a, b) in pairs {
+                let (native_out, masm_out) = eval(a, b);
+                assert_eq!(
+                    native_out, masm_out,
+                    "{name}: native vs masm mismatch for inputs ({a}, {b})"
+                );
+            }
+        }
+    }
 }
 
 /// Prepended to every case source before compilation — supplies the

--- a/tests/integration/src/end_to_end/differential/harness.rs
+++ b/tests/integration/src/end_to_end/differential/harness.rs
@@ -91,12 +91,26 @@ pub(super) fn run_case(name: &str, source: &str) {
 /// Prepended to every case source before compilation — supplies the
 /// crate-level `#![no_std]` attribute and a minimal `#[panic_handler]` so each
 /// case file only has to contain the entrypoint function and its helpers.
+///
+/// The `rust_eh_personality` stub is required for the native `cdylib`: even
+/// though the case is built with `panic = "abort"`, the precompiled `core`
+/// library is built with `panic = "unwind"`, so any case that references
+/// `core`'s panic machinery (an impossible trap, a guarded index, …) links in
+/// unwind tables that reference `rust_eh_personality`. Without `std` nothing
+/// defines that symbol, leaving the `cdylib` with an undefined symbol that
+/// `dlopen` rejects on Linux (macOS tolerates it). The no-op definition makes
+/// the library self-contained; it is never invoked, because panics abort. It is
+/// gated to non-wasm so the `cargo-miden` (wasm → MASM) build is unchanged.
 const CASE_HEADER: &str = r#"#![no_std]
 
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}
 }
+
+#[cfg(not(target_family = "wasm"))]
+#[unsafe(no_mangle)]
+extern "C" fn rust_eh_personality() {}
 
 "#;
 

--- a/tests/integration/src/end_to_end/differential/tests.rs
+++ b/tests/integration/src/end_to_end/differential/tests.rs
@@ -105,6 +105,8 @@ fn calls_selects() {
 /// sparse cf.switch ops — exercises binary-search (interval guard) and
 /// linear-search switch lowering.
 #[test]
+#[ignore = "flaky native/MASM divergence: mismatch on inputs (1669775643, 1062584501); separate \
+            run hit VM assert 'value does not fit in i32' at cycle 2474"]
 fn switch_shapes() {
     run_case("switch_shapes", include_str!("cases/case_switch_shapes.rs"));
 }
@@ -163,4 +165,65 @@ fn u64_exits() {
 #[test]
 fn u128_mix() {
     run_case("u128_mix", include_str!("cases/case_u128_mix.rs"));
+}
+
+/// Runtime-indexed u32 array — dynamic i32.load/i32.store addressing
+/// (`prepare_addr`, word load/store emitter paths).
+#[test]
+fn mem_indexed() {
+    run_case("mem_indexed", include_str!("cases/case_mem_indexed.rs"));
+}
+
+/// Runtime-length `copy_from_slice`/`copy_within` — wasm `memory.copy` /
+/// HIR MemCpy lowering (element fast path + byte fallback loop).
+#[test]
+fn mem_copy() {
+    run_case("mem_copy", include_str!("cases/case_mem_copy.rs"));
+}
+
+/// Overlapping `copy_within` (dst > src) — wasm `memory.copy` memmove
+/// semantics vs forward-copying MASM lowering.
+#[test]
+#[ignore = "native/MASM divergence: memory.copy with overlapping dst > src ranges (original repro: \
+            inputs (91264998, 3811523388) in pre-split mem_copy)"]
+fn mem_overlap() {
+    run_case("mem_overlap", include_str!("cases/case_mem_overlap.rs"));
+}
+
+/// `static` lookup tables — wasm data segments through rodata layout,
+/// merging, padding, and init-code emission.
+#[test]
+fn mem_static() {
+    run_case("mem_static", include_str!("cases/case_mem_static.rs"));
+}
+
+/// Signed sub-word loads (i32/i64.load8_s/16_s) and unaligned u16/u32/u64
+/// loads/stores via `from_le_bytes`/`to_le_bytes` at odd offsets.
+#[test]
+fn mem_bytes() {
+    run_case("mem_bytes", include_str!("cases/case_mem_bytes.rs"));
+}
+
+/// Atomic statics (`.data` segment) plus a `.rodata` table — multi-segment
+/// data layout, merging, and overlap validation; constant-address stores.
+#[test]
+fn mem_globals() {
+    run_case("mem_globals", include_str!("cases/case_mem_globals.rs"));
+}
+
+/// `memory_grow(0, 0)` twice — MemoryGrow translation and
+/// `OpEmitter::mem_grow`, with a deterministic zero difference.
+#[test]
+#[ignore = "VM error in ::intrinsics::mem::memory_grow on every input: 'if statement expected a \
+            binary value on top of the stack, but got 1179648' at cycle 76 (memory.grow with \
+            delta=0)"]
+fn mem_grow() {
+    run_case("mem_grow", include_str!("cases/case_mem_grow.rs"));
+}
+
+/// `memory_size(0)` twice around an impossible `memory_grow` — MemorySize
+/// translation and `OpEmitter::mem_size`, deterministic zero difference.
+#[test]
+fn mem_size() {
+    run_case("mem_size", include_str!("cases/case_mem_size.rs"));
 }

--- a/tests/integration/src/end_to_end/differential/tests.rs
+++ b/tests/integration/src/end_to_end/differential/tests.rs
@@ -71,3 +71,96 @@ fn widening() {
 fn bitops() {
     run_case("bitops", include_str!("cases/case_bitops.rs"));
 }
+
+/// Exercises scf.while canonicalization: duplicated yielded results, results
+/// unused after the loop, and loop-invariant carried values.
+#[test]
+fn loop_results() {
+    run_case("loop_results", include_str!("cases/case_loop_results.rs"));
+}
+
+/// Loop with three distinct exit edges — exercises cfg-to-scf exit
+/// multiplexing (`transform_to_reduce_loop`) and scf.while arg/result
+/// canonicalization.
+#[test]
+fn multi_exit_loop() {
+    run_case("multi_exit_loop", include_str!("cases/case_multi_exit_loop.rs"));
+}
+
+/// Dynamically-impossible panic path (cross-modulus contradiction) — the
+/// surviving trap exercises `ub::Unreachable` translation and lowering.
+#[test]
+fn trap_branch() {
+    run_case("trap_branch", include_str!("cases/case_trap_branch.rs"));
+}
+
+/// Non-inlined helper calls (multi-arg, u64, bool) plus reused selects —
+/// exercises call translation/lowering and select emitter variants.
+#[test]
+fn calls_selects() {
+    run_case("calls_selects", include_str!("cases/case_calls_selects.rs"));
+}
+
+/// Four-exit loop plus eq-chains that canonicalize into contiguous-at-7 and
+/// sparse cf.switch ops — exercises binary-search (interval guard) and
+/// linear-search switch lowering.
+#[test]
+fn switch_shapes() {
+    run_case("switch_shapes", include_str!("cases/case_switch_shapes.rs"));
+}
+
+/// Loop with multiple `continue` backedges and a mid-body break — exercises
+/// cfg-to-scf latch multiplexing and undef discriminator threading.
+#[test]
+fn continue_paths() {
+    run_case("continue_paths", include_str!("cases/case_continue_paths.rs"));
+}
+
+/// br_table dispatch with one impossible-panic arm — switch successor
+/// regions with mixed return-like terminators (ret vs unreachable).
+#[test]
+fn switch_trap_arm() {
+    run_case("switch_trap_arm", include_str!("cases/case_switch_trap_arm.rs"));
+}
+
+/// Reused-condition selects with operands live past them plus a u64 select —
+/// exercises dup/mov select emitter scheduling variants.
+#[test]
+fn select_sched() {
+    run_case("select_sched", include_str!("cases/case_select_sched.rs"));
+}
+
+/// Mid-loop exit with a rotation-resistant body — produces an scf.while
+/// with a non-empty `after` region.
+#[test]
+fn midloop_exit() {
+    run_case("midloop_exit", include_str!("cases/case_midloop_exit.rs"));
+}
+
+/// Right-leaning single-use expression tree — ~20 simultaneously-live
+/// operand-stack values, exercising spill analysis/transform.
+#[test]
+fn stack_pressure() {
+    run_case("stack_pressure", include_str!("cases/case_stack_pressure.rs"));
+}
+
+/// Tail-merged return paths (exit block with args) plus an impossible trap
+/// exit — cf.cond_br lowering with successor block arguments.
+#[test]
+fn ret_args() {
+    run_case("ret_args", include_str!("cases/case_ret_args.rs"));
+}
+
+/// u64-returning helper with early returns, trap exit, and loop exit —
+/// multi-word successor operands through branch lowering.
+#[test]
+fn u64_exits() {
+    run_case("u64_exits", include_str!("cases/case_u64_exits.rs"));
+}
+
+/// u128 arithmetic feeding branch conditions — wide-arithmetic wasm ops
+/// (add128/sub128/mul_wide) and their lowering.
+#[test]
+fn u128_mix() {
+    run_case("u128_mix", include_str!("cases/case_u128_mix.rs"));
+}

--- a/tests/integration/src/end_to_end/differential/tests.rs
+++ b/tests/integration/src/end_to_end/differential/tests.rs
@@ -225,12 +225,20 @@ fn mem_globals() {
     run_case("mem_globals", include_str!("cases/case_mem_globals.rs"));
 }
 
-/// `memory_grow(0, 0)` twice — MemoryGrow translation and
-/// `OpEmitter::mem_grow`, with a deterministic zero difference.
+/// `memory_grow(0, 0)` twice — MemoryGrow translation and `OpEmitter::mem_grow`.
+///
+/// Permanently ignored as out of scope rather than filed as a bug to fix:
+/// `memory.grow` is unreachable from real Miden programs. It is only emitted by a
+/// heap allocator growing linear memory, but the SDK's `BumpAlloc` (the global
+/// allocator every program links, see `sdk/alloc`) bump-allocates within a fixed
+/// region and aborts on exhaustion — it never grows. So the only way to reach the
+/// (genuinely buggy) intrinsic is a direct `core::arch::wasm32::memory_grow` call,
+/// which this case makes but no real program does. Kept as a coverage/repro
+/// artifact for the MemoryGrow translation arm.
 #[test]
-#[ignore = "VM error in ::intrinsics::mem::memory_grow on every input: 'if statement expected a \
-            binary value on top of the stack, but got 1179648' at cycle 76 (memory.grow with \
-            delta=0)"]
+#[ignore = "out of scope: memory.grow is unreachable from real Miden code (the SDK BumpAlloc never \
+            grows linear memory); only a direct core::arch::wasm32::memory_grow call reaches the \
+            intrinsic, which aborts 'if statement expected a binary value ... but got 1179648'"]
 fn mem_grow() {
     run_case("mem_grow", include_str!("cases/case_mem_grow.rs"));
 }

--- a/tests/integration/src/end_to_end/differential/tests.rs
+++ b/tests/integration/src/end_to_end/differential/tests.rs
@@ -1,6 +1,6 @@
 //! Differential cases. One `#[test]` per file under `cases/`, driven by `run_case`.
 
-use super::harness::run_case;
+use super::harness::{run_case, run_case_with_inputs};
 
 #[test]
 fn add() {
@@ -109,6 +109,20 @@ fn calls_selects() {
             run hit VM assert 'value does not fit in i32' at cycle 2474"]
 fn switch_shapes() {
     run_case("switch_shapes", include_str!("cases/case_switch_shapes.rs"));
+}
+
+/// Deterministic reproducer for the `switch_shapes` divergence: pins the
+/// exact `(input1, input2)` pair the fuzzer flagged, so the bug fails
+/// reliably on that input rather than only when proptest happens to draw it.
+#[test]
+#[ignore = "MASM VM aborts on pinned input (1669775643, 1062584501): 'value does not fit in i32'; \
+            deterministic reproducer for the switch_shapes divergence"]
+fn switch_shapes_repro() {
+    run_case_with_inputs(
+        "switch_shapes_repro",
+        include_str!("cases/case_switch_shapes.rs"),
+        &[(1669775643, 1062584501)],
+    );
 }
 
 /// Loop with multiple `continue` backedges and a mid-body break — exercises

--- a/tools/fuzza-agent/AGENT-PROMPT.md
+++ b/tools/fuzza-agent/AGENT-PROMPT.md
@@ -1,11 +1,45 @@
-**Target area:** `[area]`
+**Target area:** `[area]` — a free-form description of what to cover, e.g.
+`memory read/write`, `control flow`, `u64 arithmetic`.
+
+## Resolve the area to paths
+
+The target area is worded for humans; your first job is to translate it into
+the concrete compiler source paths it refers to, then export those as
+`FUZZA_AREA` so the coverage report scopes itself to the area.
+
+1. **Find the source.** Search the compiler crates (`codegen/`, `frontend/`,
+   `dialects/`, `hir/`, `hir-*/`, …) for the ops, emitters, passes, and
+   translation arms that implement the area. For example, `memory read/write`
+   resolves to the load/store emitters (`codegen/masm/src/emit/mem.rs`), the
+   wasm address preparation (`dialects/wasm/src/mem.rs`), and the data-segment
+   lowering (`codegen/masm/src/data_segments.rs`).
+2. **Export the resolved paths** as a comma-separated list of workspace-relative
+   prefixes (a file, or a directory ending in `/`):
+
+   ```bash
+   export FUZZA_AREA='codegen/masm/src/emit/mem.rs,dialects/wasm/src/mem.rs,codegen/masm/src/data_segments.rs'
+   ```
+
+   With `FUZZA_AREA` set, `report.md` gains a **"Target area"** section with an
+   area-only headline, an area-only delta, and the full list of cold functions
+   in the area — read that section instead of hand-summing the global numbers.
+3. **Sanity-check the mapping.** After the first `cargo make fuzza-cov`, confirm
+   the "Target area" section lists the functions you expect; widen or narrow the
+   paths if it's catching too much or too little. Record the resolved paths in
+   the scratch log so later steps reuse the same scope.
 
 ## Objective
 
 Maximize region coverage in the target area of the Miden compiler via the
-fuzza harness. **Stop when five consecutive new cases each add zero new
-regions in the target area**, or after twenty cases total, whichever comes
-first.
+fuzza harness. **Stop when any of these holds:**
+
+- Five consecutive new cases each add zero new regions in the target area, or
+- twenty cases total, or
+- **you can argue the remaining cold regions in the area are unreachable** from
+  a `(u32, u32) -> u32` `#![no_std]` entrypoint (this is the *preferred* exit —
+  reading the remaining cold functions and explaining why each is out of reach
+  beats grinding five ritual zero-delta cases). Record the argument in the
+  scratch log.
 
 ## Case constraints
 
@@ -22,6 +56,11 @@ Each new case is a single `.rs` file at
 - Avoid operations that panic on valid `u32` inputs (guard division/modulo by
   zero, use `wrapping_*` for arithmetic). The harness fuzzes with random
   `u32` pairs; a native-side panic is a case failure.
+- Be careful with mutable `static`s. The native `cdylib` is loaded **once** and
+  reused across all 16 proptest inputs, so a static (e.g. an `AtomicU32`) that
+  you mutate carries state from one invocation to the next — which breaks
+  determinism unless you restore it before returning. (Statics are still a
+  useful tool: non-zero initializers are how you reach the data-segment code.)
 
 Wire the new case in `tests/integration/src/end_to_end/differential/tests.rs`:
 
@@ -34,9 +73,11 @@ fn <name>() {
 
 ## Loop
 
-1. **Read** `target/fuzza-coverage/report.md`. Focus on entries whose `File:line`
-   is inside the target area — first in the "Top untouched functions" section,
-   then in "Partially-covered functions".
+1. **Read** `target/fuzza-coverage/report.md`. With `FUZZA_AREA` set, read its
+   **"Target area"** section: work the "Area — untouched functions" list first,
+   then "Area — partially-covered functions". (Without `FUZZA_AREA`, fall back
+   to the global "Top untouched"/"Partially-covered" sections and filter by
+   `File:line` yourself.)
 2. **Pick one target function.** Skim its source at `File:line` to understand
    what Rust-level construct triggers it (e.g. a particular HIR op kind, a
    specific branch in wasm translation).
@@ -64,11 +105,22 @@ fn <name>() {
 3. **Write** `case_<name>.rs` designed to exercise that construct through the
    `(u32, u32) -> u32` entrypoint. Keep it minimal — the less incidental code,
    the easier to interpret failures.
-4. **Run** `cargo make fuzza-cov-step`. Read the new `report.md`. The "Delta
-   since previous run" section tells you:
-   - `Regions covered: +ΔR` — was your case productive?
-   - `Newly-exercised functions` — did you hit the target or adjacent code?
-5. **Record the outcome** in a scratch log so you don't repeat dead-end ideas:
+4. **Run** `cargo make fuzza-cov-step`. Read the new `report.md`:
+   - The **"Target area"** section's `Area delta since previous run:
+     +ΔR regions` line is your productivity signal for the area — this is the
+     number the stop condition is phrased in terms of.
+   - The global "Delta since previous run" section's `Regions covered: +ΔR` and
+     `Newly-exercised functions` tell you whether the case also helped adjacent
+     code.
+
+   Note: coverage **accumulates** across `fuzza-cov-step` runs (the profile data
+   is merged, not reset). So the area headline is cumulative, the delta is
+   per-step, and deleting a case's `#[test]` does **not** drop its regions from
+   the report until the next `fuzza-cov-clean`.
+5. **Record the outcome** in a scratch log at
+   `tools/fuzza-agent/scratch/<area>-log.md` (create the dir if missing) so you
+   don't repeat dead-end ideas. This path lives outside `target/`, so it
+   survives `fuzza-cov-clean`; it is gitignored, so it won't be committed.
    - If `ΔR > 0` in the target area: keep the case, continue.
    - If `ΔR == 0`: keep the case only if it hits new regions elsewhere worth
      having; otherwise delete it and its `#[test]` entry.
@@ -77,27 +129,40 @@ fn <name>() {
      green; note it as a potential compiler bug finding. The compile-side
      coverage the case triggered before the divergence is still captured in
      the report — a failing case is not wasted work and the delta still
-     counts.
+     counts. (The noted input is the *first* random failure, not a minimized
+     one — proptest shrinking is disabled.) To understand the divergence,
+     re-emit the intermediate artifacts with `MIDENC_EMIT` (WAT/HIR/MASM) and
+     trace MASM execution with `MIDENC_TRACE=executor=trace` — see the `emit`
+     and `trace` skills.
    - If the test panicked during compile (cargo-miden error): the case
      probably hit unsupported Rust constructs — delete it, try something
      simpler.
-6. **Stop** per the objective above.
+6. **Stop** per the objective above. When you stop by the unreachability
+   argument, write the per-function reasoning into the scratch log so the next
+   run doesn't re-explore the same dead ends.
 
 ## Reference commands
 
 ```bash
+# Scope every report below to the target area. Set this to the source paths you
+# resolved the free-worded area to above (see "Resolve the area to paths"), and
+# keep it exported for the whole session:
+export FUZZA_AREA='codegen/masm/src/emit/mem.rs,dialects/wasm/src/mem.rs,codegen/masm/src/data_segments.rs'
+
 # First run (clean-slate baseline; takes several minutes for instrumented build):
 cargo make fuzza-cov
 
 # Each iteration (reuses the instrumented build; ~20-60s warm):
 cargo make fuzza-cov-step
 
-# Nuke all coverage state and start over:
+# Nuke all coverage state and start over (also wipes target/fuzza-coverage, but
+# NOT your scratch log under tools/fuzza-agent/scratch/):
 cargo make fuzza-cov-clean
 ```
 
 Outputs live under `target/fuzza-coverage/`:
-- `report.md` — what you read.
+- `report.md` — what you read; includes the "Target area" section when
+  `FUZZA_AREA` is set.
 - `report.prev.json` — previous snapshot (used for the delta).
 - `html/html/index.html` — per-line highlighted source view for debugging
   which exact lines you hit.

--- a/tools/fuzza-agent/README.md
+++ b/tools/fuzza-agent/README.md
@@ -18,8 +18,24 @@ handler, then for each case:
 3. Runs both with 16 random `(u32, u32)` input pairs via proptest.
 4. Asserts the outputs match.
 
-A divergence is a likely compiler bug; the case file itself is the minimal
-reproducer (proptest shrinking is disabled).
+A divergence is a likely compiler bug, and the case file itself is the
+reproducer. Note that proptest shrinking is disabled, so the failing
+`(input1, input2)` pair a case reports is the *first* random failure, not a
+minimized one. To investigate a divergence, re-emit the intermediate
+artifacts with `MIDENC_EMIT` (WAT/HIR/MASM) and trace VM execution with
+`MIDENC_TRACE=executor=trace` — see the `emit` and `trace` skills.
+
+### How coverage accumulates
+
+`fuzza-cov-step` runs with `--no-clean`, so llvm-cov **merges** each run's
+profile data into the previous run's rather than resetting it. Consequences:
+
+- The headline `Regions covered` is cumulative across every step since the
+  last clean; the "Delta since previous run" section is the per-step change.
+- A failing (`#[ignore]`d) case still contributes the compile-side coverage it
+  reached before diverging — a failing case is not wasted work.
+- Deleting a case's `#[test]` does **not** remove its regions from the report
+  until the next `cargo make fuzza-cov-clean`.
 
 ## Running the tests
 
@@ -51,6 +67,11 @@ crates), be deterministic, and avoid panicking on valid `u32` inputs (guard
 division/modulo by zero, use `wrapping_*` for arithmetic). A native-side
 panic is treated as a case failure.
 
+One determinism subtlety: the native `cdylib` is loaded **once** and reused
+across all 16 proptest inputs, so a mutable `static` that a case writes to
+carries state between invocations. Restore any static you mutate before
+returning, or the case will be flaky.
+
 ## Coverage-guided case generation
 
 The `cargo make` tasks below produce a Markdown report (via `cov.py`) of
@@ -59,6 +80,12 @@ The intended workflow is to hand `AGENT-PROMPT.md` to an agent and let it
 use the report to pick new cases.
 
 ```bash
+# Optional: scope the report to a target area. FUZZA_AREA is a comma-separated
+# list of workspace-relative path prefixes; an agent driven by AGENT-PROMPT.md
+# derives these from a free-worded area (e.g. "memory read/write") as its first
+# step. Keep it exported for the whole session.
+export FUZZA_AREA='codegen/masm/src/emit/mem.rs,dialects/wasm/src/mem.rs'
+
 # First run (clean-slate baseline; takes several minutes for the
 # instrumented compiler build).
 cargo make fuzza-cov
@@ -70,6 +97,12 @@ cargo make fuzza-cov-step
 cargo make fuzza-cov-clean
 ```
 
+When `FUZZA_AREA` is set, `report.md` gains a **"Target area"** section: an
+area-only `Regions covered` headline, an `Area delta since previous run` line,
+and the full list of untouched / partially-covered functions in the area. This
+is the section an area-focused agent should drive from — it removes the need to
+hand-filter the global tables by `File:line`.
+
 Outputs live under `target/fuzza-coverage/`:
 
 - `report.md` — what humans and agents read.
@@ -78,24 +111,32 @@ Outputs live under `target/fuzza-coverage/`:
 - `html/html/index.html` — per-line highlighted source view for debugging
   which exact lines a case hits.
 
+`cov.py` drops boilerplate trait impls (`fmt`, `clone`, `From`/`Into`, …) from
+the report via `BORING_NAME_RE`, so don't be surprised when such a function
+never appears in the cold lists even though it's uncovered. If your target area
+is one where those matter (parsing, attribute handling), edit that regex.
+
+Agents writing scratch notes should put them under `tools/fuzza-agent/scratch/`
+(see [`AGENT-PROMPT.md`](AGENT-PROMPT.md)). That directory lives outside
+`target/`, so it survives `fuzza-cov-clean`, and its contents are gitignored.
+
 ### Using AGENT-PROMPT.md
 
 `AGENT-PROMPT.md` is a prompt template for an agent that grows coverage in a
 specific compiler area. To use it:
 
-1. Pick a compiler directory or file to target — e.g.
-   `codegen/masm/src/emit/`, `frontend/wasm/src/code_translator/mod.rs`,
-   `dialects/scf/`.
-2. Run `cargo make fuzza-cov` (if you haven't yet) and skim
-   `target/fuzza-coverage/report.md` to confirm the area has untouched
-   functions whose signatures could plausibly be reached from a
-   `(u32, u32) -> u32` no_std cdylib. Compiler code behind
-   SDK/protocol/account/note scripts, the debug-engine UI, or anything
-   gated on a `#[component]` attribute is **not reachable** from this
-   harness — pick a different area if that's most of what shows up in the
-   cold list.
-3. Open `AGENT-PROMPT.md`, replace the `[area]` placeholder on the first
-   line with the path you chose, and hand the file to the agent.
-4. The agent iterates via `cargo make fuzza-cov-step`, reading the delta
-   in each new `report.md` to decide whether each case was productive and
-   when to stop.
+1. Describe the area in plain words — e.g. `memory read/write`, `control flow`,
+   `u64 arithmetic`. You don't need to know the file layout; the agent resolves
+   the phrase to concrete source paths as its first step.
+2. Open `AGENT-PROMPT.md`, replace the `[area]` placeholder on the first line
+   with your description, and hand the file to the agent.
+3. The agent resolves the phrase to source paths, exports them as `FUZZA_AREA`,
+   and runs `cargo make fuzza-cov`. It then sanity-checks that the "Target area"
+   section of `report.md` lists the functions you'd expect — and that they're
+   plausibly reachable from a `(u32, u32) -> u32` no_std cdylib. Compiler code
+   behind SDK/protocol/account/note scripts, the debug-engine UI, or anything
+   gated on a `#[component]` attribute is **not reachable** from this harness;
+   if the area is mostly that, it's a poor target.
+4. The agent iterates via `cargo make fuzza-cov-step`, reading the "Target
+   area" delta in each new `report.md` to decide whether each case was
+   productive and when to stop.

--- a/tools/fuzza-agent/cov.py
+++ b/tools/fuzza-agent/cov.py
@@ -80,6 +80,11 @@ def pct(a: int, b: int) -> str:
     return f"{100.0 * a / b:.1f}%" if b else "n/a"
 
 
+def in_area(func: dict, areas: tuple[str, ...]) -> bool:
+    """Return True if `func`'s workspace-relative file starts with any area prefix."""
+    return any(func["file"].startswith(a) for a in areas)
+
+
 def demangle_all(names: list[str]) -> list[str]:
     """Batch-demangle Rust symbols via `rustfilt` if available, else return as-is."""
     if not names or shutil.which("rustfilt") is None:
@@ -197,6 +202,104 @@ def emit_delta(current: list[dict], prev: list[dict], out) -> None:
         print(file=out)
 
 
+def emit_area(current: list[dict], prev: list[dict], areas: tuple[str, ...], out) -> None:
+    """Print the target-area section: scoped headline, delta, and cold-function tables.
+
+    This is the section the case-generation agent reads to drive its loop: the
+    headline and delta are restricted to `areas`, so the agent can judge whether
+    a case was productive *in the target area* without hand-summing the raw JSON.
+    The untouched/partial tables list every cold function in the area (not just
+    those over the global size threshold), so the remaining surface is visible in
+    full for exhaustion analysis.
+    """
+    area_cur = [f for f in current if in_area(f, areas)]
+
+    print(f"## Target area — {', '.join(areas)}\n", file=out)
+
+    if not area_cur:
+        print(
+            "_No compiler functions matched these prefixes. Check the path against "
+            "the `File:line` column below (paths are workspace-relative)._\n",
+            file=out,
+        )
+        return
+
+    cur_cov = sum(f["covered"] for f in area_cur)
+    cur_tot = sum(f["regions"] for f in area_cur)
+    cur_hit = sum(1 for f in area_cur if f["count"] > 0)
+    print(
+        f"- Regions covered:   **{cur_cov}/{cur_tot}** ({pct(cur_cov, cur_tot)})",
+        file=out,
+    )
+    print(
+        f"- Functions touched: **{cur_hit}/{len(area_cur)}** ({pct(cur_hit, len(area_cur))})",
+        file=out,
+    )
+
+    if prev:
+        prev_by_key = {(f["file"], f["name"]): f for f in prev if in_area(f, areas)}
+        prev_cov = sum(f["covered"] for f in prev_by_key.values())
+        prev_hit = sum(1 for f in prev_by_key.values() if f["count"] > 0)
+        print(
+            f"- **Area delta since previous run: {cur_cov - prev_cov:+d} regions, "
+            f"{cur_hit - prev_hit:+d} functions**",
+            file=out,
+        )
+        gained = sorted(
+            (
+                {
+                    **f,
+                    "gain": f["covered"]
+                    - prev_by_key.get((f["file"], f["name"]), {"covered": 0})["covered"],
+                }
+                for f in area_cur
+            ),
+            key=lambda f: -f["gain"],
+        )
+        gained = [f for f in gained if f["gain"] > 0]
+        if gained:
+            print("\n### Area functions that gained regions\n", file=out)
+            print("| Δ regions | Now hit | File:line | Function |", file=out)
+            print("| --- | --- | --- | --- |", file=out)
+            for f in gained[:TOP_N]:
+                print(
+                    f"| +{f['gain']} | {f['covered']}/{f['regions']} | "
+                    f"`{f['file']}:{f['line']}` | `{f['name']}` |",
+                    file=out,
+                )
+    print(file=out)
+
+    untouched = sorted(
+        (f for f in area_cur if f["count"] == 0),
+        key=lambda f: (-f["regions"], f["file"], f["line"]),
+    )
+    print(f"### Area — untouched functions (up to {TOP_N})\n", file=out)
+    print("| Regions | File:line | Function |", file=out)
+    print("| --- | --- | --- |", file=out)
+    for f in untouched[:TOP_N]:
+        print(f"| {f['regions']} | `{f['file']}:{f['line']}` | `{f['name']}` |", file=out)
+    if not untouched:
+        print("| _none_ | | |", file=out)
+    print(file=out)
+
+    partial = sorted(
+        (f for f in area_cur if f["count"] > 0 and f["covered"] < f["regions"]),
+        key=lambda f: (-(f["regions"] - f["covered"]), f["file"], f["line"]),
+    )
+    print(f"### Area — partially-covered functions (up to {TOP_N})\n", file=out)
+    print("| Uncovered | Regions | File:line | Function |", file=out)
+    print("| --- | --- | --- | --- |", file=out)
+    for f in partial[:TOP_N]:
+        uncov = f["regions"] - f["covered"]
+        print(
+            f"| {uncov} | {f['regions']} | `{f['file']}:{f['line']}` | `{f['name']}` |",
+            file=out,
+        )
+    if not partial:
+        print("| _none_ | | | |", file=out)
+    print(file=out)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("json", type=Path, help="current llvm-cov JSON")
@@ -207,7 +310,20 @@ def main() -> None:
         default=None,
         help="previous llvm-cov JSON; if present, emit a delta section",
     )
+    parser.add_argument(
+        "--area",
+        default=None,
+        help="comma-separated workspace-relative path prefix(es) for the target "
+        "area; if present, emit a scoped headline, delta, and cold-function "
+        "tables for just those paths (e.g. codegen/masm/src/emit/mem.rs)",
+    )
     args = parser.parse_args()
+
+    areas = (
+        tuple(p.strip() for p in args.area.split(",") if p.strip())
+        if args.area
+        else ()
+    )
 
     workspace = args.workspace.resolve()
     current = load_funcs(args.json, workspace)
@@ -240,6 +356,9 @@ def main() -> None:
 
     if prev:
         emit_delta(current, prev, out)
+
+    if areas:
+        emit_area(current, prev, areas, out)
 
     untouched = sorted(
         (f for f in current if f["count"] == 0),

--- a/tools/fuzza-agent/scratch/.gitkeep
+++ b/tools/fuzza-agent/scratch/.gitkeep
@@ -1,0 +1,9 @@
+# fuzza-agent scratch directory
+#
+# The coverage-guided case-generation agent (see ../AGENT-PROMPT.md) writes its
+# per-run scratch log here, e.g. `<area>-log.md`, recording which case ideas
+# were productive and which target regions are unreachable.
+#
+# This directory lives outside `target/`, so it survives
+# `cargo make fuzza-cov-clean`. Everything in it except this file is gitignored:
+# the notes are local working state and are not committed.


### PR DESCRIPTION
Extends the differential fuzzing setup (harness + `tools/fuzza-agent` tooling) and
adds 21 cases produced with it.

## Harness: concrete inputs

`run_case` fuzzes a case against 16 random `(u32, u32)` pairs. This adds a sibling
`run_case_with_inputs(name, source, &[(u32, u32)])` that runs the same
native-vs-MASM comparison against an **explicit, deterministic** list of inputs.

Both funnel through a new `run_case_inner`, with an `Inputs::{Random16, Explicit}`
enum selecting the mode, so the build/load/compare logic isn't duplicated. The
point is pinning a known divergence as its own reproducer: `switch_shapes_repro`
fixes the exact `(1669775643, 1062584501)` pair the fuzzer flagged, so it fails
reliably instead of only when proptest happens to draw it.

## tools/fuzza-agent: area-scoped coverage

The coverage report can now focus on a target area instead of the whole compiler:

- **`cov.py`** gains `--area` (comma-separated, workspace-relative path prefixes).
  When set, `report.md` grows a **"Target area"** section — an area-only coverage
  headline, an area-only per-step delta, and the untouched / partially-covered
  functions in the area — so the agent judges per-area productivity without
  hand-filtering the global tables. Output with no `--area` is unchanged.
- **`Makefile.toml`** threads a `FUZZA_AREA` env var into `cov.py --area` for the
  `fuzza-cov` / `fuzza-cov-step` tasks.
- **`AGENT-PROMPT.md` / `README.md`**: the area is now given in **plain words**
  (e.g. `memory read/write`); the agent resolves the phrase to concrete source
  paths and exports `FUZZA_AREA` as its first step. Also documents the
  coverage-accumulation model, the mutable-static determinism trap, and a
  gitignored `scratch/` dir for agent notes that survives `fuzza-cov-clean`.

## Cases

21 new differential cases targeting control-flow and memory read/write codegen.
A few are `#[ignore]`d because they surface real native/MASM divergences (kept as
reproducers with the failing input noted); `mem_grow` is `#[ignore]`d as
out-of-scope — `memory.grow` is unreachable from real programs since the SDK
`BumpAlloc` never grows linear memory.

Also includes a `fix(fuzza)`: a no-op `rust_eh_personality` in the case header so
the native `cdylib` is self-contained (panic-path cases link `core`'s unwind
tables; without `std` that symbol is undefined and Linux `dlopen` rejects it).
