### PR TITLE
fix: prevent `OutputStackOverflow` in intrinsic `i32::overflowing_sub`

### DIFF
--- a/codegen/masm/intrinsics/i32.masm
+++ b/codegen/masm/intrinsics/i32.masm
@@ -89,7 +89,9 @@ pub proc overflowing_sub # [b, a]
         # special handling to account for the fact that `b` was `i32::MIN`
 
         # NOTE: We treat `b` as unsigned, since we're supposed to be negating it
-        drop push.MAX         # [i32::MAX, a]
+        # We `push -> swap -> drop` to avoid the stack shrinking below its min depth. When shrinking
+        # below min depth, the processor expands the stack and we would need to clean that up.
+        push.MAX swap.1 drop  # [i32::MAX, a]
         dup.1 exec.is_signed  # [is_a_signed, i32::MAX, a]
         dup.0 eq.0            # [is_same_sign, is_a_signed, i32::MAX, a]
 

--- a/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
+++ b/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
@@ -192,7 +192,6 @@ fn i32_overflowing_add() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1163"]
 fn i32_overflowing_sub() {
     let proc_body = r#"
     # Stack: [b, a]


### PR DESCRIPTION
Closes #1163

On top of #1160 to make use of intrinsic testing.

#### Problem

https://github.com/0xMiden/compiler/blob/30544eb610c8315550aafbf07944b225f5399c76/codegen/masm/intrinsics/i32.masm#L92

The `drop` would cause stack depth to shrink below the minimum of 16, so the processor implicitly adds a stack slot by adjusting the bottom of the stack [[ref](https://github.com/0xMiden/miden-vm/blob/d1c853cd25497d17806745e64a9f0919e42f2455/processor/src/fast/mod.rs#L830)].

So after `drop push.MAX` the stack depth is 17 while in the intrinsic it's assumed to be 16. The extra slot isn't cleaned up, which results in `OutputStackOverflow`.

#### Footgun?

MASM authors should probably be aware of this, still it can be a footgun. Could this be:

- turned into a warning/error produced by a linter?
- prevented by the processor by trying to recognize such scenarios and remove the extra slot if possible?
  - though this might not always work reliably and would break MASM which builds on this behavior