### PR TITLE
fix: edge case handling in intrinsic `i32::overflowing_mul`

### DIFF
--- a/codegen/masm/intrinsics/i32.masm
+++ b/codegen/masm/intrinsics/i32.masm
@@ -141,29 +141,33 @@ pub proc overflowing_mul # [b, a]
     # if either operand are MIN, then the following rules apply
     #
     # 1. If the other operand is 1, then there is no overflow and the result is MIN
-    # 2. If the other operand is -1, then there is overflow and the result is MIN
-    # 3. If the other operand is 0, then there is no overflow and the result is zero
-    # 4. For any other value, there is overflow, and the result is zero
+    # 2. If the other operand is 0, then there is no overflow and the result is zero
+    # 3. For any other value, there is overflow, and the result is MIN if the other
+    #    operand is odd, or zero otherwise.
     if.true
-        # if either are 0, rule 3 applies
-        dup.0 eq.0           # [is_b_0, b, a]
-        dup.2 eq.0           # [is_a_0, is_b_0, b, a]
-        or                   # [is_either_0, b, a]
-        movdn.2              # [b, a, is_either_0]
+        # check if either operand is odd
+        dup.0 push.1 u32and # [b_odd, b, a]
+        dup.2 push.1 u32and # [a_odd, b_odd, b, a]
+        or                  # [result_is_MIN, b, a]
+        movdn.2             # [b, a, result_is_MIN]
 
-        # if either are 1, rule 1 applies
-        dup.0 eq.1  # [is_b_1, b, a, is_either_0]
-        dup.2 eq.1  # [is_a_1, is_b_1, b, a, is_either_0]
-        or          # [is_either_1, b, a, is_either_0]
-        # either are -1, rule 2 applies
-        movup.2 push.NEG1 eq # [is_a_neg1, is_either_1, b, is_either_0]
-        movup.2 push.NEG1 eq # [is_b_neg1, is_a_neg1, is_either_1, is_either_0]
-        or                   # [is_either_neg1, is_either_1, is_either_0]
-        # choose between rule 1/2 or rule 3/4 result
-        dup.1 or           # [result_is_MIN, is_either_1, is_either_0]
+        # check if either operand is 0
+        dup.0 eq.0           # [is_b_0, b, a, result_is_MIN]
+        dup.2 eq.0           # [is_a_0, is_b_0, b, a, result_is_MIN]
+        or                   # [is_either_0, b, a, result_is_MIN]
+        movdn.2              # [b, a, is_either_0, result_is_MIN]
+
+        # check if either operand is 1
+        eq.1        # [is_b_1, a, is_either_0, result_is_MIN]
+        swap.1 eq.1 # [is_a_1, is_b_1, is_either_0, result_is_MIN]
+        or          # [is_either_1, is_either_0, result_is_MIN]
+
+        # choose between the MIN and zero result
+        movup.2           # [result_is_MIN, is_either_1, is_either_0]
         push.MIN push.0    # [0, MIN, result_is_MIN, is_either_1, is_either_0]
         swap.2 cdrop       # [result, is_either_1, is_either_0]
-        # overflow occurred if the other operand is -1, i.e. it's neither 1 nor 0
+
+        # overflow occurred unless the other operand is 1 or 0
         swap.2 or         # [is_either_0_or_1, result]
         not               # [overflowed, result]
     else

--- a/codegen/masm/intrinsics/i32.masm
+++ b/codegen/masm/intrinsics/i32.masm
@@ -142,22 +142,30 @@ pub proc overflowing_mul # [b, a]
     #
     # 1. If the other operand is 1, then there is no overflow and the result is MIN
     # 2. If the other operand is -1, then there is overflow and the result is MIN
-    # 3. For any other value, there is overflow, and the result is zero
+    # 3. If the other operand is 0, then there is no overflow and the result is zero
+    # 4. For any other value, there is overflow, and the result is zero
     if.true
+        # if either are 0, rule 3 applies
+        dup.0 eq.0           # [is_b_0, b, a]
+        dup.2 eq.0           # [is_a_0, is_b_0, b, a]
+        or                   # [is_either_0, b, a]
+        movdn.2              # [b, a, is_either_0]
+
         # if either are 1, rule 1 applies
-        dup.0 eq.1  # [is_b_1, b, a]
-        dup.2 eq.1  # [is_a_1, is_b_1, b, a]
-        or          # [is_either_1, b, a]
+        dup.0 eq.1  # [is_b_1, b, a, is_either_0]
+        dup.2 eq.1  # [is_a_1, is_b_1, b, a, is_either_0]
+        or          # [is_either_1, b, a, is_either_0]
         # either are -1, rule 2 applies
-        movup.2 push.NEG1 eq # [is_a_neg1, is_either_1, b]
-        movup.2 push.NEG1 eq # [is_b_neg1, is_a_neg1, is_either_1]
-        or                   # [is_either_neg1, is_either_1]
-        # choose between rule 1/2 or rule 3 result
-        dup.1 or           # [result_is_MIN, is_either_1]
-        push.MIN push.0    # [0, MIN, result_is_MIN, is_either_1]
-        swap.2 cdrop       # [result, is_either_1]
-        # overflow occurred if neither operand was 1
-        swap.1 not         # [overflowed, result]
+        movup.2 push.NEG1 eq # [is_a_neg1, is_either_1, b, is_either_0]
+        movup.2 push.NEG1 eq # [is_b_neg1, is_a_neg1, is_either_1, is_either_0]
+        or                   # [is_either_neg1, is_either_1, is_either_0]
+        # choose between rule 1/2 or rule 3/4 result
+        dup.1 or           # [result_is_MIN, is_either_1, is_either_0]
+        push.MIN push.0    # [0, MIN, result_is_MIN, is_either_1, is_either_0]
+        swap.2 cdrop       # [result, is_either_1, is_either_0]
+        # overflow occurred if the other operand is -1, i.e. it's neither 1 nor 0
+        swap.2 or         # [is_either_0_or_1, result]
+        not               # [overflowed, result]
     else
         # determine what sign the result should have
         #

--- a/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
+++ b/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
@@ -484,7 +484,6 @@ fn i32_checked_sub() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1161"]
 fn i32_checked_mul() {
     let proc_body = r#"
     # Stack: [b, a]

--- a/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
+++ b/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
@@ -211,7 +211,6 @@ fn i32_overflowing_sub() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1161"]
 fn i32_overflowing_mul() {
     let proc_body = r#"
     # Stack: [b, a]

--- a/tests/integration/src/end_to_end/support.rs
+++ b/tests/integration/src/end_to_end/support.rs
@@ -255,6 +255,8 @@ where
             1 => Just((v.two, v.min)),
             1 => Just((v.min, neg_two)),
             1 => Just((neg_two, v.min)),
+            1 => Just((v.min, v.three)),
+            1 => Just((v.min, neg_three)),
             1 => Just((v.max, neg_two)),
             1 => Just((neg_two, v.max)),
             1 => Just((v.sqrt_max, v.sqrt_max)),


### PR DESCRIPTION
Stacked on top of #1160 to have intrinsic testing available.

### `i32::MIN * 0` does not overflow

Closes #1161

Previously: Overflow was reported for `i32::MIN * 0`, though the result is 0.
Now: Don't report overflow

While working on this I found another issue:

### `i32::MIN * odd_number` equals `(true, i32::MIN)`

Previously: This would return `(true, 0)` because of an incorrect assumption:

https://github.com/0xMiden/compiler/blob/30544eb610c8315550aafbf07944b225f5399c76/codegen/masm/intrinsics/i32.masm#L145

Now: Returns `(true, i32::MIN)`, for example 

```rust
i32::MIN.overflowing_mul(3) // == i32::MIN
```

