### PR TITLE
fix: trap on overflow in `i32::checked_div`

### DIFF
--- a/codegen/masm/intrinsics/i32.masm
+++ b/codegen/masm/intrinsics/i32.masm
@@ -226,10 +226,16 @@ pub proc checked_div # [b, a]
     # divide
     u32div            # [|a / b|, is_a_signed, is_b_signed]
 
-    # if the signs differ, negate the result
+    # if the signs differ, negate the result. Division overflows only for
+    # i32::MIN / -1, which corresponds to `signs_differ == 0` and `|a/b| == MIN`
     movdn.2 neq                 # [signs_differ, |a / b|]
-    dup.1 exec.unchecked_neg    # [-|a / b|, signs_differ, |a / b|]
-    swap.1 cdrop                # [result]
+    if.true
+        # no overflow if the signs differ
+        exec.unchecked_neg      # [result]
+    else
+        # trap on overflow
+        dup.0 push.MIN eq assertz       # [|a / b|]
+    end
 end
 
 # Given two i32 values in two's complement representation, compare them,

--- a/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
+++ b/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
@@ -519,11 +519,11 @@ fn i32_checked_div() {
         NumericStrategy::<i32>::div_signed_checked(),
         binary_i32op_inputs_to_stack,
         |(a, b): &(i32, i32)| {
-            // TODO(#1162) verify MIN/-1 traps VM
             if *b == 0 {
                 Err(TrapExpectation::DivideByZero)
+            } else if *a == i32::MIN && *b == -1 {
+                Err(TrapExpectation::FailedAssertionOverflow)
             } else {
-                // TODO(#1162) use checked_div
                 Ok(vec![a.wrapping_div(*b)])
             }
         },
@@ -549,44 +549,4 @@ fn i32_checked_shr() {
             }
         },
     );
-}
-
-// TODO(#1162): remove once #1162 is fixed and handle MIN/-1 in `i32_checked_div` above
-/// This test reproduces #1162
-#[test]
-fn i32_checked_div_min_by_neg1_i1162_reproducer() {
-    let proc_body = r#"
-    # Stack: [b, a]
-    exec.::intrinsics::i32::checked_div
-    # Stack: [result]
-"#;
-    let program = assemble_test_program(proc_body);
-
-    // i32::MIN / -1 overflows in two's complement
-    let a: i32 = i32::MIN;
-    let b: i32 = -1;
-    let inputs = binary_i32op_inputs_to_stack(&(a, b));
-    let stack_inputs = StackInputs::new(&inputs).expect("invalid stack inputs");
-
-    let vm_result = execute_sync(
-        &program,
-        stack_inputs,
-        AdviceInputs::default(),
-        &mut DefaultHost::default(),
-        ExecutionOptions::default(),
-    );
-
-    match vm_result {
-        Ok(trace) => {
-            let outputs: Vec<i32> = trace
-                .stack_outputs()
-                .iter()
-                .map(|f| f.as_canonical_u64() as u32 as i32)
-                .collect();
-            println!("Despite overflow in checked_div VM succeeded with outputs: {:?}", outputs);
-        }
-        Err(vm_err) => {
-            panic!("VM was expected to succeed but there was an err {vm_err}");
-        }
-    }
 }


### PR DESCRIPTION
Closes #1162 

Stacked on top of #1160 to have access to intrinsic testing.

---

The intrinsic `i32::checked_div` should trap on `i32::MIN/-1` because the result overflows `i32`. It did not trap because it didn't account for this edge case.