### PR TITLE
fix: call `truncate_stack` after intrinsic in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3839,6 +3839,7 @@ dependencies = [
  "log",
  "miden-assembly",
  "miden-core",
+ "miden-core-lib",
  "miden-debug 0.7.1",
  "miden-mast-package",
  "miden-processor",

--- a/codegen/masm/intrinsics/i32.masm
+++ b/codegen/masm/intrinsics/i32.masm
@@ -89,9 +89,7 @@ pub proc overflowing_sub # [b, a]
         # special handling to account for the fact that `b` was `i32::MIN`
 
         # NOTE: We treat `b` as unsigned, since we're supposed to be negating it
-        # We `push -> swap -> drop` to avoid the stack shrinking below its min depth. When shrinking
-        # below min depth, the processor expands the stack and we would need to clean that up.
-        push.MAX swap.1 drop  # [i32::MAX, a]
+        drop push.MAX         # [i32::MAX, a]
         dup.1 exec.is_signed  # [is_a_signed, i32::MAX, a]
         dup.0 eq.0            # [is_same_sign, is_a_signed, i32::MAX, a]
 

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 [dependencies]
 log.workspace = true
 miden-assembly.workspace = true
+miden-core-lib = { workspace = true, features = ["std"] }
 midenc-expect-test.workspace = true
 miden-core = { workspace = true, features = ["testing"] }
 miden-mast-package.workspace = true

--- a/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
+++ b/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
@@ -2,6 +2,7 @@ use std::{fmt, sync::Arc};
 
 use miden_assembly::{Assembler, DefaultSourceManager, Parse, ParseOptions, ast::ModuleKind};
 use miden_core::Felt;
+use miden_core_lib::CoreLibrary;
 use miden_processor::{
     DefaultHost, ExecutionError, ExecutionOptions, StackInputs, advice::AdviceInputs, execute_sync,
     operation::OperationError,
@@ -22,6 +23,7 @@ const I32_INTRINSICS_MASM: &str = include_str!("../../../../../codegen/masm/intr
 /// call these intrinsics by their fully-qualified path.
 fn assemble_test_program(procedure_body: &str) -> miden_processor::Program {
     let source_manager = Arc::new(DefaultSourceManager::default());
+    let core_library = CoreLibrary::default();
 
     // Parse the intrinsic module with its fully-qualified path
     let i32_intrinsics = I32_INTRINSICS_MASM
@@ -40,16 +42,29 @@ fn assemble_test_program(procedure_body: &str) -> miden_processor::Program {
         )
         .expect("failed to parse test module");
 
-    // Assemble the executable program, statically linking both modules
-    let mut assembler = Assembler::new(source_manager);
+    let mut assembler = Assembler::new(source_manager.clone());
     assembler
         .compile_and_statically_link(i32_intrinsics)
         .expect("failed to statically link i32 intrinsics");
-    assembler
-        .compile_and_statically_link(test_module)
-        .expect("failed to statically link test module");
-    assembler
-        .assemble_program("begin\n    exec.::test::test_i32_intrinsic\nend\n")
+
+    let library = assembler
+        .assemble_library([test_module])
+        .expect("failed to assemble test library");
+    Assembler::new(source_manager)
+        .with_static_library(library)
+        .expect("failed to link library")
+        .with_static_library(core_library.library())
+        .expect("failed to link core library")
+        .assemble_program(
+            r#"
+use miden::core::sys
+
+begin
+    exec.::test::test_i32_intrinsic
+    exec.sys::truncate_stack
+end
+"#,
+        )
         .expect("failed to assemble program")
 }
 
@@ -192,7 +207,6 @@ fn i32_overflowing_add() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1163"]
 fn i32_overflowing_sub() {
     let proc_body = r#"
     # Stack: [b, a]

--- a/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
+++ b/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
@@ -192,6 +192,7 @@ fn i32_overflowing_add() {
 }
 
 #[test]
+#[ignore = "https://github.com/0xMiden/compiler/issues/1163"]
 fn i32_overflowing_sub() {
     let proc_body = r#"
     # Stack: [b, a]


### PR DESCRIPTION
- Reverts #1165 
- Fixes `OutputStackOverflow` by calling `truncate_stack` after executing the intrinsic to be tested