### PR TITLE
feat: support `i32::checked_mod`

### DIFF
--- a/codegen/masm/intrinsics/i32.masm
+++ b/codegen/masm/intrinsics/i32.masm
@@ -250,6 +250,37 @@ pub proc checked_div # [b, a]
     end
 end
 
+# Computes `a % b`, asserting that both inputs are valid i32.
+#
+# This will trap on division by zero, and on `i32::MIN % -1`.
+pub proc checked_mod # [b, a]
+    u32assert2
+
+    # trap on i32::MIN % -1, since the underlying division overflows.
+    dup.0 push.NEG1 eq          # [b == -1, b, a]
+    dup.2 push.MIN eq           # [a == MIN, b == -1, b, a]
+    and assertz                # [b, a]
+
+    # get positive dividend
+    dup.1 exec.unchecked_neg    # [-a, b, a]
+    dup.2 swap.1                # [-a, a, b, a]
+    movup.3 exec.is_signed      # [is_a_signed, -a, a, b]
+    dup.0 movdn.4 cdrop         # [|a|, b, is_a_signed]
+
+    # get positive divisor
+    dup.1 exec.unchecked_neg    # [-b, |a|, b, is_a_signed]
+    dup.2 swap.1                # [-b, b, |a|, b, is_a_signed]
+    movup.3 exec.is_signed      # [is_b_signed, -b, b, |a|, is_a_signed]
+    cdrop                       # [|b|, |a|, is_a_signed]
+
+    u32mod                      # [|a % b|, is_a_signed]
+
+    # apply the dividend's sign to the result
+    dup.0 exec.unchecked_neg     # [neg(|a % b|), |a % b|, is_a_signed]
+    movup.2                      # [is_a_signed, neg(|a % b|), |a % b|]
+    cdrop                        # [result]
+end
+
 # Given two i32 values in two's complement representation, compare them,
 # returning -1 if `a` < `b`, 0 if equal, and 1 if `a` > `b`.
 pub proc icmp # [b, a]

--- a/codegen/masm/src/emit/binary.rs
+++ b/codegen/masm/src/emit/binary.rs
@@ -654,6 +654,7 @@ impl OpEmitter<'_> {
         assert_eq!(ty, rhs.ty(), "expected mod operands to be the same type");
         match &ty {
             Type::U64 => self.checked_mod_u64(span),
+            Type::I32 => self.checked_mod_i32(span),
             Type::U32 => self.checked_mod_u32(span),
             ty @ (Type::U16 | Type::U8) => {
                 self.checked_mod_uint(ty.size_in_bits() as u32, span);
@@ -677,6 +678,7 @@ impl OpEmitter<'_> {
                 self.push_immediate(imm, span);
                 self.checked_mod_u64(span);
             }
+            Type::I32 => self.checked_mod_imm_i32(imm.as_i32().unwrap(), span),
             Type::U32 => self.checked_mod_imm_u32(imm.as_u32().unwrap(), span),
             ty @ (Type::U16 | Type::U8) => {
                 self.checked_mod_imm_uint(imm.as_u32().unwrap(), ty.size_in_bits() as u32, span);

--- a/codegen/masm/src/emit/int32.rs
+++ b/codegen/masm/src/emit/int32.rs
@@ -782,6 +782,24 @@ impl OpEmitter<'_> {
         self.raw_exec("::intrinsics::i32::checked_div", span);
     }
 
+    /// Pops two i32 values off the stack, `b` and `a`, and performs `a % b`.
+    ///
+    /// This operation is checked, so if the operands or result are not valid i32, execution traps.
+    pub fn checked_mod_i32(&mut self, span: SourceSpan) {
+        self.raw_exec("::intrinsics::i32::checked_mod", span);
+    }
+
+    /// Pops a i32 value off the stack, `a`, and performs `a % <imm>`.
+    ///
+    /// This function will panic if the divisor is zero.
+    ///
+    /// This operation is checked, so if the operand or result are not valid i32, execution traps.
+    pub fn checked_mod_imm_i32(&mut self, imm: i32, span: SourceSpan) {
+        assert_ne!(imm, 0, "division by zero is not allowed");
+        self.emit_push(imm as u32, span);
+        self.raw_exec("::intrinsics::i32::checked_mod", span);
+    }
+
     /// Pops two u32 values off the stack, `b` and `a`, and performs `a / b`.
     ///
     /// This operation is unchecked, so the result is not guaranteed to be a valid u32

--- a/tests/integration/src/end_to_end/arithmetic.rs
+++ b/tests/integration/src/end_to_end/arithmetic.rs
@@ -617,7 +617,7 @@ fn overflowing_rem_u128() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1152"]
+#[ignore = "https://github.com/0xMiden/compiler/issues/1173"]
 fn overflowing_rem_i8() {
     test_overflowing_arith(
         i8::overflowing_rem,
@@ -627,7 +627,7 @@ fn overflowing_rem_i8() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1152"]
+#[ignore = "https://github.com/0xMiden/compiler/issues/1173"]
 fn overflowing_rem_i16() {
     test_overflowing_arith(
         i16::overflowing_rem,
@@ -637,7 +637,7 @@ fn overflowing_rem_i16() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1152"]
+#[ignore = "https://github.com/0xMiden/compiler/issues/1173"]
 fn overflowing_rem_i32() {
     test_overflowing_arith(
         i32::overflowing_rem,
@@ -853,19 +853,16 @@ fn checked_rem_u64() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1152"]
 fn checked_rem_i8() {
     test_checked_arith(i8::checked_rem, "checked_rem", NumericStrategy::rem_signed_checked());
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1152"]
 fn checked_rem_i16() {
     test_checked_arith(i16::checked_rem, "checked_rem", NumericStrategy::rem_signed_checked());
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1152"]
 fn checked_rem_i32() {
     test_checked_arith(i32::checked_rem, "checked_rem", NumericStrategy::rem_signed_checked());
 }

--- a/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
+++ b/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
@@ -533,7 +533,30 @@ fn i32_checked_div() {
             } else if *a == i32::MIN && *b == -1 {
                 Err(TrapExpectation::FailedAssertionOverflow)
             } else {
-                Ok(vec![a.wrapping_div(*b)])
+                Ok(vec![a.checked_div(*b).unwrap()])
+            }
+        },
+    );
+}
+
+#[test]
+fn i32_checked_mod() {
+    let proc_body = r#"
+    # Stack: [b, a]
+    exec.::intrinsics::i32::checked_mod
+    # Stack: [result]
+"#;
+    test_i32_intrinsic(
+        proc_body,
+        NumericStrategy::<i32>::rem_signed_checked(),
+        binary_i32op_inputs_to_stack,
+        |(a, b): &(i32, i32)| {
+            if *b == 0 {
+                Err(TrapExpectation::DivideByZero)
+            } else if *a == i32::MIN && *b == -1 {
+                Err(TrapExpectation::FailedAssertionOverflow)
+            } else {
+                Ok(vec![a.checked_rem(*b).unwrap()])
             }
         },
     );


### PR DESCRIPTION
- Adds intrinsic `i32::checked_mod`
- Adds codegen for `checked_mod_i32`

Closes #1152 and allows unignoring tests `checked_rem_i(8|16|32)`.

### `checked_mod` semantics

Assumes `checked_mod` corresponds to Rust's [`checked_rem`](https://doc.rust-lang.org/std/primitive.i32.html#method.checked_rem) because

- `u32mod` is based on the same `fn handle_division` as `u32div` [ref](https://github.com/0xMiden/miden-vm/blob/d1c853cd25497d17806745e64a9f0919e42f2455/crates/assembly/src/instruction/u32_ops.rs#L202)
- `u32mod` calculates the [remainder](https://github.com/0xMiden/miden-vm/blob/d1c853cd25497d17806745e64a9f0919e42f2455/crates/assembly/src/instruction/u32_ops.rs#L203) which corresponds to `a % b` in Rust [ref](https://github.com/0xMiden/miden-vm/blob/d1c853cd25497d17806745e64a9f0919e42f2455/processor/src/execution/operations/u32_ops/tests.rs#L230)