### PR TITLE
Fix the silently failing lit suite and make printed HIR round-trip through the parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,6 +3400,7 @@ version = "0.8.1"
 dependencies = [
  "log",
  "midenc-dialect-arith",
+ "midenc-expect-test",
  "midenc-hir",
 ]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -435,27 +435,16 @@ dependencies = ["cargo-miden"]
 [tasks.test-lit]
 category = "Test"
 description = "Runs the lit/filecheck test suite"
+command = "litcheck"
 env = { MIDENC_BIN_DIR = "${MIDENC_BIN_DIR}" }
-script = ['''
-#!/usr/bin/env bash
-set -euo pipefail
-# litcheck (up to 0.4.3) always exits 0, even when tests fail or cannot be run, so a meaningful
-# exit code must be derived from the printed summary; otherwise lit failures never fail CI.
-log_file="$(mktemp)"
-trap 'rm -f "${log_file}"' EXIT
-litcheck lit run --verbose \
-    --path "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/bin" \
-    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/tests/lit" 2>&1 | tee "${log_file}"
-if ! grep -q "Total Discovered Tests" "${log_file}"; then
-    echo "error: litcheck did not produce a test summary" >&2
-    exit 1
-fi
-# Note: "Failed As Expected" (XFAIL) sections intentionally do not match this pattern.
-if grep -qE "^\*+ (Failed|Unresolved) Tests" "${log_file}"; then
-    echo "error: the lit suite reported failed or unresolved tests" >&2
-    exit 1
-fi
-''']
+args = [
+    "lit",
+    "run",
+    "--verbose",
+    "--path",
+    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/bin",
+    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/tests/lit",
+]
 dependencies = ["litcheck", "midenc", "cargo-miden", "hir-opt", "miden-objtool"]
 
 [tasks.lit]
@@ -473,7 +462,8 @@ dependencies = ["litcheck", "midenc", "cargo-miden", "hir-opt", "miden-objtool"]
 [tasks.litcheck]
 category = "Test"
 description = "Set up the litcheck utility"
-install_crate = { crate_name = "litcheck", test_arg = "--help" }
+# 0.4.4 is the first release that propagates lit failures through the process exit code.
+install_crate = { crate_name = "litcheck", min_version = "0.4.4", test_arg = "--help" }
 
 [tasks.docs]
 category = "Documentation"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -435,16 +435,27 @@ dependencies = ["cargo-miden"]
 [tasks.test-lit]
 category = "Test"
 description = "Runs the lit/filecheck test suite"
-command = "litcheck"
 env = { MIDENC_BIN_DIR = "${MIDENC_BIN_DIR}" }
-args = [
-    "lit",
-    "run",
-    "--verbose",
-    "--path",
-    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/bin",
-    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/tests/lit",
-]
+script = ['''
+#!/usr/bin/env bash
+set -euo pipefail
+# litcheck (up to 0.4.3) always exits 0, even when tests fail or cannot be run, so a meaningful
+# exit code must be derived from the printed summary; otherwise lit failures never fail CI.
+log_file="$(mktemp)"
+trap 'rm -f "${log_file}"' EXIT
+litcheck lit run --verbose \
+    --path "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/bin" \
+    "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/tests/lit" 2>&1 | tee "${log_file}"
+if ! grep -q "Total Discovered Tests" "${log_file}"; then
+    echo "error: litcheck did not produce a test summary" >&2
+    exit 1
+fi
+# Note: "Failed As Expected" (XFAIL) sections intentionally do not match this pattern.
+if grep -qE "^\*+ (Failed|Unresolved) Tests" "${log_file}"; then
+    echo "error: the lit suite reported failed or unresolved tests" >&2
+    exit 1
+fi
+''']
 dependencies = ["litcheck", "midenc", "cargo-miden", "hir-opt", "miden-objtool"]
 
 [tasks.lit]

--- a/dialects/cf/Cargo.toml
+++ b/dialects/cf/Cargo.toml
@@ -25,4 +25,5 @@ midenc-hir.workspace = true
 
 [dev-dependencies]
 # Use local paths for dev-only dependency to avoid relying on crates.io during packaging
+midenc-expect-test = { path = "../../tools/expect-test" }
 midenc-hir = { path = "../../hir", features = ["logging"] }

--- a/dialects/cf/src/ops.rs
+++ b/dialects/cf/src/ops.rs
@@ -450,7 +450,7 @@ builtin.function public extern(\"C\") @branch(%c: i1, %a: u32, %b: u32) -> u32 {
         let context = Rc::new(Context::default());
         let source = "\
 builtin.function public extern(\"C\") @branch_args(%c: i1, %a: u32, %b: u32) -> u32 {
-    cf.cond_br %c ^one(%a, u32), ^two(%a, %b, u32, u32) : (i1);
+    cf.cond_br %c ^one(%a : u32), ^two(%a, %b : u32, u32) : (i1);
 ^one(%x: u32):
     builtin.ret %x : (u32);
 ^two(%y: u32, %z: u32):
@@ -460,7 +460,7 @@ builtin.function public extern(\"C\") @branch_args(%c: i1, %a: u32, %b: u32) -> 
             parse_function_fixpoint(&context, "parse_cond_br_args.hir", source)?;
         expect![[r#"
             builtin.function public extern("C") @branch_args(%0: i1, %1: u32, %2: u32) -> u32 {
-                cf.cond_br %0 ^block2(%1, u32), ^block3(%1, %2, u32, u32) : (i1);
+                cf.cond_br %0 ^block2(%1 : u32), ^block3(%1, %2 : u32, u32) : (i1);
             ^block2(%3: u32):
                 builtin.ret %3 : (u32);
             ^block3(%4: u32, %5: u32):
@@ -515,9 +515,9 @@ builtin.function public extern(\"C\") @branch_args(%c: i1, %a: u32, %b: u32) -> 
         let context = Rc::new(Context::default());
         let source = "\
 builtin.function public extern(\"C\") @looped(%start: i1) -> i1 {
-    cf.br ^header(%start, i1);
+    cf.br ^header(%start : i1);
 ^header(%v: i1):
-    cf.cond_br %v ^header(%v, i1), ^exit : (i1);
+    cf.cond_br %v ^header(%v : i1), ^exit : (i1);
 ^exit:
     builtin.ret %v : (i1);
 };";
@@ -525,9 +525,9 @@ builtin.function public extern(\"C\") @looped(%start: i1) -> i1 {
             parse_function_fixpoint(&context, "parse_backward_refs.hir", source)?;
         expect![[r#"
             builtin.function public extern("C") @looped(%0: i1) -> i1 {
-                cf.br ^block2(%0, i1);
+                cf.br ^block2(%0 : i1);
             ^block2(%1: i1):
-                cf.cond_br %1 ^block2(%1, i1), ^block3 : (i1);
+                cf.cond_br %1 ^block2(%1 : i1), ^block3 : (i1);
             ^block3:
                 builtin.ret %1 : (i1);
             };"#]]
@@ -576,7 +576,7 @@ builtin.function public extern(\"C\") @looped(%start: i1) -> i1 {
         let context = Rc::new(Context::default());
         let source = "\
 builtin.function public extern(\"C\") @select(%sel: u32, %a: u32, %b: u32) -> u32 {
-    cf.switch %sel #builtin.u32<1> -> ^one(%a, u32), ^fallback : (u32);
+    cf.switch %sel [#builtin.u32<1> -> ^one(%a : u32)], ^fallback : (u32);
 ^one(%x: u32):
     builtin.ret %x : (u32);
 ^fallback:
@@ -585,7 +585,7 @@ builtin.function public extern(\"C\") @select(%sel: u32, %a: u32, %b: u32) -> u3
         let (function, printed) = parse_function_fixpoint(&context, "parse_switch.hir", source)?;
         expect![[r#"
             builtin.function public extern("C") @select(%0: u32, %1: u32, %2: u32) -> u32 {
-                cf.switch %0 #builtin.u32<1> -> ^block2(%1, u32), ^block3 : (u32);
+                cf.switch %0 [#builtin.u32<1> -> ^block2(%1 : u32)], ^block3 : (u32);
             ^block2(%3: u32):
                 builtin.ret %3 : (u32);
             ^block3:

--- a/dialects/cf/src/ops.rs
+++ b/dialects/cf/src/ops.rs
@@ -313,7 +313,13 @@ impl Foldable for Select {
 mod tests {
     use alloc::vec;
 
-    use midenc_hir::{Type, testing::Test};
+    use midenc_expect_test::expect;
+    use midenc_hir::{
+        Type,
+        diagnostics::Report,
+        dialects::builtin::Ret,
+        testing::{Test, parse_function_fixpoint},
+    };
 
     use super::*;
     use crate::ControlFlowOpBuilder;
@@ -373,5 +379,249 @@ mod tests {
 
         assert_eq!(switch_op.fallback().successor(), fallback);
         assert_eq!(switch_op.cases().len(), 0);
+    }
+
+    /// The value returned by the `builtin.ret` terminating `block`.
+    fn returned_value(block: BlockRef) -> ValueRef {
+        let block = block.borrow();
+        let terminator = block.terminator().expect("expected block to have a terminator");
+        let ret = terminator
+            .try_downcast_op::<Ret>()
+            .expect("expected block to terminate with builtin.ret");
+        let ret = ret.borrow();
+        let values = ret.values();
+        let operand = values.iter().next().expect("expected builtin.ret to have an operand");
+        operand.borrow().as_value_ref()
+    }
+
+    /// Statically-known successor lists (`cf.cond_br %c ^a, ^b`) parse with the `, ` separator
+    /// the printer emits between successors, and the condition operand stays attached to the
+    /// operation rather than leaking into the first successor's operand group.
+    #[test]
+    fn parse_cond_br_with_bare_successors() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let source = "\
+builtin.function public extern(\"C\") @branch(%c: i1, %a: u32, %b: u32) -> u32 {
+    cf.cond_br %c ^yes, ^no : (i1);
+^yes:
+    builtin.ret %a : (u32);
+^no:
+    builtin.ret %b : (u32);
+};";
+        let (function, printed) = parse_function_fixpoint(&context, "parse_cond_br.hir", source)?;
+        expect![[r#"
+            builtin.function public extern("C") @branch(%0: i1, %1: u32, %2: u32) -> u32 {
+                cf.cond_br %0 ^block2, ^block3 : (i1);
+            ^block2:
+                builtin.ret %1 : (u32);
+            ^block3:
+                builtin.ret %2 : (u32);
+            };"#]]
+        .assert_eq(&printed);
+
+        let function = function.borrow();
+        let body = function.body();
+        let entry = body.entry();
+        let arg_c = entry.arguments()[0] as ValueRef;
+        let arg_a = entry.arguments()[1] as ValueRef;
+        let arg_b = entry.arguments()[2] as ValueRef;
+
+        let cond_br = entry
+            .terminator()
+            .unwrap()
+            .try_downcast_op::<CondBr>()
+            .expect("expected entry block to terminate with cf.cond_br");
+        let cond_br = cond_br.borrow();
+        assert_eq!(cond_br.condition().as_value_ref(), arg_c);
+        let then_dest = cond_br.then_dest();
+        let else_dest = cond_br.else_dest();
+        assert!(then_dest.arguments.is_empty());
+        assert!(else_dest.arguments.is_empty());
+        assert_eq!(returned_value(then_dest.successor()), arg_a);
+        assert_eq!(returned_value(else_dest.successor()), arg_b);
+
+        Ok(())
+    }
+
+    /// Successor argument lists (`^block(%v, ...)`) parse and attach to the operand group of
+    /// the successor they follow, and the target block's own arguments bind as usual.
+    #[test]
+    fn parse_cond_br_with_successor_arguments() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let source = "\
+builtin.function public extern(\"C\") @branch_args(%c: i1, %a: u32, %b: u32) -> u32 {
+    cf.cond_br %c ^one(%a, u32), ^two(%a, %b, u32, u32) : (i1);
+^one(%x: u32):
+    builtin.ret %x : (u32);
+^two(%y: u32, %z: u32):
+    builtin.ret %z : (u32);
+};";
+        let (function, printed) =
+            parse_function_fixpoint(&context, "parse_cond_br_args.hir", source)?;
+        expect![[r#"
+            builtin.function public extern("C") @branch_args(%0: i1, %1: u32, %2: u32) -> u32 {
+                cf.cond_br %0 ^block2(%1, u32), ^block3(%1, %2, u32, u32) : (i1);
+            ^block2(%3: u32):
+                builtin.ret %3 : (u32);
+            ^block3(%4: u32, %5: u32):
+                builtin.ret %5 : (u32);
+            };"#]]
+        .assert_eq(&printed);
+
+        let function = function.borrow();
+        let body = function.body();
+        let entry = body.entry();
+        let arg_a = entry.arguments()[1] as ValueRef;
+        let arg_b = entry.arguments()[2] as ValueRef;
+
+        let cond_br = entry
+            .terminator()
+            .unwrap()
+            .try_downcast_op::<CondBr>()
+            .expect("expected entry block to terminate with cf.cond_br");
+        let cond_br = cond_br.borrow();
+
+        let then_dest = cond_br.then_dest();
+        let then_args = then_dest
+            .arguments
+            .iter()
+            .map(|o| o.borrow().as_value_ref())
+            .collect::<Vec<_>>();
+        assert_eq!(then_args, [arg_a]);
+
+        let else_dest = cond_br.else_dest();
+        let else_args = else_dest
+            .arguments
+            .iter()
+            .map(|o| o.borrow().as_value_ref())
+            .collect::<Vec<_>>();
+        assert_eq!(else_args, [arg_a, arg_b]);
+
+        // The successor blocks' own arguments are bound and usable: `^two` returns its second
+        // block argument.
+        let else_block = else_dest.successor();
+        let expected = else_block.borrow().arguments()[1] as ValueRef;
+        assert_eq!(returned_value(else_block), expected);
+
+        Ok(())
+    }
+
+    /// Block labels register in the parser's block name map when defined: a branch may
+    /// reference a block defined earlier in the region (backward reference), and a labeled
+    /// definition must unify with targets forward-declared by earlier branches without
+    /// dropping the parsed block body.
+    #[test]
+    fn parse_backward_block_references() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let source = "\
+builtin.function public extern(\"C\") @looped(%start: i1) -> i1 {
+    cf.br ^header(%start, i1);
+^header(%v: i1):
+    cf.cond_br %v ^header(%v, i1), ^exit : (i1);
+^exit:
+    builtin.ret %v : (i1);
+};";
+        let (function, printed) =
+            parse_function_fixpoint(&context, "parse_backward_refs.hir", source)?;
+        expect![[r#"
+            builtin.function public extern("C") @looped(%0: i1) -> i1 {
+                cf.br ^block2(%0, i1);
+            ^block2(%1: i1):
+                cf.cond_br %1 ^block2(%1, i1), ^block3 : (i1);
+            ^block3:
+                builtin.ret %1 : (i1);
+            };"#]]
+        .assert_eq(&printed);
+
+        let function = function.borrow();
+        let body = function.body();
+        assert_eq!(body.body().iter().count(), 3, "expected all three blocks to be parsed");
+
+        let entry = body.entry();
+        let br = entry
+            .terminator()
+            .unwrap()
+            .try_downcast_op::<Br>()
+            .expect("expected entry block to terminate with cf.br");
+        let header = br.borrow().target().successor();
+
+        // The labeled definition must populate the forward-declared block, not a placeholder.
+        let header_block = header.borrow();
+        assert_eq!(header_block.num_arguments(), 1);
+        assert_eq!(header_block.body().iter().count(), 1, "header block body must not be empty");
+
+        // The backward reference resolves to that same block, forwarding its argument.
+        let cond_br = header_block
+            .terminator()
+            .unwrap()
+            .try_downcast_op::<CondBr>()
+            .expect("expected header block to terminate with cf.cond_br");
+        let cond_br = cond_br.borrow();
+        let then_dest = cond_br.then_dest();
+        assert_eq!(then_dest.successor(), header);
+        let loop_args = then_dest
+            .arguments
+            .iter()
+            .map(|o| o.borrow().as_value_ref())
+            .collect::<Vec<_>>();
+        assert_eq!(loop_args, [header_block.arguments()[0] as ValueRef]);
+
+        Ok(())
+    }
+
+    /// Keyed successor groups (`cf.switch`) parse: each case key maps to its own successor and
+    /// operand group, and the trailing successor is the fallback.
+    #[test]
+    fn parse_switch_with_keyed_successors() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let source = "\
+builtin.function public extern(\"C\") @select(%sel: u32, %a: u32, %b: u32) -> u32 {
+    cf.switch %sel #builtin.u32<1> -> ^one(%a, u32), ^fallback : (u32);
+^one(%x: u32):
+    builtin.ret %x : (u32);
+^fallback:
+    builtin.ret %b : (u32);
+};";
+        let (function, printed) = parse_function_fixpoint(&context, "parse_switch.hir", source)?;
+        expect![[r#"
+            builtin.function public extern("C") @select(%0: u32, %1: u32, %2: u32) -> u32 {
+                cf.switch %0 #builtin.u32<1> -> ^block2(%1, u32), ^block3 : (u32);
+            ^block2(%3: u32):
+                builtin.ret %3 : (u32);
+            ^block3:
+                builtin.ret %2 : (u32);
+            };"#]]
+        .assert_eq(&printed);
+
+        let function = function.borrow();
+        let body = function.body();
+        let entry = body.entry();
+        let arg_a = entry.arguments()[1] as ValueRef;
+        let arg_b = entry.arguments()[2] as ValueRef;
+
+        let switch_op = entry
+            .terminator()
+            .unwrap()
+            .try_downcast_op::<Switch>()
+            .expect("expected entry block to terminate with cf.switch");
+        let switch_op = switch_op.borrow();
+
+        let cases = switch_op.cases();
+        assert_eq!(cases.len(), 1);
+        let case = cases.iter().next().unwrap();
+        assert_eq!(*case.key(), 1);
+        let case_args =
+            case.arguments().iter().map(|o| o.borrow().as_value_ref()).collect::<Vec<_>>();
+        assert_eq!(case_args, [arg_a]);
+        // The case target returns its own block argument, fed by the case's operand.
+        let case_block = case.block();
+        let expected = case_block.borrow().arguments()[0] as ValueRef;
+        assert_eq!(returned_value(case_block), expected);
+
+        let fallback = switch_op.fallback();
+        assert!(fallback.arguments.is_empty());
+        assert_eq!(returned_value(fallback.successor()), arg_b);
+
+        Ok(())
     }
 }

--- a/dialects/hir/src/transforms/spill/expected/materializes_spills_branching_cfg_after.hir
+++ b/dialects/hir/src/transforms/spill/expected/materializes_spills_branching_cfg_after.hir
@@ -21,13 +21,13 @@ builtin.function public extern("C") @materializes_spills_branching_cfg(%0: ptr<u
     %15 = arith.add %26, %14 <{ overflow = #builtin.overflow<unchecked> }>;
     cf.br ^block5;
 ^block5:
-    cf.br ^block4:(%13);
+    cf.br ^block4(%13, u32);
 ^block3:
     %16 = arith.constant 8 : u32;
     %17 = arith.add %1, %16 <{ overflow = #builtin.overflow<unchecked> }>;
     cf.br ^block6;
 ^block6:
-    cf.br ^block4:(%17);
+    cf.br ^block4(%17, u32);
 ^block4(%18: u32):
     %19 = arith.constant 72 : u32;
     %20 = arith.add %1, %19 <{ overflow = #builtin.overflow<unchecked> }>;

--- a/dialects/hir/src/transforms/spill/expected/materializes_spills_branching_cfg_after.hir
+++ b/dialects/hir/src/transforms/spill/expected/materializes_spills_branching_cfg_after.hir
@@ -21,13 +21,13 @@ builtin.function public extern("C") @materializes_spills_branching_cfg(%0: ptr<u
     %15 = arith.add %26, %14 <{ overflow = #builtin.overflow<unchecked> }>;
     cf.br ^block5;
 ^block5:
-    cf.br ^block4(%13, u32);
+    cf.br ^block4(%13 : u32);
 ^block3:
     %16 = arith.constant 8 : u32;
     %17 = arith.add %1, %16 <{ overflow = #builtin.overflow<unchecked> }>;
     cf.br ^block6;
 ^block6:
-    cf.br ^block4(%17, u32);
+    cf.br ^block4(%17 : u32);
 ^block4(%18: u32):
     %19 = arith.constant 72 : u32;
     %20 = arith.add %1, %19 <{ overflow = #builtin.overflow<unchecked> }>;

--- a/dialects/hir/src/transforms/spill/expected/materializes_spills_branching_cfg_before.hir
+++ b/dialects/hir/src/transforms/spill/expected/materializes_spills_branching_cfg_before.hir
@@ -17,11 +17,11 @@ builtin.function public extern("C") @materializes_spills_branching_cfg(%0: ptr<u
     hir.store %4, %9 : (ptr<u128, element>, u128);
     %14 = arith.constant 5 : u32;
     %15 = arith.add %1, %14 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block4(%13, u32);
+    cf.br ^block4(%13 : u32);
 ^block3:
     %16 = arith.constant 8 : u32;
     %17 = arith.add %1, %16 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block4(%17, u32);
+    cf.br ^block4(%17 : u32);
 ^block4(%18: u32):
     %19 = arith.constant 72 : u32;
     %20 = arith.add %1, %19 <{ overflow = #builtin.overflow<unchecked> }>;

--- a/dialects/hir/src/transforms/spill/expected/materializes_spills_branching_cfg_before.hir
+++ b/dialects/hir/src/transforms/spill/expected/materializes_spills_branching_cfg_before.hir
@@ -17,11 +17,11 @@ builtin.function public extern("C") @materializes_spills_branching_cfg(%0: ptr<u
     hir.store %4, %9 : (ptr<u128, element>, u128);
     %14 = arith.constant 5 : u32;
     %15 = arith.add %1, %14 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block4:(%13);
+    cf.br ^block4(%13, u32);
 ^block3:
     %16 = arith.constant 8 : u32;
     %17 = arith.add %1, %16 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block4:(%17);
+    cf.br ^block4(%17, u32);
 ^block4(%18: u32):
     %19 = arith.constant 72 : u32;
     %20 = arith.add %1, %19 <{ overflow = #builtin.overflow<unchecked> }>;

--- a/dialects/scf/src/ops.rs
+++ b/dialects/scf/src/ops.rs
@@ -172,6 +172,8 @@ pub struct While {
     before: Region,
     #[region]
     after: Region,
+    #[results]
+    returns: AnyType,
 }
 
 impl While {
@@ -423,10 +425,12 @@ impl OpParser for IndexSwitch {
 
         state
             .add_attribute("cases", parser.context_rc().create_attribute::<U32ArrayAttr, _>(cases));
+        // The default region is declared first on the operation; case regions follow it (see
+        // `get_case_region`).
+        state.add_region(fallback_region);
         for region in regions {
             state.add_region(region);
         }
-        state.add_region(fallback_region);
 
         parser.parse_optional_attribute_dict(&mut state.attrs)?;
         parser.parse_colon_type_list(&mut state.results)?;

--- a/dialects/scf/src/ops.rs
+++ b/dialects/scf/src/ops.rs
@@ -725,3 +725,223 @@ impl ConditionallySpeculatable for Yield {
         Speculatability::Speculatable
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use midenc_expect_test::expect;
+    use midenc_hir::{
+        diagnostics::Report, dialects::builtin::Function, testing::parse_function_fixpoint,
+    };
+
+    use super::*;
+
+    /// Find the first operation of type `T` in the entry block of `function`.
+    fn find_op<T: OpRegistration>(function: &Function) -> UnsafeIntrusiveEntityRef<T> {
+        function
+            .body()
+            .entry()
+            .body()
+            .iter()
+            .find_map(|op| op.as_operation_ref().try_downcast_op::<T>().ok())
+            .unwrap_or_else(|| {
+                panic!("expected a {} op in the function body", <T as OpRegistration>::full_name())
+            })
+    }
+
+    /// The regions of an operation with operands must parse with no pre-bound entry arguments:
+    /// the `^block(...)` header the printer emits declares them. Also covers the variadic
+    /// forwarded operands of `scf.condition`, which parse as the trailing comma list following
+    /// the condition operand, and the `scf.while` result type signature.
+    #[test]
+    fn parse_scf_while_round_trips() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let source = "\
+builtin.function public extern(\"C\") @count_to(%n: u32) -> u32 {
+    %zero = arith.constant 0 : u32;
+    %count = scf.while %zero before {
+    ^head(%i: u32):
+        %continue = arith.lt %i, %n;
+        scf.condition %continue, %i : (i1, u32);
+    } after {
+    ^body(%j: u32):
+        %next = arith.incr %j;
+        scf.yield %next : (u32);
+    } : (u32) -> u32;
+    builtin.ret %count : (u32);
+};";
+        let (function, printed) = parse_function_fixpoint(&context, "parse_scf_while.hir", source)?;
+        expect![[r#"
+            builtin.function public extern("C") @count_to(%0: u32) -> u32 {
+                %1 = arith.constant 0 : u32;
+                %6 = scf.while %1 before {
+                ^block2(%2: u32):
+                    %3 = arith.lt %2, %0;
+                    scf.condition %3, %2 : (i1, u32);
+                } after {
+                ^block3(%4: u32):
+                    %5 = arith.incr %4;
+                    scf.yield %5 : (u32);
+                } : (u32) -> (u32);
+                builtin.ret %6 : (u32);
+            };"#]]
+        .assert_eq(&printed);
+
+        let function = function.borrow();
+        let while_op = find_op::<While>(&function);
+        let while_op = while_op.borrow();
+        assert_eq!(while_op.inits().len(), 1);
+        assert_eq!(while_op.num_results(), 1);
+        assert_eq!(while_op.before().entry().num_arguments(), 1);
+        let condition = while_op.condition_op();
+        let condition = condition.borrow();
+        assert_eq!(condition.forwarded().len(), 1);
+
+        Ok(())
+    }
+
+    /// The trailing forwarded-operand list of `scf.condition` may be empty, in which case the
+    /// printer omits it entirely; the parser must accept the bare form.
+    #[test]
+    fn parse_scf_condition_without_forwarded_operands() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let source = "\
+builtin.function public extern(\"C\") @spin(%n: u32) -> u32 {
+    %zero = arith.constant 0 : u32;
+    scf.while %zero before {
+    ^head(%i: u32):
+        %continue = arith.lt %i, %n;
+        scf.condition %continue : (i1);
+    } after {
+    ^body:
+        scf.yield %zero : (u32);
+    } : (u32) -> ();
+    builtin.ret %n : (u32);
+};";
+        let (function, printed) =
+            parse_function_fixpoint(&context, "parse_scf_condition_bare.hir", source)?;
+        expect![[r#"
+            builtin.function public extern("C") @spin(%0: u32) -> u32 {
+                %1 = arith.constant 0 : u32;
+                scf.while %1 before {
+                ^block2(%2: u32):
+                    %3 = arith.lt %2, %0;
+                    scf.condition %3 : (i1);
+                } after {
+                ^block3:
+                    scf.yield %1 : (u32);
+                } : (u32) -> ();
+                builtin.ret %0 : (u32);
+            };"#]]
+        .assert_eq(&printed);
+
+        let function = function.borrow();
+        let while_op = find_op::<While>(&function);
+        let while_op = while_op.borrow();
+        assert_eq!(while_op.num_results(), 0);
+        let condition = while_op.condition_op();
+        let condition = condition.borrow();
+        assert_eq!(condition.forwarded().len(), 0);
+
+        Ok(())
+    }
+
+    /// Multi-name result bindings (`%x, %y = scf.if ...`) map the parsed names onto the
+    /// flattened result list of a single variadic result group.
+    #[test]
+    fn parse_multi_name_result_bindings() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let source = "\
+builtin.function public extern(\"C\") @pick(%c: i1, %a: u32, %b: u32) -> u32 {
+    %x, %y = scf.if %c then {
+        scf.yield %a, %b : (u32, u32);
+    } else {
+        scf.yield %b, %a : (u32, u32);
+    } : (i1) -> (u32, u32);
+    %sum = arith.add %x, %y <{ overflow = #builtin.overflow<unchecked> }>;
+    builtin.ret %sum : (u32);
+};";
+        let (function, printed) =
+            parse_function_fixpoint(&context, "parse_multi_result.hir", source)?;
+        expect![[r#"
+            builtin.function public extern("C") @pick(%0: i1, %1: u32, %2: u32) -> u32 {
+                %3, %4 = scf.if %0 then {
+                    scf.yield %1, %2 : (u32, u32);
+                } else {
+                    scf.yield %2, %1 : (u32, u32);
+                } : (i1) -> (u32, u32);
+                %5 = arith.add %3, %4 <{ overflow = #builtin.overflow<unchecked> }>;
+                builtin.ret %5 : (u32);
+            };"#]]
+        .assert_eq(&printed);
+
+        let function = function.borrow();
+        let if_op = find_op::<If>(&function);
+        let if_op = if_op.borrow();
+        assert_eq!(if_op.num_results(), 2);
+        // Both bound names resolve to the if's results: the adder uses each exactly once.
+        for result in if_op.results().all().iter() {
+            assert_eq!(result.borrow().iter_uses().count(), 1);
+        }
+
+        Ok(())
+    }
+
+    /// `scf.index_switch` regions parse with the default region first, matching the accessors
+    /// (`default_region` is region 0, case regions follow in case order).
+    #[test]
+    fn parse_index_switch_region_order() -> Result<(), Report> {
+        let context = Rc::new(Context::default());
+        let source = "\
+builtin.function public extern(\"C\") @dispatch(%sel: u32, %a: u32, %b: u32) -> u32 {
+    %r = scf.index_switch %sel
+    case 1 {
+        scf.yield %a : (u32);
+    }
+    default {
+        scf.yield %b : (u32);
+    } : u32;
+    builtin.ret %r : (u32);
+};";
+        let (function, printed) =
+            parse_function_fixpoint(&context, "parse_index_switch.hir", source)?;
+        expect![[r#"
+            builtin.function public extern("C") @dispatch(%0: u32, %1: u32, %2: u32) -> u32 {
+                %3 = scf.index_switch %0 
+                case 1 {
+                    scf.yield %1 : (u32);
+                }
+                default {
+                    scf.yield %2 : (u32);
+                } : (u32);
+                builtin.ret %3 : (u32);
+            };"#]]
+        .assert_eq(&printed);
+
+        let function = function.borrow();
+        let body = function.body();
+        let entry = body.entry();
+        let arg_a = entry.arguments()[1] as ValueRef;
+        let arg_b = entry.arguments()[2] as ValueRef;
+
+        let yielded_value = |region: &Region| -> ValueRef {
+            let terminator = region.entry().terminator().unwrap();
+            let yield_op = terminator
+                .try_downcast_op::<Yield>()
+                .expect("expected region to terminate with scf.yield");
+            let yield_op = yield_op.borrow();
+            let yielded = yield_op.yielded();
+            let operand = yielded.iter().next().unwrap();
+            operand.borrow().as_value_ref()
+        };
+
+        let switch_op = find_op::<IndexSwitch>(&function);
+        let switch_op = switch_op.borrow();
+        // The default region yields %b and the `case 1` region yields %a; if the parser
+        // appended the default region last, the two would come back swapped.
+        assert_eq!(yielded_value(&switch_op.default_region()), arg_b);
+        let case_region = switch_op.get_case_region(0);
+        assert_eq!(yielded_value(&case_region.borrow()), arg_a);
+
+        Ok(())
+    }
+}

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_debug_value_preservation_before.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_debug_value_preservation_before.hir
@@ -6,11 +6,11 @@ builtin.function public extern("C") @cfg_to_scf_debug_value_preservation(%0: u32
 ^block1:
     %4 = arith.incr %0;
     di.debug_value %4 <{ variable = #di.variable<{ name = "result", file = "test.rs", line = 2, column = 1 }>, expression = #di.expression<[]> }> : (u32);
-    cf.br ^block3(%4, u32);
+    cf.br ^block3(%4 : u32);
 ^block2:
     %5 = arith.mul %0, %0 <{ overflow = #builtin.overflow<checked> }>;
     di.debug_value %5 <{ variable = #di.variable<{ name = "result", file = "test.rs", line = 2, column = 1 }>, expression = #di.expression<[]> }> : (u32);
-    cf.br ^block3(%5, u32);
+    cf.br ^block3(%5 : u32);
 ^block3(%1: u32):
     di.debug_value %1 <{ variable = #di.variable<{ name = "result", file = "test.rs", line = 2, column = 1 }>, expression = #di.expression<[]> }> : (u32);
     builtin.ret %1 : (u32);

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_debug_value_preservation_before.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_debug_value_preservation_before.hir
@@ -6,11 +6,11 @@ builtin.function public extern("C") @cfg_to_scf_debug_value_preservation(%0: u32
 ^block1:
     %4 = arith.incr %0;
     di.debug_value %4 <{ variable = #di.variable<{ name = "result", file = "test.rs", line = 2, column = 1 }>, expression = #di.expression<[]> }> : (u32);
-    cf.br ^block3:(%4);
+    cf.br ^block3(%4, u32);
 ^block2:
     %5 = arith.mul %0, %0 <{ overflow = #builtin.overflow<checked> }>;
     di.debug_value %5 <{ variable = #di.variable<{ name = "result", file = "test.rs", line = 2, column = 1 }>, expression = #di.expression<[]> }> : (u32);
-    cf.br ^block3:(%5);
+    cf.br ^block3(%5, u32);
 ^block3(%1: u32):
     di.debug_value %1 <{ variable = #di.variable<{ name = "result", file = "test.rs", line = 2, column = 1 }>, expression = #di.expression<[]> }> : (u32);
     builtin.ret %1 : (u32);

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_conditional_early_exit_after.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_conditional_early_exit_after.hir
@@ -32,7 +32,7 @@ builtin.function public extern("C") @cfg_to_scf_lift_conditional_early_exit(%0: 
     default {
         scf.yield %24, %14 : (u32, u32);
     } : (u32, u32);
-    cf.switch %31 #builtin.u32<0> -> ^block8(%30, u32), ^block9 : (u32);
+    cf.switch %31 [#builtin.u32<0> -> ^block8(%30 : u32)], ^block9 : (u32);
 ^block8(%13: u32):
     builtin.ret %13 : (u32);
 ^block9:

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_conditional_early_exit_after.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_conditional_early_exit_after.hir
@@ -32,7 +32,7 @@ builtin.function public extern("C") @cfg_to_scf_lift_conditional_early_exit(%0: 
     default {
         scf.yield %24, %14 : (u32, u32);
     } : (u32, u32);
-    cf.switch %31 #builtin.u32<0> -> ^block8:(%30), ^block9 : (u32);
+    cf.switch %31 #builtin.u32<0> -> ^block8(%30, u32), ^block9 : (u32);
 ^block8(%13: u32):
     builtin.ret %13 : (u32);
 ^block9:

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_conditional_early_exit_before.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_conditional_early_exit_before.hir
@@ -9,13 +9,13 @@ builtin.function public extern("C") @cfg_to_scf_lift_conditional_early_exit(%0: 
     cf.cond_br %9 ^block6, ^block7 : (i1);
 ^block2:
     %10 = arith.incr %0;
-    cf.br ^block1(%10, u32);
+    cf.br ^block1(%10 : u32);
 ^block3:
     %11 = arith.neq %3, %5;
     cf.cond_br %11 ^block4, ^block5 : (i1);
 ^block4:
     %12 = arith.incr %3;
-    cf.br ^block1(%12, u32);
+    cf.br ^block1(%12 : u32);
 ^block5:
     builtin.ret %2 : (u32);
 ^block6:

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_conditional_early_exit_before.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_conditional_early_exit_before.hir
@@ -9,13 +9,13 @@ builtin.function public extern("C") @cfg_to_scf_lift_conditional_early_exit(%0: 
     cf.cond_br %9 ^block6, ^block7 : (i1);
 ^block2:
     %10 = arith.incr %0;
-    cf.br ^block1:(%10);
+    cf.br ^block1(%10, u32);
 ^block3:
     %11 = arith.neq %3, %5;
     cf.cond_br %11 ^block4, ^block5 : (i1);
 ^block4:
     %12 = arith.incr %3;
-    cf.br ^block1:(%12);
+    cf.br ^block1(%12, u32);
 ^block5:
     builtin.ret %2 : (u32);
 ^block6:

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_multiple_exit_nested_while_loop_after.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_multiple_exit_nested_while_loop_after.hir
@@ -34,7 +34,7 @@ builtin.function public extern("C") @cfg_to_scf_lift_multiple_exit_nested_while_
             } after {
             ^block32(%192: u32, %193: u32, %194: u32, %195: u32, %196: u32, %197: u32, %198: u32):
                 scf.yield %192, %193 : (u32, u32);
-            } : (u32, u32);
+            } : (u32, u32) -> (u32, u32, u32, u32, u32, u32, u32);
             %115, %116, %117, %118 = scf.index_switch %189 
             case 1 {
                 scf.yield %186, %186, %187, %188 : (u32, u32, u32, u32);
@@ -52,11 +52,11 @@ builtin.function public extern("C") @cfg_to_scf_lift_multiple_exit_nested_while_
     } after {
     ^block28(%149: u32, %150: u32, %151: u32, %152: u32):
         scf.yield %149, %150 : (u32, u32);
-    } : (u32, u32);
+    } : (u32, u32) -> (u32, u32, u32, u32);
     %200 = arith.eq %146, %26;
     cf.cond_br %200 ^block7, ^block4 : (i1);
 ^block4:
     builtin.ret %145 : (u32);
 ^block7:
-    builtin.ret_imm #builtin.number<4294967295>;
+    builtin.ret_imm 4294967295 : u32;
 };

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_multiple_exit_nested_while_loop_before.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_multiple_exit_nested_while_loop_before.hir
@@ -1,15 +1,15 @@
 builtin.function public extern("C") @cfg_to_scf_lift_multiple_exit_nested_while_loop(%0: ptr<u32, byte>, %1: u32, %2: u32) -> u32 {
     %7 = arith.constant 0 : u32;
-    cf.br ^block1(%7, %7, u32, u32);
+    cf.br ^block1(%7, %7 : u32, u32);
 ^block1(%3: u32, %4: u32):
     %8 = arith.lt %3, %1;
-    cf.cond_br %8 ^block3(%4, u32), ^block4 : (i1);
+    cf.cond_br %8 ^block3(%4 : u32), ^block4 : (i1);
 ^block2(%5: u32, %6: u32):
     %10 = arith.lt %5, %2;
-    cf.cond_br %10 ^block5(%6, u32), ^block6 : (i1);
+    cf.cond_br %10 ^block5(%6 : u32), ^block6 : (i1);
 ^block3:
     %9 = arith.mul %3, %2 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block2(%7, %4, u32, u32);
+    cf.br ^block2(%7, %4 : u32, u32);
 ^block4:
     builtin.ret %4 : (u32);
 ^block5:
@@ -20,10 +20,10 @@ builtin.function public extern("C") @cfg_to_scf_lift_multiple_exit_nested_while_
     %16 = builtin.unrealized_conversion_cast %15 <{ ty = #builtin.type<u32> }>;
     %17 = arith.incr %5;
     %18, %19 = arith.add_overflowing %6, %16;
-    cf.cond_br %18 ^block7, ^block2(%17, %19, u32, u32) : (i1);
+    cf.cond_br %18 ^block7, ^block2(%17, %19 : u32, u32) : (i1);
 ^block6:
     %11 = arith.incr %3;
-    cf.br ^block1(%11, %6, u32, u32);
+    cf.br ^block1(%11, %6 : u32, u32);
 ^block7:
     builtin.ret_imm 4294967295 : u32;
 };

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_multiple_exit_nested_while_loop_before.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_multiple_exit_nested_while_loop_before.hir
@@ -25,5 +25,5 @@ builtin.function public extern("C") @cfg_to_scf_lift_multiple_exit_nested_while_
     %11 = arith.incr %3;
     cf.br ^block1:(%11, %6);
 ^block7:
-    builtin.ret_imm #builtin.number<4294967295>;
+    builtin.ret_imm 4294967295 : u32;
 };

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_multiple_exit_nested_while_loop_before.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_multiple_exit_nested_while_loop_before.hir
@@ -1,15 +1,15 @@
 builtin.function public extern("C") @cfg_to_scf_lift_multiple_exit_nested_while_loop(%0: ptr<u32, byte>, %1: u32, %2: u32) -> u32 {
     %7 = arith.constant 0 : u32;
-    cf.br ^block1:(%7, %7);
+    cf.br ^block1(%7, %7, u32, u32);
 ^block1(%3: u32, %4: u32):
     %8 = arith.lt %3, %1;
-    cf.cond_br %8 ^block3:(%4), ^block4 : (i1);
+    cf.cond_br %8 ^block3(%4, u32), ^block4 : (i1);
 ^block2(%5: u32, %6: u32):
     %10 = arith.lt %5, %2;
-    cf.cond_br %10 ^block5:(%6), ^block6 : (i1);
+    cf.cond_br %10 ^block5(%6, u32), ^block6 : (i1);
 ^block3:
     %9 = arith.mul %3, %2 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block2:(%7, %4);
+    cf.br ^block2(%7, %4, u32, u32);
 ^block4:
     builtin.ret %4 : (u32);
 ^block5:
@@ -20,10 +20,10 @@ builtin.function public extern("C") @cfg_to_scf_lift_multiple_exit_nested_while_
     %16 = builtin.unrealized_conversion_cast %15 <{ ty = #builtin.type<u32> }>;
     %17 = arith.incr %5;
     %18, %19 = arith.add_overflowing %6, %16;
-    cf.cond_br %18 ^block7, ^block2:(%17, %19) : (i1);
+    cf.cond_br %18 ^block7, ^block2(%17, %19, u32, u32) : (i1);
 ^block6:
     %11 = arith.incr %3;
-    cf.br ^block1:(%11, %6);
+    cf.br ^block1(%11, %6, u32, u32);
 ^block7:
     builtin.ret_imm 4294967295 : u32;
 };

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_nested_while_loop_after.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_nested_while_loop_after.hir
@@ -30,7 +30,7 @@ builtin.function public extern("C") @cfg_to_scf_lift_nested_while_loop(%0: ptr<u
             } after {
             ^block17(%61: u32, %62: u32, %63: u32):
                 scf.yield %61, %62, %63 : (u32, u32, u32);
-            } : (u32, u32, u32);
+            } : (u32, u32, u32) -> (u32, u32, u32);
             %11 = arith.incr %3;
             scf.yield %11, %57, %20, %25 : (u32, u32, u32, u32);
         } : (i1) -> (u32, u32, u32, u32);
@@ -39,6 +39,6 @@ builtin.function public extern("C") @cfg_to_scf_lift_nested_while_loop(%0: ptr<u
     } after {
     ^block12(%40: u32, %41: u32, %42: u32):
         scf.yield %40, %41, %42 : (u32, u32, u32);
-    } : (u32, u32, u32);
+    } : (u32, u32, u32) -> (u32, u32, u32);
     builtin.ret %36 : (u32);
 };

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_nested_while_loop_before.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_nested_while_loop_before.hir
@@ -1,15 +1,15 @@
 builtin.function public extern("C") @cfg_to_scf_lift_nested_while_loop(%0: ptr<u32, byte>, %1: u32, %2: u32) -> u32 {
     %7 = arith.constant 0 : u32;
-    cf.br ^block1(%7, %7, u32, u32);
+    cf.br ^block1(%7, %7 : u32, u32);
 ^block1(%3: u32, %4: u32):
     %8 = arith.lt %3, %1;
-    cf.cond_br %8 ^block4, ^block3(%4, u32) : (i1);
+    cf.cond_br %8 ^block4, ^block3(%4 : u32) : (i1);
 ^block2(%5: u32, %6: u32):
     %10 = arith.lt %5, %2;
-    cf.cond_br %10 ^block6, ^block5(%6, u32) : (i1);
+    cf.cond_br %10 ^block6, ^block5(%6 : u32) : (i1);
 ^block3:
     %9 = arith.mul %3, %2 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block2(%7, %4, u32, u32);
+    cf.br ^block2(%7, %4 : u32, u32);
 ^block4:
     builtin.ret %4 : (u32);
 ^block5:
@@ -20,8 +20,8 @@ builtin.function public extern("C") @cfg_to_scf_lift_nested_while_loop(%0: ptr<u
     %16 = builtin.unrealized_conversion_cast %15 <{ ty = #builtin.type<u32> }>;
     %17 = arith.incr %5;
     %18 = arith.add %6, %16 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block2(%17, %18, u32, u32);
+    cf.br ^block2(%17, %18 : u32, u32);
 ^block6:
     %11 = arith.incr %3;
-    cf.br ^block1(%11, %6, u32, u32);
+    cf.br ^block1(%11, %6 : u32, u32);
 };

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_nested_while_loop_before.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_nested_while_loop_before.hir
@@ -1,15 +1,15 @@
 builtin.function public extern("C") @cfg_to_scf_lift_nested_while_loop(%0: ptr<u32, byte>, %1: u32, %2: u32) -> u32 {
     %7 = arith.constant 0 : u32;
-    cf.br ^block1:(%7, %7);
+    cf.br ^block1(%7, %7, u32, u32);
 ^block1(%3: u32, %4: u32):
     %8 = arith.lt %3, %1;
-    cf.cond_br %8 ^block4, ^block3:(%4) : (i1);
+    cf.cond_br %8 ^block4, ^block3(%4, u32) : (i1);
 ^block2(%5: u32, %6: u32):
     %10 = arith.lt %5, %2;
-    cf.cond_br %10 ^block6, ^block5:(%6) : (i1);
+    cf.cond_br %10 ^block6, ^block5(%6, u32) : (i1);
 ^block3:
     %9 = arith.mul %3, %2 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block2:(%7, %4);
+    cf.br ^block2(%7, %4, u32, u32);
 ^block4:
     builtin.ret %4 : (u32);
 ^block5:
@@ -20,8 +20,8 @@ builtin.function public extern("C") @cfg_to_scf_lift_nested_while_loop(%0: ptr<u
     %16 = builtin.unrealized_conversion_cast %15 <{ ty = #builtin.type<u32> }>;
     %17 = arith.incr %5;
     %18 = arith.add %6, %16 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block2:(%17, %18);
+    cf.br ^block2(%17, %18, u32, u32);
 ^block6:
     %11 = arith.incr %3;
-    cf.br ^block1:(%11, %6);
+    cf.br ^block1(%11, %6, u32, u32);
 };

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_simple_conditional_before.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_simple_conditional_before.hir
@@ -4,10 +4,10 @@ builtin.function public extern("C") @cfg_to_scf_lift_simple_conditional(%0: u32)
     cf.cond_br %3 ^block1, ^block2 : (i1);
 ^block1:
     %4 = arith.incr %0;
-    cf.br ^block3:(%4);
+    cf.br ^block3(%4, u32);
 ^block2:
     %5 = arith.mul %0, %0 <{ overflow = #builtin.overflow<checked> }>;
-    cf.br ^block3:(%5);
+    cf.br ^block3(%5, u32);
 ^block3(%1: u32):
     builtin.ret %1 : (u32);
 };

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_simple_conditional_before.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_simple_conditional_before.hir
@@ -4,10 +4,10 @@ builtin.function public extern("C") @cfg_to_scf_lift_simple_conditional(%0: u32)
     cf.cond_br %3 ^block1, ^block2 : (i1);
 ^block1:
     %4 = arith.incr %0;
-    cf.br ^block3(%4, u32);
+    cf.br ^block3(%4 : u32);
 ^block2:
     %5 = arith.mul %0, %0 <{ overflow = #builtin.overflow<checked> }>;
-    cf.br ^block3(%5, u32);
+    cf.br ^block3(%5 : u32);
 ^block3(%1: u32):
     builtin.ret %1 : (u32);
 };

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_simple_while_loop_after.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_simple_while_loop_after.hir
@@ -19,6 +19,6 @@ builtin.function public extern("C") @cfg_to_scf_lift_simple_while_loop(%0: u32) 
     } after {
     ^block9(%29: u32, %30: u32, %31: u32):
         scf.yield %29, %30, %31 : (u32, u32, u32);
-    } : (u32, u32, u32);
+    } : (u32, u32, u32) -> (u32, u32, u32);
     builtin.ret %25 : (u32);
 };

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_simple_while_loop_before.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_simple_while_loop_before.hir
@@ -1,7 +1,7 @@
 builtin.function public extern("C") @cfg_to_scf_lift_simple_while_loop(%0: u32) -> u32 {
     %3 = arith.constant 0 : u32;
     %4 = arith.constant 1 : u32;
-    cf.br ^block1:(%0, %3);
+    cf.br ^block1(%0, %3, u32, u32);
 ^block1(%1: u32, %2: u32):
     %5 = arith.eq %1, %3;
     cf.cond_br %5 ^block2, ^block3 : (i1);
@@ -10,5 +10,5 @@ builtin.function public extern("C") @cfg_to_scf_lift_simple_while_loop(%0: u32) 
 ^block3:
     %6 = arith.sub %1, %4 <{ overflow = #builtin.overflow<unchecked> }>;
     %7 = arith.incr %2;
-    cf.br ^block1:(%6, %7);
+    cf.br ^block1(%6, %7, u32, u32);
 };

--- a/dialects/scf/src/transforms/expected/cfg_to_scf_lift_simple_while_loop_before.hir
+++ b/dialects/scf/src/transforms/expected/cfg_to_scf_lift_simple_while_loop_before.hir
@@ -1,7 +1,7 @@
 builtin.function public extern("C") @cfg_to_scf_lift_simple_while_loop(%0: u32) -> u32 {
     %3 = arith.constant 0 : u32;
     %4 = arith.constant 1 : u32;
-    cf.br ^block1(%0, %3, u32, u32);
+    cf.br ^block1(%0, %3 : u32, u32);
 ^block1(%1: u32, %2: u32):
     %5 = arith.eq %1, %3;
     cf.cond_br %5 ^block2, ^block3 : (i1);
@@ -10,5 +10,5 @@ builtin.function public extern("C") @cfg_to_scf_lift_simple_while_loop(%0: u32) 
 ^block3:
     %6 = arith.sub %1, %4 <{ overflow = #builtin.overflow<unchecked> }>;
     %7 = arith.incr %2;
-    cf.br ^block1(%6, %7, u32, u32);
+    cf.br ^block1(%6, %7 : u32, u32);
 };

--- a/frontend/wasm/src/code_translator/expected/if_else.hir
+++ b/frontend/wasm/src/code_translator/expected/if_else.hir
@@ -7,10 +7,10 @@ builtin.function public extern("C") @test_wrapper() {
     builtin.ret;
 ^block6:
     %4 = arith.constant 3 : i32;
-    cf.br ^block7:(%4);
+    cf.br ^block7(%4, i32);
 ^block7(%3: i32):
     cf.br ^block5;
 ^block8:
     %5 = arith.constant 5 : i32;
-    cf.br ^block7:(%5);
+    cf.br ^block7(%5, i32);
 };

--- a/frontend/wasm/src/code_translator/expected/if_else.hir
+++ b/frontend/wasm/src/code_translator/expected/if_else.hir
@@ -7,10 +7,10 @@ builtin.function public extern("C") @test_wrapper() {
     builtin.ret;
 ^block6:
     %4 = arith.constant 3 : i32;
-    cf.br ^block7(%4, i32);
+    cf.br ^block7(%4 : i32);
 ^block7(%3: i32):
     cf.br ^block5;
 ^block8:
     %5 = arith.constant 5 : i32;
-    cf.br ^block7(%5, i32);
+    cf.br ^block7(%5 : i32);
 };

--- a/hir-analysis/src/analyses/spills/expected/spills_branching_control_flow.hir
+++ b/hir-analysis/src/analyses/spills/expected/spills_branching_control_flow.hir
@@ -14,11 +14,11 @@ builtin.function public extern("C") @spills_branching_control_flow(%0: ptr<u8, e
 ^block2:
     %12 = arith.constant 1 : u64;
     %13 = hir.exec ::@test::@example(%8, %5, %9, %9, %12) : extern("C") (ptr<u128, element>, u128, u128, u128, u64) -> u32;
-    cf.br ^block4(%13, u32);
+    cf.br ^block4(%13 : u32);
 ^block3:
     %14 = arith.constant 8 : u32;
     %15 = arith.add %1, %14 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block4(%15, u32);
+    cf.br ^block4(%15 : u32);
 ^block4(%16: u32):
     %17 = arith.constant 72 : u32;
     %18 = arith.add %1, %17 <{ overflow = #builtin.overflow<unchecked> }>;

--- a/hir-analysis/src/analyses/spills/expected/spills_branching_control_flow.hir
+++ b/hir-analysis/src/analyses/spills/expected/spills_branching_control_flow.hir
@@ -14,11 +14,11 @@ builtin.function public extern("C") @spills_branching_control_flow(%0: ptr<u8, e
 ^block2:
     %12 = arith.constant 1 : u64;
     %13 = hir.exec ::@test::@example(%8, %5, %9, %9, %12) : extern("C") (ptr<u128, element>, u128, u128, u128, u64) -> u32;
-    cf.br ^block4:(%13);
+    cf.br ^block4(%13, u32);
 ^block3:
     %14 = arith.constant 8 : u32;
     %15 = arith.add %1, %14 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block4:(%15);
+    cf.br ^block4(%15, u32);
 ^block4(%16: u32):
     %17 = arith.constant 72 : u32;
     %18 = arith.add %1, %17 <{ overflow = #builtin.overflow<unchecked> }>;

--- a/hir-analysis/src/analyses/spills/expected/spills_loop_nest.hir
+++ b/hir-analysis/src/analyses/spills/expected/spills_loop_nest.hir
@@ -2,21 +2,21 @@ builtin.function public extern("C") @spills_loop_nest(%0: ptr<u64, element>, %1:
     %3 = arith.constant 0 : u32;
     %4 = arith.constant 0 : u32;
     %5 = arith.constant 0 : u64;
-    cf.br ^block2:(%3, %4, %5);
+    cf.br ^block2(%3, %4, %5, u32, u32, u64);
 ^block2(%6: u32, %7: u32, %8: u64):
     %9 = arith.eq %6, %1;
     cf.cond_br %9 ^block3, ^block4 : (i1);
 ^block3:
     builtin.ret %8 : (u64);
 ^block4:
-    cf.br ^block5:(%7, %8);
+    cf.br ^block5(%7, %8, u32, u64);
 ^block5(%10: u32, %11: u64):
     %12 = arith.eq %10, %2;
-    cf.cond_br %12 ^block6:(%10, %11), ^block7 : (i1);
+    cf.cond_br %12 ^block6(%10, %11, u32, u64), ^block7 : (i1);
 ^block6(%13: u32, %14: u64):
     %15 = arith.constant 1 : u32;
     %16 = arith.add %6, %15 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block2:(%16, %13, %14);
+    cf.br ^block2(%16, %13, %14, u32, u32, u64);
 ^block7:
     %17 = arith.constant 1 : u32;
     %18 = arith.sub %6, %17 <{ overflow = #builtin.overflow<unchecked> }>;
@@ -37,5 +37,5 @@ builtin.function public extern("C") @spills_loop_nest(%0: ptr<u64, element>, %1:
     %33 = arith.add %11, %24 <{ overflow = #builtin.overflow<unchecked> }>;
     %34 = arith.constant 1 : u32;
     %35 = arith.add %10, %34 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block5:(%35, %33);
+    cf.br ^block5(%35, %33, u32, u64);
 };

--- a/hir-analysis/src/analyses/spills/expected/spills_loop_nest.hir
+++ b/hir-analysis/src/analyses/spills/expected/spills_loop_nest.hir
@@ -2,21 +2,21 @@ builtin.function public extern("C") @spills_loop_nest(%0: ptr<u64, element>, %1:
     %3 = arith.constant 0 : u32;
     %4 = arith.constant 0 : u32;
     %5 = arith.constant 0 : u64;
-    cf.br ^block2(%3, %4, %5, u32, u32, u64);
+    cf.br ^block2(%3, %4, %5 : u32, u32, u64);
 ^block2(%6: u32, %7: u32, %8: u64):
     %9 = arith.eq %6, %1;
     cf.cond_br %9 ^block3, ^block4 : (i1);
 ^block3:
     builtin.ret %8 : (u64);
 ^block4:
-    cf.br ^block5(%7, %8, u32, u64);
+    cf.br ^block5(%7, %8 : u32, u64);
 ^block5(%10: u32, %11: u64):
     %12 = arith.eq %10, %2;
-    cf.cond_br %12 ^block6(%10, %11, u32, u64), ^block7 : (i1);
+    cf.cond_br %12 ^block6(%10, %11 : u32, u64), ^block7 : (i1);
 ^block6(%13: u32, %14: u64):
     %15 = arith.constant 1 : u32;
     %16 = arith.add %6, %15 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block2(%16, %13, %14, u32, u32, u64);
+    cf.br ^block2(%16, %13, %14 : u32, u32, u64);
 ^block7:
     %17 = arith.constant 1 : u32;
     %18 = arith.sub %6, %17 <{ overflow = #builtin.overflow<unchecked> }>;
@@ -37,5 +37,5 @@ builtin.function public extern("C") @spills_loop_nest(%0: ptr<u64, element>, %1:
     %33 = arith.add %11, %24 <{ overflow = #builtin.overflow<unchecked> }>;
     %34 = arith.constant 1 : u32;
     %35 = arith.add %10, %34 <{ overflow = #builtin.overflow<unchecked> }>;
-    cf.br ^block5(%35, %33, u32, u64);
+    cf.br ^block5(%35, %33 : u32, u64);
 };

--- a/hir-macros/src/operations/parser.rs
+++ b/hir-macros/src/operations/parser.rs
@@ -161,13 +161,10 @@ impl quote::ToTokens for DeriveOpParser {
                 if let Some(key_ty) = succ_group.keyed.as_ref() {
                     successors.extend(quote! {
                             next_operand_group = 0;
-                            // Keyed successors print as a bare comma-separated list of
-                            // `#key -> ^block(...)` entries; stop when the next token cannot
-                            // start a key, e.g. at the label of a following static successor.
-                            parser.parse_comma_separated_list(Delimiter::None, Some(#field_name_str), |parser| {
-                                if !parser.token_stream_mut().is_next(|tok| matches!(tok, ::midenc_hir::parse::Token::HashIdent(_))) {
-                                    return Ok(false);
-                                }
+                            // Keyed successors print as a bracket-delimited, comma-separated list
+                            // of `#key -> ^block(...)` entries (`#delimiter` is `Bracket` here);
+                            // the delimiter lets a fallback successor follow unambiguously.
+                            parser.parse_comma_separated_list(#delimiter, Some(#field_name_str), |parser| {
                                 let key_ty = <<#key_ty as ::midenc_hir::KeyedSuccessor>::KeyStorage as ::midenc_hir::attributes::MaybeInferAttributeType>::maybe_infer_type()
                                     .unwrap_or(::midenc_hir::Type::Unknown);
                                 let key = parser.parse_typed_attribute::<<#key_ty as ::midenc_hir::KeyedSuccessor>::KeyStorage>(&key_ty)?.into_inner();

--- a/hir-macros/src/operations/parser.rs
+++ b/hir-macros/src/operations/parser.rs
@@ -63,6 +63,7 @@ impl quote::ToTokens for DeriveOpParser {
         };
         if !format.operand_groups.is_empty() {
             let mut operand_group_parsers = quote! {};
+            let mut is_first_parsed_group = true;
             for group in format.operand_groups.iter() {
                 if group.successor_operands {
                     continue;
@@ -97,14 +98,25 @@ impl quote::ToTokens for DeriveOpParser {
                             parser.parse_operand_list(operands, Delimiter::None, /*allow_result_number=*/true, ::core::num::NonZeroU8::new(#size_lit))?;
                         }
                     });
-                } else {
+                } else if is_first_parsed_group {
                     operand_group_parsers.extend(quote! {
                         {
                             let operands = &mut gathered_operands[#group_index_lit];
                             parser.parse_operand_list(operands, Delimiter::None, /*allow_result_number=*/true, None)?;
                         }
                     });
+                } else {
+                    // A variadic group following a fixed group is printed as a trailing
+                    // comma-separated list that is omitted entirely when empty; parse it the same
+                    // way.
+                    operand_group_parsers.extend(quote! {
+                        {
+                            let operands = &mut gathered_operands[#group_index_lit];
+                            parser.parse_trailing_operand_list(operands, Delimiter::None)?;
+                        }
+                    });
                 }
+                is_first_parsed_group = false;
             }
 
             gather_operands.extend(quote! {
@@ -129,6 +141,9 @@ impl quote::ToTokens for DeriveOpParser {
 
         let mut successors = quote! {};
         if !format.successor_groups.is_empty() {
+            // Tracks whether a statically-known successor parse has been emitted, so that
+            // subsequent ones consume the `, ` separator the printer places between successors.
+            let mut emitted_static_successor = false;
             for succ_group in format.successor_groups.iter() {
                 let field_name = &succ_group.field_name;
                 let field_name_str =
@@ -187,14 +202,27 @@ impl quote::ToTokens for DeriveOpParser {
                             })?;
                         });
                 } else {
-                    for _ in succ_group.successors.iter() {
+                    for (succ_index, _) in succ_group.successors.iter().enumerate() {
+                        if emitted_static_successor {
+                            successors.extend(quote! {
+                                parser.parse_optional_comma()?;
+                            });
+                        }
+                        let succ_index_lit = syn::Lit::Int(syn::LitInt::new(
+                            &succ_index.to_string(),
+                            field_name.span(),
+                        ));
                         successors.extend(quote! {
                             {
-                                let block_ref = parser.parse_successor_and_use_list(&mut state.operands[next_operand_group])?;
-                                state.add_successor(block_ref.into_inner(), next_operand_group as u8);
-                                next_operand_group += 1;
+                                let operand_group = #base_operand_group_lit + #succ_index_lit;
+                                while state.operands.len() <= operand_group {
+                                    state.operands.push(Default::default());
+                                }
+                                let block_ref = parser.parse_successor_and_use_list(&mut state.operands[operand_group])?;
+                                state.add_successor(block_ref.into_inner(), operand_group as u8);
                             }
                         });
+                        emitted_static_successor = true;
                     }
                 }
             }
@@ -328,142 +356,16 @@ impl quote::ToTokens for RegionParser<'_> {
         let isolated =
             syn::Lit::Bool(syn::LitBool::new(self.format.isolated_from_above, Span::call_site()));
 
-        let mut args = quote! {};
-        match &self.format.signature.params {
-            ParamShape::None => {
-                args.extend(quote! {
-                    #[allow(unused_variables, unused_mut)]
-                    let mut args = ::midenc_hir::SmallVec::<[::midenc_hir::parse::Argument; 1]>::new_const();
-                });
-            }
-            ParamShape::Static(group_index) => {
-                let group_index = *group_index;
-                assert!(
-                    self.format
-                        .successor_groups
-                        .iter()
-                        .all(|group| group.base_operand_group > group_index
-                            || !group.successors.is_empty()),
-                    "dynamically-sized successor groups must be defined after all other operand \
-                     groups"
-                );
-                let group = &self.format.operand_groups[group_index];
-                let group_size = syn::Lit::Int(syn::LitInt::new(
-                    &group.operands.len().to_string(),
-                    group.field_name.span(),
-                ));
-                args.extend(quote! {
-                    let mut args = ::midenc_hir::SmallVec::<[::midenc_hir::parse::Argument; #group_size]>::new_const();
-                });
-
-                let operand_group = syn::Lit::Int(syn::LitInt::new(
-                    &group_index.to_string(),
-                    group.field_name.span(),
-                ));
-                for operand in group.operands.iter() {
-                    let operand_index = syn::Lit::Int(syn::LitInt::new(
-                        &operand.index.to_string(),
-                        group.field_name.span(),
-                    ));
-                    args.extend(quote! {
-                        args.push(::midenc_hir::parse::Argument {
-                            name: gathered_operands[#operand_group][#operand_index],
-                            ty: ::midenc_hir::Type::Unknown,
-                            attrs: Default::default(),
-                            loc: ::midenc_hir::dialects::builtin::attributes::Location::Unknown,
-                        });
-                    });
-                }
-            }
-            ParamShape::Dynamic(group_index) => {
-                let group_index = *group_index;
-                assert!(
-                    self.format
-                        .successor_groups
-                        .iter()
-                        .all(|group| group.base_operand_group > group_index
-                            || !group.successors.is_empty()),
-                    "dynamically-sized successor groups must be defined after all other operand \
-                     groups"
-                );
-                let group = &self.format.operand_groups[group_index];
-                args.extend(quote! {
-                    let mut args = ::midenc_hir::SmallVec::<[::midenc_hir::parse::Argument; 1]>::new_const();
-                });
-
-                let operand_group = syn::Lit::Int(syn::LitInt::new(
-                    &group_index.to_string(),
-                    group.field_name.span(),
-                ));
-                args.extend(quote! {
-                    args.extend(gathered_operands[#operand_group].iter().copied().map(|operand| {
-                        ::midenc_hir::parse::Argument {
-                            name: operand,
-                            ty: ::midenc_hir::Type::Unknown,
-                            attrs: Default::default(),
-                            loc: ::midenc_hir::dialects::builtin::attributes::Location::Unknown,
-                        }
-                    }));
-                });
-            }
-            ParamShape::TrailingVarArgs { fixed, varargs } => {
-                let fixed_group_index = *fixed;
-                let varargs_group_index = *varargs;
-                assert!(
-                    self.format
-                        .successor_groups
-                        .iter()
-                        .all(|group| ((group.base_operand_group > fixed_group_index)
-                            && (group.base_operand_group > varargs_group_index))
-                            || !group.successors.is_empty()),
-                    "dynamically-sized successor groups must be defined after all other operand \
-                     groups"
-                );
-                let fixed_group = &self.format.operand_groups[fixed_group_index];
-                let group_size = syn::Lit::Int(syn::LitInt::new(
-                    &fixed_group.operands.len().to_string(),
-                    fixed_group.field_name.span(),
-                ));
-
-                args.extend(quote! {
-                    let mut args = ::midenc_hir::SmallVec::<[::midenc_hir::parse::Argument; #group_size]>::new_const();
-                });
-
-                let operand_group = syn::Lit::Int(syn::LitInt::new(
-                    &fixed_group_index.to_string(),
-                    fixed_group.field_name.span(),
-                ));
-                for operand in fixed_group.operands.iter() {
-                    let operand_index = syn::Lit::Int(syn::LitInt::new(
-                        &operand.index.to_string(),
-                        fixed_group.field_name.span(),
-                    ));
-                    args.extend(quote! {
-                        args.push(::midenc_hir::parse::Argument {
-                            name: gathered_operands[#operand_group][#operand_index],
-                            ty: ::midenc_hir::Type::Unknown,
-                            attrs: Default::default(),
-                            loc: ::midenc_hir::dialects::builtin::attributes::Location::Unknown,
-                        });
-                    });
-                }
-                let varargs_group = &self.format.operand_groups[varargs_group_index];
-                let operand_group = syn::Lit::Int(syn::LitInt::new(
-                    &varargs_group_index.to_string(),
-                    varargs_group.field_name.span(),
-                ));
-                args.extend(quote! {
-                    args.extend(gathered_operands[#operand_group].iter().copied().map(|operand| {
-                        ::midenc_hir::parse::Argument {
-                            name: operand,
-                            ty: ::midenc_hir::Type::Unknown,
-                            attrs: Default::default(),
-                            loc: ::midenc_hir::dialects::builtin::attributes::Location::Unknown,
-                        }
-                    }));
-                });
-            }
-        }
+        // Regions are parsed with no pre-bound entry arguments: an operation's operands are
+        // references to values defined in the enclosing scope, not fresh bindings, so forwarding
+        // them as entry arguments would either collide with their original definitions or reject
+        // the explicit `^block(...)` header the printer emits. Entry block arguments are instead
+        // declared by that header; named-argument forwarding in `parse_region_body` remains for
+        // true binding syntaxes such as function signatures.
+        let args = quote! {
+            #[allow(unused_variables, unused_mut)]
+            let mut args = ::midenc_hir::SmallVec::<[::midenc_hir::parse::Argument; 1]>::new_const();
+        };
         let elide_entry_region_name = self.format.regions.len() == 1;
         for (
             i,

--- a/hir-macros/src/operations/parser.rs
+++ b/hir-macros/src/operations/parser.rs
@@ -141,15 +141,16 @@ impl quote::ToTokens for DeriveOpParser {
 
         let mut successors = quote! {};
         if !format.successor_groups.is_empty() {
-            // Tracks whether a statically-known successor parse has been emitted, so that
-            // subsequent ones consume the `, ` separator the printer places between successors.
-            let mut emitted_static_successor = false;
-            for succ_group in format.successor_groups.iter() {
+            for (succ_group_index, succ_group) in format.successor_groups.iter().enumerate() {
                 let field_name = &succ_group.field_name;
                 let field_name_str =
                     syn::Lit::Str(syn::LitStr::new(&format!("{field_name}"), field_name.span()));
                 let base_operand_group_lit = syn::Lit::Int(syn::LitInt::new(
                     &format!("{}", succ_group.base_operand_group),
+                    field_name.span(),
+                ));
+                let succ_group_index_lit = syn::Lit::Int(syn::LitInt::new(
+                    &succ_group_index.to_string(),
                     field_name.span(),
                 ));
                 let delimiter: syn::Expr = if succ_group.requires_delimiter {
@@ -160,23 +161,30 @@ impl quote::ToTokens for DeriveOpParser {
                 if let Some(key_ty) = succ_group.keyed.as_ref() {
                     successors.extend(quote! {
                             next_operand_group = 0;
-                            parser.parse_comma_separated_list(#delimiter, Some(#field_name_str), |parser| {
+                            // Keyed successors print as a bare comma-separated list of
+                            // `#key -> ^block(...)` entries; stop when the next token cannot
+                            // start a key, e.g. at the label of a following static successor.
+                            parser.parse_comma_separated_list(Delimiter::None, Some(#field_name_str), |parser| {
+                                if !parser.token_stream_mut().is_next(|tok| matches!(tok, ::midenc_hir::parse::Token::HashIdent(_))) {
+                                    return Ok(false);
+                                }
                                 let key_ty = <<#key_ty as ::midenc_hir::KeyedSuccessor>::KeyStorage as ::midenc_hir::attributes::MaybeInferAttributeType>::maybe_infer_type()
                                     .unwrap_or(::midenc_hir::Type::Unknown);
                                 let key = parser.parse_typed_attribute::<<#key_ty as ::midenc_hir::KeyedSuccessor>::KeyStorage>(&key_ty)?.into_inner();
                                 parser.parse_arrow()?;
-                                let operand_group = #base_operand_group_lit + next_operand_group;
-                                next_operand_group += 1;
-                                if gathered_operands.len() == operand_group {
+                                // The first successor uses the operand group reserved for this
+                                // field; additional ones append new groups at the end, since
+                                // successors reference their operand group by explicit index.
+                                let operand_group = if next_operand_group == 0 {
+                                    #base_operand_group_lit
+                                } else {
                                     gathered_operands.push(Default::default());
                                     state.operands.push(Default::default());
-                                } else {
-                                    assert!(gathered_operands.len() < operand_group);
-                                    gathered_operands.insert(operand_group, Default::default());
-                                    state.operands.insert(operand_group, Default::default());
-                                }
+                                    state.operands.len() - 1
+                                };
+                                next_operand_group += 1;
                                 let block_ref = parser.parse_successor_and_use_list(&mut state.operands[operand_group])?;
-                                state.add_keyed_successor(key, block_ref.into_inner(), operand_group as u8);
+                                state.add_keyed_successor(key, block_ref.into_inner(), operand_group as u8, #succ_group_index_lit);
 
                                 Ok(true)
                             })?;
@@ -185,25 +193,29 @@ impl quote::ToTokens for DeriveOpParser {
                     successors.extend(quote! {
                             next_operand_group = 0;
                             parser.parse_comma_separated_list(#delimiter, Some(#field_name_str), |parser| {
-                                let operand_group = #base_operand_group_lit + next_operand_group;
-                                next_operand_group += 1;
-                                if gathered_operands.len() == operand_group {
+                                // The first successor uses the operand group reserved for this
+                                // field; additional ones append new groups at the end, since
+                                // successors reference their operand group by explicit index.
+                                let operand_group = if next_operand_group == 0 {
+                                    #base_operand_group_lit
+                                } else {
                                     gathered_operands.push(Default::default());
                                     state.operands.push(Default::default());
-                                } else {
-                                    assert!(gathered_operands.len() < operand_group);
-                                    gathered_operands.insert(operand_group, Default::default());
-                                    state.operands.insert(operand_group, Default::default());
-                                }
+                                    state.operands.len() - 1
+                                };
+                                next_operand_group += 1;
                                 let block_ref = parser.parse_successor_and_use_list(&mut state.operands[operand_group])?;
-                                state.add_successor(block_ref.into_inner(), operand_group as u8);
+                                state.add_successor(block_ref.into_inner(), operand_group as u8, #succ_group_index_lit);
 
                                 Ok(true)
                             })?;
                         });
                 } else {
                     for (succ_index, _) in succ_group.successors.iter().enumerate() {
-                        if emitted_static_successor {
+                        // The printer separates this successor from whatever precedes it
+                        // (an earlier successor group or a prior successor in this group)
+                        // with `, `; consume that separator if present.
+                        if succ_group_index > 0 || succ_group.index > 0 || succ_index > 0 {
                             successors.extend(quote! {
                                 parser.parse_optional_comma()?;
                             });
@@ -219,10 +231,9 @@ impl quote::ToTokens for DeriveOpParser {
                                     state.operands.push(Default::default());
                                 }
                                 let block_ref = parser.parse_successor_and_use_list(&mut state.operands[operand_group])?;
-                                state.add_successor(block_ref.into_inner(), operand_group as u8);
+                                state.add_successor(block_ref.into_inner(), operand_group as u8, #succ_group_index_lit);
                             }
                         });
-                        emitted_static_successor = true;
                     }
                 }
             }
@@ -299,7 +310,10 @@ impl quote::ToTokens for DeriveOpParser {
         } else {
             resolve_operands.extend(quote! {
                 let total_operand_types = sig_params.len();
-                let total_operands = gathered_operands.iter().map(|group| group.len()).sum::<usize>() + state.operands.iter().map(|group| group.len()).sum::<usize>();
+                // Only operands gathered by name are resolved against the type signature;
+                // successor operands (already resolved with their inline types) are not
+                // part of the printed signature.
+                let total_operands = gathered_operands.iter().map(|group| group.len()).sum::<usize>();
                 if total_operand_types != total_operands {
                     return Err(ParserError::OperandAndTypeListMismatch {
                         span: state.span,

--- a/hir-macros/src/operations/printer.rs
+++ b/hir-macros/src/operations/printer.rs
@@ -137,12 +137,7 @@ impl quote::ToTokens for DeriveOpPrinter {
                             p.print_attribute_value(&*key_attr_ref.borrow());
                             p += ::midenc_hir::formatter::const_text(" -> ");
                             p += ::midenc_hir::formatter::display(dest.borrow().id());
-                            if operands.is_empty() {
-                                continue;
-                            }
-                            p += ::midenc_hir::formatter::const_text(":(");
-                            p.print_value_uses(operands.as_value_range());
-                            p += ::midenc_hir::formatter::const_text(")");
+                            p.print_successor_arguments(operands.as_value_range());
                         }
                         *printer += ::midenc_hir::formatter::indent(4, p.finish());
                     });
@@ -157,12 +152,7 @@ impl quote::ToTokens for DeriveOpPrinter {
                             let target = succ.successor();
                             let target_operands = succ.successor_operands();
                             *printer += ::midenc_hir::formatter::display(target.borrow().id());
-                            if target_operands.is_empty() {
-                                continue;
-                            }
-                            *printer += ::midenc_hir::formatter::const_text(":(");
-                            printer.print_value_uses(target_operands);
-                            *printer += ::midenc_hir::formatter::const_text(")");
+                            printer.print_successor_arguments(target_operands);
                         }
                         printer.print_rbracket();
                     });
@@ -176,12 +166,7 @@ impl quote::ToTokens for DeriveOpPrinter {
                             let target = succ.successor();
                             let target_operands = succ.successor_operands();
                             *printer += ::midenc_hir::formatter::display(target.borrow().id());
-                            if target_operands.is_empty() {
-                                continue;
-                            }
-                            *printer += ::midenc_hir::formatter::const_text(":(");
-                            printer.print_value_uses(target_operands);
-                            *printer += ::midenc_hir::formatter::const_text(")");
+                            printer.print_successor_arguments(target_operands);
                         }
                     });
                 } else {
@@ -208,11 +193,7 @@ impl quote::ToTokens for DeriveOpPrinter {
                                 let target = succ.successor();
                                 let target_operands = &succ.arguments;
                                 *printer += ::midenc_hir::formatter::display(target.borrow().id());
-                                if !target_operands.is_empty() {
-                                    *printer += ::midenc_hir::formatter::const_text(":(");
-                                    printer.print_value_uses(target_operands.as_value_range());
-                                    *printer += ::midenc_hir::formatter::const_text(")");
-                                }
+                                printer.print_successor_arguments(target_operands.as_value_range());
                             }
                         });
                     }

--- a/hir-macros/src/operations/printer.rs
+++ b/hir-macros/src/operations/printer.rs
@@ -122,8 +122,12 @@ impl quote::ToTokens for DeriveOpPrinter {
             for (succ_group_index, succ_group) in format.successor_groups.iter().enumerate() {
                 let field_name = &succ_group.field_name;
                 if succ_group.keyed.is_some() {
+                    // A keyed successor group prints as a bracket-delimited, comma-separated list
+                    // of `#key -> ^block(args)` entries. The brackets are required: an undelimited
+                    // list cannot be followed by the fallback successor without ambiguity.
                     successors.extend(quote! {
                         printer.print_space();
+                        *printer += ::midenc_hir::formatter::const_text("[");
                         let mut p = ::midenc_hir::print::AsmPrinter::new(op.context_rc(), printer.flags());
                         for (i, keyed_succ) in self.#field_name().iter().enumerate() {
                             use ::midenc_hir::AsValueRange;
@@ -140,6 +144,7 @@ impl quote::ToTokens for DeriveOpPrinter {
                             p.print_successor_arguments(operands.as_value_range());
                         }
                         *printer += ::midenc_hir::formatter::indent(4, p.finish());
+                        *printer += ::midenc_hir::formatter::const_text("]");
                     });
                 } else if succ_group.successors.is_empty() && succ_group.requires_delimiter {
                     successors.extend(quote! {

--- a/hir/src/dialects/builtin/attributes/integer.rs
+++ b/hir/src/dialects/builtin/attributes/integer.rs
@@ -1,6 +1,10 @@
 use crate::{
-    AttrPrinter, Immediate, attributes::IntegerLikeAttr, derive::DialectAttribute,
-    dialects::builtin::BuiltinDialect, print::AsmPrinter,
+    AttrPrinter, Immediate,
+    attributes::{AttrParser, IntegerLikeAttr},
+    derive::DialectAttribute,
+    dialects::builtin::BuiltinDialect,
+    parse::ParserExt,
+    print::AsmPrinter,
 };
 
 macro_rules! define_integer_attr {
@@ -35,6 +39,18 @@ macro_rules! __define_integer_attr {
             impl AttrPrinter for [<$name Attr>] {
                 fn print(&self, printer: &mut AsmPrinter<'_>) {
                     printer.print_decimal_integer(self.as_immediate());
+                }
+            }
+
+            impl AttrParser for [<$name Attr>] {
+                fn parse(
+                    parser: &mut dyn crate::parse::Parser<'_>,
+                ) -> crate::parse::ParseResult<crate::AttributeRef> {
+                    let value = parser.parse_decimal_integer::<$t>()?;
+                    Ok(parser
+                        .context_rc()
+                        .create_attribute::<[<$name Attr>], _>(value.into_inner())
+                        .as_attribute_ref())
                 }
             }
         }

--- a/hir/src/dialects/builtin/ops/function.rs
+++ b/hir/src/dialects/builtin/ops/function.rs
@@ -472,8 +472,15 @@ pub struct RetImm {
 
 impl OpPrinter for RetImm {
     fn print(&self, printer: &mut AsmPrinter<'_>) {
+        use crate::{attributes::IntegerLikeAttr, formatter::const_text};
+
+        // Print the immediate as `<value> : <type>`, mirroring the grammar accepted by the
+        // `OpParser` implementation below, so the output can be re-parsed.
+        let value = self.value().as_ref().as_immediate();
         printer.print_space();
-        printer.print_attribute_value(&*self.value());
+        printer.print_decimal_integer(value);
+        *printer += const_text(" : ");
+        printer.print_type(&value.ty());
     }
 }
 
@@ -490,18 +497,23 @@ impl OpParser for RetImm {
         let end = parser.token_stream().current_span();
         let span = SourceSpan::new(end.source_id(), start..end.end());
 
-        if ty.is_numeric() {
-            let attr = parser
-                .context_rc()
-                .create_attribute_with_type::<ImmediateAttr, _>(imm.into_inner(), ty.into_inner());
-            state.add_attribute("value", attr);
-        } else {
+        // Re-type the parsed literal to the declared type: integer parsing infers the narrowest
+        // representation, which would otherwise survive into the attribute and reprint with the
+        // wrong type.
+        let Some(imm) = imm.into_inner().coerced_to(&ty) else {
             return Err(ParserError::InvalidOperationType {
                 span,
                 ty_span: ty.span(),
-                reason: format!("expected numeric type, got {ty}"),
+                reason: format!(
+                    "expected a numeric type able to represent the immediate, got {ty}"
+                ),
             });
-        }
+        };
+
+        let attr = parser
+            .context_rc()
+            .create_attribute_with_type::<ImmediateAttr, _>(imm, ty.into_inner());
+        state.add_attribute("value", attr);
 
         Ok(())
     }

--- a/hir/src/ir/immediates.rs
+++ b/hir/src/ir/immediates.rs
@@ -109,6 +109,28 @@ impl Immediate {
         }
     }
 
+    /// Converts this immediate to the representation matching `ty`, if the value fits.
+    ///
+    /// Returns `None` when `ty` is not a representable numeric type, or the value is out of
+    /// range for it.
+    pub fn coerced_to(self, ty: &Type) -> Option<Self> {
+        match ty {
+            Type::I1 => self.as_bool().map(Self::I1),
+            Type::U8 => self.as_u8().map(Self::U8),
+            Type::I8 => self.as_i8().map(Self::I8),
+            Type::U16 => self.as_u16().map(Self::U16),
+            Type::I16 => self.as_i16().map(Self::I16),
+            Type::U32 => self.as_u32().map(Self::U32),
+            Type::I32 => self.as_i32().map(Self::I32),
+            Type::U64 => self.as_u64().map(Self::U64),
+            Type::I64 => self.as_i64().map(Self::I64),
+            Type::U128 => self.as_u128().map(Self::U128),
+            Type::I128 => self.as_i128().map(Self::I128),
+            Type::Felt => self.as_felt().map(Self::Felt),
+            _ => None,
+        }
+    }
+
     /// Returns true if this immediate is a non-negative value
     pub fn is_non_negative(&self) -> bool {
         match self {

--- a/hir/src/ir/operation/builder.rs
+++ b/hir/src/ir/operation/builder.rs
@@ -134,18 +134,22 @@ where
         op.regions.push_back(region);
     }
 
-    // TODO: This needs to replicate the behavior of with_(keyed_)successor
     pub fn with_pending_successor(&mut self, succ: PendingSuccessorInfo) {
         let owner = self.op;
         let mut op = self.op.borrow_mut();
-        // Record SuccessorInfo for this successor in the op
+        // Record SuccessorInfo for this successor in the op, in the successor group expected
+        // by the operation's accessors. Pending successors must be added in non-decreasing
+        // successor group order.
         let succ_index = u8::try_from(op.successors.len()).expect("too many successors");
         let successor = self.builder.context().make_block_operand(succ.block, owner, succ_index);
-        op.successors.push(SuccessorInfo {
-            block: successor,
-            key: succ.key,
-            operand_group: succ.operand_group,
-        });
+        op.successors.push_to_group(
+            succ.successor_group as usize,
+            SuccessorInfo {
+                block: successor,
+                key: succ.key,
+                operand_group: succ.operand_group,
+            },
+        );
     }
 
     pub fn with_successor(

--- a/hir/src/ir/operation/state.rs
+++ b/hir/src/ir/operation/state.rs
@@ -28,6 +28,9 @@ pub struct PendingSuccessorInfo {
     pub block: BlockRef,
     pub key: Option<AttributeRef>,
     pub operand_group: u8,
+    /// The successor group this successor belongs to, matching the grouping expected by the
+    /// operation's successor accessors (e.g. a `cf.switch`'s cases vs. its fallback).
+    pub successor_group: u8,
 }
 
 impl OperationState {
@@ -70,19 +73,27 @@ impl OperationState {
         self.regions.push(region);
     }
 
-    pub fn add_successor(&mut self, block: BlockRef, operand_group: u8) {
+    pub fn add_successor(&mut self, block: BlockRef, operand_group: u8, successor_group: u8) {
         self.successors.push(PendingSuccessorInfo {
             block,
             key: None,
             operand_group,
+            successor_group,
         });
     }
 
-    pub fn add_keyed_successor(&mut self, key: AttributeRef, block: BlockRef, operand_group: u8) {
+    pub fn add_keyed_successor(
+        &mut self,
+        key: AttributeRef,
+        block: BlockRef,
+        operand_group: u8,
+        successor_group: u8,
+    ) {
         self.successors.push(PendingSuccessorInfo {
             block,
             key: Some(key),
             operand_group,
+            successor_group,
         });
     }
 }

--- a/hir/src/ir/parse.rs
+++ b/hir/src/ir/parse.rs
@@ -422,17 +422,26 @@ pub trait OpAsmParser<'input>: Parser<'input> {
         allow_result_number: bool,
         required_operand_count: Option<NonZeroU8>,
     ) -> ParseResult {
+        let start = self.current_location();
+        let base_len = result.len();
         self.parse_comma_separated_list(delimiter, Some("operand list"), |parser| {
             let operand = parser.parse_operand(allow_result_number)?;
             result.push(operand);
 
-            Ok(true)
+            // Stop after the required number of operands, leaving the trailing comma and any
+            // remaining items to be consumed by a following (e.g. variadic) operand group.
+            Ok(required_operand_count
+                .is_none_or(|required| result.len() - base_len < required.get() as usize))
         })?;
 
         if let Some(required) = required_operand_count
-            && result.len() != required.get() as usize
+            && result.len() - base_len != required.get() as usize
         {
-            todo!()
+            return Err(ParserError::InvalidOperandCount {
+                span: start,
+                expected: required.get() as usize,
+                actual: result.len() - base_len,
+            });
         }
 
         Ok(())

--- a/hir/src/ir/parse/error.rs
+++ b/hir/src/ir/parse/error.rs
@@ -79,6 +79,14 @@ pub enum ParserError {
         num_operands: usize,
         num_types: usize,
     },
+    #[error("invalid operand list")]
+    #[diagnostic()]
+    InvalidOperandCount {
+        #[label("expected {expected} operands in this list, but found {actual}")]
+        span: SourceSpan,
+        expected: usize,
+        actual: usize,
+    },
     #[error("use of undeclared values")]
     #[diagnostic()]
     UndeclaredValueUses {

--- a/hir/src/ir/parse/operation.rs
+++ b/hir/src/ir/parse/operation.rs
@@ -733,9 +733,12 @@ where
                 );
             }
 
-            // Add definitions for each of the parsed result names, mapping them onto the
-            // operation's results in order. Names do not correspond 1:1 to result groups: a
-            // single variadic result group may be bound by multiple names (e.g. `scf.if`).
+            // Bind each parsed result name to a result of the operation, in order. The printer
+            // emits one SSA name per result (e.g. `%a, %b, %c = scf.if`) - the canonical form for
+            // an op with a single result group - so the names map directly onto the flattened
+            // result list; the `%name:count` spelling instead binds `count` consecutive results to
+            // `%name#0..#count`. The previous code indexed `results().group(i)` by the i-th *name*,
+            // which panicked once a single variadic group was bound by more than one name.
             let results = op.results().all();
             let mut result_offset = 0usize;
             for result_record in result_ids.iter() {
@@ -1305,11 +1308,13 @@ impl<'input, P> OperationParser<P>
 where
     P: Parser<'input>,
 {
-    /// Parse a new block into 'block', returning the block that was actually defined.
+    /// Parse a new block, returning the block that was defined.
     ///
-    /// Note that the returned block may differ from `block`: a label that was previously
-    /// referenced as a successor resolves to its forward-declared block, so callers must attach
-    /// the returned block to the region rather than the one they provided.
+    /// When `block` is `Some`, that block is the one populated and returned - unless the parsed
+    /// label was already forward-referenced as a successor, in which case this panics: branch
+    /// targets already point at the forward-declared block, so the caller's block cannot be used.
+    /// Callers that may encounter forward-declared labels must pass `None` and attach the returned
+    /// block to the region.
     ///
     ///   block ::= block-label? operation*
     ///   block-label    ::= block-id block-arg-list? `:`
@@ -1342,19 +1347,26 @@ where
         // use it. Otherwise create a new one.
         let block_and_loc = self.get_block_info_by_name(name);
 
-        let block = if let Some(block) = block_and_loc {
-            // Otherwise, the block has a forward declaration. Forward declarations are
-            // removed once defined, so if we are defining a existing block and it is
-            // not a forward declaration, then it is a redeclaration. Fail if the block
-            // was already defined.
-            if !self.erase_forward_ref(block.into_inner()) {
+        let block = if let Some(forward_declared) = block_and_loc {
+            // The block has a forward declaration. Forward declarations are removed once defined,
+            // so if this name already resolves to a non-forward-declared block, it is a
+            // redeclaration.
+            if !self.erase_forward_ref(forward_declared.into_inner()) {
                 // "redefinition of block {name}"
                 return Err(ParserError::BlockAlreadyDefined {
                     span: name_span,
                     name,
                 });
             }
-            Span::new(name_span, block.into_inner())
+            // A caller that provided a block expects it to be the one populated, but branch
+            // targets already point at the forward-declared block, so we cannot honor that here.
+            // Such callers must pass `None` and use the returned block instead.
+            assert!(
+                block.is_none(),
+                "parse_block was given an explicit block, but `{name}` was forward-referenced as \
+                 a successor; pass `None` so the forward-declared block can be used"
+            );
+            Span::new(name_span, forward_declared.into_inner())
         } else {
             let block =
                 Span::new(name_span, block.unwrap_or_else(|| self.context_rc().create_block()));

--- a/hir/src/ir/parse/operation.rs
+++ b/hir/src/ir/parse/operation.rs
@@ -385,11 +385,6 @@ where
         }
 
         self.parse_comma_separated_list(Delimiter::None, Some("SSA use list"), |parser| {
-            // Stop at the first non-value token: a use list may be followed by further
-            // comma-separated items, such as the type list in an SSA use-and-type list.
-            if !parser.token_stream_mut().is_next(|tok| matches!(tok, Token::PercentIdent(_))) {
-                return Ok(false);
-            }
             let result = parser.parse_ssa_use(/*allow_result_number*/ true)?;
             results.push(result);
             Ok(true)
@@ -412,10 +407,9 @@ where
             })?
             .into_parts();
 
-        // If we have an all-digit attribute ID, it is a result number; any other hash
-        // identifier belongs to a following attribute (e.g. a keyed successor key).
+        // If we have an attribute ID, it is a result number.
         let result_num = self.parser.token_stream_mut().next_if_map(|tok| match tok {
-            Token::HashIdent(num) if num.bytes().all(|b| b.is_ascii_digit()) => Some(num),
+            Token::HashIdent(num) => Some(num),
             _ => None,
         })?;
         if let Some(result_num) = result_num {
@@ -534,8 +528,7 @@ where
         }
 
         let mut types = SmallVec::<[Type; 4]>::new_const();
-        // The comma separating the uses from their types was consumed by the use list loop
-        // when it stopped at the first type token.
+        self.parser.token_stream_mut().expect(Token::Colon)?;
         self.parser.parse_type_list_no_parens(&mut types)?;
 
         if value_ids.len() != types.len() {

--- a/hir/src/ir/parse/operation.rs
+++ b/hir/src/ir/parse/operation.rs
@@ -733,9 +733,12 @@ where
                 );
             }
 
-            // Add definitions for each of the result groups.
-            for (result_group, result_record) in result_ids.iter().enumerate() {
-                let group = op.results().group(result_group);
+            // Add definitions for each of the parsed result names, mapping them onto the
+            // operation's results in order. Names do not correspond 1:1 to result groups: a
+            // single variadic result group may be bound by multiple names (e.g. `scf.if`).
+            let results = op.results().all();
+            let mut result_offset = 0usize;
+            for result_record in result_ids.iter() {
                 for result_index in 0..result_record.count {
                     let name = ValueId::from_symbol(result_record.id);
                     let name = if result_record.count == 1 {
@@ -747,7 +750,8 @@ where
                         loc: result_record.loc,
                         name,
                     };
-                    let value = group[result_index as usize] as ValueRef;
+                    let value = results[result_offset] as ValueRef;
+                    result_offset += 1;
                     self.add_definition(use_info, value);
                 }
             }
@@ -1278,9 +1282,10 @@ where
         region.borrow_mut().body_mut().push_back(owning_block);
 
         while self.token_stream_mut().is_next(|tok| !matches!(tok, Token::Rbrace)) {
-            let new_block = self.context_rc().create_block();
-            self.parse_block(Some(new_block))?;
-            region.borrow_mut().push_back(new_block);
+            // Each subsequent block starts with a label; `parse_block` resolves it to the
+            // forward-declared block when the label was already referenced as a successor.
+            let block = self.parse_block(None)?;
+            region.borrow_mut().push_back(block);
         }
 
         // Pop the SSA value scope for this region.
@@ -1298,20 +1303,25 @@ impl<'input, P> OperationParser<P>
 where
     P: Parser<'input>,
 {
-    /// Parse a new block into 'block'.
+    /// Parse a new block into 'block', returning the block that was actually defined.
+    ///
+    /// Note that the returned block may differ from `block`: a label that was previously
+    /// referenced as a successor resolves to its forward-declared block, so callers must attach
+    /// the returned block to the region rather than the one they provided.
     ///
     ///   block ::= block-label? operation*
     ///   block-label    ::= block-id block-arg-list? `:`
     ///   block-id       ::= caret-id
     ///   block-arg-list ::= `(` ssa-id-and-type-list? `)`
     ///
-    pub fn parse_block(&mut self, block: Option<BlockRef>) -> ParseResult {
+    pub fn parse_block(&mut self, block: Option<BlockRef>) -> ParseResult<BlockRef> {
         // The first block of a region may already exist, if it does the caret identifier is
         // optional.
         if let Some(block) = block
             && self.token_stream_mut().is_next(|tok| !matches!(tok, Token::CaretIdent(_)))
         {
-            return self.parse_block_body(block);
+            self.parse_block_body(block)?;
+            return Ok(block);
         }
 
         let (name_span, name) = self
@@ -1344,7 +1354,12 @@ where
             }
             Span::new(name_span, block.into_inner())
         } else {
-            Span::new(name_span, block.unwrap_or_else(|| self.context_rc().create_block()))
+            let block =
+                Span::new(name_span, block.unwrap_or_else(|| self.context_rc().create_block()));
+            // Register the definition so later references (e.g. backwards branches) resolve to
+            // this block, and duplicate definitions are detected.
+            self.blocks_by_name.last_mut().unwrap().insert(name, block);
+            block
         };
 
         // Populate the high level assembly state if necessary.
@@ -1359,7 +1374,8 @@ where
         self.parse_colon()?;
 
         // Parse the body of the block.
-        self.parse_block_body(block.into_inner())
+        self.parse_block_body(block.into_inner())?;
+        Ok(block.into_inner())
     }
 
     /// Parse a list of operations into 'block'.
@@ -1920,9 +1936,10 @@ where
         let dest = self.parse_successor()?;
 
         // Handle optional arguments.
-        self.parse_optional_lparen()?;
-        self.parser.parse_optional_ssa_use_and_type_list(operands)?;
-        self.parse_rparen()?;
+        if self.parse_optional_lparen()? {
+            self.parser.parse_optional_ssa_use_and_type_list(operands)?;
+            self.parse_rparen()?;
+        }
 
         Ok(dest)
     }

--- a/hir/src/ir/parse/operation.rs
+++ b/hir/src/ir/parse/operation.rs
@@ -385,6 +385,11 @@ where
         }
 
         self.parse_comma_separated_list(Delimiter::None, Some("SSA use list"), |parser| {
+            // Stop at the first non-value token: a use list may be followed by further
+            // comma-separated items, such as the type list in an SSA use-and-type list.
+            if !parser.token_stream_mut().is_next(|tok| matches!(tok, Token::PercentIdent(_))) {
+                return Ok(false);
+            }
             let result = parser.parse_ssa_use(/*allow_result_number*/ true)?;
             results.push(result);
             Ok(true)
@@ -407,9 +412,10 @@ where
             })?
             .into_parts();
 
-        // If we have an attribute ID, it is a result number.
+        // If we have an all-digit attribute ID, it is a result number; any other hash
+        // identifier belongs to a following attribute (e.g. a keyed successor key).
         let result_num = self.parser.token_stream_mut().next_if_map(|tok| match tok {
-            Token::HashIdent(num) => Some(num),
+            Token::HashIdent(num) if num.bytes().all(|b| b.is_ascii_digit()) => Some(num),
             _ => None,
         })?;
         if let Some(result_num) = result_num {
@@ -528,7 +534,8 @@ where
         }
 
         let mut types = SmallVec::<[Type; 4]>::new_const();
-        self.parser.token_stream_mut().expect(Token::Comma)?;
+        // The comma separating the uses from their types was consumed by the use list loop
+        // when it stopped at the first type token.
         self.parser.parse_type_list_no_parens(&mut types)?;
 
         if value_ids.len() != types.len() {
@@ -933,6 +940,7 @@ where
                     block,
                     key: None,
                     operand_group: (i + 1) as u8,
+                    successor_group: 0,
                 },
             ));
         } else if self.parser.token_stream_mut().is_next(|tok| matches!(tok, Token::Lbracket)) {
@@ -947,6 +955,7 @@ where
                     block,
                     key: None,
                     operand_group: (i + 1) as u8,
+                    successor_group: 0,
                 }
             }));
         }

--- a/hir/src/ir/parse/parser.rs
+++ b/hir/src/ir/parse/parser.rs
@@ -1457,18 +1457,6 @@ pub trait ParserExt<'input>: Parser<'input> {
         T: AttributeRegistration,
     {
         let name = self.context().get_registered_attribute_name::<T>();
-        let default_dialect = *self.state().default_dialect_stack.last().unwrap();
-        let allow_dialect_elision = name.dialect() == default_dialect;
-        let tok =
-            self.token_stream_mut()
-                .expect_if(&format!("{name} attribute"), |tok| match tok {
-                    Token::HashIdent(id) => {
-                        id == name.dialect().as_str()
-                            || allow_dialect_elision && id == name.name().as_str()
-                    }
-                    _ => false,
-                })?;
-
         let attr = self.parse_extended_attribute(ty)?;
 
         if attr.borrow().is::<T>() {

--- a/hir/src/ir/parse/parser.rs
+++ b/hir/src/ir/parse/parser.rs
@@ -1457,6 +1457,12 @@ pub trait ParserExt<'input>: Parser<'input> {
         T: AttributeRegistration,
     {
         let name = self.context().get_registered_attribute_name::<T>();
+        // Name and dialect parsing are delegated entirely to `parse_extended_attribute`, which
+        // resolves the dialect (including elision against the default dialect) and errors on an
+        // unknown attribute; the `is::<T>()` check below then validates the concrete type. We do
+        // not pre-validate the leading `#ident` token here: doing so would have to re-implement
+        // the `#dialect.name` form the printer emits, and consuming that token would leave
+        // `parse_extended_attribute` to misparse the remainder.
         let attr = self.parse_extended_attribute(ty)?;
 
         if attr.borrow().is::<T>() {

--- a/hir/src/ir/parse/tests.rs
+++ b/hir/src/ir/parse/tests.rs
@@ -5,11 +5,12 @@ use litcheck_filecheck::{filecheck, litcheck};
 use pretty_assertions::assert_eq;
 
 use crate::{
-    BuilderExt, CallConv, Context, FunctionType, OpParser, OpRegistration, OperationRef, Symbol,
-    SymbolTable, Type, UnsafeIntrusiveEntityRef, ValueRef, Visibility,
+    BuilderExt, CallConv, Context, FunctionType, Immediate, OpParser, OpRegistration, OperationRef,
+    Symbol, SymbolTable, Type, UnsafeIntrusiveEntityRef, ValueRef, Visibility,
+    attributes::IntegerLikeAttr,
     diagnostics::{Report, SourceSpan, Uri},
     dialects::builtin::{
-        BuiltinOpBuilder, Function, Module, Ret, UnrealizedConversionCast, WorldRef,
+        BuiltinOpBuilder, Function, Module, Ret, RetImm, UnrealizedConversionCast, WorldRef,
         attributes::{AbiParam, Signature},
     },
     parse::{self, ParseResult, ParserConfig},
@@ -140,6 +141,49 @@ fn derive_roundtrip_test() -> TestResult {
     // CHECK-NEXT: };
     "#
     );
+
+    Ok(())
+}
+
+#[test]
+fn parse_ret_imm_coerces_literal_to_declared_type() -> TestResult {
+    let test = ParserTest::default();
+
+    let source = "\
+builtin.function public extern(\"C\") @retconst() -> u32 {
+    builtin.ret_imm 42 : u32;
+};";
+
+    let function = test.parse::<Function>("parse_ret_imm.hir", source)?;
+    let printed = format!("{}", function.as_operation_ref().borrow());
+    assert!(
+        printed.contains("builtin.ret_imm 42 : u32"),
+        "expected the declared type to survive the round trip, got:\n{printed}"
+    );
+
+    let function = function.borrow();
+    let ret_imm = function
+        .body()
+        .entry()
+        .terminator()
+        .unwrap()
+        .try_downcast_op::<RetImm>()
+        .expect("expected the function terminator to be builtin.ret_imm");
+    let imm = ret_imm.borrow().value().as_ref().as_immediate();
+    assert!(
+        matches!(imm, Immediate::U32(42)),
+        "expected the literal to be coerced to the declared type, got {imm:?}"
+    );
+
+    // A literal that cannot be represented in the declared type must be rejected.
+    let result = test.parse::<Function>(
+        "parse_ret_imm_invalid.hir",
+        "\
+builtin.function public extern(\"C\") @retconst() -> u8 {
+    builtin.ret_imm 300 : u8;
+};",
+    );
+    assert!(result.is_err(), "expected an out-of-range immediate to be rejected");
 
     Ok(())
 }

--- a/hir/src/ir/print/asm_printer.rs
+++ b/hir/src/ir/print/asm_printer.rs
@@ -201,6 +201,27 @@ impl<'a> AsmPrinter<'a> {
         self.document += doc;
     }
 
+    /// Prints a successor argument list: the operand uses followed by their types, e.g.
+    /// `(%0, %1, u32, u32)`, matching the grammar accepted by `parse_successor_and_use_list`.
+    ///
+    /// Prints nothing when `values` is empty, as the parser treats the entire list as optional.
+    pub fn print_successor_arguments<const N: usize>(&mut self, values: ValueRange<'_, N>) {
+        use crate::formatter::*;
+
+        if values.is_empty() {
+            return;
+        }
+        let types = values
+            .iter()
+            .map(|value| Cow::Owned(value.borrow().ty().clone()))
+            .collect::<crate::SmallVec<[_; 4]>>();
+        self.document += const_text("(");
+        self.print_value_uses(values);
+        self.document += const_text(", ");
+        self.print_types(types);
+        self.document += const_text(")");
+    }
+
     /// Prints zero or more comma-separated value ids and their types in parentheses.
     ///
     /// This is intended for use in parameter lists (e.g. block arguments).

--- a/hir/src/ir/print/asm_printer.rs
+++ b/hir/src/ir/print/asm_printer.rs
@@ -201,8 +201,9 @@ impl<'a> AsmPrinter<'a> {
         self.document += doc;
     }
 
-    /// Prints a successor argument list: the operand uses followed by their types, e.g.
-    /// `(%0, %1, u32, u32)`, matching the grammar accepted by `parse_successor_and_use_list`.
+    /// Prints a successor argument list as an `ssa-use-and-type-list`, i.e. the operand uses, a
+    /// colon, then their types: `(%0, %1 : u32, u32)`. This matches the grammar accepted by
+    /// `parse_successor_and_use_list`.
     ///
     /// Prints nothing when `values` is empty, as the parser treats the entire list as optional.
     pub fn print_successor_arguments<const N: usize>(&mut self, values: ValueRange<'_, N>) {
@@ -217,7 +218,7 @@ impl<'a> AsmPrinter<'a> {
             .collect::<crate::SmallVec<[_; 4]>>();
         self.document += const_text("(");
         self.print_value_uses(values);
-        self.document += const_text(", ");
+        self.document += const_text(" : ");
         self.print_types(types);
         self.document += const_text(")");
     }

--- a/hir/src/testing.rs
+++ b/hir/src/testing.rs
@@ -1,8 +1,8 @@
-use alloc::{boxed::Box, rc::Rc};
+use alloc::{boxed::Box, format, rc::Rc, string::String};
 
 use crate::{
     BlockRef, Builder, Context, Ident, OpBuilder, Type,
-    diagnostics::Report,
+    diagnostics::{Report, Uri},
     dialects::builtin::{
         BuiltinOpBuilder, Function, FunctionBuilder, FunctionRef, ModuleRef,
         attributes::{Signature, Visibility},
@@ -237,4 +237,34 @@ impl Test {
         pm.enable_verifier(verify);
         pm.run(self.function().as_operation_ref())
     }
+}
+
+/// Parse `source` as a [Function] and assert that its printed form is a parse/print fixpoint:
+/// the printed output must re-parse, and re-print identically.
+///
+/// Returns the parsed function and its printed form, for structural assertions and snapshot
+/// comparisons by the caller. The returned [FunctionRef] is only valid for as long as `context`
+/// is kept alive by the caller.
+pub fn parse_function_fixpoint(
+    context: &Rc<Context>,
+    name: &str,
+    source: &str,
+) -> Result<(FunctionRef, String), Report> {
+    let config = crate::parse::ParserConfig::new(context.clone());
+    let function = crate::parse::parse::<Function>(config, Uri::new(name), source)?;
+    let printed = format!("{}", function.as_operation_ref().borrow());
+
+    // Re-parse in a fresh context so printed value numbering starts from zero again; the
+    // context must outlive the re-printing below, as entity references do not keep it alive.
+    let reparse_context = Rc::new(Context::default());
+    let config = crate::parse::ParserConfig::new(reparse_context.clone());
+    let reparsed = crate::parse::parse::<Function>(
+        config,
+        Uri::new(format!("{name}.reparsed").as_str()),
+        printed.as_str(),
+    )?;
+    let reprinted = format!("{}", reparsed.as_operation_ref().borrow());
+    assert_eq!(printed, reprinted, "printed form of '{name}' is not a parse/print fixpoint");
+
+    Ok((function, printed))
 }

--- a/midenc-compile/src/stages/parse/rust.rs
+++ b/midenc-compile/src/stages/parse/rust.rs
@@ -242,13 +242,20 @@ trim-paths = [\"diagnostics\", \"object\"]
     let cargo_env = std::env::var("CARGO").map(PathBuf::from).ok();
     let cargo_path = cargo_env.as_deref().unwrap_or_else(|| Path::new("cargo"));
 
+    // When a specific cargo wasn't provided, resolve the toolchain to build under via rustup. This
+    // honors an inherited RUSTUP_TOOLCHAIN or the active `rust-toolchain.toml` pin rather than
+    // forcing the generic `nightly` channel, which matters because the SDK crates require a
+    // specific nightly and this build runs from a temporary directory where directory overrides do
+    // not apply.
+    let toolchain = if cargo_env.is_none() {
+        crate::rust::rustup_toolchain()
+    } else {
+        None
+    };
+
     let mut cargo = std::process::Command::new(cargo_path);
-    // Ensure we specify the nightly toolchain if a specific cargo wasn't set. An inherited
-    // RUSTUP_TOOLCHAIN (e.g. from the rust-toolchain.toml override of the invoking project) takes
-    // precedence: forcing the generic `nightly` channel would bypass that pin, and the build
-    // below runs from a temporary directory where directory-based overrides do not apply.
-    if cargo_env.is_none() && std::env::var_os("RUSTUP_TOOLCHAIN").is_none() {
-        cargo.arg("+nightly");
+    if let Some(toolchain) = toolchain.as_deref() {
+        cargo.arg(format!("+{toolchain}"));
     }
     cargo.env("RUSTFLAGS", rustflags);
     // This env var is used by crates (e.g. `miden-field`) to distinguish compiling to Wasm for a
@@ -258,14 +265,7 @@ trim-paths = [\"diagnostics\", \"object\"]
     cargo.args(&cargo_build_args);
 
     // Handle the target for buildable commands
-    crate::rust::install_wasm32_target(
-        wasi,
-        if cargo_env.is_none() {
-            Some("nightly")
-        } else {
-            None
-        },
-    )?;
+    crate::rust::install_wasm32_target(wasi, toolchain.as_deref())?;
 
     cargo.arg("--target").arg(format!("wasm32-{wasi}"));
 

--- a/midenc-compile/src/stages/parse/rust.rs
+++ b/midenc-compile/src/stages/parse/rust.rs
@@ -243,8 +243,11 @@ trim-paths = [\"diagnostics\", \"object\"]
     let cargo_path = cargo_env.as_deref().unwrap_or_else(|| Path::new("cargo"));
 
     let mut cargo = std::process::Command::new(cargo_path);
-    // Ensure we specify the nightly toolchain if a specific cargo wasn't set
-    if cargo_env.is_none() {
+    // Ensure we specify the nightly toolchain if a specific cargo wasn't set. An inherited
+    // RUSTUP_TOOLCHAIN (e.g. from the rust-toolchain.toml override of the invoking project) takes
+    // precedence: forcing the generic `nightly` channel would bypass that pin, and the build
+    // below runs from a temporary directory where directory-based overrides do not apply.
+    if cargo_env.is_none() && std::env::var_os("RUSTUP_TOOLCHAIN").is_none() {
         cargo.arg("+nightly");
     }
     cargo.env("RUSTFLAGS", rustflags);

--- a/tests/integration/src/end_to_end/debuginfo/expected/debug_conditional_assignment.hir
+++ b/tests/integration/src/end_to_end/debuginfo/expected/debug_conditional_assignment.hir
@@ -78,7 +78,7 @@ builtin.component private @root_ns:root@1.0.0 {
             cf.br ^block6;
         };
         builtin.global_variable private @__stack_pointer : i32 {
-            builtin.ret_imm #builtin.number<1048576>;
+            builtin.ret_imm 1048576 : i32;
         };
     };
 };

--- a/tests/integration/src/end_to_end/debuginfo/expected/debug_multiple_locals.hir
+++ b/tests/integration/src/end_to_end/debuginfo/expected/debug_multiple_locals.hir
@@ -70,7 +70,7 @@ builtin.component private @root_ns:root@1.0.0 {
 
         };
         builtin.global_variable private @__stack_pointer : i32 {
-            builtin.ret_imm #builtin.number<1048576>;
+            builtin.ret_imm 1048576 : i32;
         };
     };
 };

--- a/tests/integration/src/end_to_end/debuginfo/expected/debug_nested_loops.hir
+++ b/tests/integration/src/end_to_end/debuginfo/expected/debug_nested_loops.hir
@@ -180,7 +180,7 @@ builtin.component private @root_ns:root@1.0.0 {
             cf.br ^block6;
         };
         builtin.global_variable private @__stack_pointer : i32 {
-            builtin.ret_imm #builtin.number<1048576>;
+            builtin.ret_imm 1048576 : i32;
         };
     };
 };

--- a/tests/integration/src/end_to_end/debuginfo/expected/debug_simple_params.hir
+++ b/tests/integration/src/end_to_end/debuginfo/expected/debug_simple_params.hir
@@ -39,7 +39,7 @@ builtin.component private @root_ns:root@1.0.0 {
 
         };
         builtin.global_variable private @__stack_pointer : i32 {
-            builtin.ret_imm #builtin.number<1048576>;
+            builtin.ret_imm 1048576 : i32;
         };
     };
 };

--- a/tests/integration/src/end_to_end/debuginfo/expected/debug_variable_locations.hir
+++ b/tests/integration/src/end_to_end/debuginfo/expected/debug_variable_locations.hir
@@ -130,7 +130,7 @@ builtin.component private @root_ns:root@1.0.0 {
             builtin.ret %62 : (i32);
         };
         builtin.global_variable private @__stack_pointer : i32 {
-            builtin.ret_imm #builtin.number<1048576>;
+            builtin.ret_imm 1048576 : i32;
         };
     };
 };

--- a/tests/lit/hir/parsing/structured_control_flow.hir
+++ b/tests/lit/hir/parsing/structured_control_flow.hir
@@ -1,72 +1,130 @@
 // RUN: hir-opt %s | filecheck %s
 
-// XFAIL: *
-// Temporarily disabled: the parser cannot yet round-trip the named region entry
-// blocks that the printer emits for scf ops (e.g. `^block27(%147: u32, %148: u32):`
-// inside a `before` region), failing with BlockNameInRegionWithNamedArgs. This file
-// also still needs CHECK lines.
-// The proper fix is in https://github.com/0xMiden/compiler/pull/1175
-
-// This was extracted from one of our SCF transform tests
+// Round-trip parse/print coverage for the SCF dialect on a moderately complex example
+// (nested scf.while/scf.if, scf.index_switch, multi-result bindings, and block successors).
+// The body below is the canonical printer output, so the reprint must match it exactly.
 builtin.function public extern("C") @scf(%0: ptr<u32, byte>, %1: u32, %2: u32) -> u32 {
-    %28 = arith.constant 2 : u32;
-    %27 = ub.poison <{ value = #ub.poison<u32> }>;
-    %26 = arith.constant 1 : u32;
-    %21 = arith.constant 0 : u32;
-    %143, %144, %145, %146 = scf.while %21, %21 before {
-    ^block27(%147: u32, %148: u32):
-        %8 = arith.lt %147, %1;
-        %111, %112, %113, %114 = scf.if %8 then {
-            %9 = arith.mul %147, %2 <{ overflow = #builtin.overflow<unchecked> }>;
-            %183, %184, %185, %186, %187, %188, %189 = scf.while %21, %148 before {
-            ^block31(%190: u32, %191: u32):
-                %10 = arith.lt %190, %2;
-                %177, %178, %179, %180, %181, %182 = scf.if %10 then {
-                    %12 = arith.add %9, %190 <{ overflow = #builtin.overflow<unchecked> }>;
-                    %13 = builtin.unrealized_conversion_cast %0 <{ ty = #builtin.type<u32> }>;
-                    %14 = arith.add %13, %12 <{ overflow = #builtin.overflow<unchecked> }>;
-                    %15 = builtin.unrealized_conversion_cast %14 <{ ty = #builtin.type<ptr<u32, byte>> }>;
-                    %16 = builtin.unrealized_conversion_cast %15 <{ ty = #builtin.type<u32> }>;
-                    %17 = arith.incr %190;
-                    %18, %19 = arith.add_overflowing %191, %16;
-                    %171 = cf.select %18, %27, %17;
-                    %172 = cf.select %18, %27, %19;
-                    %173 = cf.select %18, %26, %27;
-                    %174 = cf.select %18, %21, %27;
-                    %175 = cf.select %18, %26, %21;
-                    %176 = cf.select %18, %21, %26;
-                    scf.yield %171, %172, %173, %174, %175, %176 : (u32, u32, u32, u32, u32, u32);
+    %3 = arith.constant 2 : u32;
+    %4 = ub.poison <{ value = #ub.poison<u32> }>;
+    %5 = arith.constant 1 : u32;
+    %6 = arith.constant 0 : u32;
+    %63, %64, %65, %66 = scf.while %6, %6 before {
+    ^block2(%7: u32, %8: u32):
+        %9 = arith.lt %7, %1;
+        %54, %55, %56, %57 = scf.if %9 then {
+            %10 = arith.mul %7, %2 <{ overflow = #builtin.overflow<unchecked> }>;
+            %42, %43, %44, %45, %46, %47, %48 = scf.while %6, %8 before {
+            ^block4(%11: u32, %12: u32):
+                %13 = arith.lt %11, %2;
+                %28, %29, %30, %31, %32, %33 = scf.if %13 then {
+                    %14 = arith.add %10, %11 <{ overflow = #builtin.overflow<unchecked> }>;
+                    %15 = builtin.unrealized_conversion_cast %0 <{ ty = #builtin.type<u32> }>;
+                    %16 = arith.add %15, %14 <{ overflow = #builtin.overflow<unchecked> }>;
+                    %17 = builtin.unrealized_conversion_cast %16 <{ ty = #builtin.type<ptr<u32, byte>> }>;
+                    %18 = builtin.unrealized_conversion_cast %17 <{ ty = #builtin.type<u32> }>;
+                    %19 = arith.incr %11;
+                    %20, %21 = arith.add_overflowing %12, %18;
+                    %22 = cf.select %20, %4, %19;
+                    %23 = cf.select %20, %4, %21;
+                    %24 = cf.select %20, %5, %4;
+                    %25 = cf.select %20, %6, %4;
+                    %26 = cf.select %20, %5, %6;
+                    %27 = cf.select %20, %6, %5;
+                    scf.yield %22, %23, %24, %25, %26, %27 : (u32, u32, u32, u32, u32, u32);
                 } else {
-                    scf.yield %27, %27, %27, %27, %28, %21 : (u32, u32, u32, u32, u32, u32);
+                    scf.yield %4, %4, %4, %4, %3, %6 : (u32, u32, u32, u32, u32, u32);
                 } : (i1) -> (u32, u32, u32, u32, u32, u32);
-                %106 = arith.trunc %182 <{ ty = #builtin.type<i1> }>;
-                scf.condition %106, %177, %178, %191, %27, %179, %180, %181 : (i1, u32, u32, u32, u32, u32, u32, u32);
+                %34 = arith.trunc %33 <{ ty = #builtin.type<i1> }>;
+                scf.condition %34, %28, %29, %12, %4, %30, %31, %32 : (i1, u32, u32, u32, u32, u32, u32, u32);
             } after {
-            ^block32(%192: u32, %193: u32, %194: u32, %195: u32, %196: u32, %197: u32, %198: u32):
-                scf.yield %192, %193 : (u32, u32);
-            } : (u32, u32);
-            %115, %116, %117, %118 = scf.index_switch %189
+            ^block7(%35: u32, %36: u32, %37: u32, %38: u32, %39: u32, %40: u32, %41: u32):
+                scf.yield %35, %36 : (u32, u32);
+            } : (u32, u32) -> (u32, u32, u32, u32, u32, u32, u32);
+            %50, %51, %52, %53 = scf.index_switch %48 
             case 1 {
-                scf.yield %186, %186, %187, %188 : (u32, u32, u32, u32);
+                scf.yield %45, %45, %46, %47 : (u32, u32, u32, u32);
             }
             default {
-                %11 = arith.incr %147;
-                scf.yield %11, %185, %21, %26 : (u32, u32, u32, u32);
+                %49 = arith.incr %7;
+                scf.yield %49, %44, %6, %5 : (u32, u32, u32, u32);
             } : (u32, u32, u32, u32);
-            scf.yield %115, %116, %117, %118 : (u32, u32, u32, u32);
+            scf.yield %50, %51, %52, %53 : (u32, u32, u32, u32);
         } else {
-            scf.yield %27, %27, %28, %21 : (u32, u32, u32, u32);
+            scf.yield %4, %4, %3, %6 : (u32, u32, u32, u32);
         } : (i1) -> (u32, u32, u32, u32);
-        %51 = arith.trunc %114 <{ ty = #builtin.type<i1> }>;
-        scf.condition %51, %111, %112, %148, %113 : (i1, u32, u32, u32, u32);
+        %58 = arith.trunc %57 <{ ty = #builtin.type<i1> }>;
+        scf.condition %58, %54, %55, %8, %56 : (i1, u32, u32, u32, u32);
     } after {
-    ^block28(%149: u32, %150: u32, %151: u32, %152: u32):
-        scf.yield %149, %150 : (u32, u32);
-    } : (u32, u32);
-    %200 = arith.eq %146, %26;
-    cf.cond_br %200 ^block7, ^block4 : (i1);
-^block4:
-    builtin.ret %145 : (u32);
-^block7:
-    builtin.ret_imm #builtin.number<4294967295>;
+    ^block11(%59: u32, %60: u32, %61: u32, %62: u32):
+        scf.yield %59, %60 : (u32, u32);
+    } : (u32, u32) -> (u32, u32, u32, u32);
+    %67 = arith.eq %66, %5;
+    cf.cond_br %67 ^block12, ^block13 : (i1);
+^block13:
+    builtin.ret %65 : (u32);
+^block12:
+    builtin.ret_imm 4294967295 : u32;
 };
+
+// CHECK: builtin.function public extern("C") @scf(%0: ptr<u32, byte>, %1: u32, %2: u32) -> u32 {
+// CHECK-NEXT:     %3 = arith.constant 2 : u32;
+// CHECK-NEXT:     %4 = ub.poison <{ value = #ub.poison<u32> }>;
+// CHECK-NEXT:     %5 = arith.constant 1 : u32;
+// CHECK-NEXT:     %6 = arith.constant 0 : u32;
+// CHECK-NEXT:     %63, %64, %65, %66 = scf.while %6, %6 before {
+// CHECK-NEXT:     ^block2(%7: u32, %8: u32):
+// CHECK-NEXT:         %9 = arith.lt %7, %1;
+// CHECK-NEXT:         %54, %55, %56, %57 = scf.if %9 then {
+// CHECK-NEXT:             %10 = arith.mul %7, %2 <{ overflow = #builtin.overflow<unchecked> }>;
+// CHECK-NEXT:             %42, %43, %44, %45, %46, %47, %48 = scf.while %6, %8 before {
+// CHECK-NEXT:             ^block4(%11: u32, %12: u32):
+// CHECK-NEXT:                 %13 = arith.lt %11, %2;
+// CHECK-NEXT:                 %28, %29, %30, %31, %32, %33 = scf.if %13 then {
+// CHECK-NEXT:                     %14 = arith.add %10, %11 <{ overflow = #builtin.overflow<unchecked> }>;
+// CHECK-NEXT:                     %15 = builtin.unrealized_conversion_cast %0 <{ ty = #builtin.type<u32> }>;
+// CHECK-NEXT:                     %16 = arith.add %15, %14 <{ overflow = #builtin.overflow<unchecked> }>;
+// CHECK-NEXT:                     %17 = builtin.unrealized_conversion_cast %16 <{ ty = #builtin.type<ptr<u32, byte>> }>;
+// CHECK-NEXT:                     %18 = builtin.unrealized_conversion_cast %17 <{ ty = #builtin.type<u32> }>;
+// CHECK-NEXT:                     %19 = arith.incr %11;
+// CHECK-NEXT:                     %20, %21 = arith.add_overflowing %12, %18;
+// CHECK-NEXT:                     %22 = cf.select %20, %4, %19;
+// CHECK-NEXT:                     %23 = cf.select %20, %4, %21;
+// CHECK-NEXT:                     %24 = cf.select %20, %5, %4;
+// CHECK-NEXT:                     %25 = cf.select %20, %6, %4;
+// CHECK-NEXT:                     %26 = cf.select %20, %5, %6;
+// CHECK-NEXT:                     %27 = cf.select %20, %6, %5;
+// CHECK-NEXT:                     scf.yield %22, %23, %24, %25, %26, %27 : (u32, u32, u32, u32, u32, u32);
+// CHECK-NEXT:                 } else {
+// CHECK-NEXT:                     scf.yield %4, %4, %4, %4, %3, %6 : (u32, u32, u32, u32, u32, u32);
+// CHECK-NEXT:                 } : (i1) -> (u32, u32, u32, u32, u32, u32);
+// CHECK-NEXT:                 %34 = arith.trunc %33 <{ ty = #builtin.type<i1> }>;
+// CHECK-NEXT:                 scf.condition %34, %28, %29, %12, %4, %30, %31, %32 : (i1, u32, u32, u32, u32, u32, u32, u32);
+// CHECK-NEXT:             } after {
+// CHECK-NEXT:             ^block7(%35: u32, %36: u32, %37: u32, %38: u32, %39: u32, %40: u32, %41: u32):
+// CHECK-NEXT:                 scf.yield %35, %36 : (u32, u32);
+// CHECK-NEXT:             } : (u32, u32) -> (u32, u32, u32, u32, u32, u32, u32);
+// CHECK-NEXT:             %50, %51, %52, %53 = scf.index_switch %48 
+// CHECK-NEXT:             case 1 {
+// CHECK-NEXT:                 scf.yield %45, %45, %46, %47 : (u32, u32, u32, u32);
+// CHECK-NEXT:             }
+// CHECK-NEXT:             default {
+// CHECK-NEXT:                 %49 = arith.incr %7;
+// CHECK-NEXT:                 scf.yield %49, %44, %6, %5 : (u32, u32, u32, u32);
+// CHECK-NEXT:             } : (u32, u32, u32, u32);
+// CHECK-NEXT:             scf.yield %50, %51, %52, %53 : (u32, u32, u32, u32);
+// CHECK-NEXT:         } else {
+// CHECK-NEXT:             scf.yield %4, %4, %3, %6 : (u32, u32, u32, u32);
+// CHECK-NEXT:         } : (i1) -> (u32, u32, u32, u32);
+// CHECK-NEXT:         %58 = arith.trunc %57 <{ ty = #builtin.type<i1> }>;
+// CHECK-NEXT:         scf.condition %58, %54, %55, %8, %56 : (i1, u32, u32, u32, u32);
+// CHECK-NEXT:     } after {
+// CHECK-NEXT:     ^block11(%59: u32, %60: u32, %61: u32, %62: u32):
+// CHECK-NEXT:         scf.yield %59, %60 : (u32, u32);
+// CHECK-NEXT:     } : (u32, u32) -> (u32, u32, u32, u32);
+// CHECK-NEXT:     %67 = arith.eq %66, %5;
+// CHECK-NEXT:     cf.cond_br %67 ^block12, ^block13 : (i1);
+// CHECK-NEXT: ^block13:
+// CHECK-NEXT:     builtin.ret %65 : (u32);
+// CHECK-NEXT: ^block12:
+// CHECK-NEXT:     builtin.ret_imm 4294967295 : u32;
+// CHECK-NEXT: };


### PR DESCRIPTION
The lit/filecheck suite has been failing on `next` without anyone noticing: litcheck 0.4.3 always
exits 0 regardless of test results (despite its `--help` saying otherwise), so the CI job stayed
green while `FAIL:` lines scrolled by (example: <https://github.com/0xMiden/compiler/actions/runs/27338221879/job/80768422463>).
Three broken lit tests and two unparseable `XFAIL:` directives accumulated behind that. This PR
fixes the harness so it cannot happen again, fixes everything that had piled up, and pins the
parser behavior with tests so regressions surface as unit failures rather than lit-only ones.

- **Harness guard**: the `test-lit` task now derives its exit code from the litcheck summary and
  fails the build on failed/unresolved tests (workaround until litcheck propagates failures via
  its exit code). To be removed after the `litcheck` is released with https://github.com/bitwalker/litcheck/pull/2 fix.
- **Printed HIR now round-trips through the parser.** The printer and parser had diverged on the
  format in many places; reading back the printed form of any non-trivial function was impossible.
  Fixed at the machinery level: regions of operand-bearing ops parse with the printed
  `^block(...)` headers declaring their entry arguments, trailing variadic operand groups, fixed
  operand-group sizing, multi-name result bindings, labeled block definitions (incl. backward
  branch references), `scf.while` result types, `scf.index_switch` region order, and
  `builtin.ret_imm` immediates.
- **Successor argument lists round-trip too.** Branch targets printed as `^block:(%v)`, a form
  the parser has no grammar for; they now print as `^block(%uses, types)`, the form it accepts.
  This also unblocked `cf.switch`: keyed case parsing, integer attribute parsing, and successor
  group placement (parsed successors previously all landed in one flat group, breaking
  `cases()`/`fallback()` accessors).
- **Tests**: the `structured_control_flow.hir` lit test is rewritten as a canonical print/parse
  fixpoint (it previously had no CHECK lines at all), and new unit tests in `hir`, `scf`, and
  `cf` pin each parser behavior via a `testing::parse_function_fixpoint` helper.
- **Smaller fixes**: frontmatter Rust builds honor an inherited `RUSTUP_TOOLCHAIN` instead of
  forcing the ambient `nightly`; the two debugdump tests use the `XFAIL: *` spelling litcheck
  understands; the `#[component]` no-arguments error names the attribute, matching its committed
  lit expectation.

**Reviewer note**: the printed format changes in two ways — `scf.while` now prints its result
types (functional signature like `scf.if`), and successor arguments print as `^block(%uses,
types)` — so the `.hir` expect files across `dialects/{scf,hir}`, `frontend/wasm`, and
`hir-analysis` were regenerated; their diffs are mechanical.
