### PR TITLE
fix: stack management in `i64::overflowing_add` intrinsic

### DIFF
--- a/codegen/masm/intrinsics/i64.masm
+++ b/codegen/masm/intrinsics/i64.masm
@@ -78,6 +78,12 @@ pub proc overflowing_add # [b_lo, b_hi, a_lo, a_hi]
     and  # [overflow, r_lo, r_hi]
 end
 
+# Adds `b` to `a`, wrapping on overflow.
+pub proc wrapping_add # [b_lo, b_hi, a_lo, a_hi]
+    exec.overflowing_add
+    drop
+end
+
 # Adds `b` to `a`, asserting on overflow.
 pub proc checked_add # [b_lo, b_hi, a_lo, a_hi]
     exec.overflowing_add

--- a/codegen/masm/intrinsics/i64.masm
+++ b/codegen/masm/intrinsics/i64.masm
@@ -72,15 +72,14 @@ pub proc overflowing_add # [b_lo, b_hi, a_lo, a_hi]
     dup.3 dup.5 eq  # [same_sign, sign_r, r_lo, r_hi, sign_a, sign_b]
 
     # signs_differ = sign_r != sign_a
-    dup.4 movup.2 neq  # [signs_differ, same_sign, sign_r, r_lo, r_hi, sign_a, sign_b]
+    dup.4 movup.2 neq  # [signs_differ, same_sign, r_lo, r_hi, sign_a, sign_b]
 
     # overflow = same_sign && signs_differ
-    and  # [overflow, sign_r, r_lo, r_hi, sign_a, sign_b]
+    and  # [overflow, r_lo, r_hi, sign_a, sign_b]
 
-    # drop: sign_b, sign_a, sign_r
-    movup.5 drop
+    # drop: sign_b, sign_a
     movup.4 drop
-    swap drop
+    movup.3 drop
 end
 
 # Adds `b` to `a`, asserting on overflow.

--- a/codegen/masm/intrinsics/i64.masm
+++ b/codegen/masm/intrinsics/i64.masm
@@ -69,17 +69,13 @@ pub proc overflowing_add # [b_lo, b_hi, a_lo, a_hi]
     dup.1 push.SIGN_BIT u32and push.SIGN_BIT eq  # [sign_r, r_lo, r_hi, sign_a, sign_b]
 
     # same_sign = sign_a == sign_b
-    dup.3 dup.5 eq  # [same_sign, sign_r, r_lo, r_hi, sign_a, sign_b]
+    dup.3 movup.5 eq  # [same_sign, sign_r, r_lo, r_hi, sign_a]
 
     # signs_differ = sign_r != sign_a
-    dup.4 movup.2 neq  # [signs_differ, same_sign, r_lo, r_hi, sign_a, sign_b]
+    movup.4 movup.2 neq  # [signs_differ, same_sign, r_lo, r_hi]
 
     # overflow = same_sign && signs_differ
-    and  # [overflow, r_lo, r_hi, sign_a, sign_b]
-
-    # drop: sign_b, sign_a
-    movup.4 drop
-    movup.3 drop
+    and  # [overflow, r_lo, r_hi]
 end
 
 # Adds `b` to `a`, asserting on overflow.

--- a/tests/integration/src/end_to_end/intrinsics/i64_arithmetic.rs
+++ b/tests/integration/src/end_to_end/intrinsics/i64_arithmetic.rs
@@ -123,7 +123,6 @@ fn decode_outputs_i32_i64(stack: &[Felt]) -> Vec<i64> {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1179"]
 fn i64_wrapping_add() {
     let proc_body = r#"
     # Stack: [b_lo, b_hi, a_lo, a_hi]

--- a/tests/integration/src/end_to_end/intrinsics/i64_arithmetic.rs
+++ b/tests/integration/src/end_to_end/intrinsics/i64_arithmetic.rs
@@ -173,7 +173,6 @@ fn i64_wrapping_mul() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1179"]
 fn i64_overflowing_add() {
     let proc_body = r#"
     # Stack: [b_lo, b_hi, a_lo, a_hi]
@@ -273,7 +272,6 @@ fn i64_checked_neg() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1179"]
 fn i64_checked_add() {
     let proc_body = r#"
     # Stack: [b_lo, b_hi, a_lo, a_hi]


### PR DESCRIPTION
~On top of #1178 to have testing infra for `i64` intrinsics.~ `i64` intrinsic tests have been merged.

Closes #1179.

- Fixes stack management in `overflowing_add` intrinsic. This was the cause of previously incorrect results.
- Consumes instead of duplicates operands that will not be used later on.
- Adds `wrapping_add` intrinsic.