### PR TITLE
fix: stack management in intrinsic `i64::overflowing_sub`

### DIFF
--- a/codegen/masm/intrinsics/i64.masm
+++ b/codegen/masm/intrinsics/i64.masm
@@ -109,18 +109,13 @@ pub proc overflowing_sub # [b_lo, b_hi, a_lo, a_hi]
     dup.1 push.SIGN_BIT u32and push.SIGN_BIT eq  # [sign_r, r_lo, r_hi, sign_a, sign_b]
 
     # diff_sign = sign_a != sign_b
-    dup.3 dup.5 neq  # [diff_sign, sign_r, r_lo, r_hi, sign_a, sign_b]
+    dup.3 movup.5 neq  # [diff_sign, sign_r, r_lo, r_hi, sign_a]
 
     # signs_differ = sign_r != sign_a
-    dup.4 movup.2 neq  # [signs_differ, diff_sign, sign_r, r_lo, r_hi, sign_a, sign_b]
+    movup.4 movup.2 neq  # [signs_differ, diff_sign, r_lo, r_hi]
 
     # overflow = diff_sign && signs_differ
-    and  # [overflow, sign_r, r_lo, r_hi, sign_a, sign_b]
-
-    # drop: sign_b, sign_a, sign_r
-    movup.5 drop
-    movup.4 drop
-    swap drop
+    and  # [overflow, r_lo, r_hi]
 end
 
 # Subtracts `b` from `a`, wrapping on overflow.

--- a/tests/integration/src/end_to_end/intrinsics/i64_arithmetic.rs
+++ b/tests/integration/src/end_to_end/intrinsics/i64_arithmetic.rs
@@ -140,7 +140,6 @@ fn i64_wrapping_add() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1181"]
 fn i64_wrapping_sub() {
     let proc_body = r#"
     # Stack: [b_lo, b_hi, a_lo, a_hi]
@@ -193,7 +192,6 @@ fn i64_overflowing_add() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1181"]
 fn i64_overflowing_sub() {
     let proc_body = r#"
     # Stack: [b_lo, b_hi, a_lo, a_hi]
@@ -297,7 +295,6 @@ fn i64_checked_add() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1181"]
 fn i64_checked_sub() {
     let proc_body = r#"
     # Stack: [b_lo, b_hi, a_lo, a_hi]


### PR DESCRIPTION
On top of #1178 to have testing infra for `i64` intrinsics.

Closes #1181

- Fixes stack management in `overflowing_sub` intrinsic. This was the cause of previously incorrect results.
- Consumes instead of duplicates operands that will not be used later on.