### PR TITLE
fix: determine sign by looking at hi limb in `i64::is_signed`

### DIFF
--- a/codegen/masm/intrinsics/i64.masm
+++ b/codegen/masm/intrinsics/i64.masm
@@ -20,7 +20,7 @@ end
 #
 # This function consumes `a`.
 pub proc is_signed # [a_lo, a_hi]
-    swap.1 drop
+    drop
     push.SIGN_BIT u32and push.SIGN_BIT eq
 end
 

--- a/tests/integration/src/end_to_end/intrinsics/i64_arithmetic.rs
+++ b/tests/integration/src/end_to_end/intrinsics/i64_arithmetic.rs
@@ -391,7 +391,6 @@ fn i64_checked_shr() {
 }
 
 #[test]
-#[ignore = "https://github.com/0xMiden/compiler/issues/1187"]
 fn i64_is_signed() {
     let proc_body = r#"
     # Stack: [a_lo, a_hi]


### PR DESCRIPTION
Closes #1187 

Previously the sign was determined by looking at the `lo` limb instead of the `hi` limb.