### PR TITLE
fix(debuginfo): preserve exported type names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2506,9 +2506,9 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.23.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04e2a9fe12abe40a7a3b10f0184ead7105a081d9940d927d32120544a84c2b3"
+checksum = "69f1a80330b3e3d3f98e08817dc6a5e3d90d11ab5e88aa9c0dad5d3b4202598b"
 dependencies = [
  "miden-ace-codegen",
  "miden-core",
@@ -2522,9 +2522,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.23.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df61b8f89bb2736ec7c75ba814396ad190e8fc85ae556be07a407415fccfb3df"
+checksum = "8582d184360be35eb2111a99245f556f43e1066ed09192fbcd0f218c466862a5"
 dependencies = [
  "env_logger",
  "log",
@@ -2540,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.23.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca10f0f9108f30905eb6aaceb536395c03cec3dcd8c089a7551c7d7d75d68415"
+checksum = "ffa307bc2cbd1f0cb74ed58981823f400a433900fb8f963762331fbb8389d5dc"
 dependencies = [
  "aho-corasick",
  "env_logger",
@@ -2653,9 +2653,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.23.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bed17ecc11e59874f4d23a4488f2fc6ea971247b8596ce395300e37e770f4f6"
+checksum = "80657c32850817f5f67dcf114866495a4b055531778b7c26d0602646ce777eb8"
 dependencies = [
  "derive_more",
  "log",
@@ -2675,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.23.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5110dceb0c7590a49bbd5aa398d3234886767c306f86023dd7303f696521c39"
+checksum = "16410655f32f98537afc9ddf57b71cb6d1ca9d980da5f4eea164cafcaf891b2e"
 dependencies = [
  "env_logger",
  "fs-err",
@@ -2813,9 +2813,9 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.23.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68d205f8573f10fcc822c740acae8cb4af74bded9443d54d44a52677f8f97f"
+checksum = "956708ccb2f643db398b4b3d4f8d0baf199b1bfb5e34c8be1cd1bc811c005e8e"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -2925,9 +2925,9 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.23.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b9b1485f221dd3662e6d9f40e380c3511dd5341a84ac1929625c5428bae24b"
+checksum = "f37c21836b40785ce297d363c57740d4e33edcc411f84185a524eddadd5f53c7"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -3012,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.23.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd003f6a1931bfffbf9b97eff40d74af01e5f0739d46b95a5909059252fc3652"
+checksum = "9ece6064beb0582d1c64ba30d0c548c4b7a45f87abae6d69e22fd49c8b343258"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -3028,9 +3028,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.23.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9285c9ab8fea74fa9d0b08b27eb0f7393b36ca3128f177863943a02045742c4b"
+checksum = "ea972ca9e45dbf26aa396367e8508db0f7292adea6f6ddf8d39d0e334285fe2b"
 dependencies = [
  "itertools 0.14.0",
  "miden-air",
@@ -3046,9 +3046,9 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.23.2"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebfdca65a2e1baba65841965b0bccf2c50e2bb05d900eafe9e3b62a1aebb9f0"
+checksum = "5320e7e5b562359bd6161ac752dfe43dd4f69bb06e87f94a21a27bb656e5a20d"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ miden-stdlib-sys = { version = "0.12.0", path = "sdk/stdlib-sys" }
 
 [patch.crates-io]
 #miden-assembly = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }
+#miden-assembly = { path = "../miden-vm/assembly" }
 # miden-debug = { git = "https://github.com/0xMiden/miden-debug", branch = "main" }
 #miden-protocol = { git = "https://github.com/0xMiden/protocol", rev = "a53bbe2209f506df87876c8b9c9a1730214f456b" }
 #miden-standards = { git = "https://github.com/0xMiden/protocol", rev = "a53bbe2209f506df87876c8b9c9a1730214f456b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,15 @@ miden-stdlib-sys = { version = "0.12.0", path = "sdk/stdlib-sys" }
 [patch.crates-io]
 #miden-assembly = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }
 #miden-assembly = { path = "../miden-vm/assembly" }
+#miden-assembly-syntax = { path = "../miden-vm/assembly-syntax" }
+#miden-core = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }
+#miden-core = { path = "../miden-vm/core" }
 # miden-debug = { git = "https://github.com/0xMiden/miden-debug", branch = "main" }
+#miden-debug-types = { path = "../miden-vm/crates/debug/types" }
+#miden-processor = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }
+#miden-processor = { path = "../miden-vm/processor" }
+#miden-mast-package = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }
+#miden-mast-package = { path = "../miden-vm/package" }
 #miden-protocol = { git = "https://github.com/0xMiden/protocol", rev = "a53bbe2209f506df87876c8b9c9a1730214f456b" }
 #miden-standards = { git = "https://github.com/0xMiden/protocol", rev = "a53bbe2209f506df87876c8b9c9a1730214f456b" }
 #miden-tx = { tag = "v0.14.0-beta.4", git = "https://github.com/0xMiden/miden-base" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,17 +167,7 @@ miden-field-repr = { version = "0.12.0", path = "sdk/field-repr/repr" }
 miden-stdlib-sys = { version = "0.12.0", path = "sdk/stdlib-sys" }
 
 [patch.crates-io]
-#miden-assembly = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }
-#miden-assembly = { path = "../miden-vm/assembly" }
-#miden-assembly-syntax = { path = "../miden-vm/assembly-syntax" }
-#miden-core = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }
-#miden-core = { path = "../miden-vm/core" }
 # miden-debug = { git = "https://github.com/0xMiden/miden-debug", branch = "main" }
-#miden-debug-types = { path = "../miden-vm/crates/debug/types" }
-#miden-processor = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }
-#miden-processor = { path = "../miden-vm/processor" }
-#miden-mast-package = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }
-#miden-mast-package = { path = "../miden-vm/package" }
 #miden-protocol = { git = "https://github.com/0xMiden/protocol", rev = "a53bbe2209f506df87876c8b9c9a1730214f456b" }
 #miden-standards = { git = "https://github.com/0xMiden/protocol", rev = "a53bbe2209f506df87876c8b9c9a1730214f456b" }
 #miden-tx = { tag = "v0.14.0-beta.4", git = "https://github.com/0xMiden/miden-base" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ miden-field-repr = { version = "0.12.0", path = "sdk/field-repr/repr" }
 miden-stdlib-sys = { version = "0.12.0", path = "sdk/stdlib-sys" }
 
 [patch.crates-io]
+#miden-assembly = { git = "https://github.com/0xMiden/miden-vm", rev = "614cd7f9b52f45238b0ab59c71ebb49325051e5d" }
 # miden-debug = { git = "https://github.com/0xMiden/miden-debug", branch = "main" }
 #miden-protocol = { git = "https://github.com/0xMiden/protocol", rev = "a53bbe2209f506df87876c8b9c9a1730214f456b" }
 #miden-standards = { git = "https://github.com/0xMiden/protocol", rev = "a53bbe2209f506df87876c8b9c9a1730214f456b" }

--- a/frontend/wasm/src/component/translator.rs
+++ b/frontend/wasm/src/component/translator.rs
@@ -159,6 +159,7 @@ impl<'a> ComponentTranslator<'a> {
         types: &mut ComponentTypesBuilder,
     ) -> WasmResult<FrontendOutput> {
         self.detect_shim_modules(root_component);
+        self.register_component_export_type_names(root_component, types)?;
 
         let mut frame = ComponentFrame::new(root_component.types_ref(), FxHashMap::default());
 
@@ -417,25 +418,24 @@ impl<'a> ComponentTranslator<'a> {
                     "Component aliases are not yet supported"
                 )
             }
-            LocalInitializer::Export(_name, component_item) => {
-                match component_item {
-                    ComponentItem::Func(i) => {
-                        frame.component_funcs.push(frame.component_funcs[*i].clone());
-                    }
-                    ComponentItem::ComponentInstance(_) => {
-                        let unwrap_instance = component_item.unwrap_instance();
-                        self.component_export(frame, types, unwrap_instance)?;
-                    }
-                    ComponentItem::Type(_) => {
-                        // do nothing
-                    }
-                    _ => unsupported_diag!(
-                        self.context.diagnostics(),
-                        "Exporting of {:?} is not yet supported",
-                        component_item
-                    ),
+            LocalInitializer::Export(name, component_item) => match component_item {
+                ComponentItem::Func(i) => {
+                    frame.component_funcs.push(frame.component_funcs[*i].clone());
                 }
-            }
+                ComponentItem::ComponentInstance(_) => {
+                    let unwrap_instance = component_item.unwrap_instance();
+                    self.component_export(frame, types, unwrap_instance)?;
+                }
+                ComponentItem::Type(ty) => {
+                    let ty = types.convert_type(frame.types, *ty).map_err(Report::msg)?;
+                    types.register_type_name(ty, (*name).to_owned());
+                }
+                _ => unsupported_diag!(
+                    self.context.diagnostics(),
+                    "Exporting of {:?} is not yet supported",
+                    component_item
+                ),
+            },
         }
         Ok(())
     }
@@ -449,6 +449,7 @@ impl<'a> ComponentTranslator<'a> {
         let instance = &frame.component_instances[component_instance_idx].unwrap_instantiated();
         let static_component_idx = frame.components[instance.component].index;
         let parsed_component = &self.nested_components[static_component_idx];
+        self.register_component_export_type_names(parsed_component, types)?;
         for (name, item) in parsed_component.exports.iter() {
             if let ComponentItem::Func(f) = item {
                 self.define_component_export_lift_func(
@@ -463,6 +464,21 @@ impl<'a> ComponentTranslator<'a> {
             }
         }
         frame.component_instances.push(ComponentInstanceDef::Export);
+        Ok(())
+    }
+
+    fn register_component_export_type_names(
+        &self,
+        parsed_component: &ParsedComponent<'a>,
+        types: &mut ComponentTypesBuilder,
+    ) -> WasmResult<()> {
+        let component_types = parsed_component.types_ref();
+        for (name, item) in parsed_component.exports.iter() {
+            if let ComponentItem::Type(ty) = item {
+                let ty = types.convert_type(component_types, *ty).map_err(Report::msg)?;
+                types.register_type_name(ty, (*name).to_owned());
+            }
+        }
         Ok(())
     }
 

--- a/frontend/wasm/src/component/types/mod.rs
+++ b/frontend/wasm/src/component/types/mod.rs
@@ -530,7 +530,7 @@ impl ComponentTypesBuilder {
         }
     }
 
-    fn register_type_name(&mut self, ty: TypeDef, name: String) {
+    pub(super) fn register_type_name(&mut self, ty: TypeDef, name: String) {
         match ty {
             TypeDef::Interface(interface_ty) => {
                 self.component_types.interface_type_names.entry(interface_ty).or_insert(name);

--- a/tests/integration/src/sdk/mod.rs
+++ b/tests/integration/src/sdk/mod.rs
@@ -133,11 +133,10 @@ fn assert_component_export_signatures_match_wit(package: &miden_mast_package::Pa
             .as_str(),
         "component-model",
     );
-    let felt_struct = "struct miden:base/core-types@1.0.0/felt {\n    inner : felt}";
-    let compact_felt_struct = "struct miden:base/core-types@1.0.0/felt {inner : felt}";
+    let felt_struct = "struct miden:base/core-types@1.0.0/felt {\n    felt}";
+    let compact_felt_struct = "struct miden:base/core-types@1.0.0/felt {felt}";
     let mixed_struct = format!(
-        "struct mixed-struct {{f : u64, a : {felt_struct}, b : u32, c : {felt_struct}, d : u8, e \
-         : i1, g : u16}}"
+        "struct mixed-struct {{u64, {felt_struct}, u32, {compact_felt_struct}, u8, i1, u16}}"
     );
     let signature = assert_export_signature(component_export, &[&mixed_struct], &mixed_struct);
     assert_struct_field_types(

--- a/tests/integration/src/sdk/mod.rs
+++ b/tests/integration/src/sdk/mod.rs
@@ -133,10 +133,14 @@ fn assert_component_export_signatures_match_wit(package: &miden_mast_package::Pa
             .as_str(),
         "component-model",
     );
-    let felt_struct = "struct miden:base/core-types@1.0.0/felt {\n    felt}";
-    let compact_felt_struct = "struct miden:base/core-types@1.0.0/felt {felt}";
+    let felt_struct = "struct miden:base/core-types@1.0.0/felt {\n    inner : felt}";
+    let compact_felt_struct = "struct miden:base/core-types@1.0.0/felt {inner : felt}";
     let mixed_struct = format!(
-        "struct mixed-struct {{u64, {felt_struct}, u32, {compact_felt_struct}, u8, i1, u16}}"
+        concat!(
+            "struct mixed-struct {{f : u64, a : {felt_struct}, b : u32, ",
+            "c : {felt_struct}, d : u8, e : i1, g : u16}}"
+        ),
+        felt_struct = felt_struct
     );
     let signature = assert_export_signature(component_export, &[&mixed_struct], &mixed_struct);
     assert_struct_field_types(

--- a/tests/integration/src/sdk/mod.rs
+++ b/tests/integration/src/sdk/mod.rs
@@ -133,32 +133,20 @@ fn assert_component_export_signatures_match_wit(package: &miden_mast_package::Pa
             .as_str(),
         "component-model",
     );
-    let mixed_struct = "struct {u64, struct miden:base/core-types@1.0.0/felt {\n    felt}, u32, \
-                        struct miden:base/core-types@1.0.0/felt {felt}, u8, i1, u16}";
-    let signature = assert_export_signature(component_export, &[mixed_struct], mixed_struct);
+    let felt_struct = "struct miden:base/core-types@1.0.0/felt {\n    inner : felt}";
+    let compact_felt_struct = "struct miden:base/core-types@1.0.0/felt {inner : felt}";
+    let mixed_struct = format!(
+        "struct mixed-struct {{f : u64, a : {felt_struct}, b : u32, c : {felt_struct}, d : u8, e \
+         : i1, g : u16}}"
+    );
+    let signature = assert_export_signature(component_export, &[&mixed_struct], &mixed_struct);
     assert_struct_field_types(
         &signature.params[0],
-        &[
-            "u64",
-            "struct miden:base/core-types@1.0.0/felt {felt}",
-            "u32",
-            "struct miden:base/core-types@1.0.0/felt {felt}",
-            "u8",
-            "i1",
-            "u16",
-        ],
+        &["u64", compact_felt_struct, "u32", compact_felt_struct, "u8", "i1", "u16"],
     );
     assert_struct_field_types(
         &signature.results[0],
-        &[
-            "u64",
-            "struct miden:base/core-types@1.0.0/felt {felt}",
-            "u32",
-            "struct miden:base/core-types@1.0.0/felt {felt}",
-            "u8",
-            "i1",
-            "u16",
-        ],
+        &["u64", compact_felt_struct, "u32", compact_felt_struct, "u8", "i1", "u16"],
     );
 }
 

--- a/tests/lit/debugdump/locations-source-loc.rs
+++ b/tests/lit/debugdump/locations-source-loc.rs
@@ -1,18 +1,19 @@
 //! Test that .debug_loc section shows DebugVar entries with source locations
 //! from a real Rust project compiled with debug info.
 //!
-//! XFAIL: *
 //! RUN: env RUSTFLAGS="-Cdebuginfo=2" midenc %s --release --debug full -o %t/out.masp
 //! RUN: miden-objtool dump debug-info %t/out.masp --section locations | filecheck %s
 //!
 //! CHECK: .debug_loc contents (DebugVar entries from MAST):
-//! CHECK: Total DebugVar entries: 4
+//! CHECK: Total DebugVar entries: 8
 //! CHECK: Unique variable names: 3
 //!
 //! Check variable "arg0" - parameter from test_assertion function
 //! CHECK: Variable: "arg0"
-//! CHECK: 1 location entries:
-//! CHECK: FMP-4 (param #1)
+//! CHECK: 3 location entries:
+//! CHECK: FMP-4 (param #1) @ {{.*}}locations-source-loc.rs
+//! CHECK: stack[0] (param #1) @ {{.*}}locations-source-loc.rs
+//! CHECK: stack[0] (param #1) @ {{.*}}locations-source-loc.rs
 //!
 //! Check variable "local3" - from panic handler
 //! CHECK: Variable: "local3"
@@ -21,8 +22,11 @@
 //!
 //! Check variable "x" - parameter from entrypoint function
 //! CHECK: Variable: "x"
-//! CHECK: 2 location entries:
-//! CHECK: FMP-4 (param #1)
+//! CHECK: 4 location entries:
+//! CHECK: FMP-4 (param #1) @ {{.*}}locations-source-loc.rs
+//! CHECK: FMP-4 (param #1) @ {{.*}}locations-source-loc.rs
+//! CHECK: stack[0] (param #1) @ {{.*}}locations-source-loc.rs
+//! CHECK: stack[0] (param #1) @ {{.*}}locations-source-loc.rs
 
 #![no_std]
 #![no_main]

--- a/tests/lit/debugdump/simple.wat
+++ b/tests/lit/debugdump/simple.wat
@@ -2,22 +2,29 @@
 ;;
 ;; RUN: midenc %s --entrypoint=simple::multiply --debug full -o %t/out.masp
 ;; RUN: miden-objtool dump debug-info %t/out.masp | filecheck %s
-;; XFAIL: *
 
-;; CHECK: Name: simple
+;; CHECK: Package Info:
+;; CHECK: Name:    simple:simple
 ;; CHECK-NEXT: Version: 0.0.0
-;; CHECK-NEXT: Kind: library
+;; CHECK-NEXT: Kind:    executable
 
 ;; Check summary section is present
 ;; CHECK: Summary:
 ;; CHECK: Types:
 ;; CHECK: Sources:
 ;; CHECK: Functions:
+;; CHECK: records:   4
+;; CHECK: Found 0 debug variable records
 
-;; Check that we have functions from the WAT
+;; Check that debug functions are present for the emitted code
 ;; CHECK: .debug_functions contents:
-;; CHECK: FUNCTION: add
-;; CHECK: FUNCTION: multiply
+;; CHECK: FUNCTION: ::intrinsics::i32::unchecked_neg
+;; CHECK: FUNCTION: ::intrinsics::i32::is_signed
+;; CHECK: FUNCTION: ::intrinsics::i32::overflowing_mul
+;; CHECK: FUNCTION: ::intrinsics::i32::wrapping_mul
+
+;; CHECK: .debug_loc contents (DebugVar entries from MAST):
+;; CHECK: (no DebugVar entries found)
 
 (module
   (func $add (export "add") (param $a i32) (param $b i32) (result i32)


### PR DESCRIPTION
Preserve the type names and pass it to VM.
The VM fix for it is https://github.com/0xMiden/miden-vm/pull/3269.

Resolves https://github.com/0xMiden/compiler/issues/1198.