### PR TITLE
Don't export internal procedures in the MAST/.masp

### DIFF
--- a/codegen/masm/CHANGELOG.md
+++ b/codegen/masm/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- keep internal component procedures out of compiled MASM package exports
+- keep internal component procedures out of compiled MASM package exports so library packages expose
+  only lifted Component Model wrappers
+- preserve generated component initializer callees in MASM procedure metadata
 
 ## [0.5.1](https://github.com/0xMiden/compiler/compare/midenc-codegen-masm-v0.5.0...midenc-codegen-masm-v0.5.1) - 2025-11-13
 

--- a/codegen/masm/CHANGELOG.md
+++ b/codegen/masm/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- keep internal component procedures out of compiled MASM package exports
+
 ## [0.5.1](https://github.com/0xMiden/compiler/compare/midenc-codegen-masm-v0.5.0...midenc-codegen-masm-v0.5.1) - 2025-11-13
 
 ### Other

--- a/codegen/masm/src/artifact.rs
+++ b/codegen/masm/src/artifact.rs
@@ -17,11 +17,13 @@ pub struct MasmComponent {
     ///
     /// All components must have a canonical root module, even if empty
     pub root: Arc<Path>,
-    /// The symbol name of the component initializer function
+    /// Whether this component requires an initializer procedure.
     ///
-    /// This function is responsible for initializing global variables and writing data segments
+    /// The initializer is responsible for initializing global variables and writing data segments
     /// into memory at program startup, and at cross-context call boundaries (in callee prologue).
-    pub init: Option<masm::InvocationTarget>,
+    /// When set, a private root-local `init` procedure is generated and invoked by the lifted
+    /// export wrappers (and the generated executable entrypoint) via a same-module symbol.
+    pub requires_init: bool,
     /// The symbol name of the program entrypoint, if this component is executable.
     ///
     /// If unset, it indicates that the component is a library, even if it could be made executable.

--- a/codegen/masm/src/artifact.rs
+++ b/codegen/masm/src/artifact.rs
@@ -34,6 +34,11 @@ pub struct MasmComponent {
     pub heap_base: u32,
     /// The address of the `__stack_pointer` global, if such a global has been defined
     pub stack_pointer: Option<u32>,
+    /// Whether non-root support modules are implementation details of the component package.
+    ///
+    /// When true, support modules are statically linked into library packages instead of being
+    /// surfaced as public package modules.
+    pub link_support_modules_privately: bool,
     /// The set of modules in this component
     pub modules: Vec<Arc<masm::Module>>,
 }

--- a/codegen/masm/src/artifact.rs
+++ b/codegen/masm/src/artifact.rs
@@ -1,16 +1,13 @@
 use alloc::sync::Arc;
 use core::fmt;
 
-use miden_assembly::{Path, ast::InvocationTarget};
+use miden_assembly::Path;
 use miden_core::Word;
 use miden_mast_package::Package;
 use midenc_hir::{constants::ConstantData, dialects::builtin, interner::Symbol};
-use midenc_session::{
-    Emit, OutputMode, OutputType, Session, Writer,
-    diagnostics::{IntoDiagnostic, Report, SourceSpan, Span, WrapErr},
-};
+use midenc_session::{Emit, OutputMode, OutputType, Session, Writer, diagnostics::Report};
 
-use crate::{TraceEvent, lower::NativePtr, masm};
+use crate::{lower::NativePtr, masm};
 
 mod project_support;
 
@@ -199,137 +196,6 @@ impl MasmComponent {
             session,
             registry,
         )
-    }
-
-    /// Generate an executable module which when run expects the raw data segment data to be
-    /// provided on the advice stack in the same order as initialization, and the operands of
-    /// the entrypoint function on the operand stack.
-    fn generate_main(
-        &self,
-        entrypoint: &InvocationTarget,
-        emit_test_harness: bool,
-        source_manager: Arc<dyn midenc_session::SourceManager + Send + Sync>,
-    ) -> Result<Box<masm::Module>, Report> {
-        use masm::{Instruction as Inst, Op};
-
-        let mut exe = Box::new(masm::Module::new_executable());
-        let span = SourceSpan::default();
-        let mut invoked = Vec::new();
-        let body = {
-            let mut block = masm::Block::new(span, Vec::with_capacity(64));
-            // Invoke component initializer, if present
-            if let Some(init) = self.init.as_ref() {
-                invoked.push(masm::Invoke::new(masm::InvokeKind::Exec, init.clone()));
-                block.push(Op::Inst(Span::new(span, Inst::Exec(init.clone()))));
-            }
-
-            // Initialize test harness, if requested
-            if emit_test_harness {
-                self.emit_test_harness(&mut block);
-            }
-
-            // Invoke the program entrypoint
-            block.push(Op::Inst(Span::new(
-                span,
-                Inst::Trace(TraceEvent::FrameStart.as_u32().into()),
-            )));
-            invoked.push(masm::Invoke::new(masm::InvokeKind::Exec, entrypoint.clone()));
-            block.push(Op::Inst(Span::new(span, Inst::Exec(entrypoint.clone()))));
-            block
-                .push(Op::Inst(Span::new(span, Inst::Trace(TraceEvent::FrameEnd.as_u32().into()))));
-
-            // Truncate the stack to 16 elements on exit
-            let truncate_stack = {
-                let name = masm::ProcedureName::new("truncate_stack").unwrap();
-                let module = masm::LibraryPath::new("::miden::core::sys").unwrap();
-                let qualified = masm::QualifiedProcedureName::new(module.as_path(), name);
-                InvocationTarget::Path(Span::new(span, qualified.into_inner()))
-            };
-            invoked.push(masm::Invoke::new(masm::InvokeKind::Exec, truncate_stack.clone()));
-            block.push(Op::Inst(Span::new(span, Inst::Exec(truncate_stack))));
-            block
-        };
-        let mut start = masm::Procedure::new(
-            span,
-            masm::Visibility::Public,
-            masm::ProcedureName::main(),
-            0,
-            body,
-        );
-        start.extend_invoked(invoked);
-        exe.define_procedure(start, source_manager)
-            .into_diagnostic()
-            .wrap_err("failed to define executable `main` procedure")?;
-        Ok(exe)
-    }
-
-    fn emit_test_harness(&self, block: &mut masm::Block) {
-        use masm::{Instruction as Inst, IntValue, Op, PushValue};
-        use miden_core::Felt;
-
-        let span = SourceSpan::default();
-
-        let pipe_words_to_memory = {
-            let name = masm::ProcedureName::new("pipe_words_to_memory").unwrap();
-            let module = masm::LibraryPath::new("::miden::core::mem").unwrap();
-            let qualified = masm::QualifiedProcedureName::new(module.as_path(), name);
-            InvocationTarget::Path(Span::new(span, qualified.into_inner()))
-        };
-
-        // Step 1: Get the number of initializers to run
-        // => [inits] on operand stack
-        block.push(Op::Inst(Span::new(span, Inst::AdvPush)));
-
-        // Step 2: Evaluate the initial state of the loop condition `inits > 0`
-        // => [inits, inits]
-        block.push(Op::Inst(Span::new(span, Inst::Dup0)));
-        // => [inits > 0, inits]
-        block.push(Op::Inst(Span::new(span, Inst::Push(PushValue::Int(IntValue::U8(0)).into()))));
-        block.push(Op::Inst(Span::new(span, Inst::Gt)));
-
-        // Step 3: Loop until `inits == 0`
-        let mut loop_body = Vec::with_capacity(16);
-
-        // State of operand stack on entry to `loop_body`: [inits]
-        // State of advice stack on entry to `loop_body`: [dest_ptr, num_words, ...]
-        //
-        // Step 3a: Compute next value of `inits`, i.e. `inits'`
-        // => [inits - 1]
-        loop_body.push(Op::Inst(Span::new(span, Inst::SubImm(Felt::ONE.into()))));
-
-        // Step 3b: Copy initializer data to memory
-        // => [num_words, dest_ptr, inits']
-        loop_body.push(Op::Inst(Span::new(span, Inst::AdvPush)));
-        loop_body.push(Op::Inst(Span::new(span, Inst::AdvPush)));
-        // => [C, B, A, dest_ptr, inits'] on operand stack
-        loop_body
-            .push(Op::Inst(Span::new(span, Inst::Trace(TraceEvent::FrameStart.as_u32().into()))));
-        loop_body.push(Op::Inst(Span::new(span, Inst::Exec(pipe_words_to_memory))));
-        loop_body
-            .push(Op::Inst(Span::new(span, Inst::Trace(TraceEvent::FrameEnd.as_u32().into()))));
-        // Drop C, B, A
-        loop_body.push(Op::Inst(Span::new(span, Inst::DropW)));
-        loop_body.push(Op::Inst(Span::new(span, Inst::DropW)));
-        loop_body.push(Op::Inst(Span::new(span, Inst::DropW)));
-        // => [inits']
-        loop_body.push(Op::Inst(Span::new(span, Inst::Drop)));
-
-        // Step 3c: Evaluate loop condition `inits' > 0`
-        // => [inits', inits']
-        loop_body.push(Op::Inst(Span::new(span, Inst::Dup0)));
-        // => [inits' > 0, inits']
-        loop_body
-            .push(Op::Inst(Span::new(span, Inst::Push(PushValue::Int(IntValue::U8(0)).into()))));
-        loop_body.push(Op::Inst(Span::new(span, Inst::Gt)));
-
-        // Step 4: Enter (or skip) loop
-        block.push(Op::While {
-            span,
-            body: masm::Block::new(span, loop_body),
-        });
-
-        // Step 5: Drop `inits` after loop is evaluated
-        block.push(Op::Inst(Span::new(span, Inst::Drop)));
     }
 }
 

--- a/codegen/masm/src/artifact.rs
+++ b/codegen/masm/src/artifact.rs
@@ -39,7 +39,10 @@ pub struct MasmComponent {
     /// Whether non-root support modules are implementation details of the component package.
     ///
     /// When true, support modules are statically linked into library packages instead of being
-    /// surfaced as public package modules.
+    /// surfaced as public package modules. This static linking — not procedure visibility — is
+    /// what prunes the lowered core Wasm procedures from the package export surface in the common
+    /// (non-synthetic-wrapper) component-library case, because MASM currently lowers `Internal`
+    /// visibility to public.
     pub link_support_modules_privately: bool,
     /// The set of modules in this component
     pub modules: Vec<Arc<masm::Module>>,
@@ -181,6 +184,17 @@ impl fmt::Display for MasmComponent {
 }
 
 impl MasmComponent {
+    /// Get a mutable reference to the component root module (`modules[0]`).
+    ///
+    /// The root module is never cloned during lowering, so the unique reference is guaranteed.
+    pub(crate) fn root_module_mut(&mut self) -> &mut masm::Module {
+        debug_assert!(
+            self.modules[0].path() == self.root.as_ref(),
+            "modules[0] must be the component root module"
+        );
+        Arc::get_mut(&mut self.modules[0]).expect("expected unique reference")
+    }
+
     /// Assemble this component into a Miden package.
     pub fn assemble(
         &self,

--- a/codegen/masm/src/artifact.rs
+++ b/codegen/masm/src/artifact.rs
@@ -24,7 +24,7 @@ pub struct MasmComponent {
     /// When set, a private root-local `init` procedure is generated and invoked by the lifted
     /// export wrappers (and the generated executable entrypoint) via a same-module symbol.
     pub requires_init: bool,
-    /// The symbol name of the program entrypoint, if this component is executable.
+    /// The invocation target for the program entrypoint, if this component is executable.
     ///
     /// If unset, it indicates that the component is a library, even if it could be made executable.
     pub entrypoint: Option<masm::InvocationTarget>,

--- a/codegen/masm/src/artifact/project_support.rs
+++ b/codegen/masm/src/artifact/project_support.rs
@@ -67,13 +67,7 @@ pub(super) fn assemble_with_registry(
         || session.options.target.as_deref().is_some_and(|tname| {
             project_package.executable_targets().iter().any(|t| tname == &**t.name)
         });
-    let sources = prepare_sources(
-        component,
-        &mut assembler,
-        session.get_flag("test_harness"),
-        session,
-        is_executable_target,
-    )?;
+    let sources = prepare_sources(component, &mut assembler, is_executable_target)?;
     let mut project_assembler = assembler.for_project(project_package.clone(), registry)?;
 
     let selector = if is_executable_target {
@@ -115,8 +109,6 @@ fn selected_executable_target_name<'a>(
 fn prepare_sources(
     component: &MasmComponent,
     assembler: &mut Assembler,
-    emit_test_harness: bool,
-    session: &Session,
     generate_executable_main: bool,
 ) -> Result<ProjectSourceInputs, Report> {
     // Intrinsics must be linked into the assembler context directly so they do not become part of
@@ -159,17 +151,6 @@ fn prepare_sources(
         }
 
         support.push(Box::new(Arc::unwrap_or_clone(module.clone())));
-    }
-
-    if generate_executable_main && let Some(entrypoint) = component.entrypoint.as_ref() {
-        // Our generated main module takes precedence here, so move the root module into support
-        support.extend(root);
-        let root = component.generate_main(
-            entrypoint,
-            emit_test_harness,
-            session.source_manager.clone(),
-        )?;
-        return Ok(ProjectSourceInputs { root, support });
     }
 
     let root = root.expect("components must always have a root module");

--- a/codegen/masm/src/artifact/project_support.rs
+++ b/codegen/masm/src/artifact/project_support.rs
@@ -107,8 +107,12 @@ fn prepare_sources(
     assembler: &mut Assembler,
     is_executable_target: bool,
 ) -> Result<ProjectSourceInputs, Report> {
-    // Component library support modules are implementation details, not package exports. They are
-    // only surfaced when assembling a library; executables statically link everything into `main`.
+    // Non-root support modules hold the lowered core Wasm procedures called by lifted wrappers.
+    // For a component library they are implementation details, so statically link them into the
+    // assembler (below) rather than surfacing them as package source. This static linking — not
+    // procedure visibility — is what keeps them off the package export surface, because MASM
+    // currently lowers `Internal` to public. Executable targets and synthetic-wrapper/standalone
+    // components keep them as source inputs instead.
     let link_support_modules_privately =
         !is_executable_target && component.link_support_modules_privately;
 

--- a/codegen/masm/src/artifact/project_support.rs
+++ b/codegen/masm/src/artifact/project_support.rs
@@ -101,7 +101,8 @@ fn selected_executable_target_name<'a>(
     Ok(session.name.as_ref())
 }
 
-/// Prepare the synthetic project target and source inputs used to assemble compiler-generated MASM.
+/// Partition the component's modules into the project root, surfaced support sources, and modules
+/// statically linked into the assembler, producing the source inputs for project assembly.
 fn prepare_sources(
     component: &MasmComponent,
     assembler: &mut Assembler,

--- a/codegen/masm/src/artifact/project_support.rs
+++ b/codegen/masm/src/artifact/project_support.rs
@@ -105,11 +105,12 @@ fn selected_executable_target_name<'a>(
 fn prepare_sources(
     component: &MasmComponent,
     assembler: &mut Assembler,
-    generate_executable_main: bool,
+    is_executable_target: bool,
 ) -> Result<ProjectSourceInputs, Report> {
-    // Component library support modules are implementation details, not package exports.
+    // Component library support modules are implementation details, not package exports. They are
+    // only surfaced when assembling a library; executables statically link everything into `main`.
     let link_support_modules_privately =
-        !generate_executable_main && component.link_support_modules_privately;
+        !is_executable_target && component.link_support_modules_privately;
 
     let mut support = Vec::with_capacity(component.modules.len());
     let mut root = None;

--- a/codegen/masm/src/artifact/project_support.rs
+++ b/codegen/masm/src/artifact/project_support.rs
@@ -121,6 +121,13 @@ fn prepare_sources(
 ) -> Result<ProjectSourceInputs, Report> {
     // Intrinsics must be linked into the assembler context directly so they do not become part of
     // the assembled package surface.
+    let link_support_modules_privately = !generate_executable_main
+        && component
+            .modules
+            .iter()
+            .find(|module| module.path() == component.root.as_ref())
+            .is_some_and(|module| module_has_public_component_export(module));
+
     let mut support = Vec::with_capacity(component.modules.len());
     let mut root = None;
     for module in component.modules.iter() {
@@ -136,6 +143,18 @@ fn prepare_sources(
 
         if module.path() == component.root.as_ref() {
             root = Some(Box::new(Arc::unwrap_or_clone(module.clone())));
+            continue;
+        }
+
+        // Component library support modules contain the lowered core Wasm procedures called by
+        // lifted wrappers, but they are not part of the component package export surface.
+        if link_support_modules_privately {
+            log::debug!(
+                target: "assembly",
+                "adding component support module '{}' to assembler",
+                module.path()
+            );
+            assembler.compile_and_statically_link(module.clone())?;
             continue;
         }
 
@@ -265,4 +284,14 @@ fn recover_wasm_cm_interfaces(lib: &Library) -> BTreeMap<Arc<Path>, LibraryExpor
 /// Return true when the module belongs to the compiler's intrinsics namespace.
 fn is_intrinsics_module(module: &miden_assembly::ast::Module) -> bool {
     module.path().as_str().trim_start_matches("::").starts_with("intrinsics")
+}
+
+/// Return true when `module` contains a public lifted Component Model wrapper.
+fn module_has_public_component_export(module: &masm::Module) -> bool {
+    module.procedures().any(|procedure| {
+        procedure.visibility().is_public()
+            && procedure
+                .signature()
+                .is_some_and(|signature| signature.cc.is_wasm_canonical_abi())
+    })
 }

--- a/codegen/masm/src/artifact/project_support.rs
+++ b/codegen/masm/src/artifact/project_support.rs
@@ -62,11 +62,7 @@ pub(super) fn assemble_with_registry(
         }
     }
 
-    let is_executable_target = session.options.target_type.is_some_and(|tt| tt.is_executable())
-        || project_package.library_target().is_none()
-        || session.options.target.as_deref().is_some_and(|tname| {
-            project_package.executable_targets().iter().any(|t| tname == &**t.name)
-        });
+    let is_executable_target = session.is_executable_target();
     let sources = prepare_sources(component, &mut assembler, is_executable_target)?;
     let mut project_assembler = assembler.for_project(project_package.clone(), registry)?;
 

--- a/codegen/masm/src/artifact/project_support.rs
+++ b/codegen/masm/src/artifact/project_support.rs
@@ -107,8 +107,7 @@ fn prepare_sources(
     assembler: &mut Assembler,
     generate_executable_main: bool,
 ) -> Result<ProjectSourceInputs, Report> {
-    // Intrinsics must be linked into the assembler context directly so they do not become part of
-    // the assembled package surface.
+    // Component library support modules are implementation details, not package exports.
     let link_support_modules_privately =
         !generate_executable_main && component.link_support_modules_privately;
 
@@ -116,6 +115,8 @@ fn prepare_sources(
     let mut root = None;
     for module in component.modules.iter() {
         if is_intrinsics_module(module) {
+            // Intrinsics must be linked into the assembler context directly so they do not become
+            // part of the assembled package surface.
             log::debug!(
                 target: "assembly",
                 "adding intrinsics '{}' to assembler",

--- a/codegen/masm/src/artifact/project_support.rs
+++ b/codegen/masm/src/artifact/project_support.rs
@@ -109,12 +109,8 @@ fn prepare_sources(
 ) -> Result<ProjectSourceInputs, Report> {
     // Intrinsics must be linked into the assembler context directly so they do not become part of
     // the assembled package surface.
-    let link_support_modules_privately = !generate_executable_main
-        && component
-            .modules
-            .iter()
-            .find(|module| module.path() == component.root.as_ref())
-            .is_some_and(|module| module_has_public_component_export(module));
+    let link_support_modules_privately =
+        !generate_executable_main && component.link_support_modules_privately;
 
     let mut support = Vec::with_capacity(component.modules.len());
     let mut root = None;
@@ -261,14 +257,4 @@ fn recover_wasm_cm_interfaces(lib: &Library) -> BTreeMap<Arc<Path>, LibraryExpor
 /// Return true when the module belongs to the compiler's intrinsics namespace.
 fn is_intrinsics_module(module: &miden_assembly::ast::Module) -> bool {
     module.path().as_str().trim_start_matches("::").starts_with("intrinsics")
-}
-
-/// Return true when `module` contains a public lifted Component Model wrapper.
-fn module_has_public_component_export(module: &masm::Module) -> bool {
-    module.procedures().any(|procedure| {
-        procedure.visibility().is_public()
-            && procedure
-                .signature()
-                .is_some_and(|signature| signature.cc.is_wasm_canonical_abi())
-    })
 }

--- a/codegen/masm/src/linker.rs
+++ b/codegen/masm/src/linker.rs
@@ -43,6 +43,12 @@ impl LinkInfo {
         !self.segment_layout.is_empty()
     }
 
+    /// Returns true if the component needs an initializer procedure to populate global variables
+    /// and data segments into memory before its exports run.
+    pub fn requires_init(&self) -> bool {
+        self.has_globals() || self.has_data_segments()
+    }
+
     pub fn globals_layout(&self) -> &GlobalVariableLayout {
         &self.globals_layout
     }

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -71,7 +71,6 @@ impl ToMasmComponent for builtin::World {
         // If we have global variables or data segments, we will require a component initializer
         // function, as well as a module to hold component-level functions such as init
         let requires_init = link_info.has_globals() || link_info.has_data_segments();
-        let init = requires_init.then(|| init_invocation_target("::init", SourceSpan::default()));
 
         // Define the initial component modules set
         //
@@ -103,7 +102,7 @@ impl ToMasmComponent for builtin::World {
         let mut masm_component = MasmComponent {
             id: None,
             root,
-            init,
+            requires_init,
             entrypoint,
             kernel,
             rodata,
@@ -187,9 +186,6 @@ impl ToMasmComponent for builtin::Component {
         // If we have global variables or data segments, we will require a component initializer
         // function, as well as a module to hold component-level functions such as init
         let requires_init = link_info.has_globals() || link_info.has_data_segments();
-        let init = requires_init.then(|| {
-            init_invocation_target(component_path.as_path().to_absolute(), SourceSpan::default())
-        });
 
         // Define the initial component modules set
         //
@@ -221,7 +217,7 @@ impl ToMasmComponent for builtin::Component {
         let mut masm_component = MasmComponent {
             id: Some(id),
             root,
-            init,
+            requires_init,
             entrypoint,
             kernel,
             rodata,
@@ -294,11 +290,11 @@ struct MasmComponentBuilder<'a> {
 impl MasmComponentBuilder<'_> {
     /// Convert the component body to Miden Assembly
     pub fn build(mut self, component: &midenc_hir::Operation) -> Result<(), Report> {
-        use masm::{Instruction as Inst, InvocationTarget, Op};
+        use masm::{Instruction as Inst, Op};
 
         // If a component-level init is required, emit code to initialize the heap before any other
         // initialization code.
-        if self.component.init.is_some() {
+        if self.component.requires_init {
             let span = component.span();
 
             // Heap metadata initialization
@@ -307,12 +303,7 @@ impl MasmComponentBuilder<'_> {
                 span,
                 Inst::Push(masm::Immediate::Value(Span::unknown(heap_base.into()))),
             )));
-            let heap_init = {
-                let name = masm::ProcedureName::new("heap_init").unwrap();
-                let module = masm::LibraryPath::new("::intrinsics::mem").unwrap();
-                let qualified = masm::QualifiedProcedureName::new(module.as_path(), name);
-                InvocationTarget::Path(Span::new(span, qualified.into_inner()))
-            };
+            let heap_init = qualified_procedure_target("::intrinsics::mem", "heap_init", span);
             self.init_body.push(Op::Inst(Span::new(
                 span,
                 Inst::Trace(TraceEvent::FrameStart.as_u32().into()),
@@ -344,7 +335,7 @@ impl MasmComponentBuilder<'_> {
         }
 
         // Finalize the component-level init, if required
-        if self.component.init.is_some() {
+        if self.component.requires_init {
             let init_body = core::mem::take(&mut self.init_body);
             let invoked_from_init = core::mem::take(&mut self.invoked_from_init);
             let root_module =
@@ -370,7 +361,7 @@ impl MasmComponentBuilder<'_> {
         {
             let span = component.span();
             let root = self.component.root.clone();
-            let init = self.component.init.as_ref().map(|_| local_procedure_target("init", span));
+            let init = self.component.requires_init.then(|| local_procedure_target("init", span));
             let entrypoint = localize_root_invocation_target(&entrypoint, root.as_ref());
             let root_module =
                 Arc::get_mut(&mut self.component.modules[0]).expect("expected unique reference");
@@ -444,9 +435,8 @@ impl MasmComponentBuilder<'_> {
         let builder = MasmFunctionBuilder::new(function)?;
         let init = self
             .component
-            .init
-            .as_ref()
-            .map(|_| local_procedure_target("init", function.span()));
+            .requires_init
+            .then(|| local_procedure_target("init", function.span()));
         let procedure = builder.build(
             function,
             self.analysis_manager.nest(function.as_operation_ref()),
@@ -476,7 +466,7 @@ impl MasmComponentBuilder<'_> {
     /// populate the global heap with the data segments of this component, verifying that the
     /// commitments match.
     fn emit_data_segment_initialization(&mut self) {
-        use masm::{Instruction as Inst, InvocationTarget, Op};
+        use masm::{Instruction as Inst, Op};
 
         // Emit data segment initialization code
         //
@@ -484,12 +474,8 @@ impl MasmComponentBuilder<'_> {
         // having been placed in the advice map with the same commitment and encoding used here.
         // The program will fail to execute if this is not set up correctly.
         let span = SourceSpan::default();
-        let pipe_preimage_to_memory = {
-            let name = masm::ProcedureName::new("pipe_preimage_to_memory").unwrap();
-            let module = masm::LibraryPath::new("::miden::core::mem").unwrap();
-            let qualified = masm::QualifiedProcedureName::new(module.as_path(), name);
-            InvocationTarget::Path(Span::new(span, qualified.into_inner()))
-        };
+        let pipe_preimage_to_memory =
+            qualified_procedure_target("::miden::core::mem", "pipe_preimage_to_memory", span);
         for rodata in self.component.rodata.iter() {
             // Push the commitment hash (`COM`) for this data onto the operand stack
 
@@ -554,16 +540,6 @@ fn define_init_procedure(
     Ok(())
 }
 
-/// Build an invocation target for the qualified component initializer procedure.
-fn init_invocation_target(
-    module: impl AsRef<miden_assembly_syntax::Path>,
-    span: SourceSpan,
-) -> masm::InvocationTarget {
-    let name = masm::ProcedureName::new("init").unwrap();
-    let qualified = masm::QualifiedProcedureName::new(module, name);
-    InvocationTarget::Path(Span::new(span, qualified.into_inner()))
-}
-
 /// Define the generated executable `main` procedure in the component root module.
 ///
 /// The generated entry procedure invokes the component initializer, optional VM test harness
@@ -577,6 +553,21 @@ fn define_main_procedure(
     source_manager: Arc<dyn midenc_session::SourceManager + Send + Sync>,
 ) -> Result<(), Report> {
     use masm::{Instruction as Inst, Op};
+
+    // The generated entrypoint claims the reserved `main` procedure name in the component root
+    // module, which also holds the lifted Component Model export wrappers. A component export
+    // named `main` would otherwise surface as an opaque symbol conflict during assembly, so reject
+    // it here with an actionable error.
+    let main_name = masm::ProcedureName::main();
+    if module.procedures().any(|proc| proc.name().as_str() == main_name.as_str()) {
+        return Err(Report::msg(format!(
+            "cannot generate executable entrypoint: component root module '{}' already defines a \
+             procedure named `{}`; rename the conflicting component export or build a library \
+             instead",
+            module.path(),
+            main_name.as_str(),
+        )));
+    }
 
     let mut invoked = Vec::new();
     let body = {
@@ -600,12 +591,8 @@ fn define_main_procedure(
         block.push(Op::Inst(Span::new(span, Inst::Trace(TraceEvent::FrameEnd.as_u32().into()))));
 
         // Truncate the stack to 16 elements on exit
-        let truncate_stack = {
-            let name = masm::ProcedureName::new("truncate_stack").unwrap();
-            let module = masm::LibraryPath::new("::miden::core::sys").unwrap();
-            let qualified = masm::QualifiedProcedureName::new(module.as_path(), name);
-            InvocationTarget::Path(Span::new(span, qualified.into_inner()))
-        };
+        let truncate_stack =
+            qualified_procedure_target("::miden::core::sys", "truncate_stack", span);
         invoked.push(masm::Invoke::new(masm::InvokeKind::Exec, truncate_stack.clone()));
         block.push(Op::Inst(Span::new(span, Inst::Exec(truncate_stack))));
         block
@@ -624,12 +611,8 @@ fn emit_test_harness_initialization(block: &mut masm::Block) {
 
     let span = SourceSpan::default();
 
-    let pipe_words_to_memory = {
-        let name = masm::ProcedureName::new("pipe_words_to_memory").unwrap();
-        let module = masm::LibraryPath::new("::miden::core::mem").unwrap();
-        let qualified = masm::QualifiedProcedureName::new(module.as_path(), name);
-        InvocationTarget::Path(Span::new(span, qualified.into_inner()))
-    };
+    let pipe_words_to_memory =
+        qualified_procedure_target("::miden::core::mem", "pipe_words_to_memory", span);
 
     // Step 1: Get the number of initializers to run
     // => [inits] on operand stack
@@ -702,6 +685,19 @@ fn localize_root_invocation_target(
 /// Build an invocation target for a procedure in the current module.
 fn local_procedure_target(name: &str, span: SourceSpan) -> masm::InvocationTarget {
     masm::InvocationTarget::Symbol(masm::Ident::from_raw_parts(Span::new(span, name.into())))
+}
+
+/// Build an invocation target for a fully-qualified procedure in another module (e.g. a stdlib or
+/// intrinsics procedure referenced by absolute path).
+fn qualified_procedure_target(
+    module: &str,
+    name: &str,
+    span: SourceSpan,
+) -> masm::InvocationTarget {
+    let name = masm::ProcedureName::new(name).unwrap();
+    let module = masm::LibraryPath::new(module).unwrap();
+    let qualified = masm::QualifiedProcedureName::new(module.as_path(), name);
+    InvocationTarget::Path(Span::new(span, qualified.into_inner()))
 }
 
 struct MasmModuleBuilder<'a> {
@@ -909,13 +905,21 @@ impl MasmFunctionBuilder {
             trace_target,
         };
 
-        // For component export functions, invoke the `init` procedure first if needed.
-        // It loads the data segments and global vars into memory.
+        // Component export wrappers (Component Model calling convention) invoke the `init`
+        // procedure first to load data segments and global vars into memory.
+        //
+        // Every such wrapper is lowered in the component root module, where the caller supplies a
+        // root-local `init` target. Support-module functions are never Component Model exports and
+        // always pass `None`, so reaching this branch without a target indicates a broken lowering
+        // invariant rather than a user error.
         if function.signature().cc.is_wasm_canonical_abi()
             && (link_info.has_globals() || link_info.has_data_segments())
         {
             let init = init_target.ok_or_else(|| {
-                Report::msg("component export wrapper requires a root-local init target")
+                Report::msg(
+                    "internal error: Component Model export wrapper lowered without a root-local \
+                     `init` target",
+                )
             })?;
             let span = SourceSpan::default();
             // Add init call to the emitter's target before emitting the function body
@@ -935,12 +939,11 @@ impl MasmFunctionBuilder {
             // Since the VM's `drop` instruction not letting stack size go beyond the 16 elements
             // we most likely end up with stack size > 16 elements at the end.
             // See https://github.com/0xPolygonMiden/miden-vm/blob/c4acf49510fda9ba80f20cee1a9fb1727f410f47/processor/src/stack/mod.rs?plain=1#L226-L253
-            let truncate_stack = {
-                let name = masm::ProcedureName::new("truncate_stack").unwrap();
-                let module = masm::LibraryPath::new("::miden::core::sys").unwrap();
-                let qualified = masm::QualifiedProcedureName::new(module.as_path(), name);
-                InvocationTarget::Path(Span::new(SourceSpan::default(), qualified.into_inner()))
-            };
+            let truncate_stack = qualified_procedure_target(
+                "::miden::core::sys",
+                "truncate_stack",
+                SourceSpan::default(),
+            );
             let span = SourceSpan::default();
             invoked.insert(masm::Invoke::new(masm::InvokeKind::Exec, truncate_stack.clone()));
             body.push(masm::Op::Inst(Span::new(span, masm::Instruction::Exec(truncate_stack))));

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -473,10 +473,16 @@ impl MasmComponentBuilder<'_> {
 
     fn define_function(&mut self, function: &builtin::Function) -> Result<(), Report> {
         let builder = MasmFunctionBuilder::new(function)?;
+        let init = self
+            .component
+            .init
+            .as_ref()
+            .map(|_| local_procedure_target("init", function.span()));
         let procedure = builder.build(
             function,
             self.analysis_manager.nest(function.as_operation_ref()),
             self.link_info,
+            init,
         )?;
 
         let module =
@@ -775,6 +781,7 @@ impl MasmModuleBuilder<'_> {
             function,
             self.analysis_manager.nest(function.as_operation_ref()),
             self.link_info,
+            None,
         )?;
 
         self.module
@@ -892,6 +899,7 @@ impl MasmFunctionBuilder {
         function: &builtin::Function,
         analysis_manager: AnalysisManager,
         link_info: &LinkInfo,
+        init_target: Option<masm::InvocationTarget>,
     ) -> Result<masm::Procedure, Report> {
         use alloc::collections::BTreeSet;
 
@@ -928,17 +936,9 @@ impl MasmFunctionBuilder {
         if function.signature().cc.is_wasm_canonical_abi()
             && (link_info.has_globals() || link_info.has_data_segments())
         {
-            let init = if let Some(id) = link_info.component() {
-                let component_path = id.to_library_path();
-                let name = masm::ProcedureName::new("init").unwrap();
-                let qualified =
-                    masm::QualifiedProcedureName::new(component_path.as_path().to_absolute(), name);
-                InvocationTarget::Path(Span::new(SourceSpan::default(), qualified.into_inner()))
-            } else {
-                let name = masm::ProcedureName::new("init").unwrap();
-                let qualified = masm::QualifiedProcedureName::new("::init", name);
-                InvocationTarget::Path(Span::new(SourceSpan::default(), qualified.into_inner()))
-            };
+            let init = init_target.ok_or_else(|| {
+                Report::msg("component export wrapper requires a root-local init target")
+            })?;
             let span = SourceSpan::default();
             // Add init call to the emitter's target before emitting the function body
             emitter.invoked.insert(masm::Invoke::new(masm::InvokeKind::Exec, init.clone()));

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -97,6 +97,8 @@ impl ToMasmComponent for builtin::World {
         } else {
             None
         };
+        let emit_executable_main = is_executable_target(context.session());
+        let emit_test_harness = context.session().get_flag("test_harness");
 
         // Compute the first page boundary after the end of the globals table (or reserved memory
         // if no globals) to use as the start of the dynamic heap when the program is executed
@@ -125,6 +127,8 @@ impl ToMasmComponent for builtin::World {
             source_manager: context.session().source_manager.clone(),
             init_body: Default::default(),
             invoked_from_init: Default::default(),
+            emit_executable_main,
+            emit_test_harness,
         };
 
         builder.build(self.as_operation())?;
@@ -217,6 +221,8 @@ impl ToMasmComponent for builtin::Component {
         } else {
             None
         };
+        let emit_executable_main = is_executable_target(context.session());
+        let emit_test_harness = context.session().get_flag("test_harness");
 
         // Compute the first page boundary after the end of the globals table (or reserved memory
         // if no globals) to use as the start of the dynamic heap when the program is executed
@@ -245,6 +251,8 @@ impl ToMasmComponent for builtin::Component {
             source_manager: context.session().source_manager.clone(),
             init_body: Default::default(),
             invoked_from_init: Default::default(),
+            emit_executable_main,
+            emit_test_harness,
         };
 
         builder.build(self.as_operation())?;
@@ -286,6 +294,22 @@ fn data_segments_to_rodata(link_info: &LinkInfo) -> Result<Vec<crate::Rodata>, R
     })
 }
 
+/// Return true when this session is compiling a project executable target.
+fn is_executable_target(session: &midenc_session::Session) -> bool {
+    let project_package = session.project.package();
+    session
+        .options
+        .target_type
+        .is_some_and(|target_type| target_type.is_executable())
+        || project_package.library_target().is_none()
+        || session.options.target.as_deref().is_some_and(|target_name| {
+            project_package
+                .executable_targets()
+                .iter()
+                .any(|target| target_name == &**target.name)
+        })
+}
+
 struct MasmComponentBuilder<'a> {
     component: &'a mut MasmComponent,
     analysis_manager: AnalysisManager,
@@ -293,6 +317,8 @@ struct MasmComponentBuilder<'a> {
     source_manager: Arc<dyn midenc_session::SourceManager + Send + Sync>,
     init_body: Vec<masm::Op>,
     invoked_from_init: BTreeSet<masm::Invoke>,
+    emit_executable_main: bool,
+    emit_test_harness: bool,
 }
 
 impl MasmComponentBuilder<'_> {
@@ -353,15 +379,10 @@ impl MasmComponentBuilder<'_> {
             let invoked_from_init = core::mem::take(&mut self.invoked_from_init);
             let root_module =
                 Arc::get_mut(&mut self.component.modules[0]).expect("expected unique reference");
-            let visibility = if module_has_public_component_export(root_module) {
-                masm::Visibility::Private
-            } else {
-                masm::Visibility::Public
-            };
 
             define_init_procedure(
                 root_module,
-                visibility,
+                masm::Visibility::Private,
                 init_body,
                 invoked_from_init,
                 component.span(),
@@ -373,6 +394,27 @@ impl MasmComponentBuilder<'_> {
                 self.init_body.is_empty(),
                 "the need for an 'init' function was not expected, but code was generated for one"
             );
+        }
+
+        if self.emit_executable_main
+            && let Some(entrypoint) = self.component.entrypoint.clone()
+        {
+            let span = component.span();
+            let root = self.component.root.clone();
+            let init = self.component.init.as_ref().map(|_| local_procedure_target("init", span));
+            let entrypoint = localize_root_invocation_target(&entrypoint, root.as_ref());
+            let root_module =
+                Arc::get_mut(&mut self.component.modules[0]).expect("expected unique reference");
+
+            define_main_procedure(
+                root_module,
+                init,
+                entrypoint,
+                self.emit_test_harness,
+                span,
+                self.source_manager.clone(),
+            )
+            .wrap_err("failed to define executable `main` procedure")?;
         }
 
         Ok(())
@@ -538,14 +580,144 @@ fn define_init_procedure(
     Ok(())
 }
 
-/// Return true when `module` contains a public lifted Component Model wrapper.
-fn module_has_public_component_export(module: &masm::Module) -> bool {
-    module.procedures().any(|procedure| {
-        procedure.visibility().is_public()
-            && procedure
-                .signature()
-                .is_some_and(|signature| signature.cc.is_wasm_canonical_abi())
-    })
+/// Define the generated executable entry procedure in the component root module.
+/// Generate an executable module which when run expects the raw data segment data to be
+/// provided on the advice stack in the same order as initialization, and the operands of
+/// the entrypoint function on the operand stack.
+fn define_main_procedure(
+    module: &mut masm::Module,
+    init: Option<masm::InvocationTarget>,
+    entrypoint: masm::InvocationTarget,
+    emit_test_harness: bool,
+    span: SourceSpan,
+    source_manager: Arc<dyn midenc_session::SourceManager + Send + Sync>,
+) -> Result<(), Report> {
+    use masm::{Instruction as Inst, Op};
+
+    let mut invoked = Vec::new();
+    let body = {
+        let mut block = masm::Block::new(span, Vec::with_capacity(64));
+
+        // Invoke component initializer, if present
+        if let Some(init) = init {
+            invoked.push(masm::Invoke::new(masm::InvokeKind::Exec, init.clone()));
+            block.push(Op::Inst(Span::new(span, Inst::Exec(init))));
+        }
+
+        // Initialize test harness, if requested
+        if emit_test_harness {
+            emit_test_harness_initialization(&mut block);
+        }
+
+        // Invoke the program entrypoint
+        block.push(Op::Inst(Span::new(span, Inst::Trace(TraceEvent::FrameStart.as_u32().into()))));
+        invoked.push(masm::Invoke::new(masm::InvokeKind::Exec, entrypoint.clone()));
+        block.push(Op::Inst(Span::new(span, Inst::Exec(entrypoint))));
+        block.push(Op::Inst(Span::new(span, Inst::Trace(TraceEvent::FrameEnd.as_u32().into()))));
+
+        // Truncate the stack to 16 elements on exit
+        let truncate_stack = {
+            let name = masm::ProcedureName::new("truncate_stack").unwrap();
+            let module = masm::LibraryPath::new("::miden::core::sys").unwrap();
+            let qualified = masm::QualifiedProcedureName::new(module.as_path(), name);
+            InvocationTarget::Path(Span::new(span, qualified.into_inner()))
+        };
+        invoked.push(masm::Invoke::new(masm::InvokeKind::Exec, truncate_stack.clone()));
+        block.push(Op::Inst(Span::new(span, Inst::Exec(truncate_stack))));
+        block
+    };
+    let mut main =
+        masm::Procedure::new(span, masm::Visibility::Public, masm::ProcedureName::main(), 0, body);
+    main.extend_invoked(invoked);
+    module.define_procedure(main, source_manager).into_diagnostic()?;
+    Ok(())
+}
+
+/// Emit VM test harness initializer loading into the generated executable entry block.
+fn emit_test_harness_initialization(block: &mut masm::Block) {
+    use masm::{Instruction as Inst, IntValue, Op, PushValue};
+    use miden_core::Felt;
+
+    let span = SourceSpan::default();
+
+    let pipe_words_to_memory = {
+        let name = masm::ProcedureName::new("pipe_words_to_memory").unwrap();
+        let module = masm::LibraryPath::new("::miden::core::mem").unwrap();
+        let qualified = masm::QualifiedProcedureName::new(module.as_path(), name);
+        InvocationTarget::Path(Span::new(span, qualified.into_inner()))
+    };
+
+    // Step 1: Get the number of initializers to run
+    // => [inits] on operand stack
+    block.push(Op::Inst(Span::new(span, Inst::AdvPush)));
+
+    // Step 2: Evaluate the initial state of the loop condition `inits > 0`
+    // => [inits, inits]
+    block.push(Op::Inst(Span::new(span, Inst::Dup0)));
+    // => [inits > 0, inits]
+    block.push(Op::Inst(Span::new(span, Inst::Push(PushValue::Int(IntValue::U8(0)).into()))));
+    block.push(Op::Inst(Span::new(span, Inst::Gt)));
+
+    // Step 3: Loop until `inits == 0`
+    let mut loop_body = Vec::with_capacity(16);
+
+    // State of operand stack on entry to `loop_body`: [inits]
+    // State of advice stack on entry to `loop_body`: [dest_ptr, num_words, ...]
+    //
+    // Step 3a: Compute next value of `inits`, i.e. `inits'`
+    // => [inits - 1]
+    loop_body.push(Op::Inst(Span::new(span, Inst::SubImm(Felt::ONE.into()))));
+
+    // Step 3b: Copy initializer data to memory
+    // => [num_words, dest_ptr, inits']
+    loop_body.push(Op::Inst(Span::new(span, Inst::AdvPush)));
+    loop_body.push(Op::Inst(Span::new(span, Inst::AdvPush)));
+    // => [C, B, A, dest_ptr, inits'] on operand stack
+    loop_body.push(Op::Inst(Span::new(span, Inst::Trace(TraceEvent::FrameStart.as_u32().into()))));
+    loop_body.push(Op::Inst(Span::new(span, Inst::Exec(pipe_words_to_memory))));
+    loop_body.push(Op::Inst(Span::new(span, Inst::Trace(TraceEvent::FrameEnd.as_u32().into()))));
+    // Drop C, B, A
+    loop_body.push(Op::Inst(Span::new(span, Inst::DropW)));
+    loop_body.push(Op::Inst(Span::new(span, Inst::DropW)));
+    loop_body.push(Op::Inst(Span::new(span, Inst::DropW)));
+    // => [inits']
+    loop_body.push(Op::Inst(Span::new(span, Inst::Drop)));
+
+    // Step 3c: Evaluate loop condition `inits' > 0`
+    // => [inits', inits']
+    loop_body.push(Op::Inst(Span::new(span, Inst::Dup0)));
+    // => [inits' > 0, inits']
+    loop_body.push(Op::Inst(Span::new(span, Inst::Push(PushValue::Int(IntValue::U8(0)).into()))));
+    loop_body.push(Op::Inst(Span::new(span, Inst::Gt)));
+
+    // Step 4: Enter (or skip) loop
+    block.push(Op::While {
+        span,
+        body: masm::Block::new(span, loop_body),
+    });
+
+    // Step 5: Drop `inits` after loop is evaluated
+    block.push(Op::Inst(Span::new(span, Inst::Drop)));
+}
+
+/// Convert a root-module absolute invocation target into a local target.
+fn localize_root_invocation_target(
+    target: &masm::InvocationTarget,
+    root: &masm::LibraryPathRef,
+) -> masm::InvocationTarget {
+    if let masm::InvocationTarget::Path(path) = target
+        && path.parent().is_some_and(|parent| parent == root)
+        && let Some(name) = path.last()
+    {
+        return local_procedure_target(name, target.span());
+    }
+
+    target.clone()
+}
+
+/// Build an invocation target for a procedure in the current module.
+fn local_procedure_target(name: &str, span: SourceSpan) -> masm::InvocationTarget {
+    masm::InvocationTarget::Symbol(masm::Ident::from_raw_parts(Span::new(span, name.into())))
 }
 
 struct MasmModuleBuilder<'a> {

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -118,6 +118,7 @@ impl ToMasmComponent for builtin::World {
             rodata,
             heap_base,
             stack_pointer,
+            link_support_modules_privately: false,
             modules,
         };
         let builder = MasmComponentBuilder {
@@ -242,6 +243,7 @@ impl ToMasmComponent for builtin::Component {
             rodata,
             heap_base,
             stack_pointer,
+            link_support_modules_privately: true,
             modules,
         };
         let builder = MasmComponentBuilder {

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -70,7 +70,7 @@ impl ToMasmComponent for builtin::World {
 
         // If we have global variables or data segments, we will require a component initializer
         // function, as well as a module to hold component-level functions such as init
-        let requires_init = link_info.has_globals() || link_info.has_data_segments();
+        let requires_init = link_info.requires_init();
 
         // Define the initial component modules set
         //
@@ -108,6 +108,9 @@ impl ToMasmComponent for builtin::World {
             rodata,
             heap_base,
             stack_pointer,
+            // A World is the standalone/whole-program path: its non-root modules are the package
+            // surface itself, with no lifted-wrapper layer to hide them behind, so they are never
+            // linked privately.
             link_support_modules_privately: false,
             modules,
         };
@@ -185,7 +188,7 @@ impl ToMasmComponent for builtin::Component {
 
         // If we have global variables or data segments, we will require a component initializer
         // function, as well as a module to hold component-level functions such as init
-        let requires_init = link_info.has_globals() || link_info.has_data_segments();
+        let requires_init = link_info.requires_init();
 
         // Define the initial component modules set
         //
@@ -338,8 +341,7 @@ impl MasmComponentBuilder<'_> {
         if self.component.requires_init {
             let init_body = core::mem::take(&mut self.init_body);
             let invoked_from_init = core::mem::take(&mut self.invoked_from_init);
-            let root_module =
-                Arc::get_mut(&mut self.component.modules[0]).expect("expected unique reference");
+            let root_module = self.component.root_module_mut();
 
             define_init_procedure(
                 root_module,
@@ -363,8 +365,7 @@ impl MasmComponentBuilder<'_> {
             let root = self.component.root.clone();
             let init = self.component.requires_init.then(|| local_procedure_target("init", span));
             let entrypoint = localize_root_invocation_target(&entrypoint, root.as_ref());
-            let root_module =
-                Arc::get_mut(&mut self.component.modules[0]).expect("expected unique reference");
+            let root_module = self.component.root_module_mut();
 
             define_main_procedure(
                 root_module,
@@ -444,8 +445,7 @@ impl MasmComponentBuilder<'_> {
             init,
         )?;
 
-        let module =
-            Arc::get_mut(&mut self.component.modules[0]).expect("expected unique reference");
+        let module = self.component.root_module_mut();
         let expected_path_len = if module.path().is_absolute() { 2 } else { 1 };
         assert_eq!(
             module.path().len(),
@@ -558,14 +558,12 @@ fn define_main_procedure(
     // module, which also holds the lifted Component Model export wrappers. A component export
     // named `main` would otherwise surface as an opaque symbol conflict during assembly, so reject
     // it here with an actionable error.
-    let main_name = masm::ProcedureName::main();
-    if module.procedures().any(|proc| proc.name().as_str() == main_name.as_str()) {
+    if module.procedures().any(|proc| proc.name().is_main()) {
         return Err(Report::msg(format!(
             "cannot generate executable entrypoint: component root module '{}' already defines a \
-             procedure named `{}`; rename the conflicting component export or build a library \
+             procedure named `main`; rename the conflicting component export or build a library \
              instead",
             module.path(),
-            main_name.as_str(),
         )));
     }
 
@@ -905,22 +903,13 @@ impl MasmFunctionBuilder {
             trace_target,
         };
 
-        // Component export wrappers (Component Model calling convention) invoke the `init`
-        // procedure first to load data segments and global vars into memory.
-        //
-        // Every such wrapper is lowered in the component root module, where the caller supplies a
-        // root-local `init` target. Support-module functions are never Component Model exports and
-        // always pass `None`, so reaching this branch without a target indicates a broken lowering
-        // invariant rather than a user error.
+        // Component export wrappers (Component Model calling convention) invoke the component
+        // `init` procedure first to load data segments and global vars into memory. The caller
+        // threads a root-local `init` target exactly when initialization is required; support
+        // module functions are never Component Model exports and always pass `None`.
         if function.signature().cc.is_wasm_canonical_abi()
-            && (link_info.has_globals() || link_info.has_data_segments())
+            && let Some(init) = init_target
         {
-            let init = init_target.ok_or_else(|| {
-                Report::msg(
-                    "internal error: Component Model export wrapper lowered without a root-local \
-                     `init` target",
-                )
-            })?;
             let span = SourceSpan::default();
             // Add init call to the emitter's target before emitting the function body
             emitter.invoked.insert(masm::Invoke::new(masm::InvokeKind::Exec, init.clone()));

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -71,16 +71,7 @@ impl ToMasmComponent for builtin::World {
         // If we have global variables or data segments, we will require a component initializer
         // function, as well as a module to hold component-level functions such as init
         let requires_init = link_info.has_globals() || link_info.has_data_segments();
-        let init = if requires_init {
-            let name = masm::ProcedureName::new("init").unwrap();
-            let qualified = masm::QualifiedProcedureName::new("::init", name);
-            Some(masm::InvocationTarget::Path(Span::new(
-                SourceSpan::default(),
-                qualified.into_inner(),
-            )))
-        } else {
-            None
-        };
+        let init = requires_init.then(|| init_invocation_target("::init", SourceSpan::default()));
 
         // Define the initial component modules set
         //
@@ -196,17 +187,9 @@ impl ToMasmComponent for builtin::Component {
         // If we have global variables or data segments, we will require a component initializer
         // function, as well as a module to hold component-level functions such as init
         let requires_init = link_info.has_globals() || link_info.has_data_segments();
-        let init = if requires_init {
-            let name = masm::ProcedureName::new("init").unwrap();
-            let qualified =
-                masm::QualifiedProcedureName::new(component_path.as_path().to_absolute(), name);
-            Some(masm::InvocationTarget::Path(Span::new(
-                SourceSpan::default(),
-                qualified.into_inner(),
-            )))
-        } else {
-            None
-        };
+        let init = requires_init.then(|| {
+            init_invocation_target(component_path.as_path().to_absolute(), SourceSpan::default())
+        });
 
         // Define the initial component modules set
         //
@@ -368,7 +351,6 @@ impl MasmComponentBuilder<'_> {
 
             define_init_procedure(
                 root_module,
-                masm::Visibility::Private,
                 init_body,
                 invoked_from_init,
                 component.span(),
@@ -549,10 +531,9 @@ impl MasmComponentBuilder<'_> {
     }
 }
 
-/// Define a component initializer in `module`.
+/// Define the private component initializer in `module`.
 fn define_init_procedure(
     module: &mut masm::Module,
-    visibility: masm::Visibility,
     body: Vec<masm::Op>,
     invoked: BTreeSet<masm::Invoke>,
     span: SourceSpan,
@@ -561,7 +542,7 @@ fn define_init_procedure(
     let init_name = masm::ProcedureName::new("init").unwrap();
     let mut init = masm::Procedure::new(
         Default::default(),
-        visibility,
+        masm::Visibility::Private,
         init_name,
         0,
         masm::Block::new(span, body),
@@ -570,6 +551,16 @@ fn define_init_procedure(
     init.extend_invoked(invoked);
     module.define_procedure(init, source_manager).into_diagnostic()?;
     Ok(())
+}
+
+/// Build an invocation target for the qualified component initializer procedure.
+fn init_invocation_target(
+    module: impl AsRef<miden_assembly_syntax::Path>,
+    span: SourceSpan,
+) -> masm::InvocationTarget {
+    let name = masm::ProcedureName::new("init").unwrap();
+    let qualified = masm::QualifiedProcedureName::new(module, name);
+    InvocationTarget::Path(Span::new(span, qualified.into_inner()))
 }
 
 /// Define the generated executable `main` procedure in the component root module.

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -349,28 +349,25 @@ impl MasmComponentBuilder<'_> {
 
         // Finalize the component-level init, if required
         if self.component.init.is_some() {
-            let module =
-                Arc::get_mut(&mut self.component.modules[0]).expect("expected unique reference");
-
-            let init_name = masm::ProcedureName::new("init").unwrap();
             let init_body = core::mem::take(&mut self.init_body);
-            let init = masm::Procedure::new(
-                Default::default(),
-                masm::Visibility::Public,
-                init_name,
-                0,
-                masm::Block::new(component.span(), init_body),
-            )
-            .with_signature(masm::FunctionType::new(
-                midenc_hir::CallConv::Fast,
-                vec![],
-                vec![],
-            ));
+            let invoked_from_init = core::mem::take(&mut self.invoked_from_init);
+            let root_module =
+                Arc::get_mut(&mut self.component.modules[0]).expect("expected unique reference");
+            let visibility = if module_has_public_component_export(root_module) {
+                masm::Visibility::Private
+            } else {
+                masm::Visibility::Public
+            };
 
-            module
-                .define_procedure(init, self.source_manager.clone())
-                .into_diagnostic()
-                .wrap_err("failed to define component `init` procedure")?;
+            define_init_procedure(
+                root_module,
+                visibility,
+                init_body,
+                invoked_from_init,
+                component.span(),
+                self.source_manager.clone(),
+            )
+            .wrap_err("failed to define component `init` procedure")?;
         } else {
             assert!(
                 self.init_body.is_empty(),
@@ -516,6 +513,39 @@ impl MasmComponentBuilder<'_> {
             self.init_body.push(Op::Inst(Span::new(span, Inst::Drop)));
         }
     }
+}
+
+/// Define a component initializer in `module`.
+fn define_init_procedure(
+    module: &mut masm::Module,
+    visibility: masm::Visibility,
+    body: Vec<masm::Op>,
+    invoked: BTreeSet<masm::Invoke>,
+    span: SourceSpan,
+    source_manager: Arc<dyn midenc_session::SourceManager + Send + Sync>,
+) -> Result<(), Report> {
+    let init_name = masm::ProcedureName::new("init").unwrap();
+    let mut init = masm::Procedure::new(
+        Default::default(),
+        visibility,
+        init_name,
+        0,
+        masm::Block::new(span, body),
+    )
+    .with_signature(masm::FunctionType::new(midenc_hir::CallConv::Fast, vec![], vec![]));
+    init.extend_invoked(invoked);
+    module.define_procedure(init, source_manager).into_diagnostic()?;
+    Ok(())
+}
+
+/// Return true when `module` contains a public lifted Component Model wrapper.
+fn module_has_public_component_export(module: &masm::Module) -> bool {
+    module.procedures().any(|procedure| {
+        procedure.visibility().is_public()
+            && procedure
+                .signature()
+                .is_some_and(|signature| signature.cc.is_wasm_canonical_abi())
+    })
 }
 
 struct MasmModuleBuilder<'a> {

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -554,19 +554,6 @@ fn define_main_procedure(
 ) -> Result<(), Report> {
     use masm::{Instruction as Inst, Op};
 
-    // The generated entrypoint claims the reserved `main` procedure name in the component root
-    // module, which also holds the lifted Component Model export wrappers. A component export
-    // named `main` would otherwise surface as an opaque symbol conflict during assembly, so reject
-    // it here with an actionable error.
-    if module.procedures().any(|proc| proc.name().is_main()) {
-        return Err(Report::msg(format!(
-            "cannot generate executable entrypoint: component root module '{}' already defines a \
-             procedure named `main`; rename the conflicting component export or build a library \
-             instead",
-            module.path(),
-        )));
-    }
-
     let mut invoked = Vec::new();
     let body = {
         let mut block = masm::Block::new(span, Vec::with_capacity(64));

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -572,10 +572,10 @@ fn define_init_procedure(
     Ok(())
 }
 
-/// Define the generated executable entry procedure in the component root module.
-/// Generate an executable module which when run expects the raw data segment data to be
-/// provided on the advice stack in the same order as initialization, and the operands of
-/// the entrypoint function on the operand stack.
+/// Define the generated executable `main` procedure in the component root module.
+///
+/// The generated entry procedure invokes the component initializer, optional VM test harness
+/// initialization, selected entrypoint, and stack truncation shim in order.
 fn define_main_procedure(
     module: &mut masm::Module,
     init: Option<masm::InvocationTarget>,

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -97,7 +97,7 @@ impl ToMasmComponent for builtin::World {
         } else {
             None
         };
-        let emit_executable_main = is_executable_target(context.session());
+        let emit_executable_main = context.session().is_executable_target();
         let emit_test_harness = context.session().get_flag("test_harness");
 
         // Compute the first page boundary after the end of the globals table (or reserved memory
@@ -221,7 +221,7 @@ impl ToMasmComponent for builtin::Component {
         } else {
             None
         };
-        let emit_executable_main = is_executable_target(context.session());
+        let emit_executable_main = context.session().is_executable_target();
         let emit_test_harness = context.session().get_flag("test_harness");
 
         // Compute the first page boundary after the end of the globals table (or reserved memory
@@ -292,22 +292,6 @@ fn data_segments_to_rodata(link_info: &LinkInfo) -> Result<Vec<crate::Rodata>, R
             }]
         }
     })
-}
-
-/// Return true when this session is compiling a project executable target.
-fn is_executable_target(session: &midenc_session::Session) -> bool {
-    let project_package = session.project.package();
-    session
-        .options
-        .target_type
-        .is_some_and(|target_type| target_type.is_executable())
-        || project_package.library_target().is_none()
-        || session.options.target.as_deref().is_some_and(|target_name| {
-            project_package
-                .executable_targets()
-                .iter()
-                .any(|target| target_name == &**target.name)
-        })
 }
 
 struct MasmComponentBuilder<'a> {

--- a/codegen/masm/src/lower/component.rs
+++ b/codegen/masm/src/lower/component.rs
@@ -217,6 +217,7 @@ impl ToMasmComponent for builtin::Component {
         let heap_base = u32::try_from(heap_base)
             .expect("unable to allocate dynamic heap: global table too large");
         let stack_pointer = link_info.globals_layout().stack_pointer_offset();
+        let link_support_modules_privately = !id.is_synthetic_wrapper();
         let mut masm_component = MasmComponent {
             id: Some(id),
             root,
@@ -226,7 +227,7 @@ impl ToMasmComponent for builtin::Component {
             rodata,
             heap_base,
             stack_pointer,
-            link_support_modules_privately: true,
+            link_support_modules_privately,
             modules,
         };
         let builder = MasmComponentBuilder {

--- a/frontend/wasm/CHANGELOG.md
+++ b/frontend/wasm/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- treat core Wasm exports inside components as implementation details until lifted into Component
+  Model export wrappers
+
 ## [0.5.1](https://github.com/0xMiden/compiler/compare/midenc-frontend-wasm-v0.5.0...midenc-frontend-wasm-v0.5.1) - 2025-11-13
 
 ### Added

--- a/frontend/wasm/src/component/lift_exports.rs
+++ b/frontend/wasm/src/component/lift_exports.rs
@@ -82,9 +82,9 @@ pub fn generate_export_lifting_function(
     let export_func_span = core_export_func_ref.borrow().span();
     let export_func_ident =
         Ident::new(midenc_hir::interner::Symbol::intern(export_func_name), export_func_span);
-    // Make the lowered core WASM export internal so only the lifted wrapper is publicly exported
-    // from the component, while still allowing the component-level wrapper to call across the
-    // nested core module symbol table boundary.
+    // Promote the lowered core WASM export to internal so the lifted wrapper can call across the
+    // nested core module symbol table boundary. Package export pruning happens during MASM package
+    // assembly, since MASM currently lowers internal visibility to public procedure visibility.
     core_module_builder
         .set_function_visibility(core_export_func_path.name().as_str(), Visibility::Internal);
     let core_export_func_sig = core_export_func_ref.borrow().get_signature().clone();

--- a/frontend/wasm/src/component/lift_exports.rs
+++ b/frontend/wasm/src/component/lift_exports.rs
@@ -82,9 +82,9 @@ pub fn generate_export_lifting_function(
     let export_func_span = core_export_func_ref.borrow().span();
     let export_func_ident =
         Ident::new(midenc_hir::interner::Symbol::intern(export_func_name), export_func_span);
-    // Make the lowered core WASM export internal so only the lifted wrapper is
-    // publicly exported from the component, while still allowing the wrapper to
-    // call across the nested core module symbol table boundary.
+    // Make the lowered core WASM export internal so only the lifted wrapper is publicly exported
+    // from the component, while still allowing the component-level wrapper to call across the
+    // nested core module symbol table boundary.
     core_module_builder
         .set_function_visibility(core_export_func_path.name().as_str(), Visibility::Internal);
     let core_export_func_sig = core_export_func_ref.borrow().get_signature().clone();

--- a/frontend/wasm/src/component/translator.rs
+++ b/frontend/wasm/src/component/translator.rs
@@ -654,6 +654,7 @@ impl<'a> ComponentTranslator<'a> {
                 let module_name = parsed_module.module.name().as_str();
                 let module_ref = self.result.define_module(Ident::from(module_name)).unwrap();
                 let mut module_builder = ModuleBuilder::new(module_ref);
+                // Core exports inside a Wasm component are implementation details until lifted.
                 let mut module_state = ModuleTranslationState::new(
                     &parsed_module.module,
                     &mut module_builder,

--- a/frontend/wasm/src/component/translator.rs
+++ b/frontend/wasm/src/component/translator.rs
@@ -4,7 +4,7 @@ use cranelift_entity::PrimaryMap;
 use midenc_frontend_wasm_metadata::{FrontendMetadata, ProtocolExportKind};
 use midenc_hir::{
     self as hir2, BuilderExt, CallConv, Context, FunctionType, FxHashMap, FxHashSet, Ident,
-    SymbolNameComponent, SymbolPath,
+    SymbolNameComponent, SymbolPath, Visibility,
     diagnostics::Report,
     dialects::builtin::{self, ComponentBuilder, ModuleBuilder, World, WorldBuilder},
     formatter::DisplayValues,
@@ -660,6 +660,7 @@ impl<'a> ComponentTranslator<'a> {
                     &mut self.world_builder,
                     module_types,
                     import_canon_lower_args,
+                    Visibility::Private,
                     self.context.diagnostics(),
                 )?;
 

--- a/frontend/wasm/src/module/build_ir.rs
+++ b/frontend/wasm/src/module/build_ir.rs
@@ -78,6 +78,7 @@ pub fn translate_module_as_component(
         &mut world_builder,
         &module_types,
         FxHashMap::default(),
+        Visibility::Public,
         context.diagnostics(),
     )?;
     build_ir_module(&mut parsed_module, &module_types, &mut module_state, config, context)?;

--- a/frontend/wasm/src/module/build_ir.rs
+++ b/frontend/wasm/src/module/build_ir.rs
@@ -72,6 +72,7 @@ pub fn translate_module_as_component(
     let module_ref = cb.define_module(Ident::from(module_name)).unwrap();
 
     let mut module_builder = ModuleBuilder::new(module_ref);
+    // Standalone Wasm module exports are the package surface.
     let mut module_state = ModuleTranslationState::new(
         &parsed_module.module,
         &mut module_builder,

--- a/frontend/wasm/src/module/module_translation_state.rs
+++ b/frontend/wasm/src/module/module_translation_state.rs
@@ -32,12 +32,15 @@ impl<'a> ModuleTranslationState<'a> {
     /// `world_builder` - the Miden IR World builder
     /// `mod_types` - the Miden IR module types builder
     /// `module_args` - the module instantiation arguments, i.e. entities to "fill" module imports
+    /// `exported_func_visibility` - the visibility assigned to functions exported by the core
+    /// Wasm module
     pub fn new(
         module: &Module,
         module_builder: &'a mut ModuleBuilder,
         world_builder: &'a mut WorldBuilder,
         mod_types: &ModuleTypesBuilder,
         module_args: FxHashMap<SymbolPath, ModuleArgument>,
+        exported_func_visibility: Visibility,
         diagnostics: &DiagnosticsHandler,
     ) -> WasmResult<Self> {
         let mut functions = FxHashMap::default();
@@ -53,7 +56,7 @@ impl<'a> ModuleTranslationState<'a> {
                 ],
             };
             let visibility = if module.is_exported(index.into()) {
-                Visibility::Public
+                exported_func_visibility
             } else {
                 Visibility::Private
             };

--- a/midenc-session/src/lib.rs
+++ b/midenc-session/src/lib.rs
@@ -131,7 +131,7 @@ impl Session {
                         };
                         options.target_type = Some(target_type);
                     }
-                    let is_executable_target =
+                    let is_executable_target_type =
                         options.target_type.is_some_and(|ty| ty.is_executable());
                     let project = {
                         let package = project.package();
@@ -144,13 +144,13 @@ impl Session {
                             });
 
                         if has_virtual_executable_target
-                            || (is_cargo_project && is_executable_target)
+                            || (is_cargo_project && is_executable_target_type)
                         {
                             // HACK(pauls): Workaround bug with virtual bin targets until
                             // 0.24.x. See https://github.com/0xMiden/miden-vm/pull/3156
                             miden_project::Project::Package(fixup_targets(
                                 package,
-                                is_cargo_project && is_executable_target,
+                                is_cargo_project && is_executable_target_type,
                             ))
                         } else {
                             project

--- a/midenc-session/src/lib.rs
+++ b/midenc-session/src/lib.rs
@@ -479,6 +479,19 @@ impl Session {
         self.options.output_types.should_assemble() && !self.options.link_only
     }
 
+    /// Returns true if this session is compiling a project executable target.
+    pub fn is_executable_target(&self) -> bool {
+        let project_package = self.project.package();
+        self.options.target_type.is_some_and(|target_type| target_type.is_executable())
+            || project_package.library_target().is_none()
+            || self.options.target.as_deref().is_some_and(|target_name| {
+                project_package
+                    .executable_targets()
+                    .iter()
+                    .any(|target| target_name == &**target.name)
+            })
+    }
+
     /// Returns true if the given [OutputType] should be emitted as an output
     pub fn should_emit(&self, ty: OutputType) -> bool {
         self.options.output_types.contains_key(&ty)

--- a/tests/integration-network/src/mockchain/notes/basic_wallet.rs
+++ b/tests/integration-network/src/mockchain/notes/basic_wallet.rs
@@ -109,7 +109,7 @@ pub fn basic_wallet_p2id_transfers_asset_with_custom_tx_script() {
         .unwrap()
         .foreign_accounts(vec![faucet_inputs]);
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
-    expect!["3327"].assert_eq(prologue_cycles(&tx_measurements));
+    expect!["3309"].assert_eq(prologue_cycles(&tx_measurements));
     expect!["9323"].assert_eq(single_note_cycles(&tx_measurements));
 
     eprintln!("\n=== Checking Alice's account has the minted asset ===");

--- a/tests/integration/src/assert_helpers.rs
+++ b/tests/integration/src/assert_helpers.rs
@@ -33,6 +33,29 @@ pub(crate) fn assert_unique_protocol_export(
     );
 }
 
+/// Assert that every procedure exported by `package` is a lifted Component Model wrapper.
+///
+/// Internal procedures (lowered core Wasm functions, the component `init`, `cabi_*`, intrinsics)
+/// do not use the Component Model calling convention, so this catches such procedures leaking into
+/// the package export surface without having to enumerate the expected export names.
+pub(crate) fn assert_all_exports_are_lifted_wrappers(package: &miden_mast_package::Package) {
+    for export in package.mast.exports() {
+        let Some(proc_export) = export.as_procedure() else {
+            continue;
+        };
+        let is_lifted_wrapper = proc_export
+            .signature
+            .as_ref()
+            .is_some_and(|signature| signature.calling_convention().is_wasm_canonical_abi());
+        assert!(
+            is_lifted_wrapper,
+            "package should export only lifted Component Model wrappers, but `{}` is not one; \
+             internal procedures must not leak into the package export surface",
+            proc_export.path,
+        );
+    }
+}
+
 /// Assert that a package exposes exactly the expected lifted Component Model procedure wrappers.
 pub(crate) fn assert_lifted_component_exports(
     package: &miden_mast_package::Package,
@@ -43,13 +66,10 @@ pub(crate) fn assert_lifted_component_exports(
         .map(|export| (*export).to_string())
         .collect::<BTreeSet<_>>();
 
-    let procedure_exports = package
+    let mast_exports = package
         .mast
         .exports()
         .filter_map(|export| export.as_procedure())
-        .collect::<Vec<_>>();
-    let mast_exports = procedure_exports
-        .iter()
         .map(|export| export.path.as_ref().as_str().to_string())
         .collect::<BTreeSet<_>>();
 
@@ -58,18 +78,7 @@ pub(crate) fn assert_lifted_component_exports(
         "package should only export lifted Component Model wrappers",
     );
 
-    for export in procedure_exports {
-        assert!(
-            export
-                .signature
-                .as_ref()
-                .expect("lifted component export should have a signature")
-                .calling_convention()
-                .is_wasm_canonical_abi(),
-            "export {} should use the Component Model calling convention",
-            export.path
-        );
-    }
+    assert_all_exports_are_lifted_wrappers(package);
 
     let manifest_exports = package
         .manifest

--- a/tests/integration/src/assert_helpers.rs
+++ b/tests/integration/src/assert_helpers.rs
@@ -40,9 +40,17 @@ pub(crate) fn assert_unique_protocol_export(
 /// the package export surface without having to enumerate the expected export names.
 pub(crate) fn assert_all_exports_are_lifted_wrappers(package: &miden_mast_package::Package) {
     for export in package.mast.exports() {
+        // A library package should expose nothing but lifted wrappers, so a non-procedure
+        // (constant/type) export is itself a leak.
         let Some(proc_export) = export.as_procedure() else {
-            continue;
+            panic!(
+                "package should export only lifted Component Model wrappers, but `{}` is a \
+                 non-procedure export",
+                export.path().as_ref().as_str(),
+            );
         };
+        // Only lifted wrappers carry the Component Model calling convention; internal procedures
+        // never do, so the calling convention is a reliable proxy for "is a public package export".
         let is_lifted_wrapper = proc_export
             .signature
             .as_ref()

--- a/tests/integration/src/assert_helpers.rs
+++ b/tests/integration/src/assert_helpers.rs
@@ -1,3 +1,7 @@
+use std::collections::BTreeSet;
+
+use miden_mast_package::PackageExport;
+
 /// Asserts that the exported procedure carrying `attribute` is unique and preserves its leaf
 /// export name.
 pub(crate) fn assert_unique_protocol_export(
@@ -26,5 +30,57 @@ pub(crate) fn assert_unique_protocol_export(
     assert_eq!(
         export_name, expected_export_name,
         "expected the `{attribute}` export to preserve the user-defined procedure name",
+    );
+}
+
+/// Assert that a package exposes exactly the expected lifted Component Model procedure wrappers.
+pub(crate) fn assert_lifted_component_exports(
+    package: &miden_mast_package::Package,
+    expected_exports: &[&str],
+) {
+    let expected_exports = expected_exports
+        .iter()
+        .map(|export| (*export).to_string())
+        .collect::<BTreeSet<_>>();
+
+    let procedure_exports = package
+        .mast
+        .exports()
+        .filter_map(|export| export.as_procedure())
+        .collect::<Vec<_>>();
+    let mast_exports = procedure_exports
+        .iter()
+        .map(|export| export.path.as_ref().as_str().to_string())
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        mast_exports, expected_exports,
+        "package should only export lifted Component Model wrappers",
+    );
+
+    for export in procedure_exports {
+        assert!(
+            export
+                .signature
+                .as_ref()
+                .expect("lifted component export should have a signature")
+                .calling_convention()
+                .is_wasm_canonical_abi(),
+            "export {} should use the Component Model calling convention",
+            export.path
+        );
+    }
+
+    let manifest_exports = package
+        .manifest
+        .exports()
+        .filter_map(|export| match export {
+            PackageExport::Procedure(export) => Some(export.path.as_ref().as_str().to_string()),
+            PackageExport::Constant(_) | PackageExport::Type(_) => None,
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        manifest_exports, expected_exports,
+        "package manifest exports should match MAST exports",
     );
 }

--- a/tests/integration/src/end_to_end/examples/auth_component_no_auth.rs
+++ b/tests/integration/src/end_to_end/examples/auth_component_no_auth.rs
@@ -1,7 +1,10 @@
 use miden_core::serde::{Deserializable, Serializable};
 use midenc_frontend_wasm::WasmTranslationConfig;
 
-use crate::{CompilerTest, assert_helpers::assert_unique_protocol_export};
+use crate::{
+    CompilerTest,
+    assert_helpers::{assert_all_exports_are_lifted_wrappers, assert_unique_protocol_export},
+};
 
 #[test]
 fn auth_component_no_auth() {
@@ -11,6 +14,7 @@ fn auth_component_no_auth() {
     let auth_comp_package = test.compile_package();
     assert!(auth_comp_package.is_library());
     assert_unique_protocol_export(auth_comp_package.as_ref(), "auth_script", "auth-procedure");
+    assert_all_exports_are_lifted_wrappers(auth_comp_package.as_ref());
 
     // Test that the package loads
     let bytes = auth_comp_package.to_bytes();

--- a/tests/integration/src/end_to_end/examples/auth_component_rpo_falcon512.rs
+++ b/tests/integration/src/end_to_end/examples/auth_component_rpo_falcon512.rs
@@ -1,7 +1,10 @@
 use miden_core::serde::{Deserializable, Serializable};
 use midenc_frontend_wasm::WasmTranslationConfig;
 
-use crate::{CompilerTest, assert_helpers::assert_unique_protocol_export};
+use crate::{
+    CompilerTest,
+    assert_helpers::{assert_all_exports_are_lifted_wrappers, assert_unique_protocol_export},
+};
 
 #[test]
 fn auth_component_rpo_falcon512() {
@@ -14,6 +17,7 @@ fn auth_component_rpo_falcon512() {
     let auth_comp_package = test.compile_package();
     assert!(auth_comp_package.is_library());
     assert_unique_protocol_export(auth_comp_package.as_ref(), "auth_script", "check-signature");
+    assert_all_exports_are_lifted_wrappers(auth_comp_package.as_ref());
 
     // Test that the package loads
     let bytes = auth_comp_package.to_bytes();

--- a/tests/integration/src/end_to_end/examples/basic_wallet_package_sizes.rs
+++ b/tests/integration/src/end_to_end/examples/basic_wallet_package_sizes.rs
@@ -18,7 +18,7 @@ fn basic_wallet_and_p2id() {
     );
     let account_package = account_test.compile_package();
     assert!(account_package.is_library(), "expected library");
-    expect!["15614"].assert_eq(stripped_mast_size_str(&account_package));
+    expect!["8045"].assert_eq(stripped_mast_size_str(&account_package));
     persist_cargo_miden_dependency("../../examples/basic-wallet", account_package.as_ref());
 
     let mut tx_script_test = CompilerTest::rust_source_cargo_miden(
@@ -28,7 +28,7 @@ fn basic_wallet_and_p2id() {
     );
     let tx_script_package = tx_script_test.compile_package();
     assert!(tx_script_package.is_library(), "expected library");
-    expect!["19620"].assert_eq(stripped_mast_size_str(&tx_script_package));
+    expect!["16636"].assert_eq(stripped_mast_size_str(&tx_script_package));
 
     let mut p2id_test = CompilerTest::rust_source_cargo_miden(
         "../../examples/p2id-note",
@@ -37,7 +37,7 @@ fn basic_wallet_and_p2id() {
     );
     let note_package = p2id_test.compile_package();
     assert!(note_package.is_library(), "expected library");
-    expect!["19606"].assert_eq(stripped_mast_size_str(&note_package));
+    expect!["16681"].assert_eq(stripped_mast_size_str(&note_package));
 
     let mut p2ide_test = CompilerTest::rust_source_cargo_miden(
         "../../examples/p2ide-note",
@@ -46,5 +46,5 @@ fn basic_wallet_and_p2id() {
     );
     let p2ide_package = p2ide_test.compile_package();
     assert!(p2ide_package.is_library(), "expected library");
-    expect!["22748"].assert_eq(stripped_mast_size_str(&p2ide_package));
+    expect!["19823"].assert_eq(stripped_mast_size_str(&p2ide_package));
 }

--- a/tests/integration/src/end_to_end/examples/basic_wallet_package_sizes.rs
+++ b/tests/integration/src/end_to_end/examples/basic_wallet_package_sizes.rs
@@ -2,7 +2,9 @@ use midenc_expect_test::expect;
 use midenc_frontend_wasm::WasmTranslationConfig;
 
 use super::persist_cargo_miden_dependency;
-use crate::{CompilerTest, testing::stripped_mast_size_str};
+use crate::{
+    CompilerTest, assert_helpers::assert_lifted_component_exports, testing::stripped_mast_size_str,
+};
 
 fn no_debug_flags() -> [String; 2] {
     ["--debug".to_string(), "none".to_string()]
@@ -18,6 +20,13 @@ fn basic_wallet_and_p2id() {
     );
     let account_package = account_test.compile_package();
     assert!(account_package.is_library(), "expected library");
+    assert_lifted_component_exports(
+        account_package.as_ref(),
+        &[
+            r#"::"miden:basic-wallet/miden-basic-wallet@0.1.0"::"move-asset-to-note""#,
+            r#"::"miden:basic-wallet/miden-basic-wallet@0.1.0"::"receive-asset""#,
+        ],
+    );
     expect!["8045"].assert_eq(stripped_mast_size_str(&account_package));
     persist_cargo_miden_dependency("../../examples/basic-wallet", account_package.as_ref());
 
@@ -28,6 +37,10 @@ fn basic_wallet_and_p2id() {
     );
     let tx_script_package = tx_script_test.compile_package();
     assert!(tx_script_package.is_library(), "expected library");
+    assert_lifted_component_exports(
+        tx_script_package.as_ref(),
+        &[r#"::"miden:base/transaction-script@1.0.0"::run"#],
+    );
     expect!["16636"].assert_eq(stripped_mast_size_str(&tx_script_package));
 
     let mut p2id_test = CompilerTest::rust_source_cargo_miden(
@@ -37,6 +50,10 @@ fn basic_wallet_and_p2id() {
     );
     let note_package = p2id_test.compile_package();
     assert!(note_package.is_library(), "expected library");
+    assert_lifted_component_exports(
+        note_package.as_ref(),
+        &[r#"::"miden:p2id/miden-p2id@0.1.0"::script"#],
+    );
     expect!["16681"].assert_eq(stripped_mast_size_str(&note_package));
 
     let mut p2ide_test = CompilerTest::rust_source_cargo_miden(
@@ -46,5 +63,9 @@ fn basic_wallet_and_p2id() {
     );
     let p2ide_package = p2ide_test.compile_package();
     assert!(p2ide_package.is_library(), "expected library");
+    assert_lifted_component_exports(
+        p2ide_package.as_ref(),
+        &[r#"::"miden:p2ide/miden-p2ide@0.1.0"::run"#],
+    );
     expect!["19823"].assert_eq(stripped_mast_size_str(&p2ide_package));
 }

--- a/tests/integration/src/end_to_end/examples/counter_note.rs
+++ b/tests/integration/src/end_to_end/examples/counter_note.rs
@@ -1,62 +1,11 @@
-use std::collections::BTreeSet;
-
-use miden_mast_package::PackageExport;
 use miden_protocol::note::NoteScript;
 use midenc_frontend_wasm::WasmTranslationConfig;
 
 use super::persist_cargo_miden_dependency;
-use crate::{CompilerTestBuilder, assert_helpers::assert_unique_protocol_export};
-
-/// Assert that the counter contract package exposes only lifted Component Model wrappers.
-fn assert_counter_contract_exports_are_lifted_component_wrappers(
-    package: &miden_mast_package::Package,
-) {
-    let expected_exports = BTreeSet::from([
-        r#"::"miden:counter-contract/miden-counter-contract@0.1.0"::"get-count""#.to_string(),
-        r#"::"miden:counter-contract/miden-counter-contract@0.1.0"::"increment-count""#.to_string(),
-    ]);
-
-    let procedure_exports = package
-        .mast
-        .exports()
-        .filter_map(|export| export.as_procedure())
-        .collect::<Vec<_>>();
-    let mast_exports = procedure_exports
-        .iter()
-        .map(|export| export.path.as_ref().as_str().to_string())
-        .collect::<BTreeSet<_>>();
-
-    assert_eq!(
-        mast_exports, expected_exports,
-        "counter-contract should only export lifted Component Model wrappers",
-    );
-
-    for export in procedure_exports {
-        assert!(
-            export
-                .signature
-                .as_ref()
-                .expect("lifted component export should have a signature")
-                .calling_convention()
-                .is_wasm_canonical_abi(),
-            "export {} should use the Component Model calling convention",
-            export.path
-        );
-    }
-
-    let manifest_exports = package
-        .manifest
-        .exports()
-        .filter_map(|export| match export {
-            PackageExport::Procedure(export) => Some(export.path.as_ref().as_str().to_string()),
-            PackageExport::Constant(_) | PackageExport::Type(_) => None,
-        })
-        .collect::<BTreeSet<_>>();
-    assert_eq!(
-        manifest_exports, expected_exports,
-        "counter-contract manifest exports should match MAST exports",
-    );
-}
+use crate::{
+    CompilerTestBuilder,
+    assert_helpers::{assert_lifted_component_exports, assert_unique_protocol_export},
+};
 
 #[test]
 fn counter_note() {
@@ -68,8 +17,12 @@ fn counter_note() {
     );
     let mut counter_contract = counter_contract_builder.build();
     let counter_contract_package = counter_contract.compile_package();
-    assert_counter_contract_exports_are_lifted_component_wrappers(
+    assert_lifted_component_exports(
         counter_contract_package.as_ref(),
+        &[
+            r#"::"miden:counter-contract/miden-counter-contract@0.1.0"::"get-count""#,
+            r#"::"miden:counter-contract/miden-counter-contract@0.1.0"::"increment-count""#,
+        ],
     );
     persist_cargo_miden_dependency(
         "../../examples/counter-contract",

--- a/tests/integration/src/end_to_end/examples/counter_note.rs
+++ b/tests/integration/src/end_to_end/examples/counter_note.rs
@@ -17,6 +17,7 @@ fn counter_note() {
     );
     let mut counter_contract = counter_contract_builder.build();
     let counter_contract_package = counter_contract.compile_package();
+    assert!(counter_contract_package.is_library(), "expected library");
     assert_lifted_component_exports(
         counter_contract_package.as_ref(),
         &[

--- a/tests/integration/src/end_to_end/examples/counter_note.rs
+++ b/tests/integration/src/end_to_end/examples/counter_note.rs
@@ -1,8 +1,62 @@
+use std::collections::BTreeSet;
+
+use miden_mast_package::PackageExport;
 use miden_protocol::note::NoteScript;
 use midenc_frontend_wasm::WasmTranslationConfig;
 
 use super::persist_cargo_miden_dependency;
 use crate::{CompilerTestBuilder, assert_helpers::assert_unique_protocol_export};
+
+/// Assert that the counter contract package exposes only lifted Component Model wrappers.
+fn assert_counter_contract_exports_are_lifted_component_wrappers(
+    package: &miden_mast_package::Package,
+) {
+    let expected_exports = BTreeSet::from([
+        r#"::"miden:counter-contract/miden-counter-contract@0.1.0"::"get-count""#.to_string(),
+        r#"::"miden:counter-contract/miden-counter-contract@0.1.0"::"increment-count""#.to_string(),
+    ]);
+
+    let procedure_exports = package
+        .mast
+        .exports()
+        .filter_map(|export| export.as_procedure())
+        .collect::<Vec<_>>();
+    let mast_exports = procedure_exports
+        .iter()
+        .map(|export| export.path.as_ref().as_str().to_string())
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        mast_exports, expected_exports,
+        "counter-contract should only export lifted Component Model wrappers",
+    );
+
+    for export in procedure_exports {
+        assert!(
+            export
+                .signature
+                .as_ref()
+                .expect("lifted component export should have a signature")
+                .calling_convention()
+                .is_wasm_canonical_abi(),
+            "export {} should use the Component Model calling convention",
+            export.path
+        );
+    }
+
+    let manifest_exports = package
+        .manifest
+        .exports()
+        .filter_map(|export| match export {
+            PackageExport::Procedure(export) => Some(export.path.as_ref().as_str().to_string()),
+            PackageExport::Constant(_) | PackageExport::Type(_) => None,
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        manifest_exports, expected_exports,
+        "counter-contract manifest exports should match MAST exports",
+    );
+}
 
 #[test]
 fn counter_note() {
@@ -14,6 +68,9 @@ fn counter_note() {
     );
     let mut counter_contract = counter_contract_builder.build();
     let counter_contract_package = counter_contract.compile_package();
+    assert_counter_contract_exports_are_lifted_component_wrappers(
+        counter_contract_package.as_ref(),
+    );
     persist_cargo_miden_dependency(
         "../../examples/counter-contract",
         counter_contract_package.as_ref(),

--- a/tests/integration/src/sdk/mod.rs
+++ b/tests/integration/src/sdk/mod.rs
@@ -294,11 +294,6 @@ fn rust_sdk_cross_ctx_account_and_note() {
         .filter(|e| !e.path().as_ref().as_str().starts_with("intrinsics"))
         .map(|e| e.path().as_ref().as_str().to_string())
         .collect::<Vec<_>>();
-    assert!(
-        !lib.exports()
-            .any(|export| export.path().as_ref().as_str().starts_with("intrinsics")),
-        "expected no intrinsics in the exports"
-    );
     let expected_module_prefix = "::\"miden:cross-ctx-account/";
     let expected_function_suffix = "\"process-felt\"";
     assert!(

--- a/tests/integration/src/sdk/mod.rs
+++ b/tests/integration/src/sdk/mod.rs
@@ -11,6 +11,7 @@ use midenc_frontend_wasm::WasmTranslationConfig;
 
 use crate::{
     CompilerTest, CompilerTestBuilder,
+    assert_helpers::assert_all_exports_are_lifted_wrappers,
     cargo_proj::project,
     compiler_test::{sdk_alloc_crate_path, sdk_crate_path},
     testing::executor_with_std,
@@ -286,6 +287,7 @@ fn rust_sdk_cross_ctx_account_and_note() {
     );
     assert!(account_package.is_library());
     assert_manifest_exports_match_library(account_package.as_ref());
+    assert_all_exports_are_lifted_wrappers(account_package.as_ref());
     let lib = account_package.mast.clone();
     let exports = lib
         .exports()
@@ -345,6 +347,7 @@ fn rust_sdk_cross_ctx_account_and_note_word() {
     assert!(account_package.is_library());
     let lib = account_package.mast.clone();
     assert_component_export_signatures_match_wit(account_package.as_ref());
+    assert_all_exports_are_lifted_wrappers(account_package.as_ref());
     let expected_module_prefix = "::\"miden:cross-ctx-account-word/";
     let expected_function_suffix = "\"process-word\"";
     let exports = lib
@@ -398,6 +401,7 @@ fn rust_sdk_cross_ctx_word_arg_account_and_note() {
 
     assert!(account_package.is_library());
     let lib = account_package.mast.clone();
+    assert_all_exports_are_lifted_wrappers(account_package.as_ref());
     let expected_module_prefix = "::\"miden:cross-ctx-account-word-arg/";
     let expected_function_suffix = "\"process-word\"";
     let exports = lib

--- a/tests/support/src/testing/eval.rs
+++ b/tests/support/src/testing/eval.rs
@@ -86,9 +86,9 @@ where
 {
     // Provide initializer data and any user-supplied advice inputs via the advice stack.
     //
-    // NOTE: This relies on MasmComponent emitting a test harness via `emit_test_harness` during
-    // assembly of the package. The test harness consumes initializer inputs in FIFO order from the
-    // advice stack (top = index 0).
+    // NOTE: This relies on MasmComponent emitting a test harness via
+    // `emit_test_harness_initialization` during lowering. The test harness consumes initializer
+    // inputs in FIFO order from the advice stack (top = index 0).
     let user_advice_stack: Vec<Felt> = advice_stack.into_iter().collect();
     let mut advice_stack = Vec::new();
     let mut num_initializers = 0u64;


### PR DESCRIPTION
Close #1197 

Compiled Miden packages now export only the lifted Component Model (CM) wrapper procedures. Internal procedures — lowered core Wasm functions, the component `init`, `cabi_*`, and intrinsics — are kept off the package export surface. Previously they leaked in as public exports.

**Frontend (`frontend/wasm`)**
- Core Wasm exports inside a component are translated as `Private`; the specific core export wrapped by a lifted function is promoted to `Internal` so the wrapper can still resolve it. Standalone (non-component) module exports stay `Public`.

**Codegen (`codegen/masm`)**
- At assembly, non-root support modules are statically linked into the assembler instead of being surfaced as package source, so internal procedures never reach `Library.exports()` and now-unreachable ones are pruned by DCE.
- The component `init` procedure is now a private, root-local procedure, invoked via a same-module symbol from the lifted wrappers and the generated entrypoint.
- Executable `main`/test-harness generation moved from assembly-time into lowering.

**Session (`midenc-session`)**
- Centralized executable-target detection in `Session::is_executable_target()`.

