### PR TITLE
test: compiled Wasm result vs interpreted for some  `i32` arith

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3743,6 +3743,8 @@ dependencies = [
  "quote",
  "sha2 0.11.0",
  "syn 2.0.117",
+ "wasmi",
+ "wat",
 ]
 
 [[package]]
@@ -4728,7 +4730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -4749,7 +4751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5688,6 +5690,16 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "string-interner"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23de088478b31c349c9ba67816fa55d9355232d63c3afea8bf513e31f0f1d2c0"
+dependencies = [
+ "hashbrown 0.15.5",
+ "serde",
+]
 
 [[package]]
 name = "string_cache"
@@ -6769,6 +6781,57 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2300d0f78cba12f14e29e8dd157ea64050c0a688179aefdb2050105805594a0c"
+dependencies = [
+ "spin 0.9.8",
+ "wasmi_collections",
+ "wasmi_core",
+ "wasmi_ir",
+ "wasmparser 0.239.0",
+ "wat",
+]
+
+[[package]]
+name = "wasmi_collections"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a8c42a2a76148d43097b1d7cc2a5bf33d5c23bd4dd69015fc887e311767884"
+dependencies = [
+ "string-interner",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9013136083d988725953390bf668b64b7a218fabf26f8b913bbc59546b97ee27"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1fa003f79156f406d62ef0e1464dc03e11ace37170e9fa7524299a75ad8f68"
+dependencies = [
+ "wasmi_core",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+dependencies = [
+ "bitflags 2.11.1",
+ "indexmap",
 ]
 
 [[package]]

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -47,3 +47,5 @@ blake3 = "1.5"
 cargo_metadata = "0.19"
 concat-idents = "1.1"
 libloading = "0.8"
+wasmi = "1.1.0"
+wat.workspace = true

--- a/tests/integration/src/end_to_end/mod.rs
+++ b/tests/integration/src/end_to_end/mod.rs
@@ -8,3 +8,4 @@ mod intrinsics;
 mod memory;
 mod regressions;
 pub(crate) mod support;
+mod wasm_translation;

--- a/tests/integration/src/end_to_end/wasm_translation/i32.rs
+++ b/tests/integration/src/end_to_end/wasm_translation/i32.rs
@@ -1,0 +1,139 @@
+use std::cell::RefCell;
+
+use miden_core::Felt;
+use miden_processor::{ExecutionOptions, StackInputs, advice::AdviceInputs, execute_sync};
+use midenc_hir::{FunctionIdent, Ident, interner::Symbol};
+use proptest::{
+    prelude::*,
+    test_runner::{TestCaseError, TestError},
+};
+
+use super::wasm_interpreter::WasmInterpreter;
+use crate::{
+    CompilerTestBuilder,
+    end_to_end::support::{NumericStrategy, TrapExpectation, default_host_with_core_lib},
+};
+
+/// Proptest harness for a binary `(i32, i32) -> i32` Wasm operation.
+///
+/// The `wat_op` is executed in a function exported as `entrypoint`.
+fn test_i32_wasm_op_binary<S>(wat_op: &str, strategy: S)
+where
+    S: Strategy<Value = (i32, i32)>,
+{
+    let wat = format!(
+        r#"(module
+  (func $entrypoint (export "entrypoint") (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    local.get $b
+    {wat_op}
+  )
+)"#
+    );
+    let wasm = wat::parse_str(&wat).expect("failed to parse WAT module");
+
+    // Executing a function requires mutable access to the interpreter's store but the proptest
+    // closure is `Fn`.
+    let interpreter = RefCell::new(WasmInterpreter::new(&wasm));
+
+    let mut builder = CompilerTestBuilder::from_wasm("test", wasm, []);
+    builder.with_entrypoint(FunctionIdent {
+        module: Ident::with_empty_span(Symbol::intern("test")),
+        function: Ident::with_empty_span(Symbol::intern("entrypoint")),
+    });
+    let mut test = builder.build();
+    let package = test.compile_package();
+    let program = package.unwrap_program();
+
+    let res = NumericStrategy::<i32>::test_runner().run(&strategy, |(a, b)| {
+        let expected = interpreter
+            .borrow_mut()
+            .call_entrypoint::<(i32, i32), i32>("entrypoint", (a, b));
+
+        // The `(a, b)` entrypoint follows the C calling convention, so pass stack `[a, b]`
+        let stack_inputs = StackInputs::new(&[
+            Felt::new(a as u32 as u64).expect("u32 values fit in a felt"),
+            Felt::new(b as u32 as u64).expect("u32 values fit in a felt"),
+        ])
+        .expect("invalid stack inputs");
+
+        let vm_result = execute_sync(
+            &program,
+            stack_inputs,
+            AdviceInputs::default(),
+            &mut default_host_with_core_lib(),
+            ExecutionOptions::default(),
+        );
+
+        match (expected, vm_result) {
+            (Ok(expected), Ok(output)) => {
+                let outputs: Vec<i32> = output
+                    .stack
+                    .get_num_elements(1)
+                    .iter()
+                    .map(|f| f.as_canonical_u64() as u32 as i32)
+                    .collect();
+                prop_assert_eq!(outputs, vec![expected]);
+                Ok(())
+            }
+            (Err(wasm_err), Err(vm_err)) => {
+                let expected_trap =
+                    TrapExpectation::try_from(&wasm_err).map_err(TestCaseError::fail)?;
+                expected_trap.check(&vm_err).map_err(TestCaseError::fail)
+            }
+            (Ok(expected), Err(vm_err)) => Err(TestCaseError::fail(format!(
+                "expected Miden VM to return {expected}, but it trapped: {vm_err}"
+            ))),
+            (Err(wasm_err), Ok(output)) => {
+                let outputs: Vec<i32> =
+                    output.stack.iter().map(|f| f.as_canonical_u64() as u32 as i32).collect();
+                Err(TestCaseError::fail(format!(
+                    "expected Miden VM to trap ({wasm_err}), but it returned {outputs:?}"
+                )))
+            }
+        }
+    });
+
+    match res {
+        Err(TestError::Fail(reason, value)) => {
+            panic!("Found minimal failing case: {value:?}\n{reason}")
+        }
+        Ok(_) => (),
+        _ => panic!("Unexpected test result: {:?}", res),
+    }
+}
+
+#[test]
+fn i32_add() {
+    test_i32_wasm_op_binary("i32.add", NumericStrategy::<i32>::add_signed());
+}
+
+#[test]
+fn i32_div_s() {
+    test_i32_wasm_op_binary("i32.div_s", NumericStrategy::<i32>::div_signed_checked());
+}
+
+#[test]
+#[ignore = "https://github.com/0xMiden/compiler/issues/1206"]
+fn i32_rem_s() {
+    test_i32_wasm_op_binary("i32.rem_s", NumericStrategy::<i32>::rem_signed_checked());
+}
+
+/// Convert a [`wasmi`] trap into the [`TrapExpectation`] describing the matching Miden VM trap.
+impl<'a> TryFrom<&'a wasmi::Error> for TrapExpectation {
+    type Error = String;
+
+    fn try_from(err: &'a wasmi::Error) -> Result<Self, Self::Error> {
+        use wasmi::TrapCode;
+        match err.as_trap_code() {
+            Some(TrapCode::IntegerDivisionByZero) => Ok(TrapExpectation::DivideByZero),
+            Some(TrapCode::IntegerOverflow) => Ok(TrapExpectation::FailedAssertionOverflow),
+            Some(other) => Err(format!(
+                "no Miden VM trap mapped for wasmi trap {:?}: {}",
+                other,
+                other.trap_message()
+            )),
+            None => Err(format!("wasmi trapped without a trap code: {err:?}")),
+        }
+    }
+}

--- a/tests/integration/src/end_to_end/wasm_translation/mod.rs
+++ b/tests/integration/src/end_to_end/wasm_translation/mod.rs
@@ -1,0 +1,6 @@
+//! Contains tests that interpret Wasm instructions, treating the result of the interpreter as
+//! source of truth. The same instruction is then compiled into a program executable on Miden VM
+//! and it is asserted that executing that program produces the same result/trap as the interpreter.
+
+pub(super) mod i32;
+pub(super) mod wasm_interpreter;

--- a/tests/integration/src/end_to_end/wasm_translation/wasm_interpreter.rs
+++ b/tests/integration/src/end_to_end/wasm_translation/wasm_interpreter.rs
@@ -1,0 +1,40 @@
+use wasmi::{Engine, Error as WasmError, Instance, Linker, Store, WasmParams, WasmResults};
+
+/// An interpreter for a Wasm module that exports an `entrypoint` function with signature
+/// `(i32, i32) -> i32`.
+///
+/// The [`Store`] keeps the [`Engine`] alive for the lifetime of the instance, so the engine does
+/// not need to be stored separately.
+pub(super) struct WasmInterpreter {
+    store: Store<()>,
+    instance: Instance,
+}
+
+impl WasmInterpreter {
+    pub(super) fn new(module: &[u8]) -> Self {
+        let engine = Engine::default();
+        let module =
+            wasmi::Module::new(&engine, module).expect("failed to validate/compile wasm module");
+        let mut store = Store::new(&engine, ());
+        let linker = Linker::<()>::new(&engine);
+        let instance = linker
+            .instantiate_and_start(&mut store, &module)
+            .expect("failed to instantiate wasm module");
+        Self { store, instance }
+    }
+
+    /// Invoke the function with the given `params` and return its result.
+    ///
+    /// Returns an error if the call traps.
+    pub(super) fn call_entrypoint<P, R>(&mut self, fn_name: &str, params: P) -> Result<R, WasmError>
+    where
+        P: WasmParams,
+        R: WasmResults,
+    {
+        let func = self
+            .instance
+            .get_typed_func::<P, R>(&self.store, fn_name)
+            .expect("module must export {fn_name} with a signature matching the requested types");
+        func.call(&mut self.store, params)
+    }
+}

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub use midenc_integration_test_support::{
     self as support, CargoTest, CompilerTest, CompilerTestBuilder, Project, ProjectBuilder,
-    RustcTest, cargo_proj, compiler_test, default_session, project, testing,
+    RustcTest, WasmTest, cargo_proj, compiler_test, default_session, project, testing,
 };
 
 #[cfg(test)]

--- a/tests/support/src/compiler_test.rs
+++ b/tests/support/src/compiler_test.rs
@@ -467,7 +467,7 @@ impl CompilerTestBuilder {
                     session,
                     context,
                     artifact_name: config.module_name,
-                    entrypoint: self.entrypoint.clone(),
+                    entrypoint: self.entrypoint,
                     ..Default::default()
                 }
             }

--- a/tests/support/src/compiler_test.rs
+++ b/tests/support/src/compiler_test.rs
@@ -17,7 +17,7 @@ use midenc_frontend_wasm::WasmTranslationConfig;
 use midenc_hir::{
     Context, FunctionIdent, Ident, Op, demangle::demangle, dialects::builtin, interner::Symbol,
 };
-use midenc_session::{InputFile, Session};
+use midenc_session::{FileName, FileType, InputFile, InputType, Session};
 
 use crate::{
     cargo_proj::project,
@@ -116,17 +116,35 @@ impl RustcTest {
     }
 }
 
+/// Configuration for tests which use Wasm bytes as input
+#[derive(Debug)]
+pub struct WasmTest {
+    /// The module name to address functions. For example `"test"` makes `function entrypoint`
+    /// addressable as `"test::entrypoint"`.
+    pub module_name: Cow<'static, str>,
+    /// Wasm bytes
+    pub wasm: Vec<u8>,
+}
+
 /// The various types of input artifacts that can be used to drive compiler tests
 pub enum CompilerTestInputType {
     /// A project that uses `cargo miden build` to produce a Wasm component to use as input
     CargoMiden(CargoTest),
     /// A project that uses `rustc` to produce a core Wasm module to use as input
     Rustc(RustcTest),
+    /// A project that uses Wasm as input
+    Wasm(WasmTest),
 }
 
 impl From<RustcTest> for CompilerTestInputType {
     fn from(config: RustcTest) -> Self {
         Self::Rustc(config)
+    }
+}
+
+impl From<WasmTest> for CompilerTestInputType {
+    fn from(config: WasmTest) -> Self {
+        Self::Wasm(config)
     }
 }
 
@@ -178,10 +196,12 @@ impl CompilerTestBuilder {
         let entrypoint = match source {
             CompilerTestInputType::Rustc(_) => Some("__main".into()),
             CompilerTestInputType::CargoMiden(ref mut config) => config.entrypoint.take(),
+            CompilerTestInputType::Wasm(_) => None,
         };
         let name = match source {
             CompilerTestInputType::Rustc(ref mut config) => config.name.as_ref(),
             CompilerTestInputType::CargoMiden(ref mut config) => config.name.as_ref(),
+            CompilerTestInputType::Wasm(ref config) => config.module_name.as_ref(),
         };
         let entrypoint = entrypoint.as_deref().map(|entry| FunctionIdent {
             module: Ident::with_empty_span(Symbol::intern(name)),
@@ -262,6 +282,7 @@ impl CompilerTestBuilder {
         match self.source {
             CompilerTestInputType::CargoMiden(ref mut config) => config.release = release,
             CompilerTestInputType::Rustc(_) => (),
+            CompilerTestInputType::Wasm(_) => (),
         }
         self
     }
@@ -273,6 +294,8 @@ impl CompilerTestBuilder {
             | CompilerTestInputType::Rustc(RustcTest { target_dir, .. }) => {
                 *target_dir = Some(path.as_ref().to_path_buf());
             }
+            // Not invoking cargo/rustc
+            CompilerTestInputType::Wasm(_) => (),
         }
         self
     }
@@ -415,6 +438,39 @@ impl CompilerTestBuilder {
                     ..Default::default()
                 }
             }
+
+            CompilerTestInputType::Wasm(config) => {
+                // Provide the Wasm binary via stdin
+                let input = InputFile::new(
+                    FileType::Wasm,
+                    InputType::Stdin {
+                        name: FileName::from(PathBuf::from(format!("{}.wasm", config.module_name))),
+                        input: config.wasm,
+                    },
+                );
+
+                setup::install_reporting_hooks();
+
+                let argv = self.midenc_flags.clone();
+                let mut options = midenc_compile::Compiler::try_parse_from(
+                    std::env::current_dir().unwrap(),
+                    argv,
+                )
+                .expect("invalid compiler options");
+                options.link_modules.extend(self.link_masm_modules);
+                let source_manager = Arc::new(DefaultSourceManager::default());
+                let session = Rc::new(Session::new(input, options, None, source_manager).unwrap());
+                let context = Rc::new(Context::new(session.clone()));
+
+                CompilerTest {
+                    config: self.config,
+                    session,
+                    context,
+                    artifact_name: config.module_name,
+                    entrypoint: self.entrypoint.clone(),
+                    ..Default::default()
+                }
+            }
         }
     }
 }
@@ -436,6 +492,21 @@ impl CompilerTestBuilder {
             CargoTest::new(name, cargo_project_folder.as_ref().to_path_buf()),
         ));
         builder.with_wasm_translation_config(config);
+        builder.with_midenc_flags(midenc_flags);
+        builder
+    }
+
+    /// Compile Wasm using midenc
+    pub fn from_wasm(
+        module_name: impl Into<Cow<'static, str>>,
+        wasm: Vec<u8>,
+        midenc_flags: impl IntoIterator<Item = String>,
+    ) -> Self {
+        let module_name = module_name.into();
+        let mut builder = CompilerTestBuilder::new(WasmTest {
+            module_name: module_name.clone(),
+            wasm,
+        });
         builder.with_midenc_flags(midenc_flags);
         builder
     }
@@ -840,6 +911,15 @@ impl CompilerTest {
     ) -> Self {
         CompilerTestBuilder::rust_source_cargo_miden(cargo_project_folder, config, midenc_flags)
             .build()
+    }
+
+    /// Provide pre-compiled Wasm bytes as input to the compiler.
+    pub fn from_wasm(
+        module_name: impl Into<Cow<'static, str>>,
+        wasm: Vec<u8>,
+        midenc_flags: impl IntoIterator<Item = String>,
+    ) -> Self {
+        CompilerTestBuilder::from_wasm(module_name, wasm, midenc_flags).build()
     }
 
     /// Set the Rust source code to compile

--- a/tests/support/src/lib.rs
+++ b/tests/support/src/lib.rs
@@ -17,6 +17,6 @@ pub use self::cargo_proj::ProjectBuilder;
 /// Generates an on-disk Cargo project in the Cargo target directory for use in tests.
 pub use self::cargo_proj::project;
 pub use self::{
-    compiler_test::{CargoTest, CompilerTest, CompilerTestBuilder, RustcTest},
+    compiler_test::{CargoTest, CompilerTest, CompilerTestBuilder, RustcTest, WasmTest},
     testing::setup::default_session,
 };


### PR DESCRIPTION
Adds test coverage for the `i32` variant of the bug described in #1206. AFAIK there is not yet a test setup to compare the result of:

- Wasm instruction executed/interpreted by Wasm runtime/interpreter
- vs compiling that Wasm instruction and executing it on Miden VM

If you like this approach, I would suggest that eventually we add such tests for most/all Wasm instructions. For now this just covers:

- `i32.add`, `i32.div_s` to show the approach works
- `i32.rem_s` to reproduce #1206 

### Wasm interpreter

Using `wasmi` as it's lightweight and easy to use.