### PR TITLE
feat: add i32 intrinsics `overflowing_mod`, `wrapping_mod`

### DIFF
--- a/codegen/masm/intrinsics/i32.masm
+++ b/codegen/masm/intrinsics/i32.masm
@@ -252,33 +252,60 @@ end
 
 # Computes `a % b`, asserting that both inputs are valid i32.
 #
-# This will trap on division by zero, and on `i32::MIN % -1`.
-pub proc checked_mod # [b, a]
+# Returns the remainder modulo 2^32, plus a boolean indicating whether or not the operation
+# overflowed.
+#
+# This will trap on division by zero. For `i32::MIN % -1` it returns `(overflowed=true, result=0)`
+# because the underlying division overflows.
+pub proc overflowing_mod(b: i32, a: i32) -> (overflowed: i1, result: i32)
     u32assert2
 
-    # trap on i32::MIN % -1, since the underlying division overflows.
+    # check for i32::MIN % -1, which is the only overflow case for signed remainder
     dup.0 push.NEG1 eq          # [b == -1, b, a]
     dup.2 push.MIN eq           # [a == MIN, b == -1, b, a]
-    and assertz                # [b, a]
+    and                         # [overflows, b, a]
+    if.true
+        drop drop push.0 push.1 # [1, 0]
+    else
+        # get positive dividend
+        dup.1 exec.unchecked_neg    # [-a, b, a]
+        dup.2 swap.1                # [-a, a, b, a]
+        movup.3 exec.is_signed      # [is_a_signed, -a, a, b]
+        dup.0 movdn.4 cdrop         # [|a|, b, is_a_signed]
 
-    # get positive dividend
-    dup.1 exec.unchecked_neg    # [-a, b, a]
-    dup.2 swap.1                # [-a, a, b, a]
-    movup.3 exec.is_signed      # [is_a_signed, -a, a, b]
-    dup.0 movdn.4 cdrop         # [|a|, b, is_a_signed]
+        # get positive divisor
+        dup.1 exec.unchecked_neg    # [-b, |a|, b, is_a_signed]
+        dup.2 swap.1                # [-b, b, |a|, b, is_a_signed]
+        movup.3 exec.is_signed      # [is_b_signed, -b, b, |a|, is_a_signed]
+        cdrop                       # [|b|, |a|, is_a_signed]
 
-    # get positive divisor
-    dup.1 exec.unchecked_neg    # [-b, |a|, b, is_a_signed]
-    dup.2 swap.1                # [-b, b, |a|, b, is_a_signed]
-    movup.3 exec.is_signed      # [is_b_signed, -b, b, |a|, is_a_signed]
-    cdrop                       # [|b|, |a|, is_a_signed]
+        u32mod                      # [|a % b|, is_a_signed]
 
-    u32mod                      # [|a % b|, is_a_signed]
+        # apply the dividend's sign to the result
+        dup.0 exec.unchecked_neg     # [neg(|a % b|), |a % b|, is_a_signed]
+        movup.2                      # [is_a_signed, neg(|a % b|), |a % b|]
+        cdrop                        # [result]
 
-    # apply the dividend's sign to the result
-    dup.0 exec.unchecked_neg     # [neg(|a % b|), |a % b|, is_a_signed]
-    movup.2                      # [is_a_signed, neg(|a % b|), |a % b|]
-    cdrop                        # [result]
+        # no overflow in this branch
+        push.0                       # [0, result]
+    end
+end
+
+# Computes `a % b`, asserting that both inputs are valid i32.
+#
+# This will trap on division by zero, and on `i32::MIN % -1`.
+pub proc checked_mod(b: i32, a: i32) -> i32
+    exec.overflowing_mod # [overflowed, result]
+    assertz              # [result]
+end
+
+# Computes `a % b`, wrapping around on overflow.
+#
+# This will trap on division by zero. It will NOT trap on `i32::MIN % -1` instead it wraps and
+# returns 0.
+pub proc wrapping_mod(b: i32, a: i32) -> i32
+    exec.overflowing_mod # [overflowed, result]
+    drop
 end
 
 # Given two i32 values in two's complement representation, compare them,

--- a/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
+++ b/tests/integration/src/end_to_end/intrinsics/i32_arithmetic.rs
@@ -146,6 +146,28 @@ fn i32_overflowing_mul() {
 }
 
 #[test]
+fn i32_overflowing_mod() {
+    let proc_body = r#"
+    # Stack: [b, a]
+    exec.::intrinsics::i32::overflowing_mod
+    # Stack: [overflowed, result]
+"#;
+    test_i32_intrinsic(
+        proc_body,
+        NumericStrategy::<i32>::rem_signed_checked(),
+        binary_i32op_inputs_to_stack,
+        |(a, b): &(i32, i32)| {
+            if *b == 0 {
+                Err(TrapExpectation::DivideByZero)
+            } else {
+                let (result, overflowed) = a.overflowing_rem(*b);
+                Ok(vec![overflowed as i32, result])
+            }
+        },
+    );
+}
+
+#[test]
 fn i32_wrapping_add() {
     let proc_body = r#"
     # Stack: [b, a]
@@ -187,6 +209,27 @@ fn i32_wrapping_mul() {
         NumericStrategy::<i32>::mul_signed(),
         binary_i32op_inputs_to_stack,
         |(a, b): &(i32, i32)| Ok(vec![a.wrapping_mul(*b)]),
+    );
+}
+
+#[test]
+fn i32_wrapping_mod() {
+    let proc_body = r#"
+    # Stack: [b, a]
+    exec.::intrinsics::i32::wrapping_mod
+    # Stack: [result]
+"#;
+    test_i32_intrinsic(
+        proc_body,
+        NumericStrategy::<i32>::rem_signed_checked(),
+        binary_i32op_inputs_to_stack,
+        |(a, b): &(i32, i32)| {
+            if *b == 0 {
+                Err(TrapExpectation::DivideByZero)
+            } else {
+                Ok(vec![a.wrapping_rem(*b)])
+            }
+        },
     );
 }
 

--- a/tests/integration/src/end_to_end/support.rs
+++ b/tests/integration/src/end_to_end/support.rs
@@ -600,6 +600,8 @@ where
             1 => Just((v.max, v.two)),
             1 => Just((v.zero, v.one)),
             1 => Just((v.zero, v.min)),
+            1 => Just((v.one, v.min)),
+            1 => Just((v.two, v.min)),
             1 => Just((v.max, v.zero)),
             1 => Just((v.min, v.zero)),
             1 => Just((v.zero, v.zero)),


### PR DESCRIPTION
- Adds i32 intrinsics `overflowing_mod`, `wrapping_mod`
- Changes `checked_mod` to re-use `wrapping_mod`

### Follow up

Lower Wasm's `i32.rem_s` through `wrapping_mod` instead of `checked_mod` to match Wasm semantics. See #1206 for context. Potentially by adding op `I32RemS` to the Wasm dialect.