### PR TITLE
chore: update SDK version in Cargo.lock in test fixtures and examples

### DIFF
--- a/examples/basic-wallet-tx-script/Cargo.lock
+++ b/examples/basic-wallet-tx-script/Cargo.lock
@@ -967,7 +967,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "heck",
  "miden-assembly-syntax",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
  "miden-field-repr-derive",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr-derive"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
 ]
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm-metadata"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/examples/p2ide-note/Cargo.lock
+++ b/examples/p2ide-note/Cargo.lock
@@ -960,7 +960,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "heck",
  "miden-assembly-syntax",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
  "miden-field-repr-derive",
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr-derive"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
 ]
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm-metadata"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/examples/storage-example/Cargo.lock
+++ b/examples/storage-example/Cargo.lock
@@ -960,7 +960,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "heck",
  "miden-assembly-syntax",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
  "miden-field-repr-derive",
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr-derive"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
 ]
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm-metadata"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/tests/fixtures/components/assert-debug-test/Cargo.lock
+++ b/tests/fixtures/components/assert-debug-test/Cargo.lock
@@ -967,7 +967,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "heck",
  "miden-assembly-syntax",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
  "miden-field-repr-derive",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr-derive"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
 ]
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm-metadata"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/tests/fixtures/components/component-macros-account/Cargo.lock
+++ b/tests/fixtures/components/component-macros-account/Cargo.lock
@@ -967,7 +967,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "heck",
  "miden-assembly-syntax",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
  "miden-field-repr-derive",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr-derive"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
 ]
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm-metadata"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/tests/fixtures/components/cross-ctx-account-word-arg/Cargo.lock
+++ b/tests/fixtures/components/cross-ctx-account-word-arg/Cargo.lock
@@ -967,7 +967,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "heck",
  "miden-assembly-syntax",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
  "miden-field-repr-derive",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr-derive"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
 ]
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm-metadata"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/tests/fixtures/components/cross-ctx-account-word/Cargo.lock
+++ b/tests/fixtures/components/cross-ctx-account-word/Cargo.lock
@@ -967,7 +967,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "heck",
  "miden-assembly-syntax",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
  "miden-field-repr-derive",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr-derive"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
 ]
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm-metadata"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/tests/fixtures/components/cross-ctx-account/Cargo.lock
+++ b/tests/fixtures/components/cross-ctx-account/Cargo.lock
@@ -967,7 +967,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "heck",
  "miden-assembly-syntax",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
  "miden-field-repr-derive",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr-derive"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
 ]
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm-metadata"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/tests/fixtures/components/cross-ctx-note-word-arg/Cargo.lock
+++ b/tests/fixtures/components/cross-ctx-note-word-arg/Cargo.lock
@@ -967,7 +967,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "heck",
  "miden-assembly-syntax",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
  "miden-field-repr-derive",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr-derive"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
 ]
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm-metadata"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/tests/fixtures/components/cross-ctx-note-word/Cargo.lock
+++ b/tests/fixtures/components/cross-ctx-note-word/Cargo.lock
@@ -967,7 +967,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "heck",
  "miden-assembly-syntax",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
  "miden-field-repr-derive",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr-derive"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
 ]
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm-metadata"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/tests/fixtures/components/cross-ctx-note/Cargo.lock
+++ b/tests/fixtures/components/cross-ctx-note/Cargo.lock
@@ -967,7 +967,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "heck",
  "miden-assembly-syntax",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
  "miden-field-repr-derive",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr-derive"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-field",
 ]
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm-metadata"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
Fixes https://github.com/0xMiden/compiler/actions/runs/28454220478/job/84325027839