### PR TITLE
feat(cargo-miden): print the compiled artifact path on build

### DIFF
--- a/docs/external/src/usage/cargo-miden.md
+++ b/docs/external/src/usage/cargo-miden.md
@@ -69,7 +69,8 @@ following command from the root of the project directory:
 cargo miden build --release
 ```
 
-This will emit the compiled artifacts to `target/miden/release/foo.masp`.
+This will emit the compiled artifacts to `target/miden/release/foo.masp`, and print the path of
+the compiled Miden package on success.
 
 ## Running a compiled Miden VM program
 

--- a/tools/cargo-miden/src/main.rs
+++ b/tools/cargo-miden/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Ok;
+use cargo_miden::CommandOutput;
 
 fn main() -> anyhow::Result<()> {
     // Initialize logger
@@ -7,9 +7,17 @@ fn main() -> anyhow::Result<()> {
     builder.format_timestamp(None);
     builder.init();
 
-    if let Err(e) = cargo_miden::run(std::env::args()) {
-        eprintln!("{e:?}");
-        std::process::exit(1);
+    match cargo_miden::run(std::env::args()) {
+        Ok(Some(CommandOutput::BuildCommandOutput { output })) => {
+            for artifact_path in output {
+                println!("Compiled {}", artifact_path.display());
+            }
+        }
+        Ok(_) => {}
+        Err(e) => {
+            eprintln!("{e:?}");
+            std::process::exit(1);
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
Closes #1237

A successful `cargo miden build` gave no indication of where the compiled package was written, leaving users to hunt for the .masp file under `target/miden/<profile>/` on their own.

