### PR TITLE
fix: temporarily suppress UntrustedMastForest error logs from miden-core

### DIFF
--- a/midenc-log/src/lib.rs
+++ b/midenc-log/src/lib.rs
@@ -315,6 +315,7 @@
 
 pub mod filter;
 mod logger;
+mod suppress;
 mod writer;
 
 pub mod fmt;
@@ -322,6 +323,7 @@ pub mod fmt;
 pub use self::{
     fmt::{Target, TimestampPrecision, WriteStyle},
     logger::*,
+    suppress::SuppressKnownDependencyErrors,
 };
 
 #[doc = include_str!("../README.md")]

--- a/midenc-log/src/suppress.rs
+++ b/midenc-log/src/suppress.rs
@@ -1,0 +1,103 @@
+//! Temporary suppression of known-harmless log records emitted by dependencies of the Miden
+//! compiler binaries.
+
+use log::{Log, Metadata, Record};
+
+/// The `log` target of the suppressed [`SUPPRESSED_DEPENDENCY_ERROR_MESSAGES`] records.
+const SUPPRESSED_DEPENDENCY_ERRORS_TARGET: &str = "miden_core::mast::serialization";
+
+/// Error records emitted by the `miden-core` dependency when deserializing Miden packages whose
+/// MAST includes node hashes and debug info (as the packages produced by the compiler do). They
+/// are harmless: validation simply recomputes and checks the hashes.
+///
+/// TODO: Remove this suppression once the compiler migrates to the Miden VM release that no
+/// longer emits these records (see https://github.com/0xMiden/compiler/issues/1211).
+const SUPPRESSED_DEPENDENCY_ERROR_MESSAGES: [&str; 2] = [
+    "UntrustedMastForest expected HASHLESS input; supplied artifact includes wire node hashes, \
+     and validation will recompute them and require them to match",
+    "UntrustedMastForest expected STRIPPED input; supplied artifact includes DebugInfo and other \
+     optional payloads over the wire",
+];
+
+/// Returns `true` if the record is one of the suppressed dependency errors.
+fn is_suppressed(record: &Record<'_>) -> bool {
+    record.level() == log::Level::Error
+        && record.target() == SUPPRESSED_DEPENDENCY_ERRORS_TARGET
+        && SUPPRESSED_DEPENDENCY_ERROR_MESSAGES.contains(&record.args().to_string().as_str())
+}
+
+/// A [`Log`] adapter that drops the known-harmless dependency error records and forwards
+/// everything else to the wrapped logger.
+pub struct SuppressKnownDependencyErrors<L>(L);
+
+impl<L: Log> SuppressKnownDependencyErrors<L> {
+    /// Wraps `logger`, dropping the known-harmless dependency error records.
+    pub fn new(logger: L) -> Self {
+        Self(logger)
+    }
+}
+
+impl<L: Log> Log for SuppressKnownDependencyErrors<L> {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        self.0.enabled(metadata)
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if !is_suppressed(record) {
+            self.0.log(record);
+        }
+    }
+
+    fn flush(&self) {
+        self.0.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The suppressed messages as single-line literals copied verbatim from the `miden-core`
+    /// sources, so they can be compared against the dependency with a simple grep.
+    #[rustfmt::skip]
+    const VERBATIM_MESSAGES: [&str; 2] = [
+        "UntrustedMastForest expected HASHLESS input; supplied artifact includes wire node hashes, and validation will recompute them and require them to match",
+        "UntrustedMastForest expected STRIPPED input; supplied artifact includes DebugInfo and other optional payloads over the wire",
+    ];
+
+    /// Returns `true` if a record with the given level, target and message is suppressed.
+    fn is_suppressed(level: log::Level, target: &str, message: &str) -> bool {
+        super::is_suppressed(
+            &Record::builder()
+                .level(level)
+                .target(target)
+                .args(format_args!("{message}"))
+                .build(),
+        )
+    }
+
+    /// Verifies that the multi-line message constants match the `miden-core` sources exactly.
+    #[test]
+    fn suppressed_messages_match_miden_core_sources() {
+        assert_eq!(SUPPRESSED_DEPENDENCY_ERROR_MESSAGES, VERBATIM_MESSAGES);
+    }
+
+    #[test]
+    fn suppresses_known_dependency_errors() {
+        for message in VERBATIM_MESSAGES {
+            assert!(is_suppressed(log::Level::Error, "miden_core::mast::serialization", message));
+        }
+    }
+
+    #[test]
+    fn passes_through_other_records() {
+        // A different message from the same module at the same level is not suppressed.
+        assert!(!is_suppressed(
+            log::Level::Error,
+            "miden_core::mast::serialization",
+            "failed to deserialize MAST forest",
+        ));
+        // The known messages coming from another module are not suppressed.
+        assert!(!is_suppressed(log::Level::Error, "other_crate::module", VERBATIM_MESSAGES[1]));
+    }
+}

--- a/midenc/src/main.rs
+++ b/midenc/src/main.rs
@@ -29,8 +29,10 @@ pub fn main() -> Result<(), Report> {
     } else {
         builder.format_timestamp(None);
     }
-    let logger = Box::new(builder.build());
+    let logger = builder.build();
     let filter = logger.filter();
+    // Suppress the known-harmless dependency errors until the upstream fix ships
+    let logger = Box::new(midenc_log::SuppressKnownDependencyErrors::new(logger));
 
     // Get current working directory
     let cwd = env::current_dir()

--- a/tools/cargo-miden/src/main.rs
+++ b/tools/cargo-miden/src/main.rs
@@ -1,11 +1,20 @@
 use cargo_miden::CommandOutput;
+use midenc_log::SuppressKnownDependencyErrors;
 
-fn main() -> anyhow::Result<()> {
-    // Initialize logger
+/// Initializes the global logger, suppressing the known-harmless dependency errors.
+fn init_logger() {
     let mut builder = midenc_log::Builder::from_env("CARGO_MIDEN_LOG");
     builder.format_indent(Some(2));
     builder.format_timestamp(None);
-    builder.init();
+    let logger = builder.build();
+    let max_level = logger.filter();
+    log::set_boxed_logger(Box::new(SuppressKnownDependencyErrors::new(logger)))
+        .expect("logger already initialized");
+    log::set_max_level(max_level);
+}
+
+fn main() -> anyhow::Result<()> {
+    init_logger();
 
     match cargo_miden::run(std::env::args()) {
         Ok(Some(CommandOutput::BuildCommandOutput { output })) => {


### PR DESCRIPTION
The proper fix to #1211 is to use trusted API
`Package::read_from_bytes_trusted` in the next VM v0.24.

`cargo miden build` and `midenc` print `UntrustedMastForest expected HASHLESS/STRIPPED input` error records emitted by `miden-core` when deserializing Miden packages whose MAST includes node hashes and debug info, as all compiler-produced packages do. The errors are harmless (validation recomputes and checks the hashes) but make every build look broken.

Add a `log::Log` adapter to `midenc-log` that drops exactly these two records (matched by level, target, and full message text) and forwards everything else, and install it in both binaries. `midenc-driver` already takes the logger as `Box<dyn Log>`, so the wrapping happens at the binary entry points only. The suppression is temporary and should be removed once the compiler migrates to the Miden VM v0.24 release and trusted API.