### PR TITLE
fix(wasm): bitcast the br_table selector instead of range-checking it

### DIFF
--- a/frontend/wasm/src/code_translator/mod.rs
+++ b/frontend/wasm/src/code_translator/mod.rs
@@ -1029,12 +1029,11 @@ fn translate_br_table<B: ?Sized + Builder>(
         frame.br_destination()
     };
 
-    let selector = state.pop1();
-    let selector = if selector.borrow().ty().clone() != U32 {
-        builder.cast(selector, U32, span)?
-    } else {
-        selector
-    };
+    // The `br_table` selector is interpreted as unsigned, with any out-of-range value taking the
+    // default arm. LLVM relies on this by normalizing switch selectors with wrapping subtraction,
+    // so re-typing the sign-agnostic Wasm i32 selector must reinterpret the bits rather than
+    // assert that the value is a valid u32.
+    let selector = state.pop1_bitcasted(U32, builder, span);
 
     let mut cases = Vec::new();
     for (label_idx, depth) in targets.into_iter().enumerate() {

--- a/tests/integration/src/end_to_end/regressions/issue1243.rs
+++ b/tests/integration/src/end_to_end/regressions/issue1243.rs
@@ -1,0 +1,51 @@
+//! Regression test for https://github.com/0xMiden/compiler/issues/1243.
+//!
+//! LLVM normalizes a `switch` selector by subtracting the smallest case value with wrapping
+//! arithmetic, relying on `br_table`'s unsigned out-of-range -> default rule. The frontend used a
+//! checked I32 -> U32 cast for the selector, which the MASM backend lowers to an assertion that
+//! rejects any value with the high bit set (e.g. `0 - 1 = 0xFFFFFFFF`), trapping with
+//! "value does not fit in i32" instead of branching to the default arm.
+
+use miden_core::Felt;
+use midenc_frontend_wasm::WasmTranslationConfig;
+
+use crate::{
+    CompilerTest,
+    testing::{eval_package, setup},
+};
+
+/// A `br_table` selector that is out of range as an unsigned value must branch to the default arm,
+/// whether it got there by wrapping subtraction (`0 - 1`) or already had its high bit set.
+#[test]
+fn br_table_default_arm_for_out_of_range_selector() {
+    // The panicking `assert!` arm plus `black_box` is what makes LLVM at `opt-level = "z"` merge
+    // the two tests into a `switch` (lowered to `br_table`) with selector `v - 1`.
+    let main_fn = r#"(x: u32) -> u32 {
+        let v = core::hint::black_box(x);
+        assert!(v != 1, "must not be one");
+        if v != 2 { 10 } else { 20 }
+    }"#;
+
+    setup::enable_compiler_instrumentation();
+    let config = WasmTranslationConfig::default();
+    let mut test = CompilerTest::rust_fn_body_with_stdlib_sys("issue1243", main_fn, config, []);
+
+    let package = test.compile_package();
+
+    // `v = 0` makes the normalized selector wrap to `0xFFFFFFFF`, which must take the default arm.
+    let out =
+        eval_package::<u32, _, _>(&package, [], &[Felt::from(0u32)], &test.session, |_| Ok(()))
+            .unwrap();
+    assert_eq!(out, 10);
+
+    // A selector with the high bit set without wrapping must also take the default arm.
+    let out = eval_package::<u32, _, _>(
+        &package,
+        [],
+        &[Felt::from(0x9000_0000u32)],
+        &test.session,
+        |_| Ok(()),
+    )
+    .unwrap();
+    assert_eq!(out, 10);
+}

--- a/tests/integration/src/end_to_end/regressions/mod.rs
+++ b/tests/integration/src/end_to_end/regressions/mod.rs
@@ -2,4 +2,5 @@ mod func_arg_order;
 mod func_arg_same;
 mod invalid_stack_index_16_issue_872;
 mod invalid_stack_index_4_word_1_felt_args;
+mod issue1243;
 mod vec_realloc_copies_data_issue_811;


### PR DESCRIPTION
Close #1243

Discovered in #1158 

Wasm defines the `br_table` selector as unsigned, with any out-of-range value branching to the default arm. LLVM relies on this when it normalizes a `switch` by subtracting the smallest case value with wrapping arithmetic, so selectors with the high bit set (e.g. `0 - 1`) are legitimate take-the-default values. The frontend re-typed the selector with a checked I32 -> U32 cast, which codegen lowers to an assertion rejecting exactly those values, trapping with "value does not fit in i32". Ordinary guest code such as a `match` on `core::cmp::Ordering` hit this at runtime.


