### PR TITLE
chore: don't override `--target-dir` in the SDK macros tests

### DIFF
--- a/tests/integration/src/sdk/macros.rs
+++ b/tests/integration/src/sdk/macros.rs
@@ -7,8 +7,6 @@ fn cargo_check_miden_target(project: &crate::cargo_proj::Project) -> std::proces
         .arg("check")
         .arg("--target")
         .arg("wasm32-wasip2")
-        .arg("--target-dir")
-        .arg(project.build_dir())
         .env("RUSTFLAGS", "--cfg miden -C target-feature=+bulk-memory,+wide-arithmetic")
         .current_dir(project.root())
         .output()


### PR DESCRIPTION
This will force the tests to reuse workspace target dir to speed up tests and conserve the disc space.