### PR TITLE
[1/3] fix(hir): make Region::find_common_ancestor return the common region

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3731,7 +3731,6 @@ dependencies = [
  "anyhow",
  "base64",
  "bitflags 2.13.0",
- "bitvec",
  "blink-alloc",
  "compact_str",
  "hashbrown 0.17.1",

--- a/hir/Cargo.toml
+++ b/hir/Cargo.toml
@@ -20,7 +20,6 @@ logging = ["dep:midenc-log", "std"]
 [dependencies]
 anyhow.workspace = true
 base64 = { version = "0.22", default-features = false, features = ["alloc"] }
-bitvec.workspace = true
 bitflags.workspace = true
 blink-alloc.workspace = true
 compact_str.workspace = true

--- a/hir/src/ir/region.rs
+++ b/hir/src/ir/region.rs
@@ -3,6 +3,8 @@ mod interfaces;
 mod invocation_bounds;
 mod kind;
 mod successor;
+#[cfg(test)]
+mod tests;
 mod transforms;
 
 use alloc::rc::Rc;
@@ -584,31 +586,28 @@ impl Region {
 
 /// Queries
 impl Region {
+    /// Returns the innermost region that contains all of the given operations, if such a region
+    /// exists.
+    ///
+    /// Returns `None` if `ops` is empty, or if no common ancestor region exists.
     pub fn find_common_ancestor(ops: &[OperationRef]) -> Option<RegionRef> {
-        use bitvec::prelude::*;
-
         match ops.len() {
             0 => None,
             1 => unsafe { ops.get_unchecked(0) }.borrow().parent_region(),
-            num_ops => {
+            _ => {
                 let (first, rest) = unsafe { ops.split_first().unwrap_unchecked() };
                 let mut region = first.borrow().parent_region();
-                let mut remaining_ops = bitvec![1; num_ops - 1];
-                while let Some(r) = region.take() {
-                    while let Some(index) = remaining_ops.first_one() {
-                        // Is this op contained in `region`?
-                        if r.borrow().find_ancestor_op(rest[index]).is_some() {
-                            unsafe {
-                                remaining_ops.set_unchecked(index, false);
-                            }
-                        }
+                while let Some(r) = region {
+                    // Borrow the candidate region once for the whole containment check, rather
+                    // than reborrowing it for every operation.
+                    let candidate = r.borrow();
+                    // Is every other op contained in `region`?
+                    if rest.iter().all(|op| candidate.find_ancestor_op(*op).is_some()) {
+                        return Some(r);
                     }
-                    if remaining_ops.not_any() {
-                        break;
-                    }
-                    region = r.borrow().parent_region();
+                    region = candidate.parent_region();
                 }
-                region
+                None
             }
         }
     }

--- a/hir/src/ir/region/tests.rs
+++ b/hir/src/ir/region/tests.rs
@@ -1,0 +1,106 @@
+use alloc::rc::Rc;
+
+use crate::{
+    Context, Region, SymbolTable,
+    diagnostics::{Report, Uri},
+    dialects::builtin::{Function, Module},
+    parse::{self, ParserConfig},
+};
+
+type TestResult = Result<(), Report>;
+
+/// `Region::find_common_ancestor` returns the innermost region containing all operations.
+///
+/// Regression coverage: the previous implementation returned `None` for every multi-operation
+/// query, and did not terminate when an operation lay outside the first operation's innermost
+/// region.
+#[test]
+fn find_common_ancestor_returns_innermost_common_region() -> TestResult {
+    let context = Rc::new(Context::default());
+    // The parser anchors parsed operations in a fresh `builtin.world`, so this source produces
+    // the region hierarchy: world body > module body > function bodies.
+    let source = r#"builtin.module public @test {
+    builtin.function public extern("C") @a(%x: i32) -> u32 {
+        %v = builtin.unrealized_conversion_cast %x <{ ty = #builtin.type<u32> }>;
+        builtin.ret %v : (u32);
+    };
+    builtin.function public extern("C") @b() -> u32 {
+        builtin.ret_imm 42 : u32;
+    };
+};"#;
+    let config = ParserConfig::new(context.clone());
+    let module_op = parse::parse_any(config, Uri::new("find_common_ancestor.hir"), source)?;
+
+    let (func_a_op, func_b_op) = {
+        let module_op = module_op.borrow();
+        let module = module_op.downcast_ref::<Module>().expect("expected a module");
+        let symbols = module.symbol_manager();
+        (
+            symbols.lookup_op("a").expect("'a' was not registered in the symbol table"),
+            symbols.lookup_op("b").expect("'b' was not registered in the symbol table"),
+        )
+    };
+    let (cast_a, ret_a) = {
+        let function =
+            func_a_op.try_downcast_op::<Function>().expect("expected '@a' to be a function");
+        let function = function.borrow();
+        let cast = function.body().entry().front().unwrap();
+        let ret = function.body().entry().terminator().unwrap();
+        (cast, ret)
+    };
+    let ret_b = {
+        let function =
+            func_b_op.try_downcast_op::<Function>().expect("expected '@b' to be a function");
+        let function = function.borrow();
+        function.body().entry().terminator().unwrap()
+    };
+
+    let body_a = cast_a.borrow().parent_region().expect("op must be in a function body");
+    let module_region = func_a_op.borrow().parent_region().expect("function must be in a module");
+    let world_region = module_op.borrow().parent_region().expect("module must be in a world");
+    let world_op = world_region.parent().expect("world region must have an owner");
+
+    assert_eq!(Region::find_common_ancestor(&[]), None);
+    assert_eq!(Region::find_common_ancestor(&[cast_a]), Some(body_a));
+    assert_eq!(
+        Region::find_common_ancestor(&[cast_a, ret_a]),
+        Some(body_a),
+        "operations in one region share that region"
+    );
+    assert_eq!(
+        Region::find_common_ancestor(&[cast_a, ret_b]),
+        Some(module_region),
+        "operations in sibling function bodies share the module body region"
+    );
+    assert_eq!(
+        Region::find_common_ancestor(&[cast_a, func_b_op]),
+        Some(module_region),
+        "nested and outer operations share the outer region"
+    );
+    assert_eq!(
+        Region::find_common_ancestor(&[func_b_op, cast_a]),
+        Some(module_region),
+        "the result is independent of operation order"
+    );
+    assert_eq!(
+        Region::find_common_ancestor(&[cast_a, ret_a, ret_b]),
+        Some(module_region),
+        "a region containing only some of the operations is not a common ancestor"
+    );
+    assert_eq!(
+        Region::find_common_ancestor(&[cast_a, module_op]),
+        Some(world_region),
+        "the candidate walk crosses multiple nesting levels"
+    );
+    assert_eq!(
+        Region::find_common_ancestor(&[world_op, cast_a]),
+        None,
+        "a top-level operation has no enclosing region, so there is no common ancestor"
+    );
+    assert_eq!(
+        Region::find_common_ancestor(&[cast_a, world_op]),
+        None,
+        "a top-level operation has no enclosing region, so there is no common ancestor"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Close #1244 

For queries with two or more operations the function could never return `Some`: the candidate loop `take()`s the region binding before the containment check and `break`s on success, returning the leftover `None`, and it never advances past an operation that is not contained in the current candidate, looping forever whenever an operation lies outside the first operation's innermost region. As a result the greedy pattern-rewrite driver, the sole caller, silently ran multi-operation rewrites unscoped instead of confining them to the common ancestor region.
