### PR TITLE
perf(codegen): load and store element-space pointers with bare memory ops

### DIFF
--- a/codegen/masm/src/emit/mem.rs
+++ b/codegen/masm/src/emit/mem.rs
@@ -149,8 +149,6 @@ impl OpEmitter<'_> {
         let ptr = self.stack.pop().expect("operand stack is empty");
         match ptr.ty() {
             Type::Ptr(ref ptr_ty) => {
-                // Convert the pointer to a native pointer representation
-                self.convert_to_native_ptr(ptr_ty, span);
                 assert_eq!(
                     ty.size_in_bits(),
                     ptr_ty.pointee().size_in_bits(),
@@ -158,6 +156,19 @@ impl OpEmitter<'_> {
                      type of the pointee ({})",
                     ptr_ty.pointee()
                 );
+                // Element-address-space pointers (e.g. procedure locals) are element-aligned
+                // with no byte offset by construction, so element-sized scalars load directly
+                // from the address; the dynamic-offset intrinsics exist for the byte-addressable
+                // address space.
+                if !ptr_ty.is_byte_pointer()
+                    && matches!(ty, Type::Felt | Type::I32 | Type::U32 | Type::Ptr(_))
+                {
+                    self.emit(masm::Instruction::MemLoad, span);
+                    self.push(ty);
+                    return;
+                }
+                // Convert the pointer to a native pointer representation
+                self.convert_to_native_ptr(ptr_ty, span);
                 match &ty {
                     Type::I128 | Type::U128 => self.load_quad_word(None, span),
                     Type::I64 | Type::U64 => self.load_double_word_int(None, span),
@@ -646,8 +657,6 @@ impl OpEmitter<'_> {
         assert!(!value_ty.is_zst(), "cannot store a zero-sized type in memory");
         match ptr_ty {
             Type::Ptr(ref ptr_ty) => {
-                // Convert the pointer to a native pointer representation
-                self.convert_to_native_ptr(ptr_ty, span);
                 assert_eq!(
                     value_ty.size_in_bits(),
                     ptr_ty.pointee().size_in_bits(),
@@ -655,6 +664,18 @@ impl OpEmitter<'_> {
                      from the type of the pointee ({})",
                     ptr_ty.pointee()
                 );
+                // Element-address-space pointers (e.g. procedure locals) are element-aligned
+                // with no byte offset by construction, so element-sized scalars store directly
+                // to the address; the dynamic-offset intrinsics exist for the byte-addressable
+                // address space.
+                if !ptr_ty.is_byte_pointer()
+                    && matches!(value_ty, Type::Felt | Type::I32 | Type::U32 | Type::Ptr(_))
+                {
+                    self.emit(masm::Instruction::MemStore, span);
+                    return;
+                }
+                // Convert the pointer to a native pointer representation
+                self.convert_to_native_ptr(ptr_ty, span);
                 match value_ty {
                     Type::I128 | Type::U128 => self.store_quad_word(None, span),
                     Type::I64 | Type::U64 => self.store_double_word_int(None, span),

--- a/codegen/masm/src/lower/fpi.rs
+++ b/codegen/masm/src/lower/fpi.rs
@@ -107,15 +107,13 @@ mod tests {
         for (num_inputs, expected_padding) in [(0usize, 16usize), (1, 15), (10, 6), (15, 1)] {
             let output = emit_exec_fpi(num_inputs)?.to_pretty_string();
 
-            // Each prefix local load contributes one `push.0` for its element pointer offset, in
-            // addition to one `push.0` per padded input slot.
+            // One `push.0` per padded input slot (the prefix local loads are direct
+            // `locaddr`/`mem_load` pairs and push nothing else).
             assert_eq!(
                 output.matches("push.0").count(),
-                expected_padding + 6,
+                expected_padding,
                 "unexpected padding for {num_inputs} inputs:\n{output}"
             );
-            // `swap.1` (the one-input shuffle) is ambiguous with the pointer setup emitted by the
-            // prefix local loads, so only the multi-input `movdn.n` shuffles are counted.
             if num_inputs >= 2 {
                 let shuffle = format!("movdn.{num_inputs}");
                 assert_eq!(
@@ -125,7 +123,7 @@ mod tests {
                 );
             }
             assert_eq!(
-                output.matches("exec.::intrinsics::mem::load_felt").count(),
+                output.matches("mem_load").count(),
                 6,
                 "exec_fpi must load all six prefix locals:\n{output}"
             );
@@ -154,10 +152,10 @@ mod tests {
     fn exec_fpi_full_width_inputs_need_no_padding() -> Result<(), Report> {
         let output = emit_exec_fpi(16)?.to_pretty_string();
 
-        // Only the six prefix local loads may push zeroes (their element pointer offsets).
+        // The prefix local loads are direct `locaddr`/`mem_load` pairs, so nothing pushes zeroes.
         assert_eq!(
             output.matches("push.0").count(),
-            6,
+            0,
             "full-width exec_fpi inputs must not be padded:\n{output}"
         );
         assert!(

--- a/tests/integration-network/src/mockchain/counter/basic_auth.rs
+++ b/tests/integration-network/src/mockchain/counter/basic_auth.rs
@@ -65,7 +65,7 @@ pub fn counter_note_basic_auth_increments_storage() {
         .build_tx_context(counter_account.clone(), &[counter_note.id()], &[])
         .unwrap();
     let tx_measurements = execute_tx(&mut chain, tx_context_builder);
-    expect!["10604"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["8018"].assert_eq(single_note_cycles(&tx_measurements));
 
     // The counter contract storage value should be 2 after the note is consumed (incremented by 1).
     assert_counter_storage(

--- a/tests/integration-network/src/mockchain/counter/no_auth.rs
+++ b/tests/integration-network/src/mockchain/counter/no_auth.rs
@@ -100,8 +100,8 @@ pub fn counter_note_no_auth_increments_storage_without_signature() {
         .build_tx_context(counter_account.clone(), &[counter_note.id()], &[])
         .unwrap();
     let tx_measurements = execute_tx(&mut chain, tx_context_builder);
-    expect!["1774"].assert_eq(auth_procedure_cycles(&tx_measurements));
-    expect!["10604"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["1543"].assert_eq(auth_procedure_cycles(&tx_measurements));
+    expect!["8018"].assert_eq(single_note_cycles(&tx_measurements));
 
     // The counter contract storage value should be 2 after the note is consumed
     assert_counter_storage(

--- a/tests/integration-network/src/mockchain/counter/rpo_auth.rs
+++ b/tests/integration-network/src/mockchain/counter/rpo_auth.rs
@@ -70,7 +70,7 @@ pub fn counter_rpo_auth_rejects_unauthenticated_note_creation() {
     let tx_context = tx_context_builder.build().unwrap();
     let executed_tx =
         block_on(tx_context.execute()).expect("authorized client should be able to create a note");
-    expect!["75206"].assert_eq(auth_procedure_cycles(executed_tx.measurements()));
+    expect!["73920"].assert_eq(auth_procedure_cycles(executed_tx.measurements()));
     assert_eq!(executed_tx.output_notes().num_notes(), 1);
     assert_eq!(executed_tx.output_notes().get_note(0).id(), own_note.id());
 

--- a/tests/integration-network/src/mockchain/notes/basic_wallet.rs
+++ b/tests/integration-network/src/mockchain/notes/basic_wallet.rs
@@ -110,7 +110,7 @@ pub fn basic_wallet_p2id_transfers_asset_with_custom_tx_script() {
         .foreign_accounts(vec![faucet_inputs]);
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
     expect!["3327"].assert_eq(prologue_cycles(&tx_measurements));
-    expect!["9311"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["7032"].assert_eq(single_note_cycles(&tx_measurements));
 
     eprintln!("\n=== Checking Alice's account has the minted asset ===");
     let alice_account = chain.committed_account(alice_id).unwrap();
@@ -132,7 +132,7 @@ pub fn basic_wallet_p2id_transfers_asset_with_custom_tx_script() {
         &mut note_rng,
     );
     let tx_measurements = execute_tx(&mut chain, alice_tx_context_builder);
-    expect!["8549"].assert_eq(tx_script_processing_cycles(&tx_measurements));
+    expect!["6794"].assert_eq(tx_script_processing_cycles(&tx_measurements));
 
     eprintln!("\n=== Step 4: Bob consumes p2id note ===");
     let faucet_inputs = chain.get_foreign_account_inputs(faucet_id).unwrap();
@@ -141,7 +141,7 @@ pub fn basic_wallet_p2id_transfers_asset_with_custom_tx_script() {
         .unwrap()
         .foreign_accounts(vec![faucet_inputs]);
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
-    expect!["9311"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["7032"].assert_eq(single_note_cycles(&tx_measurements));
 
     eprintln!("\n=== Checking Bob's account has the transferred asset ===");
     let bob_account = chain.committed_account(bob_id).unwrap();
@@ -278,7 +278,7 @@ pub fn basic_wallet_p2ide_allows_recipient_claim() {
         .unwrap()
         .foreign_accounts(vec![faucet_inputs]);
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
-    expect!["9761"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["7332"].assert_eq(single_note_cycles(&tx_measurements));
 
     // Step 5: verify balances
     let bob_account = chain.committed_account(bob_id).unwrap();
@@ -415,7 +415,7 @@ pub fn basic_wallet_p2ide_allows_sender_reclaim() {
         .unwrap()
         .foreign_accounts(vec![faucet_inputs]);
     let tx_measurements = execute_tx(&mut chain, reclaim_tx_context_builder);
-    expect!["10354"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["7809"].assert_eq(single_note_cycles(&tx_measurements));
 
     // Step 5: verify Alice has her original amount back
     let alice_account = chain.committed_account(alice_id).unwrap();

--- a/tests/integration/src/end_to_end/examples/basic_wallet_package_sizes.rs
+++ b/tests/integration/src/end_to_end/examples/basic_wallet_package_sizes.rs
@@ -18,7 +18,7 @@ fn basic_wallet_and_p2id() {
     );
     let account_package = account_test.compile_package();
     assert!(account_package.is_library(), "expected library");
-    expect!["15614"].assert_eq(stripped_mast_size_str(&account_package));
+    expect!["12692"].assert_eq(stripped_mast_size_str(&account_package));
     persist_cargo_miden_dependency("../../examples/basic-wallet", account_package.as_ref());
 
     let mut tx_script_test = CompilerTest::rust_source_cargo_miden(
@@ -28,7 +28,7 @@ fn basic_wallet_and_p2id() {
     );
     let tx_script_package = tx_script_test.compile_package();
     assert!(tx_script_package.is_library(), "expected library");
-    expect!["19659"].assert_eq(stripped_mast_size_str(&tx_script_package));
+    expect!["14149"].assert_eq(stripped_mast_size_str(&tx_script_package));
 
     let mut p2id_test = CompilerTest::rust_source_cargo_miden(
         "../../examples/p2id-note",
@@ -37,7 +37,7 @@ fn basic_wallet_and_p2id() {
     );
     let note_package = p2id_test.compile_package();
     assert!(note_package.is_library(), "expected library");
-    expect!["19645"].assert_eq(stripped_mast_size_str(&note_package));
+    expect!["14628"].assert_eq(stripped_mast_size_str(&note_package));
 
     let mut p2ide_test = CompilerTest::rust_source_cargo_miden(
         "../../examples/p2ide-note",
@@ -46,5 +46,5 @@ fn basic_wallet_and_p2id() {
     );
     let p2ide_package = p2ide_test.compile_package();
     assert!(p2ide_package.is_library(), "expected library");
-    expect!["22787"].assert_eq(stripped_mast_size_str(&p2ide_package));
+    expect!["17158"].assert_eq(stripped_mast_size_str(&p2ide_package));
 }


### PR DESCRIPTION
Discovered in #1158 

Element-address-space pointers -- procedure locals and spill slots addressed via `locaddr` -- were lowered through the generic byte-addressable pointer path: the emitter pushed a constant 0 byte-offset and executed the dynamic-offset checked intrinsics (`load_sw`/`store_sw`/`load_felt`/ `store_felt`), spending ~6-11 cycles per access on offset decomposition, alignment asserts, and branching for addresses that are element-aligned with no byte offset by construction. Profiling a realistic guest program showed 531 of its 535 `load_sw`/`store_sw` executions targeting `locaddr`-derived local slots, making this the dominant per-access overhead in compiled code.

Add a fast path to `OpEmitter::load`/`OpEmitter::store`: element-space pointers holding element-sized scalars (felt, i32/u32, pointers) emit a bare `mem_load`/`mem_store` (~1-2 cycles); wider and sub-element types keep the intrinsic path. The FPI lowering shape tests are updated to the new `locaddr` + `mem_load` prefix-local sequence.

The batch-kernel fixture drops from 86894 to 44986 VM cycles (-48%) and its stripped package from 160697 to 127243 bytes; sizes shrink across the board, e.g. the basic-wallet account package goes from 15614 to 12692 bytes (-19%).