### PR TITLE
Add MASM lint mode for advice taint analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,6 +3770,7 @@ dependencies = [
  "midenc-dialect-hir",
  "midenc-dialect-scf",
  "midenc-hir",
+ "midenc-hir-analysis",
  "midenc-session",
  "rustc-hash",
 ]

--- a/codegen/masm/src/emit/binary.rs
+++ b/codegen/masm/src/emit/binary.rs
@@ -870,6 +870,16 @@ impl OpEmitter<'_> {
         self.push(ty);
     }
 
+    pub fn exp_u32_exponent(&mut self, span: SourceSpan) {
+        let rhs = self.pop().expect("operand stack is empty");
+        let lhs = self.pop().expect("operand stack is empty");
+        let ty = lhs.ty();
+        assert_eq!(ty, Type::Felt, "expected exp.u32 base to be felt");
+        assert_eq!(rhs.ty(), Type::Felt, "expected exp.u32 exponent to be felt");
+        self.emit(masm::Instruction::ExpBitLength(32), span);
+        self.push(ty);
+    }
+
     #[allow(unused)]
     pub fn exp_imm(&mut self, imm: Immediate, span: SourceSpan) {
         let lhs = self.pop().expect("operand stack is empty");

--- a/codegen/masm/src/emit/unary.rs
+++ b/codegen/masm/src/emit/unary.rs
@@ -306,6 +306,7 @@ impl OpEmitter<'_> {
                 self.felt_to_int(dst_bits, span);
             }
             // u32
+            (Type::U32, Type::Felt) => (),
             (Type::U32, Type::I64 | Type::U64 | Type::I128) => self.zext_int32(dst_bits, span),
             (Type::U32, Type::I32) => self.assert_i32(span),
             (Type::U32, Type::U16 | Type::U8 | Type::I1) => {

--- a/codegen/masm/src/lower/lowering.rs
+++ b/codegen/masm/src/lower/lowering.rs
@@ -682,7 +682,12 @@ impl HirLowering for arith::MulOverflowing {
 
 impl HirLowering for arith::Exp {
     fn emit(&self, emitter: &mut BlockEmitter<'_>) -> Result<(), Report> {
-        emitter.inst_emitter(self.as_operation()).exp(self.span());
+        let mut emitter = emitter.inst_emitter(self.as_operation());
+        if *self.get_exponent_must_be_u32() {
+            emitter.exp_u32_exponent(self.span());
+        } else {
+            emitter.exp(self.span());
+        }
         Ok(())
     }
 }

--- a/dialects/arith/src/builders.rs
+++ b/dialects/arith/src/builders.rs
@@ -359,8 +359,21 @@ pub trait ArithOpBuilder<'f, B: ?Sized + Builder> {
 
     /// Exponentiation
     fn exp(&mut self, lhs: ValueRef, rhs: ValueRef, span: SourceSpan) -> Result<ValueRef, Report> {
-        let op_builder = self.builder_mut().create::<crate::ops::Exp, _>(span);
+        let op_builder = self.builder_mut().create::<crate::ops::Exp, (ValueRef, ValueRef)>(span);
         let op = op_builder(lhs, rhs)?;
+        Ok(op.borrow().result().as_value_ref())
+    }
+
+    /// Exponentiation whose exponent operand must be u32-range constrained.
+    fn exp_u32_exponent(
+        &mut self,
+        lhs: ValueRef,
+        rhs: ValueRef,
+        span: SourceSpan,
+    ) -> Result<ValueRef, Report> {
+        let op_builder =
+            self.builder_mut().create::<crate::ops::Exp, (ValueRef, ValueRef, bool)>(span);
+        let op = op_builder(lhs, rhs, true)?;
         Ok(op.borrow().result().as_value_ref())
     }
 

--- a/dialects/arith/src/ops/binary.rs
+++ b/dialects/arith/src/ops/binary.rs
@@ -2,7 +2,7 @@ use alloc::rc::Rc;
 
 use midenc_hir::{
     derive::{EffectOpInterface, OpParser, OpPrinter, operation},
-    dialects::builtin::attributes::OverflowAttr,
+    dialects::builtin::attributes::{BoolAttr, OverflowAttr},
     effects::*,
     traits::*,
     *,
@@ -184,18 +184,38 @@ infer_return_ty_for_binary_op!(MulOverflowing, overflowed: Type::I1);
 #[operation(
     dialect = ArithDialect,
     traits(BinaryOp, SameTypeOperands, SameOperandsAndResultType),
-    implements(InferTypeOpInterface, MemoryEffectOpInterface, OpPrinter)
+    implements(
+        InferTypeOpInterface,
+        MemoryEffectOpInterface,
+        OperandRangeRequirementOpInterface,
+        OpPrinter
+    )
 )]
 pub struct Exp {
     #[operand]
     lhs: IntFelt,
     #[operand]
     rhs: IntFelt,
+    #[attr]
+    #[default]
+    exponent_must_be_u32: BoolAttr,
     #[result]
     result: IntFelt,
 }
 
 infer_return_ty_for_binary_op!(Exp);
+
+impl OperandRangeRequirementOpInterface for Exp {
+    fn operand_range_requirement(&self, operand_index: usize) -> OperandRangeRequirement {
+        if operand_index == 1 && *self.get_exponent_must_be_u32() {
+            OperandRangeRequirement::Required(ValueRangeConstraint::Type(Type::U32))
+        } else {
+            default_operand_range_requirement(self.as_operation(), operand_index)
+                .map(OperandRangeRequirement::Required)
+                .unwrap_or(OperandRangeRequirement::None)
+        }
+    }
+}
 
 /// Unsigned integer division, traps on division by zero
 #[derive(EffectOpInterface, OpPrinter, OpParser)]

--- a/dialects/hir/src/analyses/advice_taint/lattice.rs
+++ b/dialects/hir/src/analyses/advice_taint/lattice.rs
@@ -156,6 +156,7 @@ impl LatticeLike for AdviceTaintValue {
 }
 
 const MAX_CALL_CONTEXT_DEPTH: usize = 4;
+const MAX_CALL_CONTEXTS: usize = 32;
 
 type CallContext = SmallVec<[CallContextFrame; MAX_CALL_CONTEXT_DEPTH]>;
 pub(super) type AdviceTaintSparseLattice = Lattice<ContextualAdviceTaintValue>;
@@ -223,6 +224,24 @@ impl ContextualAdviceTaintValue {
             }
         }
         origins.into_iter()
+    }
+
+    pub(super) fn call_context_spans_containing_origin(
+        &self,
+        origin: AdviceTaintOrigin,
+    ) -> Vec<SourceSpan> {
+        let mut spans = Vec::new();
+        for (context, taint) in self.contexts.iter() {
+            if !taint.contains_origin(origin) {
+                continue;
+            }
+            for frame in context {
+                if !spans.contains(&frame.span) {
+                    spans.push(frame.span);
+                }
+            }
+        }
+        spans
     }
 
     pub fn mark_reported(&self) -> Self {
@@ -300,10 +319,26 @@ impl ContextualAdviceTaintValue {
         context: CallContext,
         taint: AdviceTaintValue,
     ) {
+        if context.is_empty() && !taint.is_clean() && !contexts.is_empty() {
+            let collapsed =
+                contexts.values().fold(taint, |acc, taint| LatticeLike::join(&acc, taint));
+            contexts.clear();
+            contexts.insert(CallContext::new(), collapsed);
+            return;
+        }
+        if let Some(empty) = contexts.get_mut(&CallContext::new())
+            && !empty.is_clean()
+        {
+            *empty = LatticeLike::join(empty, &taint);
+            return;
+        }
         contexts
             .entry(context)
             .and_modify(|current| *current = LatticeLike::join(current, &taint))
             .or_insert(taint);
+        canonicalize_clean_contexts(contexts);
+        remove_redundant_clean_contexts(contexts);
+        collapse_contexts_if_needed(contexts);
     }
 }
 
@@ -340,6 +375,35 @@ fn push_call_context(context: &CallContext, frame: CallContextFrame) -> CallCont
     }
     pushed.push(frame);
     pushed
+}
+
+fn collapse_contexts_if_needed(contexts: &mut BTreeMap<CallContext, AdviceTaintValue>) {
+    if contexts.len() <= MAX_CALL_CONTEXTS {
+        return;
+    }
+    if contexts.values().all(AdviceTaintValue::is_clean) {
+        return;
+    }
+
+    let collapsed = contexts
+        .values()
+        .fold(AdviceTaintValue::clean(), |acc, taint| LatticeLike::join(&acc, taint));
+    contexts.clear();
+    contexts.insert(CallContext::new(), collapsed);
+}
+
+fn remove_redundant_clean_contexts(contexts: &mut BTreeMap<CallContext, AdviceTaintValue>) {
+    if contexts.len() <= 1 {
+        return;
+    }
+    contexts.retain(|_, taint| !taint.is_clean());
+}
+
+fn canonicalize_clean_contexts(contexts: &mut BTreeMap<CallContext, AdviceTaintValue>) {
+    if contexts.values().all(AdviceTaintValue::is_clean) {
+        contexts.clear();
+        contexts.insert(CallContext::new(), AdviceTaintValue::clean());
+    }
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -384,4 +448,79 @@ pub(super) fn value_taint(value: ValueRef, solver: &DataFlowSolver) -> Contextua
         .get::<AdviceTaintSparseLattice, _>(&value)
         .map(|state| state.value().clone())
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contextual_taint_collapses_when_call_context_cap_is_exceeded() {
+        let raw = ContextualAdviceTaintValue::raw(SourceSpan::UNKNOWN);
+        let mut joined = ContextualAdviceTaintValue::clean();
+
+        for id in 0..=MAX_CALL_CONTEXTS {
+            let frame = CallContextFrame {
+                id,
+                span: SourceSpan::UNKNOWN,
+            };
+            joined = LatticeLike::join(&joined, &raw.enter_call(frame));
+        }
+
+        assert_eq!(joined.contexts.len(), 1);
+        assert!(joined.contexts.contains_key(&CallContext::new()));
+        assert!(joined.has_unreported_origin());
+    }
+
+    #[test]
+    fn contextual_taint_keeps_distinct_call_contexts_below_cap() {
+        let raw = ContextualAdviceTaintValue::raw(SourceSpan::UNKNOWN);
+        let mut joined = ContextualAdviceTaintValue::clean();
+
+        for id in 0..MAX_CALL_CONTEXTS {
+            let frame = CallContextFrame {
+                id,
+                span: SourceSpan::UNKNOWN,
+            };
+            joined = LatticeLike::join(&joined, &raw.enter_call(frame));
+        }
+
+        assert_eq!(joined.contexts.len(), MAX_CALL_CONTEXTS);
+        assert!(!joined.contexts.contains_key(&CallContext::new()));
+    }
+
+    #[test]
+    fn collapsed_contextual_taint_absorbs_precise_contexts() {
+        let raw = ContextualAdviceTaintValue::raw(SourceSpan::UNKNOWN);
+        let mut precise = ContextualAdviceTaintValue::clean();
+
+        for id in 0..MAX_CALL_CONTEXTS {
+            let frame = CallContextFrame {
+                id,
+                span: SourceSpan::UNKNOWN,
+            };
+            precise = LatticeLike::join(&precise, &raw.enter_call(frame));
+        }
+
+        let collapsed = ContextualAdviceTaintValue::raw(SourceSpan::UNKNOWN);
+        let joined = LatticeLike::join(&collapsed, &precise);
+
+        assert_eq!(joined, collapsed);
+    }
+
+    #[test]
+    fn clean_contextual_taint_stays_canonical_across_call_contexts() {
+        let clean = ContextualAdviceTaintValue::clean();
+        let mut joined = ContextualAdviceTaintValue::clean();
+
+        for id in 0..MAX_CALL_CONTEXTS {
+            let frame = CallContextFrame {
+                id,
+                span: SourceSpan::UNKNOWN,
+            };
+            joined = LatticeLike::join(&joined, &clean.enter_call(frame));
+        }
+
+        assert_eq!(joined, ContextualAdviceTaintValue::clean());
+    }
 }

--- a/dialects/hir/src/analyses/advice_taint/lattice.rs
+++ b/dialects/hir/src/analyses/advice_taint/lattice.rs
@@ -336,9 +336,7 @@ impl ContextualAdviceTaintValue {
             .entry(context)
             .and_modify(|current| *current = LatticeLike::join(current, &taint))
             .or_insert(taint);
-        canonicalize_clean_contexts(contexts);
-        remove_redundant_clean_contexts(contexts);
-        collapse_contexts_if_needed(contexts);
+        normalize_contexts(contexts);
     }
 }
 
@@ -377,11 +375,18 @@ fn push_call_context(context: &CallContext, frame: CallContextFrame) -> CallCont
     pushed
 }
 
-fn collapse_contexts_if_needed(contexts: &mut BTreeMap<CallContext, AdviceTaintValue>) {
-    if contexts.len() <= MAX_CALL_CONTEXTS {
+fn normalize_contexts(contexts: &mut BTreeMap<CallContext, AdviceTaintValue>) {
+    if contexts.values().all(AdviceTaintValue::is_clean) {
+        contexts.clear();
+        contexts.insert(CallContext::new(), AdviceTaintValue::clean());
         return;
     }
-    if contexts.values().all(AdviceTaintValue::is_clean) {
+
+    if contexts.len() > 1 {
+        contexts.retain(|_, taint| !taint.is_clean());
+    }
+
+    if contexts.len() <= MAX_CALL_CONTEXTS {
         return;
     }
 
@@ -390,20 +395,6 @@ fn collapse_contexts_if_needed(contexts: &mut BTreeMap<CallContext, AdviceTaintV
         .fold(AdviceTaintValue::clean(), |acc, taint| LatticeLike::join(&acc, taint));
     contexts.clear();
     contexts.insert(CallContext::new(), collapsed);
-}
-
-fn remove_redundant_clean_contexts(contexts: &mut BTreeMap<CallContext, AdviceTaintValue>) {
-    if contexts.len() <= 1 {
-        return;
-    }
-    contexts.retain(|_, taint| !taint.is_clean());
-}
-
-fn canonicalize_clean_contexts(contexts: &mut BTreeMap<CallContext, AdviceTaintValue>) {
-    if contexts.values().all(AdviceTaintValue::is_clean) {
-        contexts.clear();
-        contexts.insert(CallContext::new(), AdviceTaintValue::clean());
-    }
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/dialects/hir/src/analyses/advice_taint/mod.rs
+++ b/dialects/hir/src/analyses/advice_taint/mod.rs
@@ -5,7 +5,11 @@ mod propagation;
 mod sinks;
 mod storage;
 
-use alloc::{rc::Rc, vec::Vec};
+use alloc::{
+    rc::Rc,
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::any::Any;
 
 use midenc_hir::{
@@ -42,6 +46,11 @@ pub struct AdviceTaintAnalysis {
     findings: Vec<AdviceTaintFinding>,
     exit_findings: Vec<AdviceTaintExitFinding>,
     external_call_findings: Vec<AdviceTaintExternalCallFinding>,
+}
+
+pub struct AdviceTaintAnalysisResult {
+    pub analysis: AdviceTaintAnalysis,
+    pub incomplete_reason: Option<String>,
 }
 
 impl AdviceTaintAnalysis {
@@ -86,6 +95,68 @@ impl AdviceTaintAnalysis {
     pub fn solver(&self) -> &DataFlowSolver {
         &self.solver
     }
+
+    pub fn analyze_with_config(
+        &mut self,
+        op: &Operation,
+        analysis_manager: AnalysisManager,
+        config: DataFlowConfig,
+    ) -> Result<(), Report> {
+        self.run_solver_with_config(op, analysis_manager, config)?;
+        self.collect_analysis_results(op);
+        Ok(())
+    }
+
+    fn run_solver_with_config(
+        &mut self,
+        op: &Operation,
+        analysis_manager: AnalysisManager,
+        config: DataFlowConfig,
+    ) -> Result<(), Report> {
+        self.solver = DataFlowSolver::new(config);
+        self.solver.load::<AdviceTaintPropagation>();
+        self.solver.load::<AdviceTaintStoragePropagation>();
+        self.solver.initialize_and_run(op, analysis_manager)
+    }
+
+    fn collect_analysis_results(&mut self, op: &Operation) {
+        self.findings = collect_findings(op, &self.solver);
+        self.exit_findings = collect_exit_findings(op, &self.solver);
+        self.external_call_findings = collect_external_call_findings(op, &self.solver);
+    }
+
+    pub fn run_with_config(
+        op: &Operation,
+        analysis_manager: AnalysisManager,
+        config: DataFlowConfig,
+    ) -> Result<Self, Report> {
+        let mut analysis = Self::default();
+        analysis.analyze_with_config(op, analysis_manager, config)?;
+        Ok(analysis)
+    }
+
+    pub fn run_with_config_allow_partial(
+        op: &Operation,
+        analysis_manager: AnalysisManager,
+        config: DataFlowConfig,
+    ) -> Result<AdviceTaintAnalysisResult, Report> {
+        let mut analysis = Self::default();
+        let incomplete_reason = match analysis.run_solver_with_config(op, analysis_manager, config)
+        {
+            Ok(()) => None,
+            Err(err) if is_dataflow_budget_exhaustion(&err) => Some(err.to_string()),
+            Err(err) => return Err(err),
+        };
+        analysis.collect_analysis_results(op);
+        Ok(AdviceTaintAnalysisResult {
+            analysis,
+            incomplete_reason,
+        })
+    }
+}
+
+fn is_dataflow_budget_exhaustion(err: &Report) -> bool {
+    err.to_string().contains("dataflow solver exceeded worklist iteration budget")
 }
 
 impl Analysis for AdviceTaintAnalysis {
@@ -110,14 +181,7 @@ impl Analysis for AdviceTaintAnalysis {
     ) -> Result<(), Report> {
         let mut config = DataFlowConfig::new();
         config.set_interprocedural(true);
-        self.solver = DataFlowSolver::new(config);
-        self.solver.load::<AdviceTaintPropagation>();
-        self.solver.load::<AdviceTaintStoragePropagation>();
-        self.solver.initialize_and_run(op, analysis_manager)?;
-        self.findings = collect_findings(op, &self.solver);
-        self.exit_findings = collect_exit_findings(op, &self.solver);
-        self.external_call_findings = collect_external_call_findings(op, &self.solver);
-        Ok(())
+        self.analyze_with_config(op, analysis_manager, config)
     }
 
     fn invalidate(&self, _preserved_analyses: &mut PreservedAnalyses) -> bool {
@@ -149,12 +213,16 @@ fn collect_findings(op: &Operation, solver: &DataFlowSolver) -> Vec<AdviceTaintF
         let sink = operation.name();
         let sink_span = operation.span();
         for origin in operand_taint.unreported_origins() {
+            let mut contexts = collect_call_contexts(op, solver, function, origin);
+            for span in operand_taint.call_context_spans_containing_origin(origin) {
+                push_context(&mut contexts, span, AdviceTaintContextKind::CallArgument);
+            }
             let finding = AdviceTaintFinding {
                 sink: sink.clone(),
                 sink_span,
                 advice_span: origin.span,
                 origin,
-                contexts: collect_call_contexts(op, solver, function, origin),
+                contexts,
                 function,
             };
             if !findings.iter().any(|existing| same_finding(existing, &finding)) {
@@ -352,7 +420,7 @@ fn same_exit_finding(lhs: &AdviceTaintExitFinding, rhs: &AdviceTaintExitFinding)
     lhs.function == rhs.function
         && lhs.return_span == rhs.return_span
         && lhs.result_index == rhs.result_index
-        && lhs.origin == rhs.origin
+        && lhs.origin.kind == rhs.origin.kind
 }
 
 fn same_external_call_finding(

--- a/dialects/hir/src/analyses/advice_taint/sinks.rs
+++ b/dialects/hir/src/analyses/advice_taint/sinks.rs
@@ -93,7 +93,7 @@ pub(super) fn operation_result_has_advice_read_effect(
 #[cfg(test)]
 mod tests {
     use midenc_dialect_arith::ArithOpBuilder;
-    use midenc_hir::{SourceSpan, testing::Test};
+    use midenc_hir::{Felt, SourceSpan, testing::Test};
 
     use super::*;
     use crate::HirOpBuilder;
@@ -109,6 +109,27 @@ mod tests {
         let op = op.borrow();
 
         assert_eq!(range_constrained_operand_indices(&op), [0, 1]);
+    }
+
+    #[test]
+    fn exp_u32_exponent_adds_only_exponent_range_requirement() {
+        let mut test = Test::new("exp", &[], &[]);
+        let mut builder = test.function_builder();
+        let lhs = builder.felt(Felt::new(3).unwrap(), SourceSpan::UNKNOWN);
+        let rhs = builder.felt(Felt::new(2).unwrap(), SourceSpan::UNKNOWN);
+        let result = builder.exp(lhs, rhs, SourceSpan::UNKNOWN).unwrap();
+        let op = result.borrow().get_defining_op().unwrap();
+        let op = op.borrow();
+
+        assert!(range_constrained_operand_indices(&op).is_empty());
+
+        let lhs = builder.felt(Felt::new(3).unwrap(), SourceSpan::UNKNOWN);
+        let rhs = builder.felt(Felt::new(2).unwrap(), SourceSpan::UNKNOWN);
+        let result = builder.exp_u32_exponent(lhs, rhs, SourceSpan::UNKNOWN).unwrap();
+        let op = result.borrow().get_defining_op().unwrap();
+        let op = op.borrow();
+
+        assert_eq!(range_constrained_operand_indices(&op), [1]);
     }
 
     #[test]

--- a/dialects/hir/src/ops/cast.rs
+++ b/dialects/hir/src/ops/cast.rs
@@ -183,7 +183,13 @@ impl Foldable for IntToPtr {
 #[operation(
     dialect = HirDialect,
     traits(UnaryOp),
-    implements(InferTypeOpInterface, MemoryEffectOpInterface, CheckedCastOpInterface, OpPrinter)
+    implements(
+        InferTypeOpInterface,
+        MemoryEffectOpInterface,
+        OperandRangeRequirementOpInterface,
+        CheckedCastOpInterface,
+        OpPrinter
+    )
 )]
 pub struct Cast {
     #[operand]
@@ -199,6 +205,14 @@ impl InferTypeOpInterface for Cast {
         let ty = self.get_ty().clone();
         self.result_mut().set_type(ty);
         Ok(())
+    }
+}
+
+impl OperandRangeRequirementOpInterface for Cast {
+    fn operand_range_requirement(&self, _operand_index: usize) -> OperandRangeRequirement {
+        // Casts may refine their result via `CheckedCastOpInterface`, but they are
+        // not themselves semantic consumers of a range-constrained value.
+        OperandRangeRequirement::None
     }
 }
 

--- a/frontend/masm/Cargo.toml
+++ b/frontend/masm/Cargo.toml
@@ -33,4 +33,5 @@ miden-core-lib = { workspace = true, features = ["std"] }
 miden-package-registry.workspace = true
 miden-processor = { workspace = true, features = ["std"] }
 midenc-codegen-masm.workspace = true
+midenc-hir-analysis.workspace = true
 midenc-session.workspace = true

--- a/frontend/masm/src/infer.rs
+++ b/frontend/masm/src/infer.rs
@@ -6,7 +6,7 @@ use miden_assembly::{
 };
 use miden_assembly_syntax::{
     ast::{Block, Immediate, Instruction, InvocationTarget, Op, Procedure, SymbolResolution},
-    debuginfo::{SourceManager, SourceSpan},
+    debuginfo::{SourceManager, SourceSpan, Spanned},
     parser::{IntValue, PushValue, WordValue},
 };
 use midenc_hir::{
@@ -38,6 +38,67 @@ pub(crate) fn infer_signature(
     let results = state.stack.iter().rev().map(AbstractValue::ty_or_felt);
 
     Ok(Signature::with_convention(context, CallConv::Fast, params, results))
+}
+
+pub(crate) fn validate_declared_signature(
+    gid: GlobalItemIndex,
+    procedure: &Procedure,
+    context: &Rc<Context>,
+    linker: &Linker,
+    signatures: &FxHashMap<GlobalItemIndex, Signature>,
+    signature: &Signature,
+) -> Result<()> {
+    let mut state = InferState::new(gid, context, linker, signatures);
+    state.stack = signature
+        .params()
+        .iter()
+        .rev()
+        .map(|param| AbstractValue::typed(param.ty.clone(), procedure.span()))
+        .collect();
+    state.infer_block(procedure.body())?;
+
+    if !state.inputs.is_empty() {
+        return Err(Report::msg(format!(
+            "declared signature for '{}::{}' requires {} undeclared input value(s); stack \
+             underflow at {}",
+            linker[gid.module].path(),
+            procedure.name(),
+            state.inputs.len(),
+            state.format_span(procedure.span())
+        )));
+    }
+
+    let expected_results = signature.results().len();
+    if state.stack.len() < expected_results {
+        return Err(Report::msg(format!(
+            "declared signature for '{}::{}' expects {} result value(s), but the body leaves only \
+             {}; stack underflow at {}",
+            linker[gid.module].path(),
+            procedure.name(),
+            expected_results,
+            state.stack.len(),
+            state.format_span(procedure.span())
+        )));
+    }
+
+    for result in signature.results() {
+        let value = state
+            .stack
+            .pop()
+            .expect("declared signature result count was checked before popping");
+        value.constrain(result.ty.clone(), procedure.span());
+    }
+
+    if !state.stack.is_empty() {
+        return Err(Report::msg(format!(
+            "declared signature for '{}::{}' leaves {} extra value(s) on the stack",
+            linker[gid.module].path(),
+            procedure.name(),
+            state.stack.len()
+        )));
+    }
+
+    Ok(())
 }
 
 #[derive(Clone)]
@@ -312,6 +373,12 @@ impl<'a> InferState<'a> {
             }
             Exp => {
                 self.pop_with_type(Type::Felt, span)?;
+                self.pop_with_type(Type::Felt, span)?;
+                self.push(Type::Felt);
+                Ok(())
+            }
+            ExpBitLength(32) => {
+                self.pop_with_type(Type::U32, span)?;
                 self.pop_with_type(Type::Felt, span)?;
                 self.push(Type::Felt);
                 Ok(())
@@ -639,7 +706,8 @@ impl<'a> InferState<'a> {
 
         if then_state.stack.len() != else_state.stack.len() {
             return Err(Report::msg(format!(
-                "if branches leave different inferred stack depths at {span:?}: then={}, else={}",
+                "if branches leave different inferred stack depths at {}: then={}, else={}",
+                self.format_span(span),
                 then_state.stack.len(),
                 else_state.stack.len()
             )));
@@ -673,8 +741,9 @@ impl<'a> InferState<'a> {
         let expected = inputs.len() + base_stack.len() + 1;
         if body_state.stack.len() != expected {
             return Err(Report::msg(format!(
-                "while body must leave {expected} inferred value(s) for the next iteration at \
-                 {span:?}, but left {}",
+                "while body must leave {expected} inferred value(s) for the next iteration at {}, \
+                 but left {}",
+                self.format_span(span),
                 body_state.stack.len()
             )));
         }
@@ -698,6 +767,13 @@ impl<'a> InferState<'a> {
         }
         self.push(Type::Felt);
         Ok(())
+    }
+
+    fn format_span(&self, span: SourceSpan) -> String {
+        match self.source_manager.file_line_col(span) {
+            Ok(location) => format!("{location}"),
+            Err(_) => format!("{span:?}"),
+        }
     }
 
     fn ext2_binary(&mut self, span: SourceSpan) -> Result<()> {

--- a/frontend/masm/src/lib.rs
+++ b/frontend/masm/src/lib.rs
@@ -285,15 +285,6 @@ pub fn disassemble_project_target_for_lint(
     lift::lift_project_target(inputs, &lift::LiftConfig::lint(config), context)
 }
 
-/// Disassemble pre-resolved project target inputs.
-pub fn disassemble_project_target_input(
-    inputs: project::ProjectTargetInput,
-    config: &DisassemblerConfig,
-    context: Rc<Context>,
-) -> Result<DisassembledWorld> {
-    lift::lift_project_target(inputs, &lift::LiftConfig::strict(config), context)
-}
-
 /// Disassemble pre-resolved project target inputs for linting.
 pub fn disassemble_project_target_input_for_lint(
     inputs: project::ProjectTargetInput,
@@ -349,23 +340,6 @@ pub fn disassemble_project_target_with_dependency_graph(
         &context,
     )?;
     lift::lift_project_target(target, &lift::LiftConfig::strict(config), context)
-}
-
-/// Disassemble a target from a manifest and precomputed dependency graph for linting.
-pub fn disassemble_project_target_with_dependency_graph_for_lint(
-    manifest_path: impl AsRef<Path>,
-    target: Option<&str>,
-    dependency_graph: &miden_project::ProjectDependencyGraph,
-    config: &DisassemblerConfig,
-    context: Rc<Context>,
-) -> Result<DisassembledWorld> {
-    let target = project::resolve_project_target_from_manifest_path_with_dependency_graph(
-        manifest_path.as_ref(),
-        target,
-        dependency_graph,
-        &context,
-    )?;
-    lift::lift_project_target(target, &lift::LiftConfig::lint(config), context)
 }
 
 /// Disassemble a parsed MASM AST module into HIR.

--- a/frontend/masm/src/lib.rs
+++ b/frontend/masm/src/lib.rs
@@ -14,7 +14,7 @@ use std::{collections::BTreeMap, path::Path, rc::Rc, sync::Arc};
 use miden_assembly::{ProjectSourceInputs, ast::ModuleKind};
 use miden_assembly_syntax::{
     ast::{self, Module},
-    debuginfo::{SourceLanguage, SourceManager, Uri},
+    debuginfo::{SourceLanguage, SourceManager, SourceSpan, Uri},
     parser::read_modules_from_root,
 };
 use midenc_hir::{Context, FunctionType, Report, Type, dialects::builtin};
@@ -58,6 +58,16 @@ pub struct DisassembledWorld {
     /// This is retained as a convenience for single-module callers and existing analyses which
     /// operate on a module root. Multi-module callers should prefer walking `world`.
     pub module: builtin::ModuleRef,
+    /// Procedures omitted from the HIR world in lint mode.
+    pub skipped_procedures: Vec<SkippedProcedure>,
+}
+
+/// A MASM procedure skipped while building a lintable HIR world.
+#[derive(Debug, Clone)]
+pub struct SkippedProcedure {
+    pub path: Arc<ast::Path>,
+    pub span: SourceSpan,
+    pub reason: String,
 }
 
 /// Disassemble a MASM file into an HIR world.
@@ -74,7 +84,23 @@ pub fn disassemble_file(
 
     let target =
         project::ProjectTargetInput::new(ProjectSourceInputs { root, support }, Default::default());
-    lift::lift_project_target(target, config, context)
+    lift::lift_project_target(target, &lift::LiftConfig::strict(config), context)
+}
+
+/// Disassemble a MASM file for linting, skipping procedures that cannot be lifted.
+pub fn disassemble_file_for_lint(
+    path: impl AsRef<Path>,
+    config: &DisassemblerConfig,
+    context: Rc<Context>,
+) -> Result<DisassembledWorld> {
+    let path = path.as_ref();
+    let source_manager = context.source_manager();
+    let warnings_as_errors = context.session().options.diagnostics.warnings.warnings_as_errors();
+    let (root, support) =
+        read_modules_from_root(path, None, None, source_manager, warnings_as_errors)?;
+    let target =
+        project::ProjectTargetInput::new(ProjectSourceInputs { root, support }, Default::default());
+    lift::lift_project_target(target, &lift::LiftConfig::lint(config), context)
 }
 
 /// Disassemble a MASM file into an HIR world, using externally-provided procedure signatures for
@@ -97,7 +123,7 @@ pub fn disassemble_file_with_external_signatures(
             ..Default::default()
         },
     );
-    lift::lift_project_target(target, config, context)
+    lift::lift_project_target(target, &lift::LiftConfig::strict(config), context)
 }
 
 /// Disassemble a MASM source string into an HIR world.
@@ -115,7 +141,25 @@ pub fn disassemble_source(
         },
         ExternalMetadata::default(),
     );
-    lift::lift_project_target(target, config, context)
+    lift::lift_project_target(target, &lift::LiftConfig::strict(config), context)
+}
+
+/// Disassemble a MASM source string for linting, skipping procedures that cannot be lifted.
+pub fn disassemble_source_for_lint(
+    source: impl Into<String>,
+    module_path: impl AsRef<miden_assembly_syntax::Path>,
+    config: &DisassemblerConfig,
+    context: Rc<Context>,
+) -> Result<DisassembledWorld> {
+    let root = parse_source_with_module_path(source, module_path, context.clone())?;
+    let target = project::ProjectTargetInput::new(
+        ProjectSourceInputs {
+            root,
+            support: Default::default(),
+        },
+        ExternalMetadata::default(),
+    );
+    lift::lift_project_target(target, &lift::LiftConfig::lint(config), context)
 }
 
 /// Disassemble a MASM source string into an HIR world, using externally-provided procedure
@@ -193,7 +237,7 @@ pub fn disassemble_source_with_external_signatures(
     };
     target.kernel = kernel;
     target.dependency_modules.extend(modules.into_values());
-    lift::lift_project_target(target, config, context)
+    lift::lift_project_target(target, &lift::LiftConfig::strict(config), context)
 }
 
 /// Disassemble already-parsed `sources`, discovering external procedure signatures from
@@ -221,7 +265,42 @@ pub fn disassemble_project_target_with_sources(
         &context,
     )?;
     let inputs = project::ProjectTargetInput::new(sources, external_metadata);
-    lift::lift_project_target(inputs, config, context)
+    lift::lift_project_target(inputs, &lift::LiftConfig::strict(config), context)
+}
+
+/// Disassemble a project target for linting, skipping procedures that cannot be lifted.
+pub fn disassemble_project_target_for_lint(
+    project: &miden_project::Project,
+    target: Option<&str>,
+    sources: Option<ProjectSourceInputs>,
+    config: &DisassemblerConfig,
+    context: Rc<Context>,
+) -> Result<DisassembledWorld> {
+    let inputs = if let Some(sources) = sources {
+        let metadata = project::collect_dependency_metadata(project, &context)?;
+        project::ProjectTargetInput::new(sources, metadata)
+    } else {
+        project::resolve_project_target(project, target, &context)?
+    };
+    lift::lift_project_target(inputs, &lift::LiftConfig::lint(config), context)
+}
+
+/// Disassemble pre-resolved project target inputs.
+pub fn disassemble_project_target_input(
+    inputs: project::ProjectTargetInput,
+    config: &DisassemblerConfig,
+    context: Rc<Context>,
+) -> Result<DisassembledWorld> {
+    lift::lift_project_target(inputs, &lift::LiftConfig::strict(config), context)
+}
+
+/// Disassemble pre-resolved project target inputs for linting.
+pub fn disassemble_project_target_input_for_lint(
+    inputs: project::ProjectTargetInput,
+    config: &DisassemblerConfig,
+    context: Rc<Context>,
+) -> Result<DisassembledWorld> {
+    lift::lift_project_target(inputs, &lift::LiftConfig::lint(config), context)
 }
 
 /// Disassemble a target from a `miden-project.toml` package manifest.
@@ -236,7 +315,22 @@ pub fn disassemble_project_target_from_path(
         target,
         &context,
     )?;
-    lift::lift_project_target(target, config, context)
+    lift::lift_project_target(target, &lift::LiftConfig::strict(config), context)
+}
+
+/// Disassemble a target from a `miden-project.toml` package manifest for linting.
+pub fn disassemble_project_target_from_path_for_lint(
+    manifest_path: impl AsRef<Path>,
+    target: Option<&str>,
+    config: &DisassemblerConfig,
+    context: Rc<Context>,
+) -> Result<DisassembledWorld> {
+    let target = project::resolve_project_target_from_manifest_path(
+        manifest_path.as_ref(),
+        target,
+        &context,
+    )?;
+    lift::lift_project_target(target, &lift::LiftConfig::lint(config), context)
 }
 
 /// Disassemble a target from a `miden-project.toml` package manifest, using a precomputed
@@ -254,7 +348,24 @@ pub fn disassemble_project_target_with_dependency_graph(
         dependency_graph,
         &context,
     )?;
-    lift::lift_project_target(target, config, context)
+    lift::lift_project_target(target, &lift::LiftConfig::strict(config), context)
+}
+
+/// Disassemble a target from a manifest and precomputed dependency graph for linting.
+pub fn disassemble_project_target_with_dependency_graph_for_lint(
+    manifest_path: impl AsRef<Path>,
+    target: Option<&str>,
+    dependency_graph: &miden_project::ProjectDependencyGraph,
+    config: &DisassemblerConfig,
+    context: Rc<Context>,
+) -> Result<DisassembledWorld> {
+    let target = project::resolve_project_target_from_manifest_path_with_dependency_graph(
+        manifest_path.as_ref(),
+        target,
+        dependency_graph,
+        &context,
+    )?;
+    lift::lift_project_target(target, &lift::LiftConfig::lint(config), context)
 }
 
 /// Disassemble a parsed MASM AST module into HIR.
@@ -270,7 +381,23 @@ pub fn disassemble_module(
         },
         ExternalMetadata::default(),
     );
-    lift::lift_project_target(target, config, context)
+    lift::lift_project_target(target, &lift::LiftConfig::strict(config), context)
+}
+
+/// Disassemble a parsed MASM AST module for linting, skipping procedures that cannot be lifted.
+pub fn disassemble_module_for_lint(
+    root: Box<Module>,
+    config: &DisassemblerConfig,
+    context: Rc<Context>,
+) -> Result<DisassembledWorld> {
+    let target = project::ProjectTargetInput::new(
+        ProjectSourceInputs {
+            root,
+            support: Default::default(),
+        },
+        ExternalMetadata::default(),
+    );
+    lift::lift_project_target(target, &lift::LiftConfig::lint(config), context)
 }
 
 fn parse_source_with_module_path(

--- a/frontend/masm/src/lib.rs
+++ b/frontend/masm/src/lib.rs
@@ -268,20 +268,20 @@ pub fn disassemble_project_target_with_sources(
     lift::lift_project_target(inputs, &lift::LiftConfig::strict(config), context)
 }
 
-/// Disassemble a project target for linting, skipping procedures that cannot be lifted.
+/// Disassemble already-parsed project sources for linting, using the resolved dependency closure
+/// and skipping procedures that cannot be lifted.
 pub fn disassemble_project_target_for_lint(
-    project: &miden_project::Project,
-    target: Option<&str>,
-    sources: Option<ProjectSourceInputs>,
+    sources: ProjectSourceInputs,
+    dependency_graph: &miden_project::ProjectDependencyGraph,
     config: &DisassemblerConfig,
     context: Rc<Context>,
 ) -> Result<DisassembledWorld> {
-    let inputs = if let Some(sources) = sources {
-        let metadata = project::collect_dependency_metadata(project, &context)?;
-        project::ProjectTargetInput::new(sources, metadata)
-    } else {
-        project::resolve_project_target(project, target, &context)?
-    };
+    let metadata = project::collect_dependency_graph_metadata(
+        dependency_graph,
+        project::RegistryNodes::Skip,
+        &context,
+    )?;
+    let inputs = project::ProjectTargetInput::new(sources, metadata);
     lift::lift_project_target(inputs, &lift::LiftConfig::lint(config), context)
 }
 

--- a/frontend/masm/src/lift.rs
+++ b/frontend/masm/src/lift.rs
@@ -620,32 +620,36 @@ impl ModuleRegistry {
 }
 
 fn validate_lint_signature(path: &ast::Path, signature: &Signature) -> Result<()> {
-    if signature.params().len() > u8::MAX as usize {
-        return Err(Report::msg(format!(
-            "procedure '{path}' has {} parameter(s), exceeding the HIR operand limit of {}",
-            signature.params().len(),
-            u8::MAX
-        )));
-    }
-    if signature.results().len() > u8::MAX as usize {
-        return Err(Report::msg(format!(
-            "procedure '{path}' returns {} value(s), exceeding the HIR operand limit of {}",
+    let checks = [
+        (signature.params().len(), u8::MAX as usize, "has", "parameter", "HIR operand"),
+        (
             signature.results().len(),
-            u8::MAX
-        )));
-    }
-    if signature.params().len() > LINT_SIGNATURE_VALUE_LIMIT {
+            u8::MAX as usize,
+            "returns",
+            "value",
+            "HIR operand",
+        ),
+        (
+            signature.params().len(),
+            LINT_SIGNATURE_VALUE_LIMIT,
+            "has",
+            "parameter",
+            "lint analysis signature",
+        ),
+        (
+            signature.results().len(),
+            LINT_SIGNATURE_VALUE_LIMIT,
+            "returns",
+            "value",
+            "lint analysis signature",
+        ),
+    ];
+    if let Some((count, limit, verb, noun, limit_name)) =
+        checks.into_iter().find(|(count, limit, ..)| count > limit)
+    {
         return Err(Report::msg(format!(
-            "procedure '{path}' has {} parameter(s), exceeding the lint analysis signature limit \
-             of {LINT_SIGNATURE_VALUE_LIMIT}",
-            signature.params().len()
-        )));
-    }
-    if signature.results().len() > LINT_SIGNATURE_VALUE_LIMIT {
-        return Err(Report::msg(format!(
-            "procedure '{path}' returns {} value(s), exceeding the lint analysis signature limit \
-             of {LINT_SIGNATURE_VALUE_LIMIT}",
-            signature.results().len()
+            "procedure '{path}' {verb} {count} {noun}(s), exceeding the {limit_name} limit of \
+             {limit}"
         )));
     }
     Ok(())

--- a/frontend/masm/src/lift.rs
+++ b/frontend/masm/src/lift.rs
@@ -32,15 +32,40 @@ use rustc_hash::FxHashMap;
 
 use crate::{
     DisassembledWorld, DisassemblerConfig, ExternalSignatureMap, ExternalTypeMap, Result,
+    SkippedProcedure,
     events::{system_event_id, system_event_read_count},
     infer, project,
     semantics::{self, InstructionSemantics},
     stack as masm_stack,
 };
 
+const LINT_ESTIMATED_HIR_OP_LIMIT: usize = 900;
+const LINT_SIGNATURE_VALUE_LIMIT: usize = 8;
+
+pub(crate) struct LiftConfig {
+    infer_missing_signatures: bool,
+    lint: bool,
+}
+
+impl LiftConfig {
+    pub(crate) fn strict(config: &DisassemblerConfig) -> Self {
+        Self {
+            infer_missing_signatures: config.infer_missing_signatures,
+            lint: false,
+        }
+    }
+
+    pub(crate) fn lint(config: &DisassemblerConfig) -> Self {
+        Self {
+            infer_missing_signatures: config.infer_missing_signatures,
+            lint: true,
+        }
+    }
+}
+
 pub(crate) fn lift_project_target(
     target: project::ProjectTargetInput,
-    config: &DisassemblerConfig,
+    config: &LiftConfig,
     context: Rc<Context>,
 ) -> Result<DisassembledWorld> {
     let project::ProjectTargetInput {
@@ -72,7 +97,7 @@ fn lift_modules(
     kernel: Option<Arc<miden_mast_package::Package>>,
     packages: Vec<Arc<miden_mast_package::Package>>,
     extra_modules: Vec<Box<Module>>,
-    config: &DisassemblerConfig,
+    config: &LiftConfig,
     external_signatures: ExternalSignatureMap,
     external_types: ExternalTypeMap,
     context: Rc<Context>,
@@ -124,7 +149,11 @@ fn lift_modules(
             }
         }
     }
-    let module_indices = linker.link([root], support)?;
+    let (module_indices, initial_skips) = if config.lint {
+        link_modules_for_lint(&mut linker, root, support)?
+    } else {
+        (linker.link([root], support)?, Vec::new())
+    };
     let root_index = module_indices[0];
 
     let mut registry = ModuleRegistry::new(
@@ -132,6 +161,7 @@ fn lift_modules(
         module_indices,
         external_signatures,
         external_types,
+        initial_skips,
         context.clone(),
     );
     registry.infer_missing_signatures(config)?;
@@ -148,11 +178,103 @@ fn lift_modules(
     registry.lift_bodies()?;
 
     let module = registry.modules[&root_index];
+    let skipped_procedures = registry.skipped_procedures();
     Ok(DisassembledWorld {
         context,
         world,
         module,
+        skipped_procedures,
     })
+}
+
+fn link_modules_for_lint(
+    linker: &mut Linker,
+    root: Box<Module>,
+    support: Vec<Box<Module>>,
+) -> Result<(Vec<ModuleIndex>, Vec<(GlobalItemIndex, SourceSpan, String)>)> {
+    let mut module_indices = linker.link_modules([root])?;
+    module_indices.extend(linker.link_modules(support)?);
+
+    let mut skipped = BTreeMap::<GlobalItemIndex, (SourceSpan, String)>::new();
+    loop {
+        let mut progress = false;
+        for module_index in 0..linker.modules().len() {
+            let module_index = ModuleIndex::new(module_index);
+            for (item_index, item) in linker[module_index].symbols().enumerate() {
+                let gid = module_index + ast::ItemIndex::new(item_index);
+                if skipped.contains_key(&gid) {
+                    continue;
+                }
+                let SymbolItem::Procedure(procedure) = item.item() else {
+                    continue;
+                };
+                let procedure = procedure.borrow();
+                let mut reason = None;
+                for invoke in procedure.invoked() {
+                    let resolution = SymbolResolutionContext {
+                        span: invoke.span(),
+                        module: module_index,
+                        kind: Some(invoke.kind),
+                    };
+                    match linker.resolve_invoke_target(&resolution, &invoke.target) {
+                        Ok(SymbolResolution::Exact { gid: callee, .. }) => {
+                            if let Some((_, callee_reason)) = skipped.get(&callee) {
+                                let callee_path = linker[callee.module]
+                                    .path()
+                                    .join(linker[callee].name());
+                                reason = Some(format!(
+                                    "depends on skipped procedure '{callee_path}': {callee_reason}"
+                                ));
+                                break;
+                            }
+                        }
+                        Ok(_) => {}
+                        Err(err) => {
+                            reason = Some(format!(
+                                "failed to resolve invocation during signature metadata pre-scan: \
+                                 {err}; external signature metadata is missing"
+                            ));
+                            break;
+                        }
+                    }
+                }
+                if let Some(reason) = reason {
+                    skipped.insert(gid, (procedure.span(), reason));
+                    progress = true;
+                }
+            }
+        }
+        if !progress {
+            break;
+        }
+    }
+
+    for gid in skipped.keys().copied() {
+        let SymbolItem::Procedure(procedure) = linker[gid].item() else {
+            continue;
+        };
+        let mut procedure = procedure.borrow_mut();
+        let span = procedure.span();
+        let signature = procedure.signature().cloned();
+        let mut stub = Procedure::new(
+            span,
+            procedure.visibility(),
+            procedure.name().clone(),
+            procedure.num_locals(),
+            Block::new(span, Vec::new()),
+        );
+        stub.set_syscall(procedure.is_syscall());
+        if let Some(signature) = signature {
+            stub.set_signature(signature);
+        }
+        *procedure = Box::new(stub);
+    }
+
+    linker.link(core::iter::empty(), core::iter::empty())?;
+    Ok((
+        module_indices,
+        skipped.into_iter().map(|(gid, (span, reason))| (gid, span, reason)).collect(),
+    ))
 }
 
 struct ModuleRegistry {
@@ -168,6 +290,7 @@ struct ModuleRegistry {
     external_signatures: FxHashMap<Arc<ast::Path>, Signature>,
     #[allow(unused)]
     referenced_external_signatures: FxHashMap<Arc<ast::Path>, Signature>,
+    skipped_procedures: FxHashMap<GlobalItemIndex, SkippedProcedure>,
 }
 
 impl ModuleRegistry {
@@ -176,6 +299,7 @@ impl ModuleRegistry {
         top_level_modules: Vec<ModuleIndex>,
         external_signatures: ExternalSignatureMap,
         external_types: ExternalTypeMap,
+        initial_skips: Vec<(GlobalItemIndex, SourceSpan, String)>,
         context: Rc<Context>,
     ) -> Self {
         let external_signatures = external_signatures
@@ -184,7 +308,7 @@ impl ModuleRegistry {
                 (path, Signature::with_convention(&context, ty.abi, ty.params, ty.results))
             })
             .collect::<FxHashMap<_, _>>();
-        Self {
+        let mut registry = Self {
             context,
             linker,
             top_level_modules,
@@ -195,103 +319,210 @@ impl ModuleRegistry {
             external_types,
             external_signatures,
             referenced_external_signatures: FxHashMap::default(),
+            skipped_procedures: FxHashMap::default(),
+        };
+        for (gid, span, reason) in initial_skips {
+            registry.skip_item(gid, span, reason);
         }
+        registry
     }
 
-    fn infer_missing_signatures(&mut self, config: &DisassemblerConfig) -> Result<()> {
+    fn infer_missing_signatures(&mut self, config: &LiftConfig) -> Result<()> {
         let mut visited = FxHashSet::default();
-        for root in self.top_level_modules.iter().copied() {
+        for root in self.top_level_modules.clone() {
             let root_path = self.linker[root].path().clone();
-            for (index, item) in self.linker[root].symbols().enumerate() {
-                let gid = root + ast::ItemIndex::new(index);
-                if !item.is_procedure() {
-                    continue;
-                }
-                let path = root_path.join(item.name());
-                let toposort = self.linker.topological_sort_from_root(gid).map_err(|cycle| {
-                    let iter = cycle.into_node_ids();
-                    let mut nodes = Vec::with_capacity(iter.len());
-                    for node in iter {
-                        let module = self.linker[node.module].path();
-                        let proc = self.linker[node].name();
-                        nodes.push(format!("{}", module.join(proc)));
+            let roots = self.linker[root]
+                .symbols()
+                .enumerate()
+                .filter_map(|(index, item)| {
+                    item.is_procedure().then_some(root + ast::ItemIndex::new(index))
+                })
+                .collect::<Vec<_>>();
+            for gid in roots {
+                let path = root_path.join(self.linker[gid].name());
+                let toposort = match self.linker.topological_sort_from_root(gid) {
+                    Ok(toposort) => toposort,
+                    Err(cycle) => {
+                        let cycle = cycle.into_node_ids().collect::<Vec<_>>();
+                        let mut nodes = Vec::with_capacity(cycle.len());
+                        for node in cycle.iter().copied() {
+                            let module = self.linker[node.module].path();
+                            let proc = self.linker[node].name();
+                            nodes.push(format!("{}", module.join(proc)));
+                        }
+                        let reason = format!(
+                            "found cycle in call graph rooted at '{path}' involving: {}",
+                            DisplayValues::new(nodes.iter())
+                        );
+                        if config.lint {
+                            for node in cycle {
+                                self.skip_item(node, SourceSpan::UNKNOWN, reason.clone());
+                            }
+                            self.skip_item(gid, SourceSpan::UNKNOWN, reason);
+                            continue;
+                        }
+                        return Err(Report::msg(reason));
                     }
-                    Report::msg(format!(
-                        "found cycle in call graph rooted at '{path}' involving: {}",
-                        DisplayValues::new(nodes.iter())
-                    ))
-                })?;
+                };
+
                 for gid in toposort.iter().rev().copied() {
-                    if !visited.insert(gid) {
+                    if !visited.insert(gid) || self.skipped_procedures.contains_key(&gid) {
                         continue;
                     }
 
-                    let item = self.linker[gid].item();
-                    match item {
+                    match self.linker[gid].item() {
                         SymbolItem::Procedure(p) => {
-                            let p = p.borrow();
-                            let signature = self.linker.resolve_signature(gid)?;
-                            match signature {
-                                Some(sig) => {
-                                    self.signatures.insert(
-                                        gid,
-                                        Signature::with_convention(
+                            let (span, signature) = {
+                                let p = p.borrow();
+                                let span = p.span();
+                                let signature = (|| {
+                                    if config.lint {
+                                        for invoke in p.invoked() {
+                                            let resolution = SymbolResolutionContext {
+                                                span: invoke.span(),
+                                                module: gid.module,
+                                                kind: Some(invoke.kind),
+                                            };
+                                            if let SymbolResolution::Exact { gid: callee, .. } =
+                                                self.linker.resolve_invoke_target(
+                                                    &resolution,
+                                                    &invoke.target,
+                                                )?
+                                                && let Some(skipped) =
+                                                    self.skipped_procedures.get(&callee)
+                                            {
+                                                return Err(Report::msg(format!(
+                                                    "depends on skipped procedure '{}': {}",
+                                                    skipped.path, skipped.reason
+                                                )));
+                                            }
+                                        }
+                                        if let Some((inst, span)) =
+                                            first_non_liftable_instruction(p.body())
+                                        {
+                                            return Err(Report::msg(format!(
+                                                "MASM instruction {inst:?} is not supported during \
+                                                 disassembly at {span:?}"
+                                            )));
+                                        }
+                                        let count = estimated_hir_operation_count(p.body());
+                                        if count > LINT_ESTIMATED_HIR_OP_LIMIT {
+                                            return Err(Report::msg(format!(
+                                                "procedure '{}' is estimated to expand to at least \
+                                                 {count} HIR operation(s), exceeding the lint \
+                                                 analysis limit of {LINT_ESTIMATED_HIR_OP_LIMIT}",
+                                                self.item_path(gid)
+                                            )));
+                                        }
+                                    }
+
+                                    let signature = match self.linker.resolve_signature(gid)? {
+                                        Some(sig) => Signature::with_convention(
                                             &self.context,
                                             sig.abi,
                                             sig.params.iter().cloned(),
                                             sig.results.iter().cloned(),
                                         ),
-                                    );
-                                }
-                                None if !config.infer_missing_signatures => {
-                                    let path = self.linker[gid.module].path();
-                                    return Err(Report::msg(format!(
-                                        "procedure '{}' is missing a signature",
-                                        path.join(p.name().as_str())
-                                    )));
-                                }
-                                None => {
-                                    let signature = infer::infer_signature(
-                                        gid,
-                                        &p,
-                                        &self.context,
-                                        &self.linker,
-                                        &self.signatures,
-                                    )?;
+                                        None if !config.infer_missing_signatures => {
+                                            return Err(Report::msg(format!(
+                                                "procedure '{}' is missing a signature",
+                                                self.item_path(gid)
+                                            )));
+                                        }
+                                        None => infer::infer_signature(
+                                            gid,
+                                            &p,
+                                            &self.context,
+                                            &self.linker,
+                                            &self.signatures,
+                                        )?,
+                                    };
+
+                                    if config.lint {
+                                        infer::validate_declared_signature(
+                                            gid,
+                                            &p,
+                                            &self.context,
+                                            &self.linker,
+                                            &self.signatures,
+                                            &signature,
+                                        )?;
+                                        validate_lint_signature(&self.item_path(gid), &signature)?;
+                                    }
+
+                                    Ok(signature)
+                                })();
+                                (span, signature)
+                            };
+                            match signature {
+                                Ok(signature) => {
                                     self.signatures.insert(gid, signature);
                                 }
+                                Err(err) if config.lint => {
+                                    self.skip_item(gid, span, err.to_string());
+                                }
+                                Err(err) => return Err(err),
                             }
                         }
                         SymbolItem::Compiled(ItemInfo::Procedure(p)) => {
-                            match p.signature.as_deref() {
-                                Some(sig) => {
-                                    self.signatures.insert(
-                                        gid,
-                                        Signature::with_convention(
-                                            &self.context,
-                                            sig.abi,
-                                            sig.params.iter().cloned(),
-                                            sig.results.iter().cloned(),
-                                        ),
-                                    );
+                            let signature = match p.signature.as_deref() {
+                                Some(sig) => Ok(Signature::with_convention(
+                                    &self.context,
+                                    sig.abi,
+                                    sig.params.iter().cloned(),
+                                    sig.results.iter().cloned(),
+                                )),
+                                None => Err(Report::msg(format!(
+                                    "compiled procedure '{}' is missing a signature",
+                                    self.item_path(gid)
+                                ))),
+                            }
+                            .and_then(|signature| {
+                                if config.lint {
+                                    validate_lint_signature(&self.item_path(gid), &signature)?;
                                 }
-                                None => {
-                                    let path = self.linker[gid.module].path();
-                                    return Err(Report::msg(format!(
-                                        "compiled procedure '{}' is missing a signature",
-                                        path.join(p.name.as_str())
-                                    )));
+                                Ok(signature)
+                            });
+                            match signature {
+                                Ok(signature) => {
+                                    self.signatures.insert(gid, signature);
                                 }
+                                Err(err) if config.lint => {
+                                    self.skip_item(gid, SourceSpan::UNKNOWN, err.to_string());
+                                }
+                                Err(err) => return Err(err),
                             }
                         }
-                        SymbolItem::Constant(_) | SymbolItem::Type(_) | SymbolItem::Compiled(_) => {
-                        }
+                        SymbolItem::Constant(_) | SymbolItem::Type(_) | SymbolItem::Compiled(_) => {}
                     }
                 }
             }
         }
 
         Ok(())
+    }
+
+    fn item_path(&self, gid: GlobalItemIndex) -> Arc<ast::Path> {
+        self.linker[gid.module]
+            .path()
+            .join(self.linker[gid].name())
+            .into_boxed_path()
+            .into()
+    }
+
+    fn skip_item(&mut self, gid: GlobalItemIndex, span: SourceSpan, reason: String) {
+        let path = self.item_path(gid);
+        self.skipped_procedures.entry(gid).or_insert(SkippedProcedure {
+            path,
+            span,
+            reason,
+        });
+    }
+
+    fn skipped_procedures(&self) -> Vec<SkippedProcedure> {
+        let mut skipped = self.skipped_procedures.values().cloned().collect::<Vec<_>>();
+        skipped.sort_by(|lhs, rhs| lhs.path.as_str().cmp(rhs.path.as_str()));
+        skipped
     }
 
     fn declare_modules(&mut self, world: midenc_hir::dialects::builtin::WorldRef) -> Result<()> {
@@ -388,6 +619,106 @@ impl ModuleRegistry {
     }
 }
 
+fn validate_lint_signature(path: &ast::Path, signature: &Signature) -> Result<()> {
+    if signature.params().len() > u8::MAX as usize {
+        return Err(Report::msg(format!(
+            "procedure '{path}' has {} parameter(s), exceeding the HIR operand limit of {}",
+            signature.params().len(),
+            u8::MAX
+        )));
+    }
+    if signature.results().len() > u8::MAX as usize {
+        return Err(Report::msg(format!(
+            "procedure '{path}' returns {} value(s), exceeding the HIR operand limit of {}",
+            signature.results().len(),
+            u8::MAX
+        )));
+    }
+    if signature.params().len() > LINT_SIGNATURE_VALUE_LIMIT {
+        return Err(Report::msg(format!(
+            "procedure '{path}' has {} parameter(s), exceeding the lint analysis signature limit \
+             of {LINT_SIGNATURE_VALUE_LIMIT}",
+            signature.params().len()
+        )));
+    }
+    if signature.results().len() > LINT_SIGNATURE_VALUE_LIMIT {
+        return Err(Report::msg(format!(
+            "procedure '{path}' returns {} value(s), exceeding the lint analysis signature limit \
+             of {LINT_SIGNATURE_VALUE_LIMIT}",
+            signature.results().len()
+        )));
+    }
+    Ok(())
+}
+
+fn first_non_liftable_instruction(block: &Block) -> Option<(&Instruction, SourceSpan)> {
+    for op in block.iter() {
+        match op {
+            Op::Inst(inst)
+                if semantics::instruction_semantics(inst.inner())
+                    != InstructionSemantics::LiftAndInfer =>
+            {
+                return Some((inst.inner(), inst.span()));
+            }
+            Op::Inst(_) => {}
+            Op::If {
+                then_blk, else_blk, ..
+            } => {
+                if let Some(unsupported) = first_non_liftable_instruction(then_blk) {
+                    return Some(unsupported);
+                }
+                if let Some(unsupported) = first_non_liftable_instruction(else_blk) {
+                    return Some(unsupported);
+                }
+            }
+            Op::While { body, .. } | Op::DoWhile { body, .. } | Op::Repeat { body, .. } => {
+                if let Some(unsupported) = first_non_liftable_instruction(body) {
+                    return Some(unsupported);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn estimated_hir_operation_count(block: &Block) -> usize {
+    estimated_block_hir_operation_count(block, LINT_ESTIMATED_HIR_OP_LIMIT.saturating_add(1))
+}
+
+fn estimated_block_hir_operation_count(block: &Block, cap: usize) -> usize {
+    let mut total = 0usize;
+    for op in block.iter() {
+        total = total.saturating_add(estimated_op_hir_operation_count(op, cap));
+        if total >= cap {
+            return cap;
+        }
+    }
+    total
+}
+
+fn estimated_op_hir_operation_count(op: &Op, cap: usize) -> usize {
+    match op {
+        Op::Inst(_) => 4,
+        Op::If {
+            then_blk, else_blk, ..
+        } => 1usize
+            .saturating_add(estimated_block_hir_operation_count(then_blk, cap))
+            .saturating_add(estimated_block_hir_operation_count(else_blk, cap))
+            .min(cap),
+        Op::While { body, .. } | Op::DoWhile { body, .. } => {
+            1usize.saturating_add(estimated_block_hir_operation_count(body, cap)).min(cap)
+        }
+        Op::Repeat { count, body, .. } => match count {
+            Immediate::Value(count) => estimated_block_hir_operation_count(body, cap)
+                .saturating_mul(count.into_inner() as usize)
+                .min(cap),
+            Immediate::Constant(_) => {
+                1usize.saturating_add(estimated_block_hir_operation_count(body, cap)).min(cap)
+            }
+        },
+    }
+}
+
 fn masm_module_symbol_path(path: &ast::Path) -> SymbolPath {
     let path = path.as_str().strip_prefix("::").unwrap_or(path.as_str());
     SymbolPath::from_masm_module_id(path)
@@ -449,6 +780,15 @@ impl<'a> ProcedureLifter<'a> {
                 "procedure '{}' leaves {} extra value(s) on the stack",
                 self.procedure.name(),
                 self.stack.len()
+            )));
+        }
+        if results.len() > u8::MAX as usize {
+            return Err(Report::msg(format!(
+                "procedure '{}::{}' returns {} value(s), exceeding the HIR operand limit of {}",
+                self.registry.linker[self.item.module].path(),
+                self.procedure.name(),
+                results.len(),
+                u8::MAX
             )));
         }
         builder.ret(results, self.procedure.span())?;
@@ -1131,6 +1471,16 @@ impl<'a> ProcedureLifter<'a> {
             Exp => self.binary_with_type(builder, Type::Felt, span, |builder, lhs, rhs, span| {
                 builder.exp(lhs, rhs, span)
             }),
+            ExpBitLength(32) => {
+                let exponent = self.pop(span)?;
+                let base = self.pop(span)?;
+                let base = self.cast(builder, base.value, Type::Felt, span)?;
+                let exponent = self.cast(builder, exponent.value, Type::U32, span)?;
+                let exponent = self.cast(builder, exponent, Type::Felt, span)?;
+                let result = builder.exp_u32_exponent(base, exponent, span)?;
+                self.push_value(result, span);
+                Ok(())
+            }
             ExpImm(value) => {
                 self.felt_binary_imm(builder, value, span, |builder, lhs, rhs, span| {
                     builder.exp(lhs, rhs, span)
@@ -2521,9 +2871,7 @@ impl<'a> ProcedureLifter<'a> {
     }
 
     fn pop(&mut self, span: SourceSpan) -> Result<StackValue> {
-        self.stack
-            .pop()
-            .ok_or_else(|| Report::msg(format!("stack underflow at {span:?}")))
+        self.stack.pop().ok_or_else(|| self.stack_underflow(span))
     }
 
     fn pop_binary(&mut self, span: SourceSpan) -> Result<(StackValue, StackValue)> {
@@ -2540,15 +2888,15 @@ impl<'a> ProcedureLifter<'a> {
     }
 
     fn dup(&mut self, depth: usize, span: SourceSpan) -> Result<()> {
-        masm_stack::dup(&mut self.stack, depth).ok_or_else(|| stack_underflow(span))
+        masm_stack::dup(&mut self.stack, depth).ok_or_else(|| self.stack_underflow(span))
     }
 
     fn dup_word(&mut self, depth: usize, span: SourceSpan) -> Result<()> {
-        masm_stack::dup_word(&mut self.stack, depth).ok_or_else(|| stack_underflow(span))
+        masm_stack::dup_word(&mut self.stack, depth).ok_or_else(|| self.stack_underflow(span))
     }
 
     fn swap(&mut self, depth: usize, span: SourceSpan) -> Result<()> {
-        masm_stack::swap(&mut self.stack, depth).ok_or_else(|| stack_underflow(span))
+        masm_stack::swap(&mut self.stack, depth).ok_or_else(|| self.stack_underflow(span))
     }
 
     fn swap_word(&mut self, depth: usize, span: SourceSpan) -> Result<()> {
@@ -2561,11 +2909,11 @@ impl<'a> ProcedureLifter<'a> {
 
     fn swap_chunks(&mut self, chunk_len: usize, depth: usize, span: SourceSpan) -> Result<()> {
         masm_stack::swap_chunks(&mut self.stack, chunk_len, depth)
-            .ok_or_else(|| stack_underflow(span))
+            .ok_or_else(|| self.stack_underflow(span))
     }
 
     fn movup(&mut self, depth: usize, span: SourceSpan) -> Result<()> {
-        masm_stack::movup(&mut self.stack, depth).ok_or_else(|| stack_underflow(span))
+        masm_stack::movup(&mut self.stack, depth).ok_or_else(|| self.stack_underflow(span))
     }
 
     fn movup_word(&mut self, depth: usize, span: SourceSpan) -> Result<()> {
@@ -2579,11 +2927,11 @@ impl<'a> ProcedureLifter<'a> {
         span: SourceSpan,
     ) -> Result<()> {
         masm_stack::move_chunk_to_top(&mut self.stack, chunk_len, depth)
-            .ok_or_else(|| stack_underflow(span))
+            .ok_or_else(|| self.stack_underflow(span))
     }
 
     fn movdn(&mut self, depth: usize, span: SourceSpan) -> Result<()> {
-        masm_stack::movdn(&mut self.stack, depth).ok_or_else(|| stack_underflow(span))
+        masm_stack::movdn(&mut self.stack, depth).ok_or_else(|| self.stack_underflow(span))
     }
 
     fn movdn_word(&mut self, depth: usize, span: SourceSpan) -> Result<()> {
@@ -2597,15 +2945,15 @@ impl<'a> ProcedureLifter<'a> {
         span: SourceSpan,
     ) -> Result<()> {
         masm_stack::move_top_chunk_down(&mut self.stack, chunk_len, depth)
-            .ok_or_else(|| stack_underflow(span))
+            .ok_or_else(|| self.stack_underflow(span))
     }
 
     fn reverse_word(&mut self, span: SourceSpan) -> Result<()> {
-        masm_stack::reverse_n(&mut self.stack, 4).ok_or_else(|| stack_underflow(span))
+        masm_stack::reverse_n(&mut self.stack, 4).ok_or_else(|| self.stack_underflow(span))
     }
 
     fn reverse_double_word(&mut self, span: SourceSpan) -> Result<()> {
-        masm_stack::reverse_n(&mut self.stack, 8).ok_or_else(|| stack_underflow(span))
+        masm_stack::reverse_n(&mut self.stack, 8).ok_or_else(|| self.stack_underflow(span))
     }
 
     fn pop_word(&mut self, span: SourceSpan) -> Result<Vec<StackValue>> {
@@ -2649,14 +2997,30 @@ impl<'a> ProcedureLifter<'a> {
     }
 
     fn pop_chunk(&mut self, chunk_len: usize, span: SourceSpan) -> Result<Vec<StackValue>> {
-        masm_stack::pop_chunk(&mut self.stack, chunk_len).ok_or_else(|| stack_underflow(span))
+        masm_stack::pop_chunk(&mut self.stack, chunk_len).ok_or_else(|| self.stack_underflow(span))
     }
 
     fn require_depth(&self, depth: usize, span: SourceSpan) -> Result<()> {
         if self.stack.len() <= depth {
-            Err(stack_underflow(span))
+            Err(self.stack_underflow(span))
         } else {
             Ok(())
+        }
+    }
+
+    fn stack_underflow(&self, span: SourceSpan) -> Report {
+        Report::msg(format!(
+            "stack underflow in '{}::{}' at {}",
+            self.registry.linker[self.item.module].path(),
+            self.procedure.name(),
+            self.format_span(span)
+        ))
+    }
+
+    fn format_span(&self, span: SourceSpan) -> String {
+        match self.registry.context.session().source_manager.file_line_col(span) {
+            Ok(location) => format!("{location}"),
+            Err(_) => format!("{span:?}"),
         }
     }
 }
@@ -2749,10 +3113,6 @@ fn unsupported_instruction(inst: &Instruction, span: SourceSpan) -> Result<()> {
     Err(Report::msg(format!(
         "MASM instruction {inst:?} is not supported during disassembly at {span:?}"
     )))
-}
-
-fn stack_underflow(span: SourceSpan) -> miden_assembly_syntax::diagnostics::Report {
-    Report::msg(format!("stack underflow at {span:?}"))
 }
 
 fn immediate_u32(immediate: &Immediate<u32>) -> Result<u32> {

--- a/frontend/masm/src/lift.rs
+++ b/frontend/masm/src/lift.rs
@@ -41,6 +41,7 @@ use crate::{
 
 const LINT_ESTIMATED_HIR_OP_LIMIT: usize = 900;
 const LINT_SIGNATURE_VALUE_LIMIT: usize = 8;
+type InitialSkip = (GlobalItemIndex, SourceSpan, String);
 
 pub(crate) struct LiftConfig {
     infer_missing_signatures: bool,
@@ -187,11 +188,12 @@ fn lift_modules(
     })
 }
 
+#[allow(clippy::vec_box)]
 fn link_modules_for_lint(
     linker: &mut Linker,
     root: Box<Module>,
     support: Vec<Box<Module>>,
-) -> Result<(Vec<ModuleIndex>, Vec<(GlobalItemIndex, SourceSpan, String)>)> {
+) -> Result<(Vec<ModuleIndex>, Vec<InitialSkip>)> {
     let mut module_indices = linker.link_modules([root])?;
     module_indices.extend(linker.link_modules(support)?);
 
@@ -219,9 +221,8 @@ fn link_modules_for_lint(
                     match linker.resolve_invoke_target(&resolution, &invoke.target) {
                         Ok(SymbolResolution::Exact { gid: callee, .. }) => {
                             if let Some((_, callee_reason)) = skipped.get(&callee) {
-                                let callee_path = linker[callee.module]
-                                    .path()
-                                    .join(linker[callee].name());
+                                let callee_path =
+                                    linker[callee.module].path().join(linker[callee].name());
                                 reason = Some(format!(
                                     "depends on skipped procedure '{callee_path}': {callee_reason}"
                                 ));
@@ -267,7 +268,7 @@ fn link_modules_for_lint(
         if let Some(signature) = signature {
             stub.set_signature(signature);
         }
-        *procedure = Box::new(stub);
+        **procedure = stub;
     }
 
     linker.link(core::iter::empty(), core::iter::empty())?;
@@ -299,7 +300,7 @@ impl ModuleRegistry {
         top_level_modules: Vec<ModuleIndex>,
         external_signatures: ExternalSignatureMap,
         external_types: ExternalTypeMap,
-        initial_skips: Vec<(GlobalItemIndex, SourceSpan, String)>,
+        initial_skips: Vec<InitialSkip>,
         context: Rc<Context>,
     ) -> Self {
         let external_signatures = external_signatures
@@ -401,16 +402,17 @@ impl ModuleRegistry {
                                             first_non_liftable_instruction(p.body())
                                         {
                                             return Err(Report::msg(format!(
-                                                "MASM instruction {inst:?} is not supported during \
-                                                 disassembly at {span:?}"
+                                                "MASM instruction {inst:?} is not supported \
+                                                 during disassembly at {span:?}"
                                             )));
                                         }
                                         let count = estimated_hir_operation_count(p.body());
                                         if count > LINT_ESTIMATED_HIR_OP_LIMIT {
                                             return Err(Report::msg(format!(
-                                                "procedure '{}' is estimated to expand to at least \
-                                                 {count} HIR operation(s), exceeding the lint \
-                                                 analysis limit of {LINT_ESTIMATED_HIR_OP_LIMIT}",
+                                                "procedure '{}' is estimated to expand to at \
+                                                 least {count} HIR operation(s), exceeding the \
+                                                 lint analysis limit of \
+                                                 {LINT_ESTIMATED_HIR_OP_LIMIT}",
                                                 self.item_path(gid)
                                             )));
                                         }
@@ -493,7 +495,8 @@ impl ModuleRegistry {
                                 Err(err) => return Err(err),
                             }
                         }
-                        SymbolItem::Constant(_) | SymbolItem::Type(_) | SymbolItem::Compiled(_) => {}
+                        SymbolItem::Constant(_) | SymbolItem::Type(_) | SymbolItem::Compiled(_) => {
+                        }
                     }
                 }
             }
@@ -512,11 +515,9 @@ impl ModuleRegistry {
 
     fn skip_item(&mut self, gid: GlobalItemIndex, span: SourceSpan, reason: String) {
         let path = self.item_path(gid);
-        self.skipped_procedures.entry(gid).or_insert(SkippedProcedure {
-            path,
-            span,
-            reason,
-        });
+        self.skipped_procedures
+            .entry(gid)
+            .or_insert(SkippedProcedure { path, span, reason });
     }
 
     fn skipped_procedures(&self) -> Vec<SkippedProcedure> {
@@ -528,6 +529,13 @@ impl ModuleRegistry {
     fn declare_modules(&mut self, world: midenc_hir::dialects::builtin::WorldRef) -> Result<()> {
         self.world = Some(world);
         let mut world_builder = WorldBuilder::new(world);
+
+        for module_index in self.top_level_modules.iter().copied() {
+            let module = &self.linker[module_index];
+            let symbol_path = masm_module_symbol_path(module.path());
+            let module_ref = world_builder.declare_module_tree(&symbol_path)?;
+            self.modules.insert(module_index, module_ref);
+        }
 
         for (gid, signature) in self.signatures.iter() {
             let gid = *gid;
@@ -622,13 +630,7 @@ impl ModuleRegistry {
 fn validate_lint_signature(path: &ast::Path, signature: &Signature) -> Result<()> {
     let checks = [
         (signature.params().len(), u8::MAX as usize, "has", "parameter", "HIR operand"),
-        (
-            signature.results().len(),
-            u8::MAX as usize,
-            "returns",
-            "value",
-            "HIR operand",
-        ),
+        (signature.results().len(), u8::MAX as usize, "returns", "value", "HIR operand"),
         (
             signature.params().len(),
             LINT_SIGNATURE_VALUE_LIMIT,

--- a/frontend/masm/src/lift.rs
+++ b/frontend/masm/src/lift.rs
@@ -398,14 +398,7 @@ impl ModuleRegistry {
                                                 )));
                                             }
                                         }
-                                        if let Some((inst, span)) =
-                                            first_non_liftable_instruction(p.body())
-                                        {
-                                            return Err(Report::msg(format!(
-                                                "MASM instruction {inst:?} is not supported \
-                                                 during disassembly at {span:?}"
-                                            )));
-                                        }
+                                        validate_lint_liftability(p.body())?;
                                         let count = estimated_hir_operation_count(p.body());
                                         if count > LINT_ESTIMATED_HIR_OP_LIMIT {
                                             return Err(Report::msg(format!(
@@ -657,34 +650,37 @@ fn validate_lint_signature(path: &ast::Path, signature: &Signature) -> Result<()
     Ok(())
 }
 
-fn first_non_liftable_instruction(block: &Block) -> Option<(&Instruction, SourceSpan)> {
+fn validate_lint_liftability(block: &Block) -> Result<()> {
     for op in block.iter() {
         match op {
             Op::Inst(inst)
                 if semantics::instruction_semantics(inst.inner())
                     != InstructionSemantics::LiftAndInfer =>
             {
-                return Some((inst.inner(), inst.span()));
+                return Err(Report::msg(format!(
+                    "MASM instruction {:?} is not supported during disassembly at {:?}",
+                    inst.inner(),
+                    inst.span()
+                )));
             }
             Op::Inst(_) => {}
             Op::If {
                 then_blk, else_blk, ..
             } => {
-                if let Some(unsupported) = first_non_liftable_instruction(then_blk) {
-                    return Some(unsupported);
-                }
-                if let Some(unsupported) = first_non_liftable_instruction(else_blk) {
-                    return Some(unsupported);
-                }
+                validate_lint_liftability(then_blk)?;
+                validate_lint_liftability(else_blk)?;
             }
-            Op::While { body, .. } | Op::DoWhile { body, .. } | Op::Repeat { body, .. } => {
-                if let Some(unsupported) = first_non_liftable_instruction(body) {
-                    return Some(unsupported);
-                }
+            Op::While { body, .. } | Op::Repeat { body, .. } => {
+                validate_lint_liftability(body)?;
+            }
+            Op::DoWhile { span, .. } => {
+                return Err(Report::msg(format!(
+                    "MASM do-while control flow is not supported during disassembly at {span:?}"
+                )));
             }
         }
     }
-    None
+    Ok(())
 }
 
 fn estimated_hir_operation_count(block: &Block) -> usize {

--- a/frontend/masm/src/lift.rs
+++ b/frontend/masm/src/lift.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, rc::Rc, sync::Arc};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    rc::Rc,
+    sync::Arc,
+};
 
 use miden_assembly::{
     GlobalItemIndex, ModuleIndex, ProjectSourceInputs,
@@ -42,6 +46,31 @@ use crate::{
 const LINT_ESTIMATED_HIR_OP_LIMIT: usize = 900;
 const LINT_SIGNATURE_VALUE_LIMIT: usize = 8;
 type InitialSkip = (GlobalItemIndex, SourceSpan, String);
+
+struct LintProcedurePreflight {
+    gid: GlobalItemIndex,
+    span: SourceSpan,
+    outcomes: Vec<LintInvocationOutcome>,
+}
+
+enum LintInvocationOutcome {
+    Exact {
+        span: SourceSpan,
+        callee: GlobalItemIndex,
+    },
+    ResolutionFailure {
+        span: SourceSpan,
+        reason: String,
+    },
+}
+
+impl LintInvocationOutcome {
+    fn span(&self) -> SourceSpan {
+        match self {
+            Self::Exact { span, .. } | Self::ResolutionFailure { span, .. } => *span,
+        }
+    }
+}
 
 pub(crate) struct LiftConfig {
     infer_missing_signatures: bool,
@@ -197,57 +226,99 @@ fn link_modules_for_lint(
     let mut module_indices = linker.link_modules([root])?;
     module_indices.extend(linker.link_modules(support)?);
 
-    let mut skipped = BTreeMap::<GlobalItemIndex, (SourceSpan, String)>::new();
-    loop {
-        let mut progress = false;
-        for module_index in 0..linker.modules().len() {
-            let module_index = ModuleIndex::new(module_index);
-            for (item_index, item) in linker[module_index].symbols().enumerate() {
-                let gid = module_index + ast::ItemIndex::new(item_index);
-                if skipped.contains_key(&gid) {
-                    continue;
-                }
-                let SymbolItem::Procedure(procedure) = item.item() else {
-                    continue;
+    let mut procedures = Vec::<LintProcedurePreflight>::new();
+    let mut callers = FxHashMap::<GlobalItemIndex, Vec<GlobalItemIndex>>::default();
+    let mut skipped_gids = FxHashSet::<GlobalItemIndex>::default();
+    let mut pending = VecDeque::<GlobalItemIndex>::new();
+
+    for module_index in 0..linker.modules().len() {
+        let module_index = ModuleIndex::new(module_index);
+        for (item_index, item) in linker[module_index].symbols().enumerate() {
+            let gid = module_index + ast::ItemIndex::new(item_index);
+            let SymbolItem::Procedure(procedure) = item.item() else {
+                continue;
+            };
+            let procedure = procedure.borrow();
+            let mut outcomes = Vec::new();
+            let mut has_resolution_failure = false;
+            for invoke in procedure.invoked() {
+                let resolution = SymbolResolutionContext {
+                    span: invoke.span(),
+                    module: module_index,
+                    kind: Some(invoke.kind),
                 };
-                let procedure = procedure.borrow();
-                let mut reason = None;
-                for invoke in procedure.invoked() {
-                    let resolution = SymbolResolutionContext {
-                        span: invoke.span(),
-                        module: module_index,
-                        kind: Some(invoke.kind),
-                    };
-                    match linker.resolve_invoke_target(&resolution, &invoke.target) {
-                        Ok(SymbolResolution::Exact { gid: callee, .. }) => {
-                            if let Some((_, callee_reason)) = skipped.get(&callee) {
-                                let callee_path =
-                                    linker[callee.module].path().join(linker[callee].name());
-                                reason = Some(format!(
-                                    "depends on skipped procedure '{callee_path}': {callee_reason}"
-                                ));
-                                break;
-                            }
-                        }
-                        Ok(_) => {}
-                        Err(err) => {
-                            reason = Some(format!(
+                match linker.resolve_invoke_target(&resolution, &invoke.target) {
+                    Ok(SymbolResolution::Exact { gid: callee, .. }) => {
+                        callers.entry(callee).or_default().push(gid);
+                        outcomes.push(LintInvocationOutcome::Exact {
+                            span: invoke.span(),
+                            callee,
+                        });
+                    }
+                    Ok(_) => {}
+                    Err(err) => {
+                        has_resolution_failure = true;
+                        outcomes.push(LintInvocationOutcome::ResolutionFailure {
+                            span: invoke.span(),
+                            reason: format!(
                                 "failed to resolve invocation during signature metadata pre-scan: \
                                  {err}; external signature metadata is missing"
-                            ));
-                            break;
-                        }
+                            ),
+                        });
                     }
                 }
-                if let Some(reason) = reason {
-                    skipped.insert(gid, (procedure.span(), reason));
-                    progress = true;
-                }
+            }
+            // `Procedure::invoked` is target-ordered, so restore lexical source order before
+            // selecting which deterministic diagnostic to report.
+            outcomes.sort_by_key(LintInvocationOutcome::span);
+            if has_resolution_failure && skipped_gids.insert(gid) {
+                pending.push_back(gid);
+            }
+            procedures.push(LintProcedurePreflight {
+                gid,
+                span: procedure.span(),
+                outcomes,
+            });
+        }
+    }
+
+    while let Some(callee) = pending.pop_front() {
+        let Some(callee_callers) = callers.get(&callee) else {
+            continue;
+        };
+        for caller in callee_callers.iter().copied() {
+            if skipped_gids.insert(caller) {
+                pending.push_back(caller);
             }
         }
-        if !progress {
-            break;
+    }
+
+    let mut skipped = BTreeMap::<GlobalItemIndex, (SourceSpan, String)>::new();
+    for procedure in procedures {
+        if !skipped_gids.contains(&procedure.gid) {
+            continue;
         }
+        let reason = procedure
+            .outcomes
+            .iter()
+            .find_map(|outcome| match outcome {
+                LintInvocationOutcome::ResolutionFailure { reason, .. } => Some(reason.clone()),
+                LintInvocationOutcome::Exact { .. } => None,
+            })
+            .or_else(|| {
+                procedure.outcomes.iter().find_map(|outcome| match outcome {
+                    LintInvocationOutcome::Exact { callee, .. }
+                        if skipped_gids.contains(callee) =>
+                    {
+                        let callee_path = linker[callee.module].path().join(linker[*callee].name());
+                        Some(skipped_dependency_reason(callee_path.as_str()))
+                    }
+                    LintInvocationOutcome::Exact { .. }
+                    | LintInvocationOutcome::ResolutionFailure { .. } => None,
+                })
+            })
+            .expect("a skipped procedure must have a failing invocation");
+        skipped.insert(procedure.gid, (procedure.span, reason));
     }
 
     for gid in skipped.keys().copied() {
@@ -392,10 +463,11 @@ impl ModuleRegistry {
                                                 && let Some(skipped) =
                                                     self.skipped_procedures.get(&callee)
                                             {
-                                                return Err(Report::msg(format!(
-                                                    "depends on skipped procedure '{}': {}",
-                                                    skipped.path, skipped.reason
-                                                )));
+                                                return Err(Report::msg(
+                                                    skipped_dependency_reason(
+                                                        skipped.path.as_str(),
+                                                    ),
+                                                ));
                                             }
                                         }
                                         validate_lint_liftability(p.body())?;
@@ -648,6 +720,10 @@ fn validate_lint_signature(path: &ast::Path, signature: &Signature) -> Result<()
         )));
     }
     Ok(())
+}
+
+fn skipped_dependency_reason(path: &str) -> String {
+    format!("depends on skipped procedure '{path}'")
 }
 
 fn validate_lint_liftability(block: &Block) -> Result<()> {

--- a/frontend/masm/src/semantics.rs
+++ b/frontend/masm/src/semantics.rs
@@ -25,7 +25,7 @@ macro_rules! define_instruction_semantics {
     ) => {
         #[cfg(test)]
         pub(crate) const LIFT_AND_INFER_INSTRUCTION_VARIANT_COUNT: usize =
-            count_instruction_patterns!($($lift_and_infer),*);
+            count_instruction_patterns!($($lift_and_infer),*) + 1;
         #[cfg(test)]
         pub(crate) const INFER_ONLY_INSTRUCTION_VARIANT_COUNT: usize =
             count_instruction_patterns!($($infer_only),*);
@@ -35,6 +35,8 @@ macro_rules! define_instruction_semantics {
 
         pub(crate) fn instruction_semantics(instruction: &Instruction) -> InstructionSemantics {
             match instruction {
+                Instruction::ExpBitLength(32) => InstructionSemantics::LiftAndInfer,
+                Instruction::ExpBitLength(_) => InstructionSemantics::Unsupported,
                 $($lift_and_infer => InstructionSemantics::LiftAndInfer,)*
                 $($infer_only => InstructionSemantics::InferOnly,)*
                 $($unsupported => InstructionSemantics::Unsupported,)*
@@ -287,7 +289,6 @@ define_instruction_semantics! {
         Instruction::ProcRef(_),
     ],
     unsupported: [
-        Instruction::ExpBitLength(_),
         Instruction::DynExec,
         Instruction::DynCall,
     ],

--- a/frontend/masm/src/tests.rs
+++ b/frontend/masm/src/tests.rs
@@ -2413,7 +2413,10 @@ path = "missing.masm"
     .unwrap();
     let context = Rc::new(Context::default());
     let manifest_path = app_dir.join("miden-project.toml");
-    let project = Project::load(&manifest_path, &context.session().source_manager)?;
+    let registry = NoPackageStore;
+    let dependency_graph = ProjectDependencyGraphBuilder::new(&registry)
+        .with_source_manager(context.session().source_manager.clone())
+        .build_from_path(&manifest_path)?;
     let app = parse_test_module_with_path(
         r#"
 pub proc entry() -> felt
@@ -2424,17 +2427,59 @@ end
         &context,
     )?;
     let output = disassemble_project_target_for_lint(
-        &project,
-        None,
-        Some(ProjectSourceInputs {
+        ProjectSourceInputs {
             root: app,
             support: vec![],
-        }),
+        },
+        &dependency_graph,
         &DisassemblerConfig::default(),
         context,
     )?;
 
     let _ = find_function(output.module, "entry");
+    assert!(output.skipped_procedures.is_empty());
+
+    let _ = fs::remove_dir_all(root);
+
+    Ok(())
+}
+
+#[test]
+fn lint_project_disassembly_with_preparsed_sources_uses_transitive_dependencies() -> Result<()> {
+    let (root, app_dir) =
+        write_transitive_source_dependency_project("midenc_frontend_masm_lint_transitive_dep");
+    let context = Rc::new(Context::default());
+    let registry = NoPackageStore;
+    let dependency_graph = ProjectDependencyGraphBuilder::new(&registry)
+        .with_source_manager(context.session().source_manager.clone())
+        .build_from_path(app_dir.join("miden-project.toml"))?;
+    let app = parse_test_module_with_path(
+        r#"
+pub proc entry(a: felt) -> felt
+    exec.::dep::callee
+end
+"#,
+        "app",
+        &context,
+    )?;
+
+    let output = disassemble_project_target_for_lint(
+        ProjectSourceInputs {
+            root: app,
+            support: vec![],
+        },
+        &dependency_graph,
+        &DisassemblerConfig::default(),
+        context,
+    )?;
+
+    let entry = find_function(output.module, "entry");
+    assert_eq!(top_level_op_count::<midenc_dialect_hir::Exec>(entry), 1);
+    let dep = find_world_module(output.world, "dep");
+    let callee = find_function(dep, "callee");
+    assert_eq!(top_level_op_count::<midenc_dialect_hir::Exec>(callee), 1);
+    let transitive = find_world_module(output.world, "transitive");
+    let _ = find_function(transitive, "callee");
     assert!(output.skipped_procedures.is_empty());
 
     let _ = fs::remove_dir_all(root);
@@ -6248,6 +6293,89 @@ pub proc callee(a: Scalar) -> Scalar
 end
 "#,
     )
+}
+
+fn write_transitive_source_dependency_project(
+    prefix: &str,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let root = temp_project_dir(prefix);
+    let app_dir = root.join("app");
+    let dep_dir = root.join("dep");
+    let transitive_dir = root.join("transitive");
+    fs::create_dir_all(&app_dir).unwrap();
+    fs::create_dir_all(&dep_dir).unwrap();
+    fs::create_dir_all(&transitive_dir).unwrap();
+
+    fs::write(
+        transitive_dir.join("miden-project.toml"),
+        r#"[package]
+name = "transitive"
+version = "0.0.1"
+
+[lib]
+path = "lib.masm"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        transitive_dir.join("lib.masm"),
+        r#"
+pub proc callee(a: felt) -> felt
+    add.1
+end
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        dep_dir.join("miden-project.toml"),
+        r#"[package]
+name = "dep"
+version = "0.0.1"
+
+[lib]
+path = "lib.masm"
+
+[dependencies]
+transitive = { path = "../transitive" }
+"#,
+    )
+    .unwrap();
+    fs::write(
+        dep_dir.join("lib.masm"),
+        r#"
+pub proc callee(a: felt) -> felt
+    exec.::transitive::callee
+end
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        app_dir.join("miden-project.toml"),
+        r#"[package]
+name = "app"
+version = "0.0.1"
+
+[lib]
+path = "main.masm"
+
+[dependencies]
+dep = { path = "../dep" }
+"#,
+    )
+    .unwrap();
+    fs::write(
+        app_dir.join("main.masm"),
+        r#"
+pub proc entry(a: felt) -> felt
+    exec.::dep::callee
+end
+"#,
+    )
+    .unwrap();
+
+    (root, app_dir)
 }
 
 fn write_source_dependency_project_with_content(

--- a/frontend/masm/src/tests.rs
+++ b/frontend/masm/src/tests.rs
@@ -179,7 +179,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     );
@@ -1004,7 +1003,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1034,7 +1032,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1061,7 +1058,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1095,7 +1091,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1142,7 +1137,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1186,7 +1180,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1225,7 +1218,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1274,7 +1266,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1306,7 +1297,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1335,7 +1325,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1378,7 +1367,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1487,7 +1475,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1523,7 +1510,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1552,7 +1538,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1582,7 +1567,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1609,7 +1593,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1654,7 +1637,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1700,7 +1682,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1732,7 +1713,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1790,7 +1770,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1850,7 +1829,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1906,7 +1884,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -1962,7 +1939,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     )?;
@@ -2058,7 +2034,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         &external_signatures,
         context,
@@ -2171,7 +2146,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         &external_signatures,
         context,
@@ -2228,8 +2202,6 @@ end
     assert_eq!(signature.results().len(), 1);
     assert_eq!(signature.results()[0].ty, Type::from(ArrayType::new(Type::Felt, 4)));
 
-    Ok(())
-}
     Ok(())
 }
 
@@ -3014,7 +2986,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     ) {
@@ -4384,7 +4355,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         &external_signatures,
         context,
@@ -4426,7 +4396,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         &external_signatures,
         context,
@@ -5193,7 +5162,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     );
@@ -5248,7 +5216,6 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
-            ..Default::default()
         },
         context,
     );
@@ -5316,9 +5283,7 @@ pub proc bad(cond: i1) -> felt
 end
 "#,
         "test",
-        &DisassemblerConfig {
-            ..Default::default()
-        },
+        &DisassemblerConfig::default(),
         context,
     )?;
 
@@ -5346,9 +5311,7 @@ pub proc bad(value: felt) -> felt
 end
 "#,
         "test",
-        &DisassemblerConfig {
-            ..Default::default()
-        },
+        &DisassemblerConfig::default(),
         context,
     )?;
 
@@ -5377,9 +5340,7 @@ pub proc bad(value: felt) -> felt
 end
 "#,
         "test",
-        &DisassemblerConfig {
-            ..Default::default()
-        },
+        &DisassemblerConfig::default(),
         context,
     )?;
 
@@ -5409,9 +5370,7 @@ pub proc bad() -> felt
 end
 "#,
         "test",
-        &DisassemblerConfig {
-            ..Default::default()
-        },
+        &DisassemblerConfig::default(),
         context,
     )?;
 
@@ -5436,9 +5395,7 @@ pub proc id(value: felt) -> felt
 end
 "#,
         "test",
-        &DisassemblerConfig {
-            ..Default::default()
-        },
+        &DisassemblerConfig::default(),
         context,
     )?;
 
@@ -5557,9 +5514,7 @@ pub proc dynamic(value: felt) -> felt
 end
 "#,
         "test",
-        &DisassemblerConfig {
-            ..Default::default()
-        },
+        &DisassemblerConfig::default(),
         context,
     )?;
 
@@ -5589,9 +5544,7 @@ pub proc exp_u8(base: felt, exponent: u32) -> felt
 end
 "#,
         "test",
-        &DisassemblerConfig {
-            ..Default::default()
-        },
+        &DisassemblerConfig::default(),
         context,
     )?;
 
@@ -5625,9 +5578,7 @@ pub proc capture() -> [felt; 4]
 end
 "#,
         "test",
-        &DisassemblerConfig {
-            ..Default::default()
-        },
+        &DisassemblerConfig::default(),
         context,
     )?;
 
@@ -5718,9 +5669,7 @@ pub proc huge(value: felt) -> felt
 end
 "#,
         "test",
-        &DisassemblerConfig {
-            ..Default::default()
-        },
+        &DisassemblerConfig::default(),
         context,
     )?;
 
@@ -5766,9 +5715,7 @@ pub proc wide(
 end
 "#,
         "test",
-        &DisassemblerConfig {
-            ..Default::default()
-        },
+        &DisassemblerConfig::default(),
         context,
     )?;
 

--- a/frontend/masm/src/tests.rs
+++ b/frontend/masm/src/tests.rs
@@ -5309,6 +5309,44 @@ end
 }
 
 #[test]
+fn lint_disassembly_skips_unsupported_do_while_procedure() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc good
+    push.1
+end
+
+pub proc bad
+    do
+        push.1
+        dup.0
+        neq.0
+    while
+        dup.0
+        lt.10
+    end
+end
+"#,
+        "test",
+        &DisassemblerConfig {
+            infer_missing_signatures: true,
+        },
+        context,
+    )?;
+
+    let _ = find_function(output.module, "good");
+    assert!(!module_has_function(output.module, "bad"));
+    assert_eq!(output.skipped_procedures.len(), 1);
+    let skipped = &output.skipped_procedures[0];
+    assert_eq!(skipped.path.as_str(), "::test::bad");
+    assert_ne!(skipped.span, SourceSpan::UNKNOWN);
+    assert!(skipped.reason.contains("do-while control flow is not supported"));
+
+    Ok(())
+}
+
+#[test]
 fn lint_disassembly_skips_known_signature_stack_shape_mismatch() -> Result<()> {
     let context = Rc::new(Context::default());
     let output = disassemble_source_for_lint(

--- a/frontend/masm/src/tests.rs
+++ b/frontend/masm/src/tests.rs
@@ -5483,6 +5483,152 @@ end
 }
 
 #[test]
+fn lint_signature_prescan_propagates_immediate_skip_reasons_through_call_chain() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc good() -> felt
+    push.1
+end
+
+pub proc p0(value: felt) -> felt
+    exec.p1
+end
+
+pub proc p1(value: felt) -> felt
+    exec.p2
+end
+
+pub proc p2(value: felt) -> felt
+    exec.p3
+    exec.p3
+end
+
+pub proc p3(value: felt) -> felt
+    exec.p4
+end
+
+pub proc p4(value: felt) -> felt
+    exec.p5
+end
+
+pub proc p5(value: felt) -> felt
+    exec.::dep::missing
+end
+"#,
+        "test",
+        &DisassemblerConfig::default(),
+        context,
+    )?;
+
+    let _ = find_function(output.module, "good");
+    assert_eq!(output.skipped_procedures.len(), 6);
+    for index in 0..5 {
+        let path = format!("::test::p{index}");
+        let skipped = output
+            .skipped_procedures
+            .iter()
+            .find(|skipped| skipped.path.as_str() == path)
+            .unwrap_or_else(|| panic!("expected {path} to be skipped"));
+        assert_eq!(
+            skipped.reason,
+            format!("depends on skipped procedure '::test::p{}'", index + 1)
+        );
+    }
+    let terminal = output
+        .skipped_procedures
+        .iter()
+        .find(|skipped| skipped.path.as_str() == "::test::p5")
+        .expect("expected terminal procedure to be skipped");
+    assert!(terminal.reason.contains("::dep::missing"));
+    assert!(terminal.reason.contains("signature metadata is missing"));
+
+    Ok(())
+}
+
+#[test]
+fn lint_signature_prescan_uses_deterministic_skip_reason_precedence() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc own_missing(value: felt) -> felt
+    exec.skipped_b
+    exec.::dep::own_missing
+end
+
+pub proc choose_callee(value: felt) -> felt
+    exec.skipped_b
+    exec.skipped_a
+end
+
+pub proc skipped_a(value: felt) -> felt
+    exec.::dep::missing_a
+end
+
+pub proc skipped_b(value: felt) -> felt
+    exec.::dep::missing_b
+end
+"#,
+        "test",
+        &DisassemblerConfig::default(),
+        context,
+    )?;
+
+    assert_eq!(output.skipped_procedures.len(), 4);
+    let own_missing = output
+        .skipped_procedures
+        .iter()
+        .find(|skipped| skipped.path.as_str() == "::test::own_missing")
+        .expect("expected own_missing to be skipped");
+    assert!(own_missing.reason.contains("::dep::own_missing"));
+
+    let choose_callee = output
+        .skipped_procedures
+        .iter()
+        .find(|skipped| skipped.path.as_str() == "::test::choose_callee")
+        .expect("expected choose_callee to be skipped");
+    assert_eq!(choose_callee.reason, "depends on skipped procedure '::test::skipped_b'");
+
+    Ok(())
+}
+
+#[test]
+fn lint_signature_prescan_preserves_direct_root_error_in_seeded_cycle() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc cycle_a(value: felt) -> felt
+    exec.cycle_b
+end
+
+pub proc cycle_b(value: felt) -> felt
+    exec.cycle_a
+    exec.::dep::cycle_root
+end
+"#,
+        "test",
+        &DisassemblerConfig::default(),
+        context,
+    )?;
+
+    assert_eq!(output.skipped_procedures.len(), 2);
+    let cycle_a = output
+        .skipped_procedures
+        .iter()
+        .find(|skipped| skipped.path.as_str() == "::test::cycle_a")
+        .expect("expected cycle_a to be skipped");
+    assert_eq!(cycle_a.reason, "depends on skipped procedure '::test::cycle_b'");
+    let cycle_b = output
+        .skipped_procedures
+        .iter()
+        .find(|skipped| skipped.path.as_str() == "::test::cycle_b")
+        .expect("expected cycle_b to be skipped");
+    assert!(cycle_b.reason.contains("::dep::cycle_root"));
+
+    Ok(())
+}
+
+#[test]
 fn lint_disassembly_skips_declared_signature_body_arity_drift() -> Result<()> {
     let context = Rc::new(Context::default());
     let output = disassemble_source_for_lint(
@@ -5549,6 +5695,10 @@ pub proc caller
     exec.bad
 end
 
+pub proc outer
+    exec.caller
+end
+
 pub proc bad
     push.1
     if.true
@@ -5569,6 +5719,7 @@ end
     let _ = find_function(output.module, "good");
     assert!(!module_has_function(output.module, "bad"));
     assert!(!module_has_function(output.module, "caller"));
+    assert!(!module_has_function(output.module, "outer"));
 
     let bad = output
         .skipped_procedures
@@ -5582,7 +5733,14 @@ end
         .iter()
         .find(|skipped| skipped.path.as_str() == "::test::caller")
         .expect("expected caller procedure to be skipped");
-    assert!(caller.reason.contains("depends on skipped procedure '::test::bad'"));
+    assert_eq!(caller.reason, "depends on skipped procedure '::test::bad'");
+
+    let outer = output
+        .skipped_procedures
+        .iter()
+        .find(|skipped| skipped.path.as_str() == "::test::outer")
+        .expect("expected outer procedure to be skipped");
+    assert_eq!(outer.reason, "depends on skipped procedure '::test::caller'");
 
     Ok(())
 }

--- a/frontend/masm/src/tests.rs
+++ b/frontend/masm/src/tests.rs
@@ -8,15 +8,18 @@ use std::{
 };
 
 use miden_assembly::{
-    Assembler,
+    Assembler, ProjectSourceInputs,
     ast::ItemIndex,
     linker::{Linker, SymbolItem},
 };
-use miden_assembly_syntax::ast::{self, Instruction};
+use miden_assembly_syntax::{
+    ast::{self, Instruction},
+    debuginfo::SourceSpan,
+};
 use miden_package_registry::{
     NoPackageStore, PackageId, PackageRecord, PackageRegistry, PackageVersions, Version,
 };
-use miden_project::ProjectDependencyGraphBuilder;
+use miden_project::{Project, ProjectDependencyGraphBuilder};
 use midenc_dialect_arith as arith;
 use midenc_dialect_cf as cf;
 use midenc_dialect_hir::{
@@ -38,6 +41,7 @@ use midenc_hir::{
     effects::AdviceEffect,
     pass::AnalysisManager,
 };
+use midenc_hir_analysis::DataFlowConfig;
 
 use super::*;
 use crate::semantics::{
@@ -175,6 +179,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     );
@@ -347,6 +352,7 @@ fn supported_instruction_matrix_lifts() {
         felt_instruction_case("incr", 1, 1, "add.1"),
         felt_instruction_case("pow2", 1, 1, "pow2"),
         felt_instruction_case("exp", 2, 1, "exp"),
+        instruction_case("exp_u32", &["felt", "u32"], &["felt"], "exp.u32"),
         felt_instruction_case("exp_imm", 1, 1, "exp.2"),
         instruction_case("not", &["i1"], &["i1"], "not"),
         instruction_case("and", &["i1", "i1"], &["i1"], "and"),
@@ -950,7 +956,7 @@ fn unsupported_instruction_matrix_reports_diagnostics() {
     let cases = [
         unsupported_instruction_case("dynexec", 0, "dynexec"),
         unsupported_instruction_case("dyncall", 0, "dyncall"),
-        unsupported_instruction_case("exp_bit_length", 2, "exp.u32"),
+        unsupported_instruction_case("exp_u8", 0, "exp.u8"),
     ];
 
     for case in &cases {
@@ -960,9 +966,9 @@ fn unsupported_instruction_matrix_reports_diagnostics() {
 
 #[test]
 fn instruction_inventory_classifies_all_masm_instruction_variants() {
-    assert_eq!(LIFT_AND_INFER_INSTRUCTION_VARIANT_COUNT, 237);
+    assert_eq!(LIFT_AND_INFER_INSTRUCTION_VARIANT_COUNT, 238);
     assert_eq!(INFER_ONLY_INSTRUCTION_VARIANT_COUNT, 1);
-    assert_eq!(UNSUPPORTED_INSTRUCTION_VARIANT_COUNT, 3);
+    assert_eq!(UNSUPPORTED_INSTRUCTION_VARIANT_COUNT, 2);
     assert_eq!(
         LIFT_AND_INFER_INSTRUCTION_VARIANT_COUNT
             + INFER_ONLY_INSTRUCTION_VARIANT_COUNT
@@ -975,6 +981,14 @@ fn instruction_inventory_classifies_all_masm_instruction_variants() {
             miden_assembly_syntax::ast::InvocationTarget::Symbol("foo".parse().unwrap())
         )),
         InstructionSemantics::InferOnly
+    );
+    assert_eq!(
+        instruction_semantics(&Instruction::ExpBitLength(32)),
+        InstructionSemantics::LiftAndInfer
+    );
+    assert_eq!(
+        instruction_semantics(&Instruction::ExpBitLength(8)),
+        InstructionSemantics::Unsupported
     );
 }
 
@@ -990,6 +1004,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1019,6 +1034,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1045,6 +1061,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1078,6 +1095,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1124,6 +1142,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1167,6 +1186,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1205,6 +1225,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1253,6 +1274,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1284,6 +1306,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1312,6 +1335,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1354,6 +1378,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1462,6 +1487,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1497,6 +1523,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1525,6 +1552,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1554,6 +1582,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1580,6 +1609,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1624,6 +1654,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1669,6 +1700,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1700,6 +1732,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1757,6 +1790,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1816,6 +1850,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1871,6 +1906,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -1926,6 +1962,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     )?;
@@ -2021,6 +2058,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         &external_signatures,
         context,
@@ -2133,6 +2171,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         &external_signatures,
         context,
@@ -2168,10 +2207,68 @@ end
 
     Ok(())
 }
+#[test]
+fn known_signature_array_alias_preserves_first_class_stack_value() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source(
+        r#"
+pub type Caller = [felt; 4]
+
+pub proc get_caller() -> Caller
+    caller
+end
+"#,
+        "test",
+        &DisassemblerConfig::default(),
+        context,
+    )?;
+
+    let signature = find_function(output.module, "get_caller").borrow().get_signature().clone();
+    assert_eq!(signature.params().len(), 0);
+    assert_eq!(signature.results().len(), 1);
+    assert_eq!(signature.results()[0].ty, Type::from(ArrayType::new(Type::Felt, 4)));
+
+    Ok(())
+}
+    Ok(())
+}
 
 #[test]
-fn project_disassembly_uses_source_dependency_signatures() -> Result<()> {
-    let (root, app_dir) = write_source_dependency_project("midenc_frontend_masm_source_dep");
+fn external_hir_array_signature_preserves_first_class_stack_value() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let array = Type::from(ArrayType::new(Type::Felt, 4));
+    let mut external_signatures = ExternalSignatureMap::new();
+    external_signatures
+        .insert(ast::Path::new("::dep::api::callee").into(), masm_signature([], [array.clone()]));
+
+    let output = disassemble_source_with_external_signatures(
+        r#"
+pub type Caller = [felt; 4]
+
+pub proc entry() -> Caller
+    exec.::dep::api::callee
+end
+"#,
+        "test",
+        &DisassemblerConfig::default(),
+        &external_signatures,
+        context,
+    )?;
+
+    let dep_api = find_world_module(output.world, "dep::api");
+    let callee = find_function(dep_api, "callee");
+    let signature = callee.borrow().get_signature().clone();
+    assert_eq!(signature.params().len(), 0);
+    assert_eq!(signature.results().len(), 1);
+    assert_eq!(signature.results()[0].ty, array);
+
+    Ok(())
+}
+
+#[test]
+fn project_disassembly_uses_source_dependency_module_index_metadata() -> Result<()> {
+    let (root, app_dir) =
+        write_source_dependency_module_index_project("midenc_frontend_masm_source_dep_index");
 
     let context = Rc::new(Context::default());
     let output = disassemble_project_target_from_path(
@@ -2218,6 +2315,212 @@ fn project_disassembly_loads_support_modules_into_world_tree() -> Result<()> {
         callee.borrow().as_symbol_operation().nearest_parent_op::<builtin::Module>()
             == Some(support)
     );
+
+    let _ = fs::remove_dir_all(root);
+
+    Ok(())
+}
+
+#[test]
+fn project_disassembly_accepts_module_index_roots() -> Result<()> {
+    let (root, app_dir) = write_module_index_project("midenc_frontend_masm_module_index");
+
+    let context = Rc::new(Context::default());
+    let output = disassemble_project_target_from_path(
+        app_dir.join("miden-project.toml"),
+        None,
+        &DisassemblerConfig::default(),
+        context,
+    )?;
+
+    let child = find_world_module(output.world, "app::child");
+    let leaf = find_world_module(output.world, "app::child::leaf");
+    let child_function = find_function(child, "double");
+    let signature = child_function.borrow().get_signature().clone();
+    assert_eq!(signature.params().len(), 1);
+    assert_eq!(signature.params()[0].ty, Type::Felt);
+    assert_eq!(signature.results().len(), 1);
+    assert_eq!(signature.results()[0].ty, Type::Felt);
+
+    let function = find_function(leaf, "inc");
+    let signature = function.borrow().get_signature().clone();
+    assert_eq!(signature.params().len(), 1);
+    assert_eq!(signature.params()[0].ty, Type::Felt);
+    assert_eq!(signature.results().len(), 1);
+    assert_eq!(signature.results()[0].ty, Type::Felt);
+    assert!(child.borrow().get(SymbolName::intern("leaf")).is_some());
+
+    let entry_block = child_function.borrow().entry_block();
+    let entry_block = entry_block.borrow();
+    let mut callee = None;
+    for op in entry_block.body().iter() {
+        if let Some(op) = op.as_trait::<dyn CallOpInterface>() {
+            callee = Some(op.resolve().expect("re-exported leaf callee should resolve"));
+            break;
+        }
+    }
+    let callee = callee.expect("child::double should call through the public re-export");
+    assert_eq!(callee.borrow().name().as_str(), "inc");
+
+    let _ = fs::remove_dir_all(root);
+
+    Ok(())
+}
+
+#[test]
+fn project_disassembly_accepts_private_child_module_declaration() -> Result<()> {
+    let (root, app_dir) =
+        write_private_child_module_index_project("midenc_frontend_masm_private_child_index");
+
+    let context = Rc::new(Context::default());
+    let output = disassemble_project_target_from_path(
+        app_dir.join("miden-project.toml"),
+        None,
+        &DisassemblerConfig::default(),
+        context,
+    )?;
+
+    let function = find_function(output.module, "call_secret");
+    assert_eq!(top_level_op_count::<midenc_dialect_hir::Exec>(function), 1);
+
+    let _ = fs::remove_dir_all(root);
+
+    Ok(())
+}
+
+#[test]
+fn lint_project_disassembly_with_preparsed_sources_does_not_read_target_path() -> Result<()> {
+    let root = temp_project_dir("midenc_frontend_masm_lint_preparsed_index");
+    let app_dir = root.join("app");
+    fs::create_dir_all(&app_dir).unwrap();
+    fs::write(
+        app_dir.join("miden-project.toml"),
+        r#"[package]
+name = "app"
+version = "0.0.1"
+
+[lib]
+path = "missing.masm"
+"#,
+    )
+    .unwrap();
+    let context = Rc::new(Context::default());
+    let manifest_path = app_dir.join("miden-project.toml");
+    let project = Project::load(&manifest_path, &context.session().source_manager)?;
+    let app = parse_test_module_with_path(
+        r#"
+pub proc entry() -> felt
+    push.7
+end
+"#,
+        "app",
+        &context,
+    )?;
+    let output = disassemble_project_target_for_lint(
+        &project,
+        None,
+        Some(ProjectSourceInputs {
+            root: app,
+            support: vec![],
+        }),
+        &DisassemblerConfig::default(),
+        context,
+    )?;
+
+    let _ = find_function(output.module, "entry");
+    assert!(output.skipped_procedures.is_empty());
+
+    let _ = fs::remove_dir_all(root);
+
+    Ok(())
+}
+
+#[test]
+fn lint_project_disassembly_with_resolved_input_keeps_module_index_metadata() -> Result<()> {
+    let (root, app_dir) =
+        write_private_child_module_index_project("midenc_frontend_masm_lint_resolved_index");
+
+    let context = Rc::new(Context::default());
+    let manifest_path = app_dir.join("miden-project.toml");
+    let project = Project::load(&manifest_path, &context.session().source_manager)?;
+    let target = project::resolve_project_target(&project, None, &context)?;
+    let output =
+        disassemble_project_target_input_for_lint(target, &DisassemblerConfig::default(), context)?;
+
+    let function = find_function(output.module, "call_secret");
+    assert_eq!(top_level_op_count::<midenc_dialect_hir::Exec>(function), 1);
+    assert!(output.skipped_procedures.is_empty());
+
+    let _ = fs::remove_dir_all(root);
+
+    Ok(())
+}
+
+#[test]
+fn project_disassembly_does_not_fallback_to_undeclared_child_procedure() -> Result<()> {
+    let (root, app_dir) =
+        write_undeclared_child_module_index_project("midenc_frontend_masm_undeclared_child_index");
+
+    let context = Rc::new(Context::default());
+    let err = match disassemble_project_target_from_path(
+        app_dir.join("miden-project.toml"),
+        None,
+        &DisassemblerConfig::default(),
+        context,
+    ) {
+        Ok(_) => panic!("undeclared child procedure should not resolve through fallback"),
+        Err(err) => err,
+    };
+
+    let message = err.to_string();
+    assert!(message.contains("leaf::secret"));
+    assert!(message.contains("failed to resolve") || message.contains("could not resolve"));
+
+    let _ = fs::remove_dir_all(root);
+
+    Ok(())
+}
+
+#[test]
+fn project_disassembly_does_not_strip_invalid_module_declarations() -> Result<()> {
+    let root = temp_project_dir("midenc_frontend_masm_invalid_module_declaration");
+    let app_dir = root.join("app");
+    fs::create_dir_all(&app_dir).unwrap();
+    fs::write(
+        app_dir.join("miden-project.toml"),
+        r#"[package]
+name = "app"
+version = "0.0.1"
+
+[lib]
+path = "mod.masm"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        app_dir.join("mod.masm"),
+        r#"
+mod child::
+
+pub proc entry() -> felt
+    push.1
+end
+"#,
+    )
+    .unwrap();
+
+    let context = Rc::new(Context::default());
+    let err = match disassemble_project_target_from_path(
+        app_dir.join("miden-project.toml"),
+        None,
+        &DisassemblerConfig::default(),
+        context,
+    ) {
+        Ok(_) => panic!("invalid module declaration should be reported by the parser"),
+        Err(err) => err,
+    };
+
+    assert!(err.to_string().contains("invalid syntax"));
 
     let _ = fs::remove_dir_all(root);
 
@@ -2711,6 +3014,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     ) {
@@ -2894,6 +3198,24 @@ end
 
     let findings = advice_taint_findings(output.module)?;
     assert_eq!(sink_names(&findings), ["arith.add"]);
+    assert_eq!(findings[0].function.map(|name| name.as_str()), Some("entry"));
+
+    Ok(())
+}
+
+#[test]
+fn advice_taint_reports_raw_advice_used_by_exp_u32_exponent() -> Result<()> {
+    let findings = advice_taint_findings_for_source(
+        r#"
+pub proc entry() -> felt
+    push.3
+    adv_push
+    exp.u32
+end
+"#,
+    )?;
+
+    assert_eq!(sink_names(&findings), ["arith.exp"]);
     assert_eq!(findings[0].function.map(|name| name.as_str()), Some("entry"));
 
     Ok(())
@@ -3737,6 +4059,114 @@ end
 }
 
 #[test]
+fn advice_taint_handles_duplicate_call_return_values() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source(
+        r#"
+proc duplicate(value: u32) -> (u32, u32)
+    dup
+end
+
+pub proc entry(rhs: u32) -> u32
+    adv_push
+    exec.duplicate
+    drop
+    u32wrapping_add
+end
+"#,
+        "test",
+        &DisassemblerConfig::default(),
+        context,
+    )?;
+
+    let findings = advice_taint_findings(output.module)?;
+    assert_eq!(sink_names(&findings), ["arith.add"]);
+
+    Ok(())
+}
+
+#[test]
+fn advice_taint_reports_worklist_budget_exhaustion() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source(
+        r#"
+proc duplicate(value: u32) -> (u32, u32)
+    dup
+end
+
+pub proc entry(rhs: u32) -> u32
+    adv_push
+    exec.duplicate
+    drop
+    u32wrapping_add
+end
+"#,
+        "test",
+        &DisassemblerConfig::default(),
+        context,
+    )?;
+
+    let analysis_manager = AnalysisManager::new(output.module.as_operation_ref(), None);
+    let mut config = DataFlowConfig::new();
+    config.set_interprocedural(true).set_max_worklist_iterations(Some(0));
+    let module = output.module.borrow();
+    let err =
+        match AdviceTaintAnalysis::run_with_config(module.as_operation(), analysis_manager, config)
+        {
+            Ok(_) => panic!("expected advice taint analysis to report worklist budget exhaustion"),
+            Err(err) => err,
+        };
+
+    let err = err.to_string();
+    assert!(err.contains("dataflow solver exceeded worklist iteration budget"));
+    assert!(err.contains("queued analyses:"));
+
+    Ok(())
+}
+
+#[test]
+fn advice_taint_partial_run_reports_budget_exhaustion() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source(
+        r#"
+proc duplicate(value: u32) -> (u32, u32)
+    dup
+end
+
+pub proc entry(rhs: u32) -> u32
+    adv_push
+    exec.duplicate
+    drop
+    u32wrapping_add
+end
+"#,
+        "test",
+        &DisassemblerConfig::default(),
+        context,
+    )?;
+
+    let analysis_manager = AnalysisManager::new(output.module.as_operation_ref(), None);
+    let mut config = DataFlowConfig::new();
+    config.set_interprocedural(true).set_max_worklist_iterations(Some(0));
+    let module = output.module.borrow();
+    let result = AdviceTaintAnalysis::run_with_config_allow_partial(
+        module.as_operation(),
+        analysis_manager,
+        config,
+    )?;
+
+    let reason = result
+        .incomplete_reason
+        .expect("expected partial advice taint analysis to report budget exhaustion");
+    assert!(reason.contains("dataflow solver exceeded worklist iteration budget"));
+    assert!(reason.contains("queued analyses:"));
+    let source_manager = output.world.borrow().as_operation().context().source_manager();
+    let _ = result.analysis.diagnostics(&source_manager);
+
+    Ok(())
+}
+
+#[test]
 fn advice_taint_keeps_nested_passthrough_call_results_call_site_specific() -> Result<()> {
     let context = Rc::new(Context::default());
     let output = disassemble_source(
@@ -3954,6 +4384,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         &external_signatures,
         context,
@@ -3995,6 +4426,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         &external_signatures,
         context,
@@ -4081,6 +4513,34 @@ end
             "unconstrained value returns from a call here",
         ]
     );
+
+    Ok(())
+}
+
+#[test]
+fn advice_taint_deduplicates_public_return_origins_for_same_result() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source(
+        r#"
+pub proc entry() -> felt
+    adv_push
+    adv_push
+    add
+end
+"#,
+        "test",
+        &DisassemblerConfig::default(),
+        context,
+    )?;
+
+    let exits = advice_taint_exit_findings(output.module)?;
+    assert_eq!(exits.len(), 1, "{exits:#?}");
+    assert_eq!(exits[0].function.as_str(), "entry");
+    assert_eq!(exits[0].result_index, 0);
+    assert_eq!(exits[0].origin.kind, AdviceTaintOriginKind::Advice);
+
+    let diagnostics = advice_taint_diagnostics(output.module)?;
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
 
     Ok(())
 }
@@ -4733,6 +5193,7 @@ end
         "test",
         &DisassemblerConfig {
             infer_missing_signatures: true,
+            ..Default::default()
         },
         context,
     );
@@ -4768,6 +5229,562 @@ end
 
     assert!(err.to_string().contains("if branches leave different stack depths"));
 }
+
+#[test]
+fn strict_disassembly_still_errors_on_lint_branch_depth_fixture() {
+    let context = Rc::new(Context::default());
+    let result = disassemble_source(
+        r#"
+pub proc bad
+    push.1
+    if.true
+        push.1
+    else
+        push.1
+        push.2
+    end
+end
+"#,
+        "test",
+        &DisassemblerConfig {
+            infer_missing_signatures: true,
+            ..Default::default()
+        },
+        context,
+    );
+    let err = match result {
+        Ok(_) => panic!("expected strict disassembly to reject mismatched branch stack depths"),
+        Err(err) => err,
+    };
+
+    assert!(err.to_string().contains("if branches leave different inferred stack depths"));
+}
+
+#[test]
+fn lint_disassembly_skips_branch_depth_mismatch_procedure() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc good
+    push.1
+end
+
+pub proc bad
+    push.1
+    if.true
+        push.1
+    else
+        push.1
+        push.2
+    end
+end
+"#,
+        "test",
+        &DisassemblerConfig {
+            infer_missing_signatures: true,
+        },
+        context,
+    )?;
+
+    let _ = find_function(output.module, "good");
+    assert!(!module_has_function(output.module, "bad"));
+    assert_eq!(output.skipped_procedures.len(), 1);
+    let skipped = &output.skipped_procedures[0];
+    assert_eq!(skipped.path.as_str(), "::test::bad");
+    assert_ne!(skipped.span, SourceSpan::UNKNOWN);
+    assert!(skipped.reason.contains("if branches leave different inferred stack depths"));
+
+    Ok(())
+}
+
+#[test]
+fn lint_disassembly_skips_known_signature_stack_shape_mismatch() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc good() -> felt
+    push.1
+end
+
+pub proc bad(cond: i1) -> felt
+    if.true
+        push.1
+    else
+        push.1
+        push.2
+    end
+end
+"#,
+        "test",
+        &DisassemblerConfig {
+            ..Default::default()
+        },
+        context,
+    )?;
+
+    let _ = find_function(output.module, "good");
+    assert!(!module_has_function(output.module, "bad"));
+    assert_eq!(output.skipped_procedures.len(), 1);
+    let skipped = &output.skipped_procedures[0];
+    assert_eq!(skipped.path.as_str(), "::test::bad");
+    assert!(skipped.reason.contains("if branches leave different inferred stack depths"));
+
+    Ok(())
+}
+
+#[test]
+fn lint_single_module_skips_missing_external_after_core_metadata_prescan() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc good() -> felt
+    push.1
+end
+
+pub proc bad(value: felt) -> felt
+    exec.::dep::missing
+end
+"#,
+        "test",
+        &DisassemblerConfig {
+            ..Default::default()
+        },
+        context,
+    )?;
+
+    let _ = find_function(output.module, "good");
+    assert!(!module_has_function(output.module, "bad"));
+    assert_eq!(output.skipped_procedures.len(), 1);
+    let skipped = &output.skipped_procedures[0];
+    assert_eq!(skipped.path.as_str(), "::test::bad");
+    assert!(skipped.reason.contains("::dep::missing"));
+    assert!(skipped.reason.contains("signature metadata is missing"));
+
+    Ok(())
+}
+
+#[test]
+fn lint_disassembly_skips_unresolved_relative_invoke_during_signature_prescan() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc good() -> felt
+    push.1
+end
+
+pub proc bad(value: felt) -> felt
+    exec.missing::callee
+end
+"#,
+        "test",
+        &DisassemblerConfig {
+            ..Default::default()
+        },
+        context,
+    )?;
+
+    let _ = find_function(output.module, "good");
+    assert!(!module_has_function(output.module, "bad"));
+    assert_eq!(output.skipped_procedures.len(), 1);
+    let skipped = &output.skipped_procedures[0];
+    assert_eq!(skipped.path.as_str(), "::test::bad");
+    assert!(skipped.reason.contains("signature metadata pre-scan"));
+    assert!(skipped.reason.contains("missing::callee"));
+
+    Ok(())
+}
+
+#[test]
+fn lint_disassembly_skips_declared_signature_body_arity_drift() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc good() -> felt
+    push.1
+end
+
+pub proc bad() -> felt
+    push.1
+    push.2
+end
+"#,
+        "test",
+        &DisassemblerConfig {
+            ..Default::default()
+        },
+        context,
+    )?;
+
+    let _ = find_function(output.module, "good");
+    assert!(!module_has_function(output.module, "bad"));
+    assert_eq!(output.skipped_procedures.len(), 1);
+    let skipped = &output.skipped_procedures[0];
+    assert_eq!(skipped.path.as_str(), "::test::bad");
+    assert!(skipped.reason.contains("declared signature"));
+    assert!(skipped.reason.contains("extra value"));
+
+    Ok(())
+}
+
+#[test]
+fn lint_disassembly_keeps_declared_pass_through_signature() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc id(value: felt) -> felt
+    nop
+end
+"#,
+        "test",
+        &DisassemblerConfig {
+            ..Default::default()
+        },
+        context,
+    )?;
+
+    let signature = find_function(output.module, "id").borrow().get_signature().clone();
+    assert_eq!(signature.params().len(), 1);
+    assert_eq!(signature.params()[0].ty, Type::Felt);
+    assert_eq!(signature.results().len(), 1);
+    assert_eq!(signature.results()[0].ty, Type::Felt);
+    assert!(output.skipped_procedures.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn lint_disassembly_skips_callers_of_skipped_procedures() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc good
+    push.1
+end
+
+pub proc caller
+    exec.bad
+end
+
+pub proc bad
+    push.1
+    if.true
+        push.1
+    else
+        push.1
+        push.2
+    end
+end
+"#,
+        "test",
+        &DisassemblerConfig {
+            infer_missing_signatures: true,
+        },
+        context,
+    )?;
+
+    let _ = find_function(output.module, "good");
+    assert!(!module_has_function(output.module, "bad"));
+    assert!(!module_has_function(output.module, "caller"));
+
+    let bad = output
+        .skipped_procedures
+        .iter()
+        .find(|skipped| skipped.path.as_str() == "::test::bad")
+        .expect("expected bad procedure to be skipped");
+    assert!(bad.reason.contains("if branches leave different inferred stack depths"));
+
+    let caller = output
+        .skipped_procedures
+        .iter()
+        .find(|skipped| skipped.path.as_str() == "::test::caller")
+        .expect("expected caller procedure to be skipped");
+    assert!(caller.reason.contains("depends on skipped procedure '::test::bad'"));
+
+    Ok(())
+}
+
+#[test]
+fn lint_advice_taint_reports_findings_when_other_procedures_are_skipped() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc entry() -> u32
+    adv_push
+    push.1
+    u32wrapping_add
+end
+
+pub proc bad
+    push.1
+    if.true
+        push.1
+    else
+        push.1
+        push.2
+    end
+end
+"#,
+        "test",
+        &DisassemblerConfig {
+            infer_missing_signatures: true,
+        },
+        context,
+    )?;
+
+    assert!(module_has_function(output.module, "entry"));
+    assert!(!module_has_function(output.module, "bad"));
+    assert_eq!(output.skipped_procedures.len(), 1);
+    assert_eq!(output.skipped_procedures[0].path.as_str(), "::test::bad");
+
+    let findings = advice_taint_findings(output.module)?;
+    assert_eq!(sink_names(&findings), ["arith.add"]);
+    assert_eq!(findings[0].function.map(|name| name.as_str()), Some("entry"));
+
+    Ok(())
+}
+
+#[test]
+fn lint_disassembly_skips_unsupported_dynamic_invocation() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc good() -> felt
+    push.1
+end
+
+pub proc dynamic(value: felt) -> felt
+    dynexec
+end
+"#,
+        "test",
+        &DisassemblerConfig {
+            ..Default::default()
+        },
+        context,
+    )?;
+
+    let _ = find_function(output.module, "good");
+    assert!(!module_has_function(output.module, "dynamic"));
+    assert_eq!(output.skipped_procedures.len(), 1);
+    let skipped = &output.skipped_procedures[0];
+    assert_eq!(skipped.path.as_str(), "::test::dynamic");
+    assert_ne!(skipped.span, SourceSpan::UNKNOWN);
+    assert!(skipped.reason.contains("DynExec"));
+    assert!(skipped.reason.contains("not supported during disassembly"));
+
+    Ok(())
+}
+
+#[test]
+fn lint_disassembly_skips_unsupported_exp_bit_length() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc good() -> felt
+    push.1
+end
+
+pub proc exp_u8(base: felt, exponent: u32) -> felt
+    exp.u8
+end
+"#,
+        "test",
+        &DisassemblerConfig {
+            ..Default::default()
+        },
+        context,
+    )?;
+
+    let _ = find_function(output.module, "good");
+    assert!(!module_has_function(output.module, "exp_u8"));
+    assert_eq!(output.skipped_procedures.len(), 1);
+    let skipped = &output.skipped_procedures[0];
+    assert_eq!(skipped.path.as_str(), "::test::exp_u8");
+    assert_ne!(skipped.span, SourceSpan::UNKNOWN);
+    assert!(skipped.reason.contains("ExpBitLength(8)"));
+    assert!(skipped.reason.contains("not supported during disassembly"));
+
+    Ok(())
+}
+
+#[test]
+fn lint_disassembly_skips_infer_only_proc_ref() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc good() -> felt
+    push.1
+end
+
+proc target()
+    nop
+end
+
+pub proc capture() -> [felt; 4]
+    procref.target
+end
+"#,
+        "test",
+        &DisassemblerConfig {
+            ..Default::default()
+        },
+        context,
+    )?;
+
+    let _ = find_function(output.module, "good");
+    assert!(!module_has_function(output.module, "capture"));
+    let skipped = output
+        .skipped_procedures
+        .iter()
+        .find(|skipped| skipped.path.as_str() == "::test::capture")
+        .expect("expected procref procedure to be skipped");
+    assert!(skipped.reason.contains("ProcRef"));
+    assert!(skipped.reason.contains("not supported during disassembly"));
+
+    Ok(())
+}
+
+#[test]
+fn lint_disassembly_skips_oversized_inferred_signatures() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let pushes = std::iter::repeat_n("    padw", 64).collect::<Vec<_>>().join("\n");
+    let source = format!(
+        r#"
+pub proc good() -> felt
+    push.1
+end
+
+pub proc caller() -> felt
+    exec.huge
+end
+
+pub proc huge
+{pushes}
+end
+"#
+    );
+
+    let output = disassemble_source_for_lint(
+        &source,
+        "test",
+        &DisassemblerConfig {
+            infer_missing_signatures: true,
+        },
+        context,
+    )?;
+
+    let _ = find_function(output.module, "good");
+    assert!(!module_has_function(output.module, "huge"));
+    assert!(!module_has_function(output.module, "caller"));
+
+    let huge = output
+        .skipped_procedures
+        .iter()
+        .find(|skipped| skipped.path.as_str() == "::test::huge")
+        .expect("expected huge procedure to be skipped");
+    assert!(huge.reason.contains("returns 256 value(s)"));
+    assert!(huge.reason.contains("HIR operand limit"));
+
+    let caller = output
+        .skipped_procedures
+        .iter()
+        .find(|skipped| skipped.path.as_str() == "::test::caller")
+        .expect("expected caller procedure to be skipped");
+    assert!(
+        caller.reason.contains("depends on skipped procedure '::test::huge'")
+            || caller.reason.contains("declared signature")
+    );
+
+    Ok(())
+}
+
+#[test]
+fn lint_disassembly_skips_oversized_expanded_bodies() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc good(value: felt) -> felt
+    add.1
+end
+
+pub proc caller(value: felt) -> felt
+    exec.huge
+end
+
+pub proc huge(value: felt) -> felt
+    repeat.801
+        add.1
+    end
+end
+"#,
+        "test",
+        &DisassemblerConfig {
+            ..Default::default()
+        },
+        context,
+    )?;
+
+    let _ = find_function(output.module, "good");
+    assert!(!module_has_function(output.module, "huge"));
+    assert!(!module_has_function(output.module, "caller"));
+
+    let huge = output
+        .skipped_procedures
+        .iter()
+        .find(|skipped| skipped.path.as_str() == "::test::huge")
+        .expect("expected huge procedure to be skipped");
+    assert!(huge.reason.contains("estimated to expand to at least 901 HIR operation"));
+    assert!(huge.reason.contains("lint analysis limit"));
+
+    let caller = output
+        .skipped_procedures
+        .iter()
+        .find(|skipped| skipped.path.as_str() == "::test::caller")
+        .expect("expected caller procedure to be skipped");
+    assert!(caller.reason.contains("depends on skipped procedure '::test::huge'"));
+
+    Ok(())
+}
+
+#[test]
+fn lint_disassembly_skips_wide_signatures() -> Result<()> {
+    let context = Rc::new(Context::default());
+    let output = disassemble_source_for_lint(
+        r#"
+pub proc good() -> felt
+    push.1
+end
+
+pub proc wide(
+    v0: felt, v1: felt, v2: felt, v3: felt, v4: felt,
+    v5: felt, v6: felt, v7: felt, v8: felt
+) -> felt
+    drop
+    dropw
+    dropw
+    push.1
+end
+"#,
+        "test",
+        &DisassemblerConfig {
+            ..Default::default()
+        },
+        context,
+    )?;
+
+    let _ = find_function(output.module, "good");
+    assert!(!module_has_function(output.module, "wide"));
+    let wide = output
+        .skipped_procedures
+        .iter()
+        .find(|skipped| skipped.path.as_str() == "::test::wide")
+        .expect("expected wide procedure to be skipped");
+    assert!(wide.reason.contains("has 9 parameter(s)"));
+    assert!(wide.reason.contains("signature limit of 8"));
+
+    Ok(())
+}
+
 
 #[test]
 fn rejects_mutual_recursion() -> Result<()> {
@@ -4847,8 +5864,16 @@ fn parse_test_module(
     source: &str,
     context: &Rc<Context>,
 ) -> Result<Box<miden_assembly_syntax::ast::Module>> {
+    parse_test_module_with_path(source, "test", context)
+}
+
+fn parse_test_module_with_path(
+    source: &str,
+    path: &str,
+    context: &Rc<Context>,
+) -> Result<Box<miden_assembly_syntax::ast::Module>> {
     miden_assembly::ModuleParser::new(Some(ast::ModuleKind::Library)).parse_str(
-        Some(ast::Path::new("test")),
+        Some(ast::Path::new(path)),
         source,
         context.source_manager(),
     )
@@ -5026,6 +6051,17 @@ fn find_function(module: builtin::ModuleRef, name: &str) -> builtin::FunctionRef
     }
 
     panic!("expected function '{name}'");
+}
+
+fn module_has_function(module: builtin::ModuleRef, name: &str) -> bool {
+    if module.borrow().get(SymbolName::intern(name)).is_some() {
+        return true;
+    }
+
+    module.borrow().body().entry().body().iter().any(|op| {
+        op.downcast_ref::<Function>()
+            .is_some_and(|function| function.get_name().as_str() == name)
+    })
 }
 
 fn find_world_module(world: builtin::WorldRef, module_path: &str) -> builtin::ModuleRef {
@@ -5229,6 +6265,74 @@ dep = { path = "../dep" }
     (root, app_dir)
 }
 
+fn write_source_dependency_module_index_project(
+    prefix: &str,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let root = temp_project_dir(prefix);
+    let app_dir = root.join("app");
+    let dep_dir = root.join("dep");
+    fs::create_dir_all(&app_dir).unwrap();
+    fs::create_dir_all(&dep_dir).unwrap();
+
+    fs::write(
+        dep_dir.join("miden-project.toml"),
+        r#"[package]
+name = "dep"
+version = "0.0.1"
+
+[lib]
+path = "mod.masm"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        dep_dir.join("mod.masm"),
+        r#"
+pub mod child
+
+pub proc entry(a: felt) -> felt
+    exec.child::leaf
+end
+"#,
+    )
+    .unwrap();
+    fs::write(
+        dep_dir.join("child.masm"),
+        r#"
+pub proc leaf(a: felt) -> felt
+    add.1
+end
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        app_dir.join("miden-project.toml"),
+        r#"[package]
+name = "app"
+version = "0.0.1"
+
+[lib]
+path = "main.masm"
+
+[dependencies]
+dep = { path = "../dep" }
+"#,
+    )
+    .unwrap();
+    fs::write(
+        app_dir.join("main.masm"),
+        r#"
+pub proc entry(a: felt) -> felt
+    exec.::dep::entry
+end
+"#,
+    )
+    .unwrap();
+
+    (root, app_dir)
+}
+
 fn write_multi_module_project(prefix: &str) -> (std::path::PathBuf, std::path::PathBuf) {
     let root = temp_project_dir(prefix);
     let app_dir = root.join("app");
@@ -5269,6 +6373,155 @@ pub mod math
         r#"
 pub proc inc(a: felt) -> felt
     add.1
+end
+"#,
+    )
+    .unwrap();
+
+    (root, app_dir)
+}
+
+fn write_module_index_project(prefix: &str) -> (std::path::PathBuf, std::path::PathBuf) {
+    let root = temp_project_dir(prefix);
+    let app_dir = root.join("app");
+    let child_dir = app_dir.join("child");
+    fs::create_dir_all(&child_dir).unwrap();
+
+    fs::write(
+        app_dir.join("miden-project.toml"),
+        r#"[package]
+name = "app"
+version = "0.0.1"
+
+[lib]
+path = "mod.masm"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        app_dir.join("mod.masm"),
+        r#"
+#! This root is only a module index.
+
+pub mod child
+"#,
+    )
+    .unwrap();
+    fs::write(
+        child_dir.join("mod.masm"),
+        r#"
+pub mod leaf
+pub use {inc} from self::leaf
+
+pub proc double(a: felt) -> felt
+    exec.inc
+end
+"#,
+    )
+    .unwrap();
+    fs::write(
+        child_dir.join("leaf.masm"),
+        r#"
+pub proc inc(a: felt) -> felt
+    add.1
+end
+"#,
+    )
+    .unwrap();
+
+    (root, app_dir)
+}
+
+fn write_private_child_module_index_project(
+    prefix: &str,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let root = temp_project_dir(prefix);
+    let app_dir = root.join("app");
+    let child_dir = app_dir.join("child");
+    fs::create_dir_all(&child_dir).unwrap();
+
+    fs::write(
+        app_dir.join("miden-project.toml"),
+        r#"[package]
+name = "app"
+version = "0.0.1"
+
+[lib]
+path = "mod.masm"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        app_dir.join("mod.masm"),
+        r#"
+mod child
+
+pub proc call_secret() -> felt
+    exec.child::leaf::secret
+end
+"#,
+    )
+    .unwrap();
+    fs::write(
+        child_dir.join("mod.masm"),
+        r#"
+pub mod leaf
+"#,
+    )
+    .unwrap();
+    fs::write(
+        child_dir.join("leaf.masm"),
+        r#"
+pub proc secret() -> felt
+    push.1
+end
+"#,
+    )
+    .unwrap();
+
+    (root, app_dir)
+}
+
+fn write_undeclared_child_module_index_project(
+    prefix: &str,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let root = temp_project_dir(prefix);
+    let app_dir = root.join("app");
+    let child_dir = app_dir.join("child");
+    fs::create_dir_all(&child_dir).unwrap();
+
+    fs::write(
+        app_dir.join("miden-project.toml"),
+        r#"[package]
+name = "app"
+version = "0.0.1"
+
+[lib]
+path = "mod.masm"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        app_dir.join("mod.masm"),
+        r#"
+pub proc call_secret() -> felt
+    exec.child::leaf::secret
+end
+"#,
+    )
+    .unwrap();
+    fs::write(
+        child_dir.join("mod.masm"),
+        r#"
+pub mod leaf
+"#,
+    )
+    .unwrap();
+    fs::write(
+        child_dir.join("leaf.masm"),
+        r#"
+pub proc secret() -> felt
+    push.1
 end
 "#,
     )

--- a/frontend/masm/src/tests.rs
+++ b/frontend/masm/src/tests.rs
@@ -32,7 +32,7 @@ use midenc_dialect_hir::{
 use midenc_dialect_scf as scf;
 use midenc_hir::{
     AddressSpace, ArrayType, CallConv, CallOpInterface, FunctionType, Immediate, Op, PointerType,
-    SymbolName, SymbolPath, SymbolTable, Type,
+    Spanned, SymbolName, SymbolPath, SymbolTable, Type,
     diagnostics::{Report, Severity},
     dialects::builtin::{
         self, Function, UnrealizedConversionCast,
@@ -2340,6 +2340,41 @@ fn project_disassembly_accepts_module_index_roots() -> Result<()> {
 }
 
 #[test]
+fn project_disassembly_preserves_module_index_source_spans() -> Result<()> {
+    let (root, app_dir) =
+        write_private_child_module_index_project("midenc_frontend_masm_module_index_spans");
+
+    let context = Rc::new(Context::default());
+    let output = disassemble_project_target_from_path_for_lint(
+        app_dir.join("miden-project.toml"),
+        None,
+        &DisassemblerConfig::default(),
+        context,
+    )?;
+
+    let function = find_function(output.module, "call_secret");
+    let entry_block = function.borrow().entry_block();
+    let op_span = {
+        let entry_block = entry_block.borrow();
+        entry_block
+            .body()
+            .iter()
+            .next()
+            .expect("call_secret should contain a lifted operation")
+            .span()
+    };
+    let source_manager = output.context.session().source_manager.clone();
+    let loc = source_manager
+        .file_line_col(op_span)
+        .map_err(|err| Report::msg(err.to_string()))?;
+    assert!(loc.uri.to_string().ends_with("mod.masm"));
+
+    let _ = fs::remove_dir_all(root);
+
+    Ok(())
+}
+
+#[test]
 fn project_disassembly_accepts_private_child_module_declaration() -> Result<()> {
     let (root, app_dir) =
         write_private_child_module_index_project("midenc_frontend_masm_private_child_index");
@@ -2446,7 +2481,12 @@ fn project_disassembly_does_not_fallback_to_undeclared_child_procedure() -> Resu
 
     let message = err.to_string();
     assert!(message.contains("leaf::secret"));
-    assert!(message.contains("failed to resolve") || message.contains("could not resolve"));
+    assert!(
+        message.contains("failed to resolve")
+            || message.contains("could not resolve")
+            || message.contains("invalid relative item path"),
+        "{message}"
+    );
 
     let _ = fs::remove_dir_all(root);
 
@@ -2492,7 +2532,11 @@ end
         Err(err) => err,
     };
 
-    assert!(err.to_string().contains("invalid syntax"));
+    let message = err.to_string();
+    assert!(
+        message.contains("invalid syntax") || message.contains("syntax error"),
+        "{message}"
+    );
 
     let _ = fs::remove_dir_all(root);
 
@@ -5731,7 +5775,6 @@ end
 
     Ok(())
 }
-
 
 #[test]
 fn rejects_mutual_recursion() -> Result<()> {

--- a/frontend/masm/tests/e2e.rs
+++ b/frontend/masm/tests/e2e.rs
@@ -69,6 +69,19 @@ end
 }
 
 #[test]
+fn e2e_roundtrip_exp_u32() {
+    let source = r#"
+pub proc entry(base: felt, exponent: u32) -> felt
+    exp.u32
+end
+"#;
+    assert_roundtrip_outputs(source, &[3, 5], 1);
+
+    let emitted = render_roundtripped_masm(source, e2e_context());
+    assert!(emitted.contains("exp.u32"), "{emitted}");
+}
+
+#[test]
 fn e2e_roundtrip_word_immediate_order() {
     assert_roundtrip_outputs(
         r#"
@@ -312,6 +325,19 @@ end
         )
         .map(Arc::from)
         .expect("round-tripped MASM program should assemble")
+}
+
+fn render_roundtripped_masm(source: &str, context: Rc<Context>) -> String {
+    let disassembled =
+        disassemble_source(source, "test", &DisassemblerConfig::default(), context.clone())
+            .expect("MASM should disassemble to HIR");
+    let analysis_manager = AnalysisManager::new(disassembled.world.as_operation_ref(), None);
+    disassembled
+        .world
+        .borrow()
+        .to_masm_component(analysis_manager)
+        .expect("HIR should lower back to MASM")
+        .to_string()
 }
 
 fn execute_program(

--- a/hir-analysis/src/config.rs
+++ b/hir-analysis/src/config.rs
@@ -3,6 +3,8 @@
 pub struct DataFlowConfig {
     /// Indicates whether the solver should operation interprocedurally
     interprocedural: bool,
+    /// Optional limit on queued analysis visits while solving to fixpoint.
+    max_worklist_iterations: Option<usize>,
 }
 
 impl DataFlowConfig {
@@ -17,6 +19,11 @@ impl DataFlowConfig {
         self.interprocedural
     }
 
+    #[inline(always)]
+    pub const fn max_worklist_iterations(&self) -> Option<usize> {
+        self.max_worklist_iterations
+    }
+
     /// Set whether the solver should operate interprocedurally, i.e. enter the callee body when
     /// available.
     ///
@@ -24,6 +31,15 @@ impl DataFlowConfig {
     /// be computed and the fixpoint convergence takes longer.
     pub fn set_interprocedural(&mut self, yes: bool) -> &mut Self {
         self.interprocedural = yes;
+        self
+    }
+
+    /// Set a maximum number of queued analysis visits while solving to fixpoint.
+    ///
+    /// This is intended for lint and diagnostic callers that need a bounded analysis result instead
+    /// of an unbounded run on large or currently unsupported IR graphs.
+    pub fn set_max_worklist_iterations(&mut self, max: Option<usize>) -> &mut Self {
+        self.max_worklist_iterations = max;
         self
     }
 }

--- a/hir-analysis/src/solver.rs
+++ b/hir-analysis/src/solver.rs
@@ -586,23 +586,7 @@ impl DataFlowSolver {
 fn summarize_queued_analyses(
     names: impl IntoIterator<Item = &'static str>,
 ) -> alloc::string::String {
-    let mut counts = Vec::<(&'static str, usize)>::new();
-    for name in names {
-        if let Some((_, count)) = counts.iter_mut().find(|(existing, _)| *existing == name) {
-            *count += 1;
-        } else {
-            counts.push((name, 1));
-        }
-    }
-    counts.sort_by(|(lhs_name, lhs_count), (rhs_name, rhs_count)| {
-        rhs_count.cmp(lhs_count).then_with(|| lhs_name.cmp(rhs_name))
-    });
-    counts
-        .into_iter()
-        .take(5)
-        .map(|(name, count)| format!("{name}={count}"))
-        .collect::<Vec<_>>()
-        .join(", ")
+    summarize_top_counts(names.into_iter().map(ToString::to_string))
 }
 
 fn describe_program_point_owner(point: &ProgramPoint) -> alloc::string::String {
@@ -628,15 +612,20 @@ fn describe_program_point_owner_name(point: &ProgramPoint) -> Option<alloc::stri
 fn summarize_queued_program_point_owners<'a>(
     points: impl IntoIterator<Item = &'a ProgramPoint>,
 ) -> alloc::string::String {
+    summarize_top_counts(points.into_iter().map(|point| {
+        describe_program_point_owner_name(point).unwrap_or_else(|| "<unknown>".into())
+    }))
+}
+
+fn summarize_top_counts(
+    items: impl IntoIterator<Item = alloc::string::String>,
+) -> alloc::string::String {
     let mut counts = Vec::<(alloc::string::String, usize)>::new();
-    for name in points
-        .into_iter()
-        .map(|point| describe_program_point_owner_name(point).unwrap_or_else(|| "<unknown>".into()))
-    {
-        if let Some((_, count)) = counts.iter_mut().find(|(existing, _)| *existing == name) {
+    for item in items {
+        if let Some((_, count)) = counts.iter_mut().find(|(existing, _)| *existing == item) {
             *count += 1;
         } else {
-            counts.push((name, 1));
+            counts.push((item, 1));
         }
     }
     counts.sort_by(|(lhs_name, lhs_count), (rhs_name, rhs_count)| {

--- a/hir-analysis/src/solver.rs
+++ b/hir-analysis/src/solver.rs
@@ -596,9 +596,7 @@ fn describe_program_point_owner(point: &ProgramPoint) -> alloc::string::String {
 }
 
 fn describe_program_point_owner_name(point: &ProgramPoint) -> Option<alloc::string::String> {
-    let Some(op_ref) = point.operation() else {
-        return None;
-    };
+    let op_ref = point.operation()?;
     let op = op_ref.borrow();
     if let Some(function) = op.downcast_ref::<builtin::Function>() {
         return Some(function.get_name().as_str().to_string());

--- a/hir-analysis/src/solver.rs
+++ b/hir-analysis/src/solver.rs
@@ -1,10 +1,10 @@
 mod allocator;
 
-use alloc::{collections::VecDeque, rc::Rc};
+use alloc::{collections::VecDeque, format, rc::Rc, string::ToString, vec::Vec};
 use core::{any::TypeId, cell::RefCell, ptr::NonNull};
 
 use midenc_hir::{
-    EntityRef, FxHashMap, Operation, ProgramPoint, Report, SmallVec, hashbrown,
+    EntityRef, FxHashMap, Operation, ProgramPoint, Report, SmallVec, dialects::builtin, hashbrown,
     pass::AnalysisManager,
 };
 
@@ -307,6 +307,7 @@ impl DataFlowSolver {
         log::debug!(target: "dataflow:solver", "running queued dataflow analyses to fixpoint..");
 
         // Run the analysis until fixpoint
+        let mut iterations = 0usize;
         while let Some(QueuedAnalysis {
             point,
             mut analysis,
@@ -314,6 +315,32 @@ impl DataFlowSolver {
             let mut worklist = self.worklist.borrow_mut();
             worklist.pop_front()
         } {
+            if let Some(max) = self.config.max_worklist_iterations()
+                && iterations >= max
+            {
+                let remaining = self.worklist.borrow().len() + 1;
+                let analysis_name = unsafe { analysis.as_ref().debug_name() };
+                let owner = describe_program_point_owner(&point);
+                let queue_summary = summarize_queued_analyses(
+                    core::iter::once(analysis_name).chain(
+                        self.worklist
+                            .borrow()
+                            .iter()
+                            .map(|queued| unsafe { queued.analysis.as_ref().debug_name() }),
+                    ),
+                );
+                let owner_summary = summarize_queued_program_point_owners(
+                    core::iter::once(&point)
+                        .chain(self.worklist.borrow().iter().map(|queued| &queued.point)),
+                );
+                return Err(Report::msg(format!(
+                    "dataflow solver exceeded worklist iteration budget of {max}; next analysis \
+                     would run {analysis_name} at {point}{owner}, with {remaining} queued item(s) \
+                     remaining; queued analyses: {queue_summary}; queued functions: \
+                     {owner_summary}",
+                )));
+            }
+            iterations += 1;
             self.current_analysis = Some(analysis);
             unsafe {
                 let analysis = analysis.as_mut();
@@ -554,6 +581,73 @@ impl DataFlowSolver {
             analysis_anchor_id == anchor_id
         });
     }
+}
+
+fn summarize_queued_analyses(
+    names: impl IntoIterator<Item = &'static str>,
+) -> alloc::string::String {
+    let mut counts = Vec::<(&'static str, usize)>::new();
+    for name in names {
+        if let Some((_, count)) = counts.iter_mut().find(|(existing, _)| *existing == name) {
+            *count += 1;
+        } else {
+            counts.push((name, 1));
+        }
+    }
+    counts.sort_by(|(lhs_name, lhs_count), (rhs_name, rhs_count)| {
+        rhs_count.cmp(lhs_count).then_with(|| lhs_name.cmp(rhs_name))
+    });
+    counts
+        .into_iter()
+        .take(5)
+        .map(|(name, count)| format!("{name}={count}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn describe_program_point_owner(point: &ProgramPoint) -> alloc::string::String {
+    describe_program_point_owner_name(point)
+        .map(|name| format!(" in function '{name}'"))
+        .unwrap_or_default()
+}
+
+fn describe_program_point_owner_name(point: &ProgramPoint) -> Option<alloc::string::String> {
+    let Some(op_ref) = point.operation() else {
+        return None;
+    };
+    let op = op_ref.borrow();
+    if let Some(function) = op.downcast_ref::<builtin::Function>() {
+        return Some(function.get_name().as_str().to_string());
+    }
+    op.nearest_parent_op::<builtin::Function>().map(|function| {
+        let function = function.borrow();
+        function.get_name().as_str().to_string()
+    })
+}
+
+fn summarize_queued_program_point_owners<'a>(
+    points: impl IntoIterator<Item = &'a ProgramPoint>,
+) -> alloc::string::String {
+    let mut counts = Vec::<(alloc::string::String, usize)>::new();
+    for name in points
+        .into_iter()
+        .map(|point| describe_program_point_owner_name(point).unwrap_or_else(|| "<unknown>".into()))
+    {
+        if let Some((_, count)) = counts.iter_mut().find(|(existing, _)| *existing == name) {
+            *count += 1;
+        } else {
+            counts.push((name, 1));
+        }
+    }
+    counts.sort_by(|(lhs_name, lhs_count), (rhs_name, rhs_count)| {
+        rhs_count.cmp(lhs_count).then_with(|| lhs_name.cmp(rhs_name))
+    });
+    counts
+        .into_iter()
+        .take(5)
+        .map(|(name, count)| format!("{name}={count}"))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Represents an analysis that has derived facts at a specific program point from the state of

--- a/hir-analysis/src/solver.rs
+++ b/hir-analysis/src/solver.rs
@@ -618,14 +618,11 @@ fn summarize_queued_program_point_owners<'a>(
 fn summarize_top_counts(
     items: impl IntoIterator<Item = alloc::string::String>,
 ) -> alloc::string::String {
-    let mut counts = Vec::<(alloc::string::String, usize)>::new();
+    let mut counts = FxHashMap::<alloc::string::String, usize>::default();
     for item in items {
-        if let Some((_, count)) = counts.iter_mut().find(|(existing, _)| *existing == item) {
-            *count += 1;
-        } else {
-            counts.push((item, 1));
-        }
+        *counts.entry(item).or_insert(0) += 1;
     }
+    let mut counts = counts.into_iter().collect::<Vec<_>>();
     counts.sort_by(|(lhs_name, lhs_count), (rhs_name, rhs_count)| {
         rhs_count.cmp(lhs_count).then_with(|| lhs_name.cmp(rhs_name))
     });
@@ -635,6 +632,39 @@ fn summarize_top_counts(
         .map(|(name, count)| format!("{name}={count}"))
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{format, string::ToString};
+
+    use super::summarize_top_counts;
+
+    #[test]
+    fn summarize_top_counts_handles_empty_input_duplicates_and_ties() {
+        assert_eq!(summarize_top_counts(core::iter::empty()), "");
+
+        let summary = summarize_top_counts(
+            ["beta", "alpha", "gamma", "beta", "alpha"].into_iter().map(ToString::to_string),
+        );
+        assert_eq!(summary, "alpha=2, beta=2, gamma=1");
+    }
+
+    #[test]
+    fn summarize_top_counts_breaks_the_fifth_place_tie_by_name() {
+        let summary = summarize_top_counts(
+            ["zeta", "gamma", "epsilon", "delta", "beta", "alpha", "zeta"]
+                .into_iter()
+                .map(ToString::to_string),
+        );
+        assert_eq!(summary, "zeta=2, alpha=1, beta=1, delta=1, epsilon=1");
+    }
+
+    #[test]
+    fn summarize_top_counts_handles_many_unique_names() {
+        let summary = summarize_top_counts((0..4096).rev().map(|index| format!("item{index:04}")));
+        assert_eq!(summary, "item0000=1, item0001=1, item0002=1, item0003=1, item0004=1");
+    }
 }
 
 /// Represents an analysis that has derived facts at a specific program point from the state of

--- a/hir-analysis/src/sparse/forward.rs
+++ b/hir-analysis/src/sparse/forward.rs
@@ -288,8 +288,14 @@ where
         for predecessor in predecessors.known_predecessors() {
             let inputs = predecessors.successor_inputs(predecessor);
             let mut operand_lattices = SmallVec::<[_; 4]>::with_capacity(inputs.len());
+            let mut required_inputs = SmallVec::<[ValueRef; 4]>::new();
             for operand in inputs.iter().copied() {
-                let operand_lattice = get_lattice_element_for::<A>(current_point, operand, solver);
+                let operand_lattice = if required_inputs.contains(&operand) {
+                    get_lattice_element::<A>(operand, solver)
+                } else {
+                    required_inputs.push(operand);
+                    get_lattice_element_for::<A>(current_point, operand, solver)
+                };
                 operand_lattices.push(operand_lattice);
             }
             analysis.visit_call_control_flow_transfer(

--- a/hir/src/dialects/builtin/ops/cast.rs
+++ b/hir/src/dialects/builtin/ops/cast.rs
@@ -3,14 +3,22 @@ use crate::{
     derive::{EffectOpInterface, OpParser, OpPrinter, operation},
     dialects::builtin::{BuiltinDialect, attributes::TypeAttr},
     effects::MemoryEffectOpInterface,
-    traits::{AnyType, InferTypeOpInterface, UnaryOp},
+    traits::{
+        AnyType, InferTypeOpInterface, OperandRangeRequirement, OperandRangeRequirementOpInterface,
+        UnaryOp,
+    },
 };
 
 #[derive(EffectOpInterface, OpPrinter, OpParser)]
 #[operation(
     dialect = BuiltinDialect,
     traits(UnaryOp),
-    implements(InferTypeOpInterface, MemoryEffectOpInterface, OpPrinter)
+    implements(
+        InferTypeOpInterface,
+        MemoryEffectOpInterface,
+        OperandRangeRequirementOpInterface,
+        OpPrinter
+    )
 )]
 pub struct UnrealizedConversionCast {
     #[operand]
@@ -26,5 +34,14 @@ impl InferTypeOpInterface for UnrealizedConversionCast {
         let ty = self.get_ty().clone();
         self.result_mut().set_type(ty);
         Ok(())
+    }
+}
+
+impl OperandRangeRequirementOpInterface for UnrealizedConversionCast {
+    fn operand_range_requirement(&self, _operand_index: usize) -> OperandRangeRequirement {
+        // Unrealized casts bridge representations while conversion/legalization is in progress.
+        // The operation that semantically consumes a constrained value should carry the range
+        // requirement.
+        OperandRangeRequirement::None
     }
 }


### PR DESCRIPTION
This PR lets the MASM frontend build a *partial* HIR world for lint use. This is part of #1209.

Strict MASM disassembly stops on the first procedure it cannot lift. That blocks advice taint analysis on large MASM projects, including the Miden VM core library. This change adds a lint path that skips procedures the frontend cannot lift yet. It records the procedure path, source span, and reason. It also skips callers that depend on skipped procedures.

This change also adds support for `mod.masm` module index files, relative calls through declared child modules, source dependency metadata, and `exp.u32`.

This PR does not wire this into `midenc --lint`. That should be a follow-up PR, with a clear policy for skipped procedures and partial analysis.