### PR TITLE
fix(hir): make operation equivalence hashing consistent with equality

### DIFF
--- a/hir-transform/src/cfg_to_scf/transform.rs
+++ b/hir-transform/src/cfg_to_scf/transform.rs
@@ -1299,27 +1299,43 @@ impl<'a> TransformationContext<'a> {
 ///
 /// This means that both operations are of the same kind, have the same amount of operands and types
 /// and the same attributes and properties. The operands themselves don't have to be equivalent.
+///
+/// Operand identity is irrelevant, but operand types are not: [Self::combine_exit] forwards the
+/// operands of every equivalent return-like operation to a single exit block whose arguments are
+/// typed from the first such operation, so keys must only match when the operand types line up.
+/// Hence the [ValueTypeEquivalence]/[ValueTypeHasher] pair below.
+///
+/// [Self::combine_exit]: TransformationContext::combine_exit
+/// [ValueTypeEquivalence]: midenc_hir::equivalence::ValueTypeEquivalence
+/// [ValueTypeHasher]: midenc_hir::equivalence::ValueTypeHasher
 #[derive(Copy, Clone)]
 struct ReturnLikeOpKey(OperationRef);
 impl Eq for ReturnLikeOpKey {}
 impl PartialEq for ReturnLikeOpKey {
     fn eq(&self, other: &Self) -> bool {
-        use midenc_hir::equivalence::{OperationEquivalenceFlags, ignore_value_equivalence};
+        use midenc_hir::equivalence::{OperationEquivalenceFlags, ValueTypeEquivalence};
         let a = self.0.borrow();
         a.is_equivalent_with_options(
             &other.0.borrow(),
             OperationEquivalenceFlags::IGNORE_LOCATIONS,
-            ignore_value_equivalence,
+            ValueTypeEquivalence,
         )
     }
 }
 impl core::hash::Hash for ReturnLikeOpKey {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        use midenc_hir::equivalence::{IgnoreValueEquivalenceOperationHasher, OperationHasher};
+        use midenc_hir::equivalence::{
+            IgnoreValueHasher, OperationEquivalenceFlags, ValueTypeHasher,
+        };
 
-        const HASHER: IgnoreValueEquivalenceOperationHasher = IgnoreValueEquivalenceOperationHasher;
-
-        HASHER.hash_operation(&self.0.borrow(), state);
+        // Operands are hashed by type, mirroring the `ValueTypeEquivalence` used by `PartialEq`;
+        // result identity is ignored, and result types are always hashed structurally.
+        self.0.borrow().hash_with_options(
+            OperationEquivalenceFlags::IGNORE_LOCATIONS,
+            ValueTypeHasher,
+            IgnoreValueHasher,
+            state,
+        );
     }
 }
 
@@ -1354,4 +1370,86 @@ where
 /// Returns true if this block is an exit block of the region.
 fn is_region_exit_block(block: &Block) -> bool {
     block.num_successors() == 0
+}
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use midenc_hir::{
+        Builder, SourceSpan, Type, ValueRef, dialects::builtin::BuiltinOpBuilder, testing::Test,
+    };
+
+    use super::ReturnLikeOpKey;
+
+    /// A [core::hash::Hasher] that records the exact byte stream written to it, so two keys can
+    /// be compared on the input they feed a hasher rather than on a lossy `finish()` value.
+    #[derive(Default)]
+    struct RecordingHasher(Vec<u8>);
+
+    impl core::hash::Hasher for RecordingHasher {
+        fn finish(&self) -> u64 {
+            0
+        }
+
+        fn write(&mut self, bytes: &[u8]) {
+            self.0.extend_from_slice(bytes);
+        }
+    }
+
+    fn hash_stream(key: &ReturnLikeOpKey) -> Vec<u8> {
+        use core::hash::Hash;
+        let mut hasher = RecordingHasher::default();
+        key.hash(&mut hasher);
+        hasher.0
+    }
+
+    /// [ReturnLikeOpKey] groups return-like operations by operand types, not operand identity:
+    /// `combine_exit` forwards the operands of every matching operation into one exit block
+    /// typed from the first, so keys must match across distinct operands of equal types and must
+    /// never match across different operand types. Hash must agree with equality in both
+    /// directions of the contract.
+    #[test]
+    fn return_like_op_key_matches_operand_types_not_identity() {
+        let span = SourceSpan::UNKNOWN;
+        let mut test = Test::named("return_like_op_key").in_module("test");
+
+        let define_returning_function = |test: &mut Test, name: &'static str, ty: Type| {
+            let module_body = test.module().borrow().body().entry_block_ref().unwrap();
+            test.builder_mut().set_insertion_point_to_end(module_body);
+            let signature = [ty];
+            test.with_function(name, &signature, &signature);
+            {
+                let mut builder = test.function_builder();
+                let arg = builder.entry_block().borrow().arguments()[0] as ValueRef;
+                builder.ret([arg], span).unwrap();
+            }
+            test.entry_block().borrow().terminator().unwrap()
+        };
+
+        let ret1 = define_returning_function(&mut test, "f1", Type::I32);
+        let ret2 = define_returning_function(&mut test, "f2", Type::I32);
+        let ret3 = define_returning_function(&mut test, "f3", Type::I64);
+
+        let k1 = ReturnLikeOpKey(ret1);
+        let k2 = ReturnLikeOpKey(ret2);
+        let k3 = ReturnLikeOpKey(ret3);
+
+        // Same operand types with different operand identities: equal, and the hash streams must
+        // be identical, or map lookups would depend on allocation addresses.
+        assert!(k1 == k2, "return-like ops with equal operand types must key equal");
+        assert_eq!(
+            hash_stream(&k1),
+            hash_stream(&k2),
+            "equal keys must feed identical bytes to the hasher"
+        );
+
+        // Different operand types: never equal, or combine_exit would forward operands into an
+        // exit block with mismatched argument types.
+        assert!(k1 != k3, "return-like ops with different operand types must not key equal");
+        assert_ne!(
+            hash_stream(&k1),
+            hash_stream(&k3),
+            "operand types are part of the key, so they must be hashed as well"
+        );
+    }
 }

--- a/hir-transform/src/cse.rs
+++ b/hir-transform/src/cse.rs
@@ -684,6 +684,52 @@ builtin.function public extern("C") @ssa_memory_reads(%0: ptr<u8, byte>) -> (u8,
         );
     }
 
+    /// Regression test for https://github.com/0xMiden/compiler/issues/1257
+    ///
+    /// Commutative operations are equal under [OpKey] regardless of operand order, and the key
+    /// hashes operands in the same canonical order equality compares them in, so both the
+    /// identical and the operand-swapped duplicates must always be deduplicated. Previously the
+    /// swapped pair compared equal but hashed differently, so whether CSE fired for it depended
+    /// on hash-bucket coincidences, i.e. on allocation addresses, making compilation output
+    /// non-deterministic.
+    #[test]
+    fn cse_commutative_operand_order() {
+        let mut test =
+            Test::new("commutative", &[Type::I32, Type::I32], &[Type::I32, Type::I32, Type::I32]);
+        {
+            let mut builder = test.function_builder();
+            let a = builder.entry_block().borrow().arguments()[0] as ValueRef;
+            let b = builder.entry_block().borrow().arguments()[1] as ValueRef;
+            let v0 = builder.add(a, b, SourceSpan::UNKNOWN).unwrap();
+            let v1 = builder.add(b, a, SourceSpan::UNKNOWN).unwrap();
+            let v2 = builder.add(a, b, SourceSpan::UNKNOWN).unwrap();
+            builder.ret([v0, v1, v2], SourceSpan::UNKNOWN).unwrap();
+        }
+
+        test.apply_pass::<CommonSubexpressionElimination>(true).expect("invalid ir");
+
+        let flags = Default::default();
+        let mut printer = AsmPrinter::new(test.context_rc(), &flags);
+        printer.print_operation(test.function().borrow());
+        let output = format!("{}", printer.finish());
+        filecheck!(
+            output,
+            r#"
+builtin.function public extern("C") @commutative(%0: i32, %1: i32) -> (i32, i32, i32) {
+    // CHECK: [[SUM:%\d+]] = arith.add %0, %1
+    %2 = arith.add %0, %1 <{ overflow = #builtin.overflow<checked> }> : i32;
+
+    // Both the operand-swapped and the identical duplicate are deduplicated.
+    %3 = arith.add %1, %0 <{ overflow = #builtin.overflow<checked> }> : i32;
+    %4 = arith.add %0, %1 <{ overflow = #builtin.overflow<checked> }> : i32;
+
+    // CHECK-NEXT: builtin.ret [[SUM]], [[SUM]], [[SUM]] : (i32, i32, i32);
+    builtin.ret %2, %3, %4 : (i32, i32, i32);
+};
+            "#
+        );
+    }
+
     #[test]
     fn basic() {
         let mut test = Test::new("basic", &[], &[Type::I32, Type::I32]);

--- a/hir-transform/src/cse.rs
+++ b/hir-transform/src/cse.rs
@@ -544,7 +544,7 @@ impl core::hash::Hash for OpKey {
 impl Eq for OpKey {}
 impl PartialEq for OpKey {
     fn eq(&self, other: &Self) -> bool {
-        use midenc_hir::equivalence::OperationEquivalenceFlags;
+        use midenc_hir::equivalence::{DefaultValueEquivalence, OperationEquivalenceFlags};
 
         if self.0 == other.0 {
             return true;
@@ -552,9 +552,12 @@ impl PartialEq for OpKey {
         let lhs = self.0.borrow();
         let rhs = other.0.borrow();
 
-        lhs.is_equivalent_with_options(&rhs, OperationEquivalenceFlags::IGNORE_LOCATIONS, |l, r| {
-            core::ptr::addr_eq(l, r)
-        })
+        // Operands are compared by identity, mirroring the `DefaultValueHasher` used by `Hash`.
+        lhs.is_equivalent_with_options(
+            &rhs,
+            OperationEquivalenceFlags::IGNORE_LOCATIONS,
+            DefaultValueEquivalence,
+        )
     }
 }
 

--- a/hir-transform/src/cse.rs
+++ b/hir-transform/src/cse.rs
@@ -730,6 +730,105 @@ builtin.function public extern("C") @commutative(%0: i32, %1: i32) -> (i32, i32,
         );
     }
 
+    /// A [core::hash::Hasher] that records the exact byte stream written to it, so two keys can be
+    /// compared on the input they feed a hasher rather than on a lossy `finish()` value.
+    #[derive(Default)]
+    struct RecordingHasher(alloc::vec::Vec<u8>);
+
+    impl core::hash::Hasher for RecordingHasher {
+        fn finish(&self) -> u64 {
+            0
+        }
+
+        fn write(&mut self, bytes: &[u8]) {
+            self.0.extend_from_slice(bytes);
+        }
+    }
+
+    fn opkey_hash_stream(key: OpKey) -> alloc::vec::Vec<u8> {
+        use core::hash::Hash;
+        let mut hasher = RecordingHasher::default();
+        key.hash(&mut hasher);
+        hasher.0
+    }
+
+    /// Directly pins the [OpKey] Hash/Eq contract that issue #1257 violated: whenever two
+    /// operations are equal under [OpKey], they must feed an identical byte stream to the hasher.
+    /// A violation makes CSE deduplication depend on hash-bucket coincidence, i.e. on allocation
+    /// addresses, which is non-deterministic. Recording the hash input (rather than comparing
+    /// `finish()` values) keeps the check exact and independent of the concrete hasher.
+    #[test]
+    fn opkey_hash_is_consistent_with_eq() {
+        let mut test = Test::new(
+            "opkey_contract",
+            &[Type::I32, Type::I32],
+            &[Type::I32, Type::I32, Type::I32, Type::I32],
+        );
+        let (ab, ba, ab_again, aa) = {
+            let mut builder = test.function_builder();
+            let a = builder.entry_block().borrow().arguments()[0] as ValueRef;
+            let b = builder.entry_block().borrow().arguments()[1] as ValueRef;
+            let ab = builder.add(a, b, SourceSpan::UNKNOWN).unwrap();
+            let ba = builder.add(b, a, SourceSpan::UNKNOWN).unwrap();
+            let ab_again = builder.add(a, b, SourceSpan::UNKNOWN).unwrap();
+            let aa = builder.add(a, a, SourceSpan::UNKNOWN).unwrap();
+            let ops = (
+                ab.borrow().get_defining_op().unwrap(),
+                ba.borrow().get_defining_op().unwrap(),
+                ab_again.borrow().get_defining_op().unwrap(),
+                aa.borrow().get_defining_op().unwrap(),
+            );
+            builder.ret([ab, ba, ab_again, aa], SourceSpan::UNKNOWN).unwrap();
+            ops
+        };
+
+        // Commutative operands are canonicalized, so a swap is equal and must hash identically.
+        assert!(OpKey(ab) == OpKey(ba), "commutative operand swap must be equal");
+        assert_eq!(opkey_hash_stream(OpKey(ab)), opkey_hash_stream(OpKey(ba)));
+
+        // Result identity is ignored, so two distinct `add(a, b)` ops (with distinct result
+        // values) are equal and must hash identically. Guards against the hash observing more than
+        // equality does.
+        assert!(OpKey(ab) == OpKey(ab_again), "distinct result identity must be ignored");
+        assert_eq!(opkey_hash_stream(OpKey(ab)), opkey_hash_stream(OpKey(ab_again)));
+
+        // Sanity that the check is not vacuous: different operands are not equal, and the hash
+        // streams differ accordingly.
+        assert!(OpKey(ab) != OpKey(aa), "different operands must not be equal");
+        assert_ne!(opkey_hash_stream(OpKey(ab)), opkey_hash_stream(OpKey(aa)));
+    }
+
+    /// Sentinel for the exact regression that caused issue #1257: [DefaultValueHasher] must hash a
+    /// value by its thin address only. Hashing the fat pointer instead (data address plus the
+    /// vtable pointer, which can differ for the same value across codegen units) makes equal CSE
+    /// keys hash differently, which is what made deduplication non-deterministic.
+    #[test]
+    fn default_value_hasher_hashes_thin_address_only() {
+        use core::hash::Hash;
+
+        use midenc_hir::equivalence::{DefaultValueHasher, ValueHasher};
+
+        let mut test = Test::new("value_hasher", &[Type::I32], &[Type::I32]);
+        let value = {
+            let mut builder = test.function_builder();
+            let a = builder.entry_block().borrow().arguments()[0] as ValueRef;
+            builder.ret([a], SourceSpan::UNKNOWN).unwrap();
+            a
+        };
+
+        let mut via_hasher = RecordingHasher::default();
+        DefaultValueHasher.hash_value(value, &mut via_hasher);
+
+        let mut via_thin_address = RecordingHasher::default();
+        ValueRef::as_ptr(&value).addr().hash(&mut via_thin_address);
+
+        assert_eq!(
+            via_hasher.0, via_thin_address.0,
+            "DefaultValueHasher must hash only the thin value address; hashing the fat pointer \
+             reintroduces the non-determinism of issue #1257"
+        );
+    }
+
     #[test]
     fn basic() {
         let mut test = Test::new("basic", &[], &[Type::I32, Type::I32]);

--- a/hir/src/ir/operation/equivalence.rs
+++ b/hir/src/ir/operation/equivalence.rs
@@ -52,6 +52,23 @@ impl OperationHasher for IgnoreValueEquivalenceOperationHasher {
     }
 }
 
+/// A strategy for hashing an SSA value as part of operation equivalence hashing.
+///
+/// # Pairing with [ValueEquivalence]
+///
+/// Every implementation of this trait must be mirrored by a semantically equivalent
+/// [ValueEquivalence] implementation, and vice versa: whenever the paired equivalence considers
+/// two values equivalent, the hasher must write identical data for both. Using mismatched
+/// implementations in the `Hash` and `Eq` of a hash-map key breaks the `Hash`/`Eq` contract:
+/// equal keys land in different buckets, lookups miss depending on allocation addresses, and
+/// compiler output becomes non-deterministic
+/// (see https://github.com/0xMiden/compiler/issues/1257).
+///
+/// The canonical pairs are:
+///
+/// - [DefaultValueHasher] ↔ [DefaultValueEquivalence]: value identity
+/// - [ValueTypeHasher] ↔ [ValueTypeEquivalence]: value type only
+/// - [IgnoreValueHasher] ↔ [IgnoreValueEquivalence]: values ignored entirely
 pub trait ValueHasher {
     fn hash_value<H: Hasher>(&self, value: ValueRef, hasher: &mut H);
 }
@@ -59,7 +76,7 @@ pub trait ValueHasher {
 /// A [ValueHasher] impl that hashes a value based on its address in memory.
 ///
 /// This is generally used with [OperationHasher] to require operands/results between two
-/// operations to be exactly the same.
+/// operations to be exactly the same. Pairs with [DefaultValueEquivalence].
 #[derive(Default)]
 pub struct DefaultValueHasher;
 
@@ -72,12 +89,96 @@ impl ValueHasher for DefaultValueHasher {
     }
 }
 
+/// A [ValueHasher] impl that hashes a value based only on its type.
+///
+/// Pairs with [ValueTypeEquivalence].
+#[derive(Default)]
+pub struct ValueTypeHasher;
+
+impl ValueHasher for ValueTypeHasher {
+    fn hash_value<H: Hasher>(&self, value: ValueRef, hasher: &mut H) {
+        value.borrow().ty().hash(hasher);
+    }
+}
+
 /// A [ValueHasher] impl that ignores operands/results, i.e. the hash is unchanged
+///
+/// Pairs with [IgnoreValueEquivalence].
 #[derive(Default)]
 pub struct IgnoreValueHasher;
 
 impl ValueHasher for IgnoreValueHasher {
     fn hash_value<H: Hasher>(&self, _value: ValueRef, _hasher: &mut H) {}
+}
+
+/// A strategy for deciding whether two SSA values are equivalent as part of operation
+/// equivalence checks.
+///
+/// # Pairing with [ValueHasher]
+///
+/// Every implementation of this trait must be mirrored by a semantically equivalent
+/// [ValueHasher] implementation, and vice versa: whenever `is_equivalent` holds for two values,
+/// the paired hasher must write identical data for both. Using mismatched implementations in
+/// the `Hash` and `Eq` of a hash-map key breaks the `Hash`/`Eq` contract: equal keys land in
+/// different buckets, lookups miss depending on allocation addresses, and compiler output
+/// becomes non-deterministic (see https://github.com/0xMiden/compiler/issues/1257).
+///
+/// The canonical pairs are:
+///
+/// - [DefaultValueHasher] ↔ [DefaultValueEquivalence]: value identity
+/// - [ValueTypeHasher] ↔ [ValueTypeEquivalence]: value type only
+/// - [IgnoreValueHasher] ↔ [IgnoreValueEquivalence]: values ignored entirely
+pub trait ValueEquivalence {
+    fn is_equivalent(&self, lhs: &dyn Value, rhs: &dyn Value) -> bool;
+}
+
+impl<F> ValueEquivalence for F
+where
+    F: Fn(&dyn Value, &dyn Value) -> bool,
+{
+    #[inline]
+    fn is_equivalent(&self, lhs: &dyn Value, rhs: &dyn Value) -> bool {
+        self(lhs, rhs)
+    }
+}
+
+/// A [ValueEquivalence] impl that compares values by their address in memory, i.e. two values
+/// are equivalent if and only if they are the same value.
+///
+/// Pairs with [DefaultValueHasher].
+#[derive(Default)]
+pub struct DefaultValueEquivalence;
+
+impl ValueEquivalence for DefaultValueEquivalence {
+    fn is_equivalent(&self, lhs: &dyn Value, rhs: &dyn Value) -> bool {
+        core::ptr::addr_eq(lhs, rhs)
+    }
+}
+
+/// A [ValueEquivalence] impl under which values are equivalent if and only if they have the
+/// same type, regardless of their identity.
+///
+/// Pairs with [ValueTypeHasher].
+#[derive(Default)]
+pub struct ValueTypeEquivalence;
+
+impl ValueEquivalence for ValueTypeEquivalence {
+    fn is_equivalent(&self, lhs: &dyn Value, rhs: &dyn Value) -> bool {
+        lhs.ty() == rhs.ty()
+    }
+}
+
+/// A [ValueEquivalence] impl that considers all values equivalent, regardless of their identity
+/// or even their type.
+///
+/// Pairs with [IgnoreValueHasher].
+#[derive(Default)]
+pub struct IgnoreValueEquivalence;
+
+impl ValueEquivalence for IgnoreValueEquivalence {
+    fn is_equivalent(&self, _lhs: &dyn Value, _rhs: &dyn Value) -> bool {
+        true
+    }
 }
 
 impl Operation {
@@ -140,18 +241,15 @@ impl Operation {
     }
 
     pub fn is_equivalent(&self, rhs: &Operation, flags: OperationEquivalenceFlags) -> bool {
-        self.is_equivalent_with_options(rhs, flags, |l, r| core::ptr::addr_eq(l, r))
+        self.is_equivalent_with_options(rhs, flags, DefaultValueEquivalence)
     }
 
-    pub fn is_equivalent_with_options<F>(
+    pub fn is_equivalent_with_options(
         &self,
         rhs: &Operation,
         flags: OperationEquivalenceFlags,
-        check_equivalent: F,
-    ) -> bool
-    where
-        F: Fn(&dyn Value, &dyn Value) -> bool,
-    {
+        value_equivalence: impl ValueEquivalence,
+    ) -> bool {
         if core::ptr::addr_eq(self, rhs) {
             return true;
         }
@@ -180,14 +278,14 @@ impl Operation {
             lhs_operands.sort_by(sort_operands);
             let mut rhs_operands = SmallVec::<[_; 2]>::from_slice(rhs_operands.as_slice());
             rhs_operands.sort_by(sort_operands);
-            if !are_operands_equivalent(&lhs_operands, &rhs_operands, &check_equivalent) {
+            if !are_operands_equivalent(&lhs_operands, &rhs_operands, &value_equivalence) {
                 return false;
             }
         } else {
             // Check pair-wise for equivalence
             let lhs = self.operands.all();
             let rhs = rhs.operands.all();
-            if !are_operands_equivalent(lhs.as_slice(), rhs.as_slice(), &check_equivalent) {
+            if !are_operands_equivalent(lhs.as_slice(), rhs.as_slice(), &value_equivalence) {
                 return false;
             }
         }
@@ -205,7 +303,7 @@ impl Operation {
 
         // 4. Compare regions
         for (lhs_region, rhs_region) in self.regions().iter().zip(rhs.regions().iter()) {
-            if !is_region_equivalent_to(&lhs_region, &rhs_region, flags, &check_equivalent) {
+            if !is_region_equivalent_to(&lhs_region, &rhs_region, flags, &value_equivalence) {
                 return false;
             }
         }
@@ -214,26 +312,26 @@ impl Operation {
     }
 }
 
-pub fn ignore_value_equivalence(_lhs: &dyn Value, _rhs: &dyn Value) -> bool {
-    true
-}
-
-pub fn exact_value_match(lhs: &dyn Value, rhs: &dyn Value) -> bool {
-    core::ptr::addr_eq(lhs, rhs)
-}
-
-fn is_region_equivalent_to<F>(
+fn is_region_equivalent_to<VE>(
     _lhs: &Region,
     _rhs: &Region,
     _flags: OperationEquivalenceFlags,
-    _check_equivalent: F,
+    _value_equivalence: &VE,
 ) -> bool
 where
-    F: Fn(&dyn Value, &dyn Value) -> bool,
+    VE: ValueEquivalence + ?Sized,
 {
     todo!()
 }
 
+/// Orders operands canonically (by value address) for commutative operand comparison and
+/// hashing.
+///
+/// NOTE: address order is only a sound canonicalization for identity-based value equivalence
+/// ([DefaultValueEquivalence]/[DefaultValueHasher]), where equal operand sets sort identically
+/// on both sides. A commutative operation compared under an equivalence that ignores identity
+/// (e.g. [ValueTypeEquivalence]) would need a structural canonicalization instead; no such
+/// caller exists today.
 fn sort_operands(a: &OpOperand, b: &OpOperand) -> core::cmp::Ordering {
     let a = a.borrow().as_value_ref();
     let b = b.borrow().as_value_ref();
@@ -242,9 +340,9 @@ fn sort_operands(a: &OpOperand, b: &OpOperand) -> core::cmp::Ordering {
     a.cmp(&b)
 }
 
-fn are_operands_equivalent<F>(a: &[OpOperand], b: &[OpOperand], check_equivalent: F) -> bool
+fn are_operands_equivalent<VE>(a: &[OpOperand], b: &[OpOperand], value_equivalence: &VE) -> bool
 where
-    F: Fn(&dyn Value, &dyn Value) -> bool,
+    VE: ValueEquivalence + ?Sized,
 {
     // Check pair-wise for equivalence
     for (a, b) in a.iter().copied().zip(b.iter().copied()) {
@@ -255,10 +353,7 @@ where
         if core::ptr::addr_eq(&*a, &*b) {
             continue;
         }
-        if a.ty() != b.ty() {
-            return false;
-        }
-        if !check_equivalent(&*a, &*b) {
+        if !value_equivalence.is_equivalent(&*a, &*b) {
             return false;
         }
     }

--- a/hir/src/ir/operation/equivalence.rs
+++ b/hir/src/ir/operation/equivalence.rs
@@ -1,4 +1,4 @@
-use core::hash::Hasher;
+use core::hash::{Hash, Hasher};
 
 use bitflags::bitflags;
 use smallvec::SmallVec;
@@ -65,7 +65,10 @@ pub struct DefaultValueHasher;
 
 impl ValueHasher for DefaultValueHasher {
     fn hash_value<H: Hasher>(&self, value: ValueRef, hasher: &mut H) {
-        core::ptr::hash(ValueRef::as_ptr(&value), hasher);
+        // Hash only the address, discarding the fat pointer metadata: equivalence checks compare
+        // values with `core::ptr::addr_eq`, and the vtable pointer of the same value can differ
+        // between codegen units, which would make equal keys hash differently.
+        ValueRef::as_ptr(&value).addr().hash(hasher);
     }
 }
 
@@ -87,8 +90,6 @@ impl Operation {
     ) where
         H: core::hash::Hasher,
     {
-        use core::hash::Hash;
-
         // Hash operations based upon their:
         //
         // - Operation name
@@ -110,10 +111,24 @@ impl Operation {
         }
 
         // Operands
+        //
+        // Commutative operations are equivalent regardless of operand order, so their operands
+        // must be hashed in the same canonical order used by `is_equivalent_with_options`, or
+        // equal keys could hash differently.
         self.operands().len().hash(hasher);
-        for operand in self.operands().iter() {
-            let operand = operand.borrow();
-            operand_hasher.hash_value(operand.as_value_ref(), hasher);
+        if self.implements::<dyn Commutative>() {
+            let operands = self.operands().all();
+            let mut operands = SmallVec::<[_; 2]>::from_slice(operands.as_slice());
+            operands.sort_by(sort_operands);
+            for operand in operands {
+                let operand = operand.borrow();
+                operand_hasher.hash_value(operand.as_value_ref(), hasher);
+            }
+        } else {
+            for operand in self.operands().iter() {
+                let operand = operand.borrow();
+                operand_hasher.hash_value(operand.as_value_ref(), hasher);
+            }
         }
 
         // Results

--- a/tests/integration-network/src/mockchain/counter/basic_auth.rs
+++ b/tests/integration-network/src/mockchain/counter/basic_auth.rs
@@ -65,7 +65,7 @@ pub fn counter_note_basic_auth_increments_storage() {
         .build_tx_context(counter_account.clone(), &[counter_note.id()], &[])
         .unwrap();
     let tx_measurements = execute_tx(&mut chain, tx_context_builder);
-    expect!["9116"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["9058"].assert_eq(single_note_cycles(&tx_measurements));
 
     // The counter contract storage value should be 2 after the note is consumed (incremented by 1).
     assert_counter_storage(

--- a/tests/integration-network/src/mockchain/counter/no_auth.rs
+++ b/tests/integration-network/src/mockchain/counter/no_auth.rs
@@ -101,7 +101,7 @@ pub fn counter_note_no_auth_increments_storage_without_signature() {
         .unwrap();
     let tx_measurements = execute_tx(&mut chain, tx_context_builder);
     expect!["1807"].assert_eq(auth_procedure_cycles(&tx_measurements));
-    expect!["9116"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["9058"].assert_eq(single_note_cycles(&tx_measurements));
 
     // The counter contract storage value should be 2 after the note is consumed
     assert_counter_storage(

--- a/tests/integration-network/src/mockchain/counter/rpo_auth.rs
+++ b/tests/integration-network/src/mockchain/counter/rpo_auth.rs
@@ -70,7 +70,7 @@ pub fn counter_rpo_auth_rejects_unauthenticated_note_creation() {
     let tx_context = tx_context_builder.build().unwrap();
     let executed_tx =
         block_on(tx_context.execute()).expect("authorized client should be able to create a note");
-    expect!["73753"].assert_eq(auth_procedure_cycles(executed_tx.measurements()));
+    expect!["73748"].assert_eq(auth_procedure_cycles(executed_tx.measurements()));
     assert_eq!(executed_tx.output_notes().num_notes(), 1);
     assert_eq!(executed_tx.output_notes().get_note(0).id(), own_note.id());
 

--- a/tests/integration-network/src/mockchain/notes/basic_wallet.rs
+++ b/tests/integration-network/src/mockchain/notes/basic_wallet.rs
@@ -110,7 +110,7 @@ pub fn basic_wallet_p2id_transfers_asset_with_custom_tx_script() {
         .foreign_accounts(vec![faucet_inputs]);
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
     expect!["3327"].assert_eq(prologue_cycles(&tx_measurements));
-    expect!["7071"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["7068"].assert_eq(single_note_cycles(&tx_measurements));
 
     eprintln!("\n=== Checking Alice's account has the minted asset ===");
     let alice_account = chain.committed_account(alice_id).unwrap();
@@ -132,7 +132,7 @@ pub fn basic_wallet_p2id_transfers_asset_with_custom_tx_script() {
         &mut note_rng,
     );
     let tx_measurements = execute_tx(&mut chain, alice_tx_context_builder);
-    expect!["6816"].assert_eq(tx_script_processing_cycles(&tx_measurements));
+    expect!["6815"].assert_eq(tx_script_processing_cycles(&tx_measurements));
 
     eprintln!("\n=== Step 4: Bob consumes p2id note ===");
     let faucet_inputs = chain.get_foreign_account_inputs(faucet_id).unwrap();
@@ -141,7 +141,7 @@ pub fn basic_wallet_p2id_transfers_asset_with_custom_tx_script() {
         .unwrap()
         .foreign_accounts(vec![faucet_inputs]);
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
-    expect!["7071"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["7068"].assert_eq(single_note_cycles(&tx_measurements));
 
     eprintln!("\n=== Checking Bob's account has the transferred asset ===");
     let bob_account = chain.committed_account(bob_id).unwrap();
@@ -278,7 +278,7 @@ pub fn basic_wallet_p2ide_allows_recipient_claim() {
         .unwrap()
         .foreign_accounts(vec![faucet_inputs]);
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
-    expect!["7360"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["7357"].assert_eq(single_note_cycles(&tx_measurements));
 
     // Step 5: verify balances
     let bob_account = chain.committed_account(bob_id).unwrap();
@@ -415,7 +415,7 @@ pub fn basic_wallet_p2ide_allows_sender_reclaim() {
         .unwrap()
         .foreign_accounts(vec![faucet_inputs]);
     let tx_measurements = execute_tx(&mut chain, reclaim_tx_context_builder);
-    expect!["7822"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["7819"].assert_eq(single_note_cycles(&tx_measurements));
 
     // Step 5: verify Alice has her original amount back
     let alice_account = chain.committed_account(alice_id).unwrap();

--- a/tests/integration/src/end_to_end/examples/basic_wallet_package_sizes.rs
+++ b/tests/integration/src/end_to_end/examples/basic_wallet_package_sizes.rs
@@ -28,7 +28,7 @@ fn basic_wallet_and_p2id() {
     );
     let tx_script_package = tx_script_test.compile_package();
     assert!(tx_script_package.is_library(), "expected library");
-    expect!["14149"].assert_eq(stripped_mast_size_str(&tx_script_package));
+    expect!["14238"].assert_eq(stripped_mast_size_str(&tx_script_package));
 
     let mut p2id_test = CompilerTest::rust_source_cargo_miden(
         "../../examples/p2id-note",
@@ -37,7 +37,7 @@ fn basic_wallet_and_p2id() {
     );
     let note_package = p2id_test.compile_package();
     assert!(note_package.is_library(), "expected library");
-    expect!["14792"].assert_eq(stripped_mast_size_str(&note_package));
+    expect!["14875"].assert_eq(stripped_mast_size_str(&note_package));
 
     let mut p2ide_test = CompilerTest::rust_source_cargo_miden(
         "../../examples/p2ide-note",
@@ -46,5 +46,5 @@ fn basic_wallet_and_p2id() {
     );
     let p2ide_package = p2ide_test.compile_package();
     assert!(p2ide_package.is_library(), "expected library");
-    expect!["17169"].assert_eq(stripped_mast_size_str(&p2ide_package));
+    expect!["17252"].assert_eq(stripped_mast_size_str(&p2ide_package));
 }

--- a/tests/integration/src/sdk/mod.rs
+++ b/tests/integration/src/sdk/mod.rs
@@ -374,6 +374,53 @@ fn rust_sdk_cross_ctx_account_and_note_word() {
     let _trace = exec.execute(&program, test.session.source_manager.clone());
 }
 
+/// Regression test for https://github.com/0xMiden/compiler/issues/1257
+///
+/// Compiling the same account project several times must produce byte-identical package
+/// artifacts. A non-deterministic build changes the package digest between compilations, so a
+/// dependent package (e.g. a note script) records a dependency digest that no longer matches the
+/// account package loaded into the executor's dependency resolver.
+#[test]
+fn rust_sdk_account_package_build_is_deterministic() {
+    let config = WasmTranslationConfig::default();
+    let mut baseline: Option<(miden_core::Word, Vec<u8>, String)> = None;
+    for run in 0..5 {
+        let mut test = CompilerTest::rust_source_cargo_miden(
+            "../fixtures/components/cross-ctx-account-word",
+            config.clone(),
+            [],
+        );
+        let masm_src = test.masm_src();
+        let package = test.compile_package();
+        let digest = *package.mast.digest();
+        let bytes = package.to_bytes();
+        let Some((first_digest, first_bytes, first_masm)) = baseline.as_ref() else {
+            baseline = Some((digest, bytes, masm_src));
+            continue;
+        };
+        assert!(
+            *first_masm == masm_src,
+            "MASM source of compilation #{run} differs from compilation #0"
+        );
+        assert_eq!(
+            *first_digest, digest,
+            "MAST digest of compilation #{run} differs from compilation #0 (identical MASM \
+             source, so the divergence is introduced at assembly)"
+        );
+        let first_mismatch = first_bytes
+            .iter()
+            .zip(bytes.iter())
+            .position(|(first, current)| first != current);
+        assert!(
+            first_bytes.len() == bytes.len() && first_mismatch.is_none(),
+            "package bytes of compilation #{run} differ from compilation #0: lengths {} vs {}, \
+             first mismatch at offset {first_mismatch:?}",
+            first_bytes.len(),
+            bytes.len(),
+        );
+    }
+}
+
 #[test]
 fn rust_sdk_cross_ctx_word_arg_account_and_note() {
     let config = WasmTranslationConfig::default();


### PR DESCRIPTION
Closes #1257

**This PR is stacked on #1265 and should be merged after it.** 

## Problem

`rust_sdk_cross_ctx_account_and_note_word` was flaky on CI: the same account project
occasionally compiled to a different MAST digest within one test run, so a dependent note
script recorded a dependency digest that no longer matched the account package loaded into the
executor's resolver. This is the third distinct source of this symptom, after the linear
operand scheduling fix (9d89a4792) and the predecessor discovery order fix (670579f7b).

## Root cause

CSE keys its candidate map with `OpKey`, whose `Eq`/`Hash` are built on the operation
equivalence infrastructure in `midenc-hir`, and the two violated the Hash/Eq contract (`a == b`
must imply `hash(a) == hash(b)`):

- **Eq** compares operands by value address (`core::ptr::addr_eq`), order-insensitively for
  `Commutative` operations.
- **Hash** fed each operand's **fat pointer** to the hasher — the data address **plus the
  vtable pointer**, which can differ for the same value across codegen units — and always in
  program order.

Equal keys therefore usually hashed differently and landed in different buckets. Whether CSE
deduplicated an equivalent pair depended on the two hashes coinciding modulo the current table
capacity — a function of heap allocation addresses: almost always a miss, occasionally a hit.
The rare hit changed the emitted schedule, the MAST, and the package digest. On a quiet machine
the allocator reproduces the same addresses run after run, which is why it only ever reproduced
under CI heap-layout variance.

## Fix (commit 1)

- `DefaultValueHasher` hashes only the value address (`.addr()`), discarding fat-pointer
  metadata so the hash matches the `addr_eq` comparison.
- `hash_with_options` hashes the operands of `Commutative` operations in the same canonical
  sorted order equality compares them in.

Deduplication is now a pure function of the IR rather than of the heap layout: byte-identical
packages across repeated compilations, compilation orderings, and hosts. Cycle counts drop
where previously luck-dependent deduplications now always apply.

## Hardening (commit 2)

- **`test(transform): pin the OpKey Hash/Eq contract against issue #1257`** — two unit tests near
  `OpKey`, both using a hasher that records the written byte stream (so they compare the hash
  *input*, not a lossy `finish()`):
  - `opkey_hash_is_consistent_with_eq` — operations equal under `OpKey` must hash to the same
    stream: a commutative operand swap, and two distinct `add(a, b)` ops with distinct result
    identities (which `OpKey` ignores). A different-operands negative pair keeps the check
    non-vacuous. Catches program-order operand hashing or result identity leaking into the hash.
  - `default_value_hasher_hashes_thin_address_only` — `DefaultValueHasher` must hash the thin
    value address, catching the exact fat-pointer regression of #1257.

  Both fail deterministically when their regression is reintroduced, independent of allocator
  layout, hash-table capacity, or machine noise — unlike an end-to-end determinism run, which
  only catches the bug if a divergent artifact happens to be observed.
