### PR TITLE
chore: cleanup Cargo.lock (v0.10 -> v0.9.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-miden"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "miden-objtool"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "midenc"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "human-panic",
  "midenc-driver",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-benchmark-runner"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-codegen-masm"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "inventory",
@@ -3561,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-compile"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "cargo_metadata 0.23.1",
  "clap",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-arith"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "midenc-hir",
  "paste",
@@ -3593,7 +3593,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-cf"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "log",
  "midenc-dialect-arith",
@@ -3603,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-hir"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "litcheck-filecheck",
  "log",
@@ -3619,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-scf"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "bitvec",
  "log",
@@ -3633,14 +3633,14 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-ub"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "midenc-hir",
 ]
 
 [[package]]
 name = "midenc-dialect-wasm"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "midenc-dialect-arith",
  "midenc-dialect-hir",
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-driver"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "clap",
  "log",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-expect-test"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "once_cell",
  "similar",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-masm"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "miden-assembly",
  "miden-assembly-syntax",
@@ -3691,7 +3691,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "addr2line 0.26.1",
  "anyhow",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-analysis"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "bitvec",
  "blink-alloc",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-eval"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "log",
  "miden-core",
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-macros"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "Inflector",
  "darling",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-opt"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-symbol"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "Inflector",
  "compact_str",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-transform"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "litcheck-filecheck",
  "log",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-integration-network-tests"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "miden-client",
  "miden-core",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-integration-test-support"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "cargo-util",
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-integration-tests"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "blake3",
  "cargo_metadata 0.19.2",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-log"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-session"
-version = "0.10.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
Was introduced in 6d2d167c4a695f09d52de74967e04dcf053643b3