### PR TITLE
perf: set release `opt-level = 2` (instead of `s`)

### DIFF
--- a/midenc-compile/src/stages/cargo.rs
+++ b/midenc-compile/src/stages/cargo.rs
@@ -51,6 +51,9 @@ pub mod support {
 
     use crate::{CompilerResult, cargo::CargoOptions};
 
+    /// The LLVM optimization level used for release guest builds.
+    const RELEASE_OPT_LEVEL: &str = "2";
+
     /// Executes a Cargo-based build with the provided compiler options and package registry
     pub fn cargo_build(
         manifest_path: &Path,
@@ -304,7 +307,7 @@ pub mod support {
             ("profile.dev.overflow-checks", "false"),
             ("profile.dev.debug", "true"),
             ("profile.dev.debug-assertions", "false"),
-            ("profile.release.opt-level", "\"s\""),
+            ("profile.release.opt-level", RELEASE_OPT_LEVEL),
             ("profile.release.lto", "true"),
             ("profile.release.codegen-units", "1"),
             ("profile.release.panic", "\"abort\""),

--- a/midenc-compile/src/stages/cargo.rs
+++ b/midenc-compile/src/stages/cargo.rs
@@ -45,14 +45,11 @@ pub mod support {
         diagnostics::{IntoDiagnostic, SourceManagerExt},
     };
     use midenc_session::{
-        InputFile, RemapPathPrefix, miden_project, registry::HybridPackageRegistry,
+        InputFile, OptLevel, RemapPathPrefix, miden_project, registry::HybridPackageRegistry,
     };
     use tempfile::TempDir;
 
     use crate::{CompilerResult, cargo::CargoOptions};
-
-    /// The LLVM optimization level used for release guest builds.
-    const RELEASE_OPT_LEVEL: &str = "2";
 
     /// Executes a Cargo-based build with the provided compiler options and package registry
     pub fn cargo_build(
@@ -239,7 +236,7 @@ pub mod support {
         )?;
 
         let rustup_toolchain = crate::rust::rustup_toolchain();
-        let cargo_build_args = build_cargo_args(cargo_opts);
+        let cargo_build_args = build_cargo_args(cargo_opts, compiler_opts.optimize);
 
         // Enable memcopy and 128-bit arithmetic ops
         let mut extra_rust_flags = String::from("-C target-feature=+bulk-memory,+wide-arithmetic");
@@ -284,8 +281,19 @@ pub mod support {
         Ok(InputFile::from_path(wasm_output).unwrap())
     }
 
+    /// Returns the Cargo profile value for a compiler optimization level.
+    fn cargo_profile_opt_level(opt_level: OptLevel) -> &'static str {
+        match opt_level {
+            OptLevel::None | OptLevel::Balanced => "2",
+            OptLevel::Basic => "1",
+            OptLevel::Max => "3",
+            OptLevel::Size => "\"s\"",
+            OptLevel::SizeMin => "\"z\"",
+        }
+    }
+
     /// Builds the argument vector for the underlying `cargo build` invocation.
-    fn build_cargo_args(cargo_opts: &CargoOptions) -> Vec<String> {
+    fn build_cargo_args(cargo_opts: &CargoOptions, opt_level: OptLevel) -> Vec<String> {
         let mut args = vec!["build".to_string()];
 
         // Add build-std flags required for Miden compilation
@@ -307,7 +315,7 @@ pub mod support {
             ("profile.dev.overflow-checks", "false"),
             ("profile.dev.debug", "true"),
             ("profile.dev.debug-assertions", "false"),
-            ("profile.release.opt-level", RELEASE_OPT_LEVEL),
+            ("profile.release.opt-level", cargo_profile_opt_level(opt_level)),
             ("profile.release.lto", "true"),
             ("profile.release.codegen-units", "1"),
             ("profile.release.panic", "\"abort\""),

--- a/tests/integration-network/src/mockchain/counter/basic_auth.rs
+++ b/tests/integration-network/src/mockchain/counter/basic_auth.rs
@@ -65,7 +65,7 @@ pub fn counter_note_basic_auth_increments_storage() {
         .build_tx_context(counter_account.clone(), &[counter_note.id()], &[])
         .unwrap();
     let tx_measurements = execute_tx(&mut chain, tx_context_builder);
-    expect!["8430"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["8052"].assert_eq(single_note_cycles(&tx_measurements));
 
     // The counter contract storage value should be 2 after the note is consumed (incremented by 1).
     assert_counter_storage(

--- a/tests/integration-network/src/mockchain/counter/no_auth.rs
+++ b/tests/integration-network/src/mockchain/counter/no_auth.rs
@@ -101,7 +101,7 @@ pub fn counter_note_no_auth_increments_storage_without_signature() {
         .unwrap();
     let tx_measurements = execute_tx(&mut chain, tx_context_builder);
     expect!["1726"].assert_eq(auth_procedure_cycles(&tx_measurements));
-    expect!["8430"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["8052"].assert_eq(single_note_cycles(&tx_measurements));
 
     // The counter contract storage value should be 2 after the note is consumed
     assert_counter_storage(

--- a/tests/integration-network/src/mockchain/notes/basic_wallet.rs
+++ b/tests/integration-network/src/mockchain/notes/basic_wallet.rs
@@ -110,7 +110,7 @@ pub fn basic_wallet_p2id_transfers_asset_with_custom_tx_script() {
         .foreign_accounts(vec![faucet_inputs]);
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
     expect!["3327"].assert_eq(prologue_cycles(&tx_measurements));
-    expect!["6720"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["6242"].assert_eq(single_note_cycles(&tx_measurements));
 
     eprintln!("\n=== Checking Alice's account has the minted asset ===");
     let alice_account = chain.committed_account(alice_id).unwrap();
@@ -132,7 +132,7 @@ pub fn basic_wallet_p2id_transfers_asset_with_custom_tx_script() {
         &mut note_rng,
     );
     let tx_measurements = execute_tx(&mut chain, alice_tx_context_builder);
-    expect!["6528"].assert_eq(tx_script_processing_cycles(&tx_measurements));
+    expect!["6337"].assert_eq(tx_script_processing_cycles(&tx_measurements));
 
     eprintln!("\n=== Step 4: Bob consumes p2id note ===");
     let faucet_inputs = chain.get_foreign_account_inputs(faucet_id).unwrap();
@@ -141,7 +141,7 @@ pub fn basic_wallet_p2id_transfers_asset_with_custom_tx_script() {
         .unwrap()
         .foreign_accounts(vec![faucet_inputs]);
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
-    expect!["6720"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["6242"].assert_eq(single_note_cycles(&tx_measurements));
 
     eprintln!("\n=== Checking Bob's account has the transferred asset ===");
     let bob_account = chain.committed_account(bob_id).unwrap();
@@ -278,7 +278,7 @@ pub fn basic_wallet_p2ide_allows_recipient_claim() {
         .unwrap()
         .foreign_accounts(vec![faucet_inputs]);
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
-    expect!["6984"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["6508"].assert_eq(single_note_cycles(&tx_measurements));
 
     // Step 5: verify balances
     let bob_account = chain.committed_account(bob_id).unwrap();
@@ -415,7 +415,7 @@ pub fn basic_wallet_p2ide_allows_sender_reclaim() {
         .unwrap()
         .foreign_accounts(vec![faucet_inputs]);
     let tx_measurements = execute_tx(&mut chain, reclaim_tx_context_builder);
-    expect!["7426"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["6950"].assert_eq(single_note_cycles(&tx_measurements));
 
     // Step 5: verify Alice has her original amount back
     let alice_account = chain.committed_account(alice_id).unwrap();

--- a/tests/integration/src/end_to_end/examples/basic_wallet_package_sizes.rs
+++ b/tests/integration/src/end_to_end/examples/basic_wallet_package_sizes.rs
@@ -18,7 +18,7 @@ fn basic_wallet_and_p2id() {
     );
     let account_package = account_test.compile_package();
     assert!(account_package.is_library(), "expected library");
-    expect!["12469"].assert_eq(stripped_mast_size_str(&account_package));
+    expect!["13178"].assert_eq(stripped_mast_size_str(&account_package));
     persist_cargo_miden_dependency("../../examples/basic-wallet", account_package.as_ref());
 
     let mut tx_script_test = CompilerTest::rust_source_cargo_miden(
@@ -28,7 +28,7 @@ fn basic_wallet_and_p2id() {
     );
     let tx_script_package = tx_script_test.compile_package();
     assert!(tx_script_package.is_library(), "expected library");
-    expect!["12981"].assert_eq(stripped_mast_size_str(&tx_script_package));
+    expect!["14526"].assert_eq(stripped_mast_size_str(&tx_script_package));
 
     let mut p2id_test = CompilerTest::rust_source_cargo_miden(
         "../../examples/p2id-note",
@@ -37,7 +37,7 @@ fn basic_wallet_and_p2id() {
     );
     let note_package = p2id_test.compile_package();
     assert!(note_package.is_library(), "expected library");
-    expect!["14097"].assert_eq(stripped_mast_size_str(&note_package));
+    expect!["15353"].assert_eq(stripped_mast_size_str(&note_package));
 
     let mut p2ide_test = CompilerTest::rust_source_cargo_miden(
         "../../examples/p2ide-note",
@@ -46,5 +46,5 @@ fn basic_wallet_and_p2id() {
     );
     let p2ide_package = p2ide_test.compile_package();
     assert!(p2ide_package.is_library(), "expected library");
-    expect!["16360"].assert_eq(stripped_mast_size_str(&p2ide_package));
+    expect!["17785"].assert_eq(stripped_mast_size_str(&p2ide_package));
 }


### PR DESCRIPTION
Size-optimized LLVM output leaves execution improvements on the table for release guest builds, while the resulting package-size tradeoff depends on the guest.

On the batch-kernel #1242, isolated opt-`s` versus opt-2 measurements showed:

| Workload | Cycle reduction |
| --- | ---: |
| Batch scenario 1 | 13.6% (34,916 → 30,151) |
| Batch note-erasure scenario | 13.5% (30,553 → 26,436) |
| Tampered-preimage rejection | 11.2% (950 → 844) |
| Consume-before-create rejection | 9.8% (15,969 → 14,411) |

The stripped batch-kernel MAST also decreased by 9.9%, from 112,218 to 101,144 bytes. On this branch, the updated integration-network pins likewise show cycle reductions across the counter, P2ID, custom transaction script, and P2IDE workflows.

This is primarily an execution-speed optimization: package-size effects depend on the guest. The four small example packages measured on this branch grow by 6.9–13.7% under opt-2.
