### PR TITLE
# feat(sdk): typed fungible asset amounts (`AssetAmount`) + other integer semantics (instead of `Felt`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,6 +2871,7 @@ name = "miden-base-sys"
 version = "0.13.1"
 dependencies = [
  "miden-field-repr",
+ "miden-protocol",
  "miden-stdlib-sys",
 ]
 

--- a/examples/auth-component-rpo-falcon512/src/lib.rs
+++ b/examples/auth-component-rpo-falcon512/src/lib.rs
@@ -40,7 +40,7 @@ impl AuthComponent for AuthComponentStorage {
         let input_notes_commit = tx::get_input_notes_commitment();
         let output_notes_commit = tx::get_output_notes_commitment();
 
-        let salt = Word::from([felt!(0), felt!(0), ref_block_num, final_nonce.into()]);
+        let salt = Word::from([felt!(0), felt!(0), ref_block_num.into(), final_nonce.into()]);
 
         let tx_summary = [acct_delta_commit, input_notes_commit, output_notes_commit, salt];
         let msg: Word = hash_words(&tx_summary).into();

--- a/examples/auth-component-rpo-falcon512/src/lib.rs
+++ b/examples/auth-component-rpo-falcon512/src/lib.rs
@@ -40,7 +40,7 @@ impl AuthComponent for AuthComponentStorage {
         let input_notes_commit = tx::get_input_notes_commitment();
         let output_notes_commit = tx::get_output_notes_commitment();
 
-        let salt = Word::from([felt!(0), felt!(0), ref_block_num, final_nonce]);
+        let salt = Word::from([felt!(0), felt!(0), ref_block_num, final_nonce.into()]);
 
         let tx_summary = [acct_delta_commit, input_notes_commit, output_notes_commit, salt];
         let msg: Word = hash_words(&tx_summary).into();

--- a/examples/p2ide-note/src/lib.rs
+++ b/examples/p2ide-note/src/lib.rs
@@ -48,8 +48,8 @@ impl P2ideNote {
         // [target_account_id_suffix, target_account_id_prefix, reclaim_height, timelock_height]
         let target_account_id_suffix = inputs[0];
         let target_account_id_prefix = inputs[1];
-        let reclaim_height = inputs[2];
-        let timelock_height = inputs[3];
+        let reclaim_height = BlockNumber::try_from(inputs[2]).unwrap();
+        let timelock_height = BlockNumber::try_from(inputs[3]).unwrap();
 
         // get block number
         let block_number = tx::get_block_number();
@@ -65,7 +65,7 @@ impl P2ideNote {
         if is_target {
             consume_assets(account);
         } else {
-            assert!(reclaim_height != felt!(0));
+            assert!(reclaim_height.as_u32() != 0);
             assert!(block_number >= reclaim_height);
             reclaim_assets(account, consuming_account_id);
         }

--- a/examples/storage-example/src/lib.rs
+++ b/examples/storage-example/src/lib.rs
@@ -7,7 +7,7 @@
 //
 // extern crate alloc;
 
-use miden::{Asset, Felt, StorageMap, StorageValue, Word, component_storage};
+use miden::{Asset, AssetAmount, StorageMap, StorageValue, Word, component_storage};
 
 use crate::bindings::exports::miden::storage_example::*;
 
@@ -23,12 +23,12 @@ struct MyAccount {
 
     /// A map from asset vault key to quantity held by the account.
     #[storage(description = "asset quantity map")]
-    asset_qty_map: StorageMap<Word, Felt>,
+    asset_qty_map: StorageMap<Word, AssetAmount>,
 }
 
 impl foo::Guest for MyAccount {
     /// Sets the quantity for `asset` if `pub_key` matches the stored owner key.
-    fn set_asset_qty(pub_key: Word, asset: Asset, qty: Felt) {
+    fn set_asset_qty(pub_key: Word, asset: Asset, qty: AssetAmount) {
         let mut my_account = MyAccount::default();
         let owner_key: Word = my_account.owner_public_key.get();
         if pub_key == owner_key {
@@ -37,7 +37,7 @@ impl foo::Guest for MyAccount {
     }
 
     /// Returns the stored quantity for `asset`, or 0 if not present.
-    fn get_asset_qty(asset: Asset) -> Felt {
+    fn get_asset_qty(asset: Asset) -> AssetAmount {
         let my_account = MyAccount::default();
         my_account.asset_qty_map.get(asset.key)
     }

--- a/examples/storage-example/wit/storage-example.wit
+++ b/examples/storage-example/wit/storage-example.wit
@@ -3,10 +3,10 @@ package miden:storage-example@1.0.0;
 use miden:base/core-types@1.0.0;
 
 interface foo {
-    use core-types.{felt, word, asset};
+    use core-types.{asset-amount, word, asset};
 
-    set-asset-qty: func(pub-key: word, asset: asset, qty: felt);
-    get-asset-qty: func(asset: asset) -> felt;
+    set-asset-qty: func(pub-key: word, asset: asset, qty: asset-amount);
+    get-asset-qty: func(asset: asset) -> asset-amount;
 }
 
 world foo-world {

--- a/sdk/base-macros/src/account_component_metadata.rs
+++ b/sdk/base-macros/src/account_component_metadata.rs
@@ -52,7 +52,7 @@ fn schema_type_from_storage_type_arg(ty: &syn::Type) -> SchemaType {
 
     match last_segment.ident.to_string().as_str() {
         "Word" => SchemaType::native_word(),
-        "Felt" => SchemaType::native_felt(),
+        "Felt" | "AssetAmount" => SchemaType::native_felt(),
         "u8" => SchemaType::u8(),
         "u16" => SchemaType::u16(),
         "u32" => SchemaType::u32(),

--- a/sdk/base-macros/src/generate.rs
+++ b/sdk/base-macros/src/generate.rs
@@ -548,6 +548,7 @@ fn push_default_with_entries(opts: &mut Opts) {
     push_path_entry(opts, &format!("{CORE_TYPES_INTERFACE}/recipient"), "::miden::Recipient");
     push_path_entry(opts, &format!("{CORE_TYPES_INTERFACE}/note-idx"), "::miden::NoteIdx");
     push_path_entry(opts, &format!("{CORE_TYPES_INTERFACE}/nonce"), "::miden::Nonce");
+    push_path_entry(opts, &format!("{CORE_TYPES_INTERFACE}/block-number"), "::miden::BlockNumber");
 }
 
 fn push_path_entry(opts: &mut Opts, key: &str, value: &str) {

--- a/sdk/base-macros/src/generate.rs
+++ b/sdk/base-macros/src/generate.rs
@@ -547,6 +547,7 @@ fn push_default_with_entries(opts: &mut Opts) {
     push_path_entry(opts, &format!("{CORE_TYPES_INTERFACE}/note-type"), "::miden::NoteType");
     push_path_entry(opts, &format!("{CORE_TYPES_INTERFACE}/recipient"), "::miden::Recipient");
     push_path_entry(opts, &format!("{CORE_TYPES_INTERFACE}/note-idx"), "::miden::NoteIdx");
+    push_path_entry(opts, &format!("{CORE_TYPES_INTERFACE}/nonce"), "::miden::Nonce");
 }
 
 fn push_path_entry(opts: &mut Opts, key: &str, value: &str) {

--- a/sdk/base-macros/src/generate.rs
+++ b/sdk/base-macros/src/generate.rs
@@ -541,6 +541,7 @@ fn push_default_with_entries(opts: &mut Opts) {
     push_path_entry(opts, &format!("{CORE_TYPES_INTERFACE}/felt"), "::miden::Felt");
     push_path_entry(opts, &format!("{CORE_TYPES_INTERFACE}/word"), "::miden::Word");
     push_path_entry(opts, &format!("{CORE_TYPES_INTERFACE}/asset"), "::miden::Asset");
+    push_path_entry(opts, &format!("{CORE_TYPES_INTERFACE}/asset-amount"), "::miden::AssetAmount");
     push_path_entry(opts, &format!("{CORE_TYPES_INTERFACE}/account-id"), "::miden::AccountId");
     push_path_entry(opts, &format!("{CORE_TYPES_INTERFACE}/tag"), "::miden::Tag");
     push_path_entry(opts, &format!("{CORE_TYPES_INTERFACE}/note-type"), "::miden::NoteType");

--- a/sdk/base-macros/src/types/tests.rs
+++ b/sdk/base-macros/src/types/tests.rs
@@ -34,6 +34,20 @@ fn allows_sdk_type_without_export_attribute() {
 }
 
 #[test]
+fn allows_asset_amount_without_export_attribute() {
+    reset_export_type_registry_for_tests();
+    let ty: Type = syn::parse_str("AssetAmount").unwrap();
+    let exported = HashMap::new();
+    let type_ref = map_type_to_type_ref(&ty, &exported).expect("asset amount should resolve");
+    assert_eq!(type_ref.wit_name, "asset-amount");
+    assert!(!type_ref.is_custom);
+    assert!(type_ref.requires_core_type_import());
+    let exported_names = HashSet::new();
+    ensure_custom_type_defined(&type_ref, &exported_names, Span::call_site())
+        .expect("core types require no export");
+}
+
+#[test]
 fn allows_wit_primitive_type_without_export_attribute() {
     reset_export_type_registry_for_tests();
     let ty: Type = syn::parse_str("u64").unwrap();

--- a/sdk/base-macros/src/types/tests.rs
+++ b/sdk/base-macros/src/types/tests.rs
@@ -34,6 +34,20 @@ fn allows_sdk_type_without_export_attribute() {
 }
 
 #[test]
+fn allows_block_number_without_export_attribute() {
+    reset_export_type_registry_for_tests();
+    let ty: Type = syn::parse_str("BlockNumber").unwrap();
+    let exported = HashMap::new();
+    let type_ref = map_type_to_type_ref(&ty, &exported).expect("block number should resolve");
+    assert_eq!(type_ref.wit_name, "block-number");
+    assert!(!type_ref.is_custom);
+    assert!(type_ref.requires_core_type_import());
+    let exported_names = HashSet::new();
+    ensure_custom_type_defined(&type_ref, &exported_names, Span::call_site())
+        .expect("core types require no export");
+}
+
+#[test]
 fn allows_nonce_without_export_attribute() {
     reset_export_type_registry_for_tests();
     let ty: Type = syn::parse_str("Nonce").unwrap();

--- a/sdk/base-macros/src/types/tests.rs
+++ b/sdk/base-macros/src/types/tests.rs
@@ -34,6 +34,20 @@ fn allows_sdk_type_without_export_attribute() {
 }
 
 #[test]
+fn allows_nonce_without_export_attribute() {
+    reset_export_type_registry_for_tests();
+    let ty: Type = syn::parse_str("Nonce").unwrap();
+    let exported = HashMap::new();
+    let type_ref = map_type_to_type_ref(&ty, &exported).expect("nonce should resolve");
+    assert_eq!(type_ref.wit_name, "nonce");
+    assert!(!type_ref.is_custom);
+    assert!(type_ref.requires_core_type_import());
+    let exported_names = HashSet::new();
+    ensure_custom_type_defined(&type_ref, &exported_names, Span::call_site())
+        .expect("core types require no export");
+}
+
+#[test]
 fn allows_asset_amount_without_export_attribute() {
     reset_export_type_registry_for_tests();
     let ty: Type = syn::parse_str("AssetAmount").unwrap();

--- a/sdk/base-macros/wit/miden.wit
+++ b/sdk/base-macros/wit/miden.wit
@@ -80,6 +80,11 @@ interface core-types {
         inner: felt
     }
 
+    /// A block height in the chain
+    record block-number {
+        inner: felt
+    }
+
     /// Account hash
     record account-hash {
         inner: word

--- a/sdk/base-macros/wit/miden.wit
+++ b/sdk/base-macros/wit/miden.wit
@@ -70,6 +70,11 @@ interface core-types {
         value: word,
     }
 
+    /// A validated fungible asset amount, at most 2^63 - 2^31.
+    record asset-amount {
+        inner: felt
+    }
+
     /// Account nonce
     record nonce {
         inner: felt

--- a/sdk/base-sys/Cargo.toml
+++ b/sdk/base-sys/Cargo.toml
@@ -22,6 +22,9 @@ doctest = false
 miden-stdlib-sys.workspace = true
 miden-field-repr.workspace = true
 
+[dev-dependencies]
+miden-protocol.workspace = true
+
 [features]
 default = []
 

--- a/sdk/base-sys/src/bindings/active_account.rs
+++ b/sdk/base-sys/src/bindings/active_account.rs
@@ -1,6 +1,6 @@
 use miden_stdlib_sys::{Felt, Word, WordAligned};
 
-use super::types::{AccountId, RawAccountId};
+use super::types::{AccountId, Nonce, RawAccountId};
 
 #[allow(improper_ctypes)]
 unsafe extern "C" {
@@ -66,8 +66,10 @@ pub fn get_id() -> AccountId {
 
 /// Returns the nonce of the active account.
 #[inline]
-pub fn get_nonce() -> Felt {
-    unsafe { extern_active_account_get_nonce() }
+pub fn get_nonce() -> Nonce {
+    Nonce {
+        inner: unsafe { extern_active_account_get_nonce() },
+    }
 }
 
 /// Computes and returns the commitment of the current account data.
@@ -193,7 +195,7 @@ pub trait ActiveAccount {
 
     /// Returns the nonce of the active account.
     #[inline]
-    fn get_nonce(&self) -> Felt {
+    fn get_nonce(&self) -> Nonce {
         self.__assert_active_account();
         get_nonce()
     }

--- a/sdk/base-sys/src/bindings/active_account.rs
+++ b/sdk/base-sys/src/bindings/active_account.rs
@@ -137,8 +137,10 @@ pub fn get_vault_root() -> Word {
 
 /// Returns the number of procedures exported by the active account.
 #[inline]
-pub fn get_num_procedures() -> Felt {
-    unsafe { extern_active_account_get_num_procedures() }
+pub fn get_num_procedures() -> u32 {
+    // The transaction kernel guarantees procedure counts fit in a u32.
+    let count = unsafe { extern_active_account_get_num_procedures() };
+    count.as_canonical_u64() as u32
 }
 
 /// Returns the procedure root for the procedure at `index`.
@@ -242,7 +244,7 @@ pub trait ActiveAccount {
 
     /// Returns the number of procedures exported by the active account.
     #[inline]
-    fn get_num_procedures(&self) -> Felt {
+    fn get_num_procedures(&self) -> u32 {
         self.__assert_active_account();
         get_num_procedures()
     }

--- a/sdk/base-sys/src/bindings/active_account.rs
+++ b/sdk/base-sys/src/bindings/active_account.rs
@@ -147,13 +147,10 @@ pub fn get_num_procedures() -> u32 {
 
 /// Returns the procedure root for the procedure at `index`.
 #[inline]
-pub fn get_procedure_root(index: u8) -> Word {
+pub fn get_procedure_root(index: u32) -> Word {
     unsafe {
         let mut ret_area = WordAligned::new(::core::mem::MaybeUninit::<Word>::uninit());
-        extern_active_account_get_procedure_root(
-            Felt::new(index as u64).unwrap(),
-            ret_area.as_mut_ptr(),
-        );
+        extern_active_account_get_procedure_root(Felt::from_u32(index), ret_area.as_mut_ptr());
         ret_area.into_inner().assume_init()
     }
 }
@@ -253,7 +250,7 @@ pub trait ActiveAccount {
 
     /// Returns the procedure root for the procedure at `index`.
     #[inline]
-    fn get_procedure_root(&self, index: u8) -> Word {
+    fn get_procedure_root(&self, index: u32) -> Word {
         self.__assert_active_account();
         get_procedure_root(index)
     }

--- a/sdk/base-sys/src/bindings/active_note.rs
+++ b/sdk/base-sys/src/bindings/active_note.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use miden_stdlib_sys::{Felt, Word, WordAligned};
 
-use super::{AccountId, Asset, AttachmentLocation, NoteMetadata, RawAccountId, Recipient};
+use super::{AccountId, Asset, NoteMetadata, RawAccountId, RawAttachmentLocation, Recipient};
 
 const MAX_ATTACHMENTS_PER_NOTE: usize = 4;
 const MAX_ATTACHMENT_WORDS: usize = 256;
@@ -49,7 +49,7 @@ unsafe extern "C" {
     fn extern_note_write_attachment_to_memory(dest_ptr: *mut Felt, attachment_idx: Felt) -> usize;
     #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::active_note::find_attachment"]
-    fn extern_note_find_attachment(attachment_scheme: Felt, ptr: *mut AttachmentLocation);
+    fn extern_note_find_attachment(attachment_scheme: Felt, ptr: *mut RawAttachmentLocation);
 }
 
 /// Returns the storage of the currently executing note.
@@ -187,11 +187,11 @@ pub fn write_attachment_commitments_to_memory() -> Vec<Word> {
 }
 
 /// Writes the selected attachment to memory and returns it as protocol words.
-pub fn write_attachment_to_memory(attachment_idx: Felt) -> Vec<Word> {
+pub fn write_attachment_to_memory(attachment_idx: u32) -> Vec<Word> {
     let mut attachment: Vec<Word> = Vec::with_capacity(MAX_ATTACHMENT_WORDS);
     let num_words = unsafe {
         let ptr = (attachment.as_mut_ptr() as usize) / 4;
-        extern_note_write_attachment_to_memory(ptr as *mut Felt, attachment_idx)
+        extern_note_write_attachment_to_memory(ptr as *mut Felt, Felt::from_u32(attachment_idx))
     };
     assert!(
         num_words <= MAX_ATTACHMENT_WORDS,
@@ -204,11 +204,11 @@ pub fn write_attachment_to_memory(attachment_idx: Felt) -> Vec<Word> {
 }
 
 /// Searches the active note metadata for `attachment_scheme`.
-pub fn find_attachment(attachment_scheme: Felt) -> AttachmentLocation {
+pub fn find_attachment(attachment_scheme: Felt) -> Option<u32> {
     unsafe {
         let mut ret_area =
-            WordAligned::new(::core::mem::MaybeUninit::<AttachmentLocation>::uninit());
+            WordAligned::new(::core::mem::MaybeUninit::<RawAttachmentLocation>::uninit());
         extern_note_find_attachment(attachment_scheme, ret_area.as_mut_ptr());
-        ret_area.into_inner().assume_init()
+        ret_area.into_inner().assume_init().into_attachment_index()
     }
 }

--- a/sdk/base-sys/src/bindings/input_note.rs
+++ b/sdk/base-sys/src/bindings/input_note.rs
@@ -71,13 +71,13 @@ unsafe extern "C" {
 /// Contains summary information about the assets stored in an input note.
 pub struct InputNoteAssetsInfo {
     pub commitment: Word,
-    pub num_assets: Felt,
+    pub num_assets: u32,
 }
 
 /// Contains summary information about the storage stored in an input note.
 pub struct InputNoteStorageInfo {
     pub commitment: Word,
-    pub num_storage_items: Felt,
+    pub num_storage_items: u32,
 }
 
 /// Returns the initial assets commitment and asset count for the input note at `note_index`.
@@ -90,7 +90,8 @@ pub fn get_initial_assets_info(note_index: NoteIdx) -> InputNoteAssetsInfo {
         let (commitment, num_assets) = ret_area.into_inner().assume_init();
         InputNoteAssetsInfo {
             commitment,
-            num_assets,
+            // The transaction kernel guarantees asset counts fit in a u32.
+            num_assets: num_assets.as_canonical_u64() as u32,
         }
     }
 }
@@ -146,7 +147,8 @@ pub fn get_storage_info(note_index: NoteIdx) -> InputNoteStorageInfo {
         let (commitment, num_storage_items) = ret_area.into_inner().assume_init();
         InputNoteStorageInfo {
             commitment,
-            num_storage_items,
+            // The transaction kernel guarantees storage item counts fit in a u32.
+            num_storage_items: num_storage_items.as_canonical_u64() as u32,
         }
     }
 }

--- a/sdk/base-sys/src/bindings/input_note.rs
+++ b/sdk/base-sys/src/bindings/input_note.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use miden_stdlib_sys::{Felt, Word, WordAligned};
 
 use super::types::{
-    AccountId, Asset, AttachmentLocation, NoteIdx, NoteMetadata, RawAccountId, Recipient,
+    AccountId, Asset, NoteIdx, NoteMetadata, RawAccountId, RawAttachmentLocation, Recipient,
 };
 
 const MAX_ATTACHMENTS_PER_NOTE: usize = 4;
@@ -64,7 +64,7 @@ unsafe extern "C" {
     fn extern_input_note_find_attachment(
         attachment_scheme: Felt,
         note_index: Felt,
-        ptr: *mut AttachmentLocation,
+        ptr: *mut RawAttachmentLocation,
     );
 }
 
@@ -211,13 +211,13 @@ pub fn write_attachment_commitments_to_memory(note_index: NoteIdx) -> Vec<Word> 
 }
 
 /// Writes the selected input-note attachment to memory and returns it as protocol words.
-pub fn write_attachment_to_memory(note_index: NoteIdx, attachment_idx: Felt) -> Vec<Word> {
+pub fn write_attachment_to_memory(note_index: NoteIdx, attachment_idx: u32) -> Vec<Word> {
     let mut attachment: Vec<Word> = Vec::with_capacity(MAX_ATTACHMENT_WORDS);
     let num_words = unsafe {
         let ptr = (attachment.as_mut_ptr() as usize) / 4;
         extern_input_note_write_attachment_to_memory(
             ptr as *mut Felt,
-            attachment_idx,
+            Felt::from_u32(attachment_idx),
             note_index.inner,
         )
     };
@@ -232,15 +232,15 @@ pub fn write_attachment_to_memory(note_index: NoteIdx, attachment_idx: Felt) -> 
 }
 
 /// Searches the input note metadata for `attachment_scheme`.
-pub fn find_attachment(note_index: NoteIdx, attachment_scheme: Felt) -> AttachmentLocation {
+pub fn find_attachment(note_index: NoteIdx, attachment_scheme: Felt) -> Option<u32> {
     unsafe {
         let mut ret_area =
-            WordAligned::new(::core::mem::MaybeUninit::<AttachmentLocation>::uninit());
+            WordAligned::new(::core::mem::MaybeUninit::<RawAttachmentLocation>::uninit());
         extern_input_note_find_attachment(
             attachment_scheme,
             note_index.inner,
             ret_area.as_mut_ptr(),
         );
-        ret_area.into_inner().assume_init()
+        ret_area.into_inner().assume_init().into_attachment_index()
     }
 }

--- a/sdk/base-sys/src/bindings/native_account.rs
+++ b/sdk/base-sys/src/bindings/native_account.rs
@@ -72,7 +72,8 @@ unsafe extern "C" {
 ///
 /// Panics:
 /// - If the asset is not valid.
-/// - If the total value of two fungible assets is greater than or equal to 2^63.
+/// - If the total value of two fungible assets is greater than
+///   [`AssetAmount::MAX_U64`](super::types::AssetAmount::MAX_U64).
 /// - If the vault already contains the same non-fungible asset.
 ///
 /// # Examples
@@ -235,7 +236,8 @@ pub trait NativeAccount {
     /// # Panics
     ///
     /// - If the asset is not valid.
-    /// - If the total value of two fungible assets is greater than or equal to 2^63.
+    /// - If the total value of two fungible assets is greater than
+    ///   [`AssetAmount::MAX_U64`](super::types::AssetAmount::MAX_U64).
     /// - If the vault already contains the same non-fungible asset.
     ///
     /// # Examples

--- a/sdk/base-sys/src/bindings/native_account.rs
+++ b/sdk/base-sys/src/bindings/native_account.rs
@@ -1,6 +1,6 @@
 use miden_stdlib_sys::{Felt, Word, WordAligned};
 
-use super::types::{AccountId, Asset, RawAccountId};
+use super::types::{AccountId, Asset, Nonce, RawAccountId};
 
 #[allow(improper_ctypes)]
 unsafe extern "C" {
@@ -150,8 +150,10 @@ pub fn get_id() -> AccountId {
 
 /// Increments the account nonce by one and returns the new nonce.
 #[inline]
-pub fn incr_nonce() -> Felt {
-    unsafe { extern_native_account_incr_nonce() }
+pub fn incr_nonce() -> Nonce {
+    Nonce {
+        inner: unsafe { extern_native_account_incr_nonce() },
+    }
 }
 
 /// Computes and returns the commitment to the native account's delta for this transaction.
@@ -277,7 +279,7 @@ pub trait NativeAccount {
 
     /// Increments the account nonce by one and returns the new nonce.
     #[inline]
-    fn incr_nonce(&mut self) -> Felt {
+    fn incr_nonce(&mut self) -> Nonce {
         incr_nonce()
     }
 

--- a/sdk/base-sys/src/bindings/note.rs
+++ b/sdk/base-sys/src/bindings/note.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use miden_stdlib_sys::{Felt, Word, WordAligned};
 
-use super::{AccountId, AttachmentLocation, NoteType, RawAccountId, Recipient, Tag};
+use super::{AccountId, NoteType, RawAccountId, RawAttachmentLocation, Recipient, Tag};
 
 const MAX_NOTE_STORAGE_ITEMS: usize = 1024;
 const MAX_ATTACHMENTS_PER_NOTE: usize = 4;
@@ -119,7 +119,7 @@ unsafe extern "C" {
         metadata_f1: Felt,
         metadata_f2: Felt,
         metadata_f3: Felt,
-        ptr: *mut AttachmentLocation,
+        ptr: *mut RawAttachmentLocation,
     );
 }
 
@@ -260,7 +260,7 @@ pub fn write_attachment_to_memory(attachment_commitment: Word) -> Vec<Word> {
 /// The advice map must contain the selected attachment elements.
 pub fn write_indexed_attachment_to_memory(
     attachment_commitments: &[Word],
-    attachment_idx: Felt,
+    attachment_idx: u32,
 ) -> Vec<Word> {
     assert!(
         attachment_commitments.len() <= MAX_ATTACHMENTS_PER_NOTE,
@@ -278,7 +278,7 @@ pub fn write_indexed_attachment_to_memory(
         extern_note_write_indexed_attachment_to_memory(
             Felt::from_u32(attachment_commitments.len() as u32),
             commitments_ptr as *const Felt,
-            attachment_idx,
+            Felt::from_u32(attachment_idx),
             dest_ptr as *mut Felt,
         )
     };
@@ -374,10 +374,10 @@ pub fn metadata_into_tag(metadata: Word) -> Tag {
 }
 
 /// Searches a metadata header word for `attachment_scheme`.
-pub fn find_attachment_idx(attachment_scheme: Felt, metadata: Word) -> AttachmentLocation {
+pub fn find_attachment_idx(attachment_scheme: Felt, metadata: Word) -> Option<u32> {
     unsafe {
         let mut ret_area =
-            WordAligned::new(::core::mem::MaybeUninit::<AttachmentLocation>::uninit());
+            WordAligned::new(::core::mem::MaybeUninit::<RawAttachmentLocation>::uninit());
         extern_note_find_attachment_idx(
             attachment_scheme,
             metadata[0],
@@ -386,6 +386,6 @@ pub fn find_attachment_idx(attachment_scheme: Felt, metadata: Word) -> Attachmen
             metadata[3],
             ret_area.as_mut_ptr(),
         );
-        ret_area.into_inner().assume_init()
+        ret_area.into_inner().assume_init().into_attachment_index()
     }
 }

--- a/sdk/base-sys/src/bindings/output_note.rs
+++ b/sdk/base-sys/src/bindings/output_note.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use miden_stdlib_sys::{Felt, Word, WordAligned};
 
-use super::types::{Asset, AttachmentLocation, NoteIdx, NoteMetadata, NoteType, Recipient, Tag};
+use super::types::{Asset, NoteIdx, NoteMetadata, NoteType, RawAttachmentLocation, Recipient, Tag};
 
 const MAX_ATTACHMENTS_PER_NOTE: usize = 4;
 const MAX_ATTACHMENT_WORDS: usize = 256;
@@ -78,10 +78,10 @@ unsafe extern "C" {
     );
     #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::output_note::find_attachment"]
-    pub fn extern_output_note_find_attachment(
+    pub(crate) fn extern_output_note_find_attachment(
         attachment_scheme: Felt,
         note_index: Felt,
-        ptr: *mut AttachmentLocation,
+        ptr: *mut RawAttachmentLocation,
     );
     #[cfg_attr(target_family = "wasm", linkage = "extern_weak")]
     #[link_name = "miden::protocol::output_note::write_attachment_commitments_to_memory"]
@@ -296,16 +296,16 @@ pub fn get_metadata(note_index: NoteIdx) -> NoteMetadata {
 }
 
 /// Searches the output note metadata for `attachment_scheme`.
-pub fn find_attachment(note_index: NoteIdx, attachment_scheme: Felt) -> AttachmentLocation {
+pub fn find_attachment(note_index: NoteIdx, attachment_scheme: Felt) -> Option<u32> {
     unsafe {
         let mut ret_area =
-            WordAligned::new(::core::mem::MaybeUninit::<AttachmentLocation>::uninit());
+            WordAligned::new(::core::mem::MaybeUninit::<RawAttachmentLocation>::uninit());
         extern_output_note_find_attachment(
             attachment_scheme,
             note_index.inner,
             ret_area.as_mut_ptr(),
         );
-        ret_area.into_inner().assume_init()
+        ret_area.into_inner().assume_init().into_attachment_index()
     }
 }
 
@@ -330,13 +330,13 @@ pub fn write_attachment_commitments_to_memory(note_index: NoteIdx) -> Vec<Word> 
 }
 
 /// Writes the selected output-note attachment to memory and returns it as protocol words.
-pub fn write_attachment_to_memory(note_index: NoteIdx, attachment_idx: Felt) -> Vec<Word> {
+pub fn write_attachment_to_memory(note_index: NoteIdx, attachment_idx: u32) -> Vec<Word> {
     let mut attachment: Vec<Word> = Vec::with_capacity(MAX_ATTACHMENT_WORDS);
     let num_words = unsafe {
         let ptr = (attachment.as_mut_ptr() as usize) / 4;
         extern_output_note_write_attachment_to_memory(
             ptr as *mut Felt,
-            attachment_idx,
+            Felt::from_u32(attachment_idx),
             note_index.inner,
         )
     };

--- a/sdk/base-sys/src/bindings/output_note.rs
+++ b/sdk/base-sys/src/bindings/output_note.rs
@@ -237,7 +237,7 @@ pub fn add_asset(asset: Asset, note_idx: NoteIdx) {
 /// Contains summary information about the assets of an output note.
 pub struct OutputNoteAssetsInfo {
     pub commitment: Word,
-    pub num_assets: Felt,
+    pub num_assets: u32,
 }
 
 /// Retrieves the assets commitment and asset count for the output note at `note_index`.
@@ -248,7 +248,8 @@ pub fn get_assets_info(note_index: NoteIdx) -> OutputNoteAssetsInfo {
         let (commitment, num_assets) = ret_area.into_inner().assume_init();
         OutputNoteAssetsInfo {
             commitment,
-            num_assets,
+            // The transaction kernel guarantees asset counts fit in a u32.
+            num_assets: num_assets.as_canonical_u64() as u32,
         }
     }
 }

--- a/sdk/base-sys/src/bindings/tx.rs
+++ b/sdk/base-sys/src/bindings/tx.rs
@@ -186,13 +186,17 @@ pub fn get_block_timestamp() -> Felt {
 }
 
 /// Returns the total number of input notes consumed by the transaction.
-pub fn get_num_input_notes() -> Felt {
-    unsafe { extern_tx_get_num_input_notes() }
+pub fn get_num_input_notes() -> u32 {
+    // The transaction kernel guarantees note counts fit in a u32.
+    let count = unsafe { extern_tx_get_num_input_notes() };
+    count.as_canonical_u64() as u32
 }
 
 /// Returns the number of output notes created so far in the transaction.
-pub fn get_num_output_notes() -> Felt {
-    unsafe { extern_tx_get_num_output_notes() }
+pub fn get_num_output_notes() -> u32 {
+    // The transaction kernel guarantees note counts fit in a u32.
+    let count = unsafe { extern_tx_get_num_output_notes() };
+    count.as_canonical_u64() as u32
 }
 
 /// Returns the transaction expiration block delta.

--- a/sdk/base-sys/src/bindings/tx.rs
+++ b/sdk/base-sys/src/bindings/tx.rs
@@ -204,9 +204,9 @@ pub fn get_num_output_notes() -> u32 {
     count.as_canonical_u64() as u32
 }
 
-/// Returns the transaction expiration block delta.
+/// Returns the transaction expiration block delta, or `0` if no expiration delta has been set.
 pub fn get_expiration_block_delta() -> u16 {
-    // The transaction kernel bounds expiration deltas to 1..=u16::MAX.
+    // Set deltas are kernel-bounded to 1..=u16::MAX; the kernel returns 0 for an unset delta.
     let delta = unsafe { extern_tx_get_expiration_block_delta() };
     delta.as_canonical_u64() as u16
 }

--- a/sdk/base-sys/src/bindings/tx.rs
+++ b/sdk/base-sys/src/bindings/tx.rs
@@ -1,6 +1,6 @@
 use miden_stdlib_sys::{Felt, Word, WordAligned};
 
-use super::types::AccountId;
+use super::types::{AccountId, BlockNumber};
 
 /// Marker trait for raw FPI input array lengths supported by the protocol executor.
 #[doc(hidden)]
@@ -158,8 +158,11 @@ unsafe extern "C" {
 }
 
 /// Returns the current block number.
-pub fn get_block_number() -> Felt {
-    unsafe { extern_tx_get_block_number() }
+pub fn get_block_number() -> BlockNumber {
+    BlockNumber {
+        // The transaction kernel guarantees block numbers fit in a u32.
+        inner: unsafe { extern_tx_get_block_number() },
+    }
 }
 
 /// Returns the input notes commitment digest.
@@ -180,9 +183,11 @@ pub fn get_block_commitment() -> Word {
     }
 }
 
-/// Returns the timestamp of the reference block.
-pub fn get_block_timestamp() -> Felt {
-    unsafe { extern_tx_get_block_timestamp() }
+/// Returns the timestamp of the reference block, in seconds.
+pub fn get_block_timestamp() -> u32 {
+    // The transaction kernel guarantees block timestamps fit in a u32.
+    let timestamp = unsafe { extern_tx_get_block_timestamp() };
+    timestamp.as_canonical_u64() as u32
 }
 
 /// Returns the total number of input notes consumed by the transaction.
@@ -200,14 +205,18 @@ pub fn get_num_output_notes() -> u32 {
 }
 
 /// Returns the transaction expiration block delta.
-pub fn get_expiration_block_delta() -> Felt {
-    unsafe { extern_tx_get_expiration_block_delta() }
+pub fn get_expiration_block_delta() -> u16 {
+    // The transaction kernel bounds expiration deltas to 1..=u16::MAX.
+    let delta = unsafe { extern_tx_get_expiration_block_delta() };
+    delta.as_canonical_u64() as u16
 }
 
 /// Updates the transaction expiration block delta.
-pub fn update_expiration_block_delta(delta: Felt) {
+///
+/// The transaction kernel accepts deltas in `1..=u16::MAX`.
+pub fn update_expiration_block_delta(delta: u16) {
     unsafe {
-        extern_tx_update_expiration_block_delta(delta);
+        extern_tx_update_expiration_block_delta(Felt::from(delta));
     }
 }
 

--- a/sdk/base-sys/src/bindings/types.rs
+++ b/sdk/base-sys/src/bindings/types.rs
@@ -91,11 +91,263 @@ impl Asset {
             value: value.into(),
         }
     }
+
+    /// Returns this asset's amount when its key and value have a valid fungible encoding.
+    ///
+    /// Returns `None` for non-fungible assets and malformed fungible asset encodings.
+    pub fn amount(&self) -> Option<AssetAmount> {
+        // Bit layout of the vault-key metadata byte (the low byte of the faucet-id suffix limb),
+        // mirroring `miden_protocol::asset::AssetVaultKey`: bits 0-1 encode the asset
+        // composition, bit 2 the callback flag, and bits 3-7 are reserved and must be zero.
+        const METADATA_BYTE_MASK: u64 = 0xff;
+        const COMPOSITION_MASK: u8 = 0b11;
+        const FUNGIBLE_COMPOSITION: u8 = 0b01;
+        const RESERVED_METADATA_MASK: u8 = 0b1111_1000;
+
+        let metadata = (self.key[2].as_canonical_u64() & METADATA_BYTE_MASK) as u8;
+        let is_fungible = metadata & COMPOSITION_MASK == FUNGIBLE_COMPOSITION;
+        let has_reserved_metadata = metadata & RESERVED_METADATA_MASK != 0;
+        let has_asset_id = self.key[0] != Felt::ZERO || self.key[1] != Felt::ZERO;
+        let has_value_padding = self.value[1] != Felt::ZERO
+            || self.value[2] != Felt::ZERO
+            || self.value[3] != Felt::ZERO;
+
+        if !is_fungible || has_reserved_metadata || has_asset_id || has_value_padding {
+            return None;
+        }
+
+        AssetAmount::try_from(self.value[0]).ok()
+    }
 }
 
 impl From<Asset> for (Word, Word) {
     fn from(val: Asset) -> Self {
         (val.key, val.value)
+    }
+}
+
+/// An error produced while constructing an [`AssetAmount`] from an out-of-range value.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum AssetAmountError {
+    /// The amount exceeds [`AssetAmount::MAX_U64`].
+    AmountTooBig(u64),
+}
+
+impl core::fmt::Display for AssetAmountError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::AmountTooBig(amount) => {
+                write!(f, "asset amount {amount} exceeds the maximum {}", AssetAmount::MAX_U64)
+            }
+        }
+    }
+}
+
+impl core::error::Error for AssetAmountError {}
+
+/// A validated fungible asset amount.
+///
+/// Values created through this type's constructors, conversions, and arithmetic operations wrap
+/// a [`Felt`] whose canonical value is at most [`AssetAmount::MAX_U64`]. The API mirrors
+/// `miden_protocol::asset::AssetAmount` so that on-chain and off-chain code handle amounts the
+/// same way, while the felt representation avoids integer/felt conversions around the
+/// transaction kernel procedures.
+///
+/// Unlike a raw [`Felt`], an amount only offers integer semantics: addition and subtraction
+/// panic on overflow and underflow instead of wrapping, and comparison follows the canonical
+/// integer value. Finite field arithmetic (wrapping at the field modulus, division via the
+/// multiplicative inverse) is intentionally unavailable; convert with [`AssetAmount::as_u64`]
+/// when full integer functionality is needed.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct AssetAmount {
+    /// The raw field representation.
+    ///
+    /// Assigning this field directly bypasses amount validation; the checked arithmetic rejects
+    /// out-of-range operands. It is public only because component-model bindings construct WIT
+    /// records by field — use the checked constructors and accessors instead.
+    #[doc(hidden)]
+    pub inner: Felt,
+}
+
+impl AssetAmount {
+    /// The maximum value an asset amount can represent, equal to `2^63 - 2^31`.
+    ///
+    /// Matches `miden_protocol::asset::AssetAmount::MAX`, which is chosen so that an amount fits
+    /// in a field element as both a positive and a negative value.
+    // Felt constants on the Miden target are limited to 32-bit values, so the maximum amount
+    // cannot be an associated `AssetAmount` constant; see `Self::max`.
+    pub const MAX_U64: u64 = (1u64 << 63) - (1u64 << 31);
+    /// The zero amount.
+    pub const ZERO: Self = Self { inner: Felt::ZERO };
+
+    /// Returns the maximum representable asset amount, equal to [`Self::MAX_U64`].
+    #[inline]
+    pub fn max() -> Self {
+        Self {
+            inner: Self::max_inner(),
+        }
+    }
+
+    /// Returns a new asset amount if `amount` does not exceed [`Self::MAX_U64`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `amount` is greater than [`Self::MAX_U64`].
+    pub fn new(amount: u64) -> Result<Self, AssetAmountError> {
+        if amount > Self::MAX_U64 {
+            return Err(AssetAmountError::AmountTooBig(amount));
+        }
+        // The bound check above also guarantees the value is below the field modulus.
+        Ok(Self {
+            inner: Felt::new_unchecked(amount),
+        })
+    }
+
+    /// Returns the amount as a `u64` value.
+    #[inline]
+    pub fn as_u64(&self) -> u64 {
+        self.inner.as_canonical_u64()
+    }
+
+    /// Returns the amount as a raw [`Felt`] for advanced use.
+    #[inline]
+    pub fn as_felt(&self) -> Felt {
+        self.inner
+    }
+
+    /// Returns the maximum amount as a raw felt.
+    #[inline(always)]
+    fn max_inner() -> Felt {
+        // MAX_U64 is below the field modulus, so no reduction occurs.
+        Felt::new_unchecked(Self::MAX_U64)
+    }
+
+    /// Builds the out-of-range error for the provided felt.
+    #[inline]
+    fn amount_too_big(value: Felt) -> AssetAmountError {
+        // The felt-to-integer conversion only runs on error paths.
+        AssetAmountError::AmountTooBig(value.as_canonical_u64())
+    }
+}
+
+// Two maximal amounts must sum to exactly the field modulus minus one; the checked arithmetic
+// below relies on this to rule out field wrap-around for validated operands.
+const _: () = assert!(AssetAmount::MAX_U64 * 2 == Felt::ORDER - 1);
+
+impl core::ops::Add for AssetAmount {
+    type Output = Self;
+
+    /// Adds two asset amounts, staying in the field domain.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either operand or the sum exceeds [`AssetAmount::MAX_U64`].
+    fn add(self, other: Self) -> Self {
+        let max = Self::max_inner();
+        // Reject an out-of-range operand (possible via direct `inner` assignment) before
+        // relying on its value.
+        assert!(self.inner <= max, "asset amount exceeds the maximum allowed amount");
+        // `self` is in range, so this felt subtraction is exact and the headroom is at most
+        // MAX_U64. One comparison then proves both that `other` is in range
+        // (other <= headroom <= MAX_U64) and that the sum stays in range
+        // (self + other <= MAX_U64), so the felt addition below cannot wrap around.
+        let headroom = max - self.inner;
+        assert!(other.inner <= headroom, "asset amount addition overflow");
+        Self {
+            inner: self.inner + other.inner,
+        }
+    }
+}
+
+impl core::ops::Sub for AssetAmount {
+    type Output = Self;
+
+    /// Subtracts `other` from `self`, staying in the field domain.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either operand exceeds [`AssetAmount::MAX_U64`] or if `other` is greater than
+    /// `self`.
+    fn sub(self, other: Self) -> Self {
+        let max = Self::max_inner();
+        // An out-of-range minuend (possible via direct `inner` assignment) could otherwise
+        // produce an out-of-range result.
+        assert!(self.inner <= max, "asset amount exceeds the maximum allowed amount");
+        // When this check passes, other <= self <= MAX_U64, so `other` is in range, the felt
+        // subtraction cannot wrap around, and the result needs no validation.
+        assert!(other.inner <= self.inner, "asset amount subtraction underflow");
+        Self {
+            inner: self.inner - other.inner,
+        }
+    }
+}
+
+impl Default for AssetAmount {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl From<u8> for AssetAmount {
+    fn from(value: u8) -> Self {
+        Self {
+            inner: Felt::from(value),
+        }
+    }
+}
+
+impl From<u16> for AssetAmount {
+    fn from(value: u16) -> Self {
+        Self {
+            inner: Felt::from(value),
+        }
+    }
+}
+
+impl From<u32> for AssetAmount {
+    fn from(value: u32) -> Self {
+        // Any u32 value is below the maximum amount.
+        Self {
+            inner: Felt::from_u32(value),
+        }
+    }
+}
+
+impl TryFrom<u64> for AssetAmount {
+    type Error = AssetAmountError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<Felt> for AssetAmount {
+    type Error = AssetAmountError;
+
+    fn try_from(value: Felt) -> Result<Self, Self::Error> {
+        if value > Self::max_inner() {
+            return Err(Self::amount_too_big(value));
+        }
+        Ok(Self { inner: value })
+    }
+}
+
+impl From<AssetAmount> for u64 {
+    fn from(amount: AssetAmount) -> Self {
+        amount.as_u64()
+    }
+}
+
+impl From<AssetAmount> for Felt {
+    fn from(amount: AssetAmount) -> Self {
+        amount.inner
+    }
+}
+
+impl core::fmt::Display for AssetAmount {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.as_u64())
     }
 }
 
@@ -299,9 +551,11 @@ impl StorageSlotId {
 
 #[cfg(test)]
 mod tests {
-    use miden_stdlib_sys::{Word, felt};
+    use miden_stdlib_sys::{Felt, Word, felt};
 
-    use super::{felt_from_padded_word, padded_word_from_felt};
+    use super::{
+        Asset, AssetAmount, AssetAmountError, felt_from_padded_word, padded_word_from_felt,
+    };
 
     /// Ensures `padded_word_from_felt` zero-pads the trailing three limbs.
     #[test]
@@ -327,5 +581,244 @@ mod tests {
         let value = felt!(42);
 
         assert_eq!(felt_from_padded_word(padded_word_from_felt(value)), Ok(value));
+    }
+
+    /// Ensures amounts within the bound construct successfully and convert back losslessly.
+    #[test]
+    fn asset_amount_valid_amounts() {
+        assert_eq!(AssetAmount::new(0).unwrap().as_u64(), 0);
+        assert_eq!(AssetAmount::new(1000).unwrap().as_u64(), 1000);
+        assert_eq!(AssetAmount::new(AssetAmount::MAX_U64).unwrap(), AssetAmount::max());
+    }
+
+    /// Ensures amounts above the bound are rejected with the offending value.
+    #[test]
+    fn asset_amount_exceeds_max() {
+        assert_eq!(
+            AssetAmount::new(AssetAmount::MAX_U64 + 1),
+            Err(AssetAmountError::AmountTooBig(AssetAmount::MAX_U64 + 1))
+        );
+        assert_eq!(AssetAmount::new(u64::MAX), Err(AssetAmountError::AmountTooBig(u64::MAX)));
+    }
+
+    /// Ensures the maximum amount constant matches its documented value.
+    #[test]
+    fn asset_amount_max_value() {
+        assert_eq!(AssetAmount::MAX_U64, 2u64.pow(63) - 2u64.pow(31));
+        assert_eq!(AssetAmount::max().as_u64(), AssetAmount::MAX_U64);
+    }
+
+    /// Ensures the infallible conversions from small integer types.
+    #[test]
+    fn asset_amount_from_small_types() {
+        assert_eq!(AssetAmount::from(42u8).as_u64(), 42);
+        assert_eq!(AssetAmount::from(1000u16).as_u64(), 1000);
+        assert_eq!(AssetAmount::from(u32::MAX).as_u64(), u32::MAX as u64);
+    }
+
+    /// Ensures the fallible conversions from `u64` and `Felt` enforce the bound.
+    #[test]
+    fn asset_amount_try_from() {
+        assert!(AssetAmount::try_from(AssetAmount::MAX_U64).is_ok());
+        assert!(AssetAmount::try_from(AssetAmount::MAX_U64 + 1).is_err());
+        assert!(AssetAmount::try_from(Felt::new(AssetAmount::MAX_U64).unwrap()).is_ok());
+        assert!(AssetAmount::try_from(Felt::new(AssetAmount::MAX_U64 + 1).unwrap()).is_err());
+        // The largest canonical felt is far above the bound and must be rejected.
+        assert_eq!(
+            AssetAmount::try_from(Felt::new(Felt::ORDER - 1).unwrap()),
+            Err(AssetAmountError::AmountTooBig(Felt::ORDER - 1))
+        );
+    }
+
+    /// Ensures addition computes exact integer sums for in-range amounts.
+    #[test]
+    fn asset_amount_add() {
+        let a = AssetAmount::new(100).unwrap();
+        let b = AssetAmount::new(200).unwrap();
+
+        assert_eq!((a + b).as_u64(), 300);
+        assert_eq!(AssetAmount::ZERO + AssetAmount::ZERO, AssetAmount::ZERO);
+        assert_eq!(AssetAmount::max() + AssetAmount::ZERO, AssetAmount::max());
+    }
+
+    /// Ensures addition panics when the sum exceeds the maximum amount.
+    #[test]
+    #[should_panic(expected = "asset amount addition overflow")]
+    fn asset_amount_add_panics_on_overflow() {
+        let _ = AssetAmount::max() + AssetAmount::new(1).unwrap();
+    }
+
+    /// Ensures addition rejects an out-of-range left operand built via direct field assignment
+    /// instead of laundering it into a valid-looking sum; this operand would wrap the field to
+    /// zero if it were not rejected.
+    #[test]
+    #[should_panic(expected = "asset amount exceeds the maximum allowed amount")]
+    fn asset_amount_add_panics_on_forged_lhs() {
+        let wrapping = AssetAmount {
+            inner: Felt::new(Felt::ORDER - 1).unwrap(),
+        };
+
+        let _ = wrapping + AssetAmount::new(1).unwrap();
+    }
+
+    /// Ensures addition rejects an out-of-range right operand built via direct field
+    /// assignment (reported as an overflowing sum).
+    #[test]
+    #[should_panic(expected = "asset amount addition overflow")]
+    fn asset_amount_add_panics_on_forged_rhs() {
+        let forged = AssetAmount {
+            inner: Felt::new(AssetAmount::MAX_U64 + 1).unwrap(),
+        };
+
+        let _ = AssetAmount::new(1).unwrap() + forged;
+    }
+
+    /// Ensures subtraction computes exact integer differences for in-range amounts.
+    #[test]
+    fn asset_amount_sub() {
+        let a = AssetAmount::new(300).unwrap();
+        let b = AssetAmount::new(100).unwrap();
+
+        assert_eq!((a - b).as_u64(), 200);
+        assert_eq!(AssetAmount::ZERO - AssetAmount::ZERO, AssetAmount::ZERO);
+        assert_eq!(AssetAmount::max() - AssetAmount::max(), AssetAmount::ZERO);
+    }
+
+    /// Ensures subtraction panics when the subtrahend exceeds the minuend.
+    #[test]
+    #[should_panic(expected = "asset amount subtraction underflow")]
+    fn asset_amount_sub_panics_on_underflow() {
+        let _ = AssetAmount::ZERO - AssetAmount::new(1).unwrap();
+    }
+
+    /// Ensures subtraction rejects an out-of-range minuend built via direct field assignment,
+    /// which could otherwise produce an out-of-range result.
+    #[test]
+    #[should_panic(expected = "asset amount exceeds the maximum allowed amount")]
+    fn asset_amount_sub_panics_on_forged_minuend() {
+        let forged = AssetAmount {
+            inner: Felt::new(AssetAmount::MAX_U64 + 1).unwrap(),
+        };
+
+        let _ = forged - AssetAmount::new(1).unwrap();
+    }
+
+    /// Ensures the SDK amount arithmetic agrees with the off-chain protocol implementation
+    /// whenever the protocol operation succeeds (the SDK panics where the protocol errors).
+    #[test]
+    fn asset_amount_differential_vs_protocol() {
+        use miden_protocol::asset::AssetAmount as ProtocolAmount;
+
+        let values = [
+            0u64,
+            1,
+            2,
+            31,
+            u32::MAX as u64,
+            1 << 40,
+            AssetAmount::MAX_U64 / 2,
+            AssetAmount::MAX_U64 - 1,
+            AssetAmount::MAX_U64,
+        ];
+        for &a in &values {
+            for &b in &values {
+                let ours = (AssetAmount::new(a).unwrap(), AssetAmount::new(b).unwrap());
+                let theirs = (ProtocolAmount::new(a).unwrap(), ProtocolAmount::new(b).unwrap());
+
+                if let Ok(sum) = theirs.0 + theirs.1 {
+                    assert_eq!(
+                        (ours.0 + ours.1).as_u64(),
+                        sum.as_u64(),
+                        "sum mismatch for {a} + {b}"
+                    );
+                }
+
+                if let Ok(difference) = theirs.0 - theirs.1 {
+                    assert_eq!(
+                        (ours.0 - ours.1).as_u64(),
+                        difference.as_u64(),
+                        "difference mismatch for {a} - {b}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Ensures comparison follows canonical integer ordering.
+    #[test]
+    fn asset_amount_ordering() {
+        assert!(AssetAmount::new(1).unwrap() < AssetAmount::new(2).unwrap());
+        assert!(AssetAmount::max() > AssetAmount::ZERO);
+        assert_eq!(AssetAmount::default(), AssetAmount::ZERO);
+    }
+
+    /// Ensures the amount displays as a decimal integer.
+    #[test]
+    fn asset_amount_display() {
+        extern crate alloc;
+        use alloc::string::ToString;
+
+        assert_eq!(AssetAmount::new(12345).unwrap().to_string(), "12345");
+    }
+
+    /// Ensures the felt accessor and conversions roundtrip the underlying value.
+    #[test]
+    fn asset_amount_felt_roundtrip() {
+        let amount = AssetAmount::new(500).unwrap();
+
+        assert_eq!(amount.as_felt(), felt!(500));
+        assert_eq!(Felt::from(amount), felt!(500));
+        assert_eq!(u64::from(amount), 500);
+    }
+
+    /// Creates a raw fungible asset encoding (composition bits `0b01` in the key metadata byte)
+    /// for amount tests.
+    fn fungible_asset(amount: Felt) -> Asset {
+        Asset::new(
+            Word::new([felt!(0), felt!(0), felt!(1), felt!(0)]),
+            Word::new([amount, felt!(0), felt!(0), felt!(0)]),
+        )
+    }
+
+    /// Ensures fungible asset amounts are decoded from valid key/value encodings.
+    #[test]
+    fn asset_amount_decodes_valid_fungible_assets() {
+        let asset = fungible_asset(felt!(42));
+        // Metadata byte 0b101: fungible composition with the callback flag set.
+        let callback_asset =
+            Asset::new(Word::new([felt!(0), felt!(0), felt!(5), felt!(0)]), asset.value);
+
+        assert_eq!(asset.amount(), Some(AssetAmount::new(42).unwrap()));
+        assert_eq!(callback_asset.amount(), Some(AssetAmount::new(42).unwrap()));
+    }
+
+    /// Ensures non-fungible and malformed asset encodings have no amount.
+    #[test]
+    fn asset_amount_rejects_invalid_asset_encodings() {
+        let amount = felt!(42);
+        let non_fungible = Asset::new(
+            Word::new([felt!(1), felt!(0), felt!(0), felt!(0)]),
+            Word::new([amount, felt!(0), felt!(0), felt!(0)]),
+        );
+        let non_zero_asset_id = Asset::new(
+            Word::new([felt!(1), felt!(0), felt!(1), felt!(0)]),
+            Word::new([amount, felt!(0), felt!(0), felt!(0)]),
+        );
+        // Metadata byte 0b1001: fungible composition but a reserved bit is set.
+        let reserved_metadata = Asset::new(
+            Word::new([felt!(0), felt!(0), felt!(9), felt!(0)]),
+            Word::new([amount, felt!(0), felt!(0), felt!(0)]),
+        );
+        let non_zero_value_padding = Asset::new(
+            Word::new([felt!(0), felt!(0), felt!(1), felt!(0)]),
+            Word::new([amount, felt!(1), felt!(0), felt!(0)]),
+        );
+        let excessive_amount = fungible_asset(Felt::new(AssetAmount::MAX_U64 + 1).unwrap());
+
+        assert_eq!(non_fungible.amount(), None);
+        assert_eq!(non_zero_asset_id.amount(), None);
+        assert_eq!(reserved_metadata.amount(), None);
+        assert_eq!(non_zero_value_padding.amount(), None);
+        assert_eq!(excessive_amount.amount(), None);
     }
 }

--- a/sdk/base-sys/src/bindings/types.rs
+++ b/sdk/base-sys/src/bindings/types.rs
@@ -101,7 +101,6 @@ impl Asset {
     /// # Panics
     ///
     /// Panics if the asset is not fungible or its amount exceeds [`AssetAmount::MAX_U64`].
-    #[inline(never)]
     pub fn amount(&self) -> AssetAmount {
         assert!(self.is_fungible(), "asset is not fungible");
         let amount = self.value[0];

--- a/sdk/base-sys/src/bindings/types.rs
+++ b/sdk/base-sys/src/bindings/types.rs
@@ -92,31 +92,28 @@ impl Asset {
         }
     }
 
-    /// Returns this asset's amount when its key and value have a valid fungible encoding.
+    /// Returns this asset's fungible amount.
     ///
-    /// Returns `None` for non-fungible assets and malformed fungible asset encodings.
-    pub fn amount(&self) -> Option<AssetAmount> {
-        // Bit layout of the vault-key metadata byte (the low byte of the faucet-id suffix limb),
-        // mirroring `miden_protocol::asset::AssetVaultKey`: bits 0-1 encode the asset
-        // composition, bit 2 the callback flag, and bits 3-7 are reserved and must be zero.
-        const METADATA_BYTE_MASK: u64 = 0xff;
-        const COMPOSITION_MASK: u8 = 0b11;
-        const FUNGIBLE_COMPOSITION: u8 = 0b01;
-        const RESERVED_METADATA_MASK: u8 = 0b1111_1000;
-
-        let metadata = (self.key[2].as_canonical_u64() & METADATA_BYTE_MASK) as u8;
-        let is_fungible = metadata & COMPOSITION_MASK == FUNGIBLE_COMPOSITION;
-        let has_reserved_metadata = metadata & RESERVED_METADATA_MASK != 0;
-        let has_asset_id = self.key[0] != Felt::ZERO || self.key[1] != Felt::ZERO;
-        let has_value_padding = self.value[1] != Felt::ZERO
-            || self.value[2] != Felt::ZERO
-            || self.value[3] != Felt::ZERO;
-
-        if !is_fungible || has_reserved_metadata || has_asset_id || has_value_padding {
-            return None;
-        }
-
-        AssetAmount::try_from(self.value[0]).ok()
+    /// Intended for kernel-encoded assets (e.g. the ones returned by the `get_assets`
+    /// bindings), whose encoding invariants make the composition bit sufficient to discriminate
+    /// fungibility.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the asset is not fungible or its amount exceeds [`AssetAmount::MAX_U64`].
+    #[inline(never)]
+    pub fn amount(&self) -> AssetAmount {
+        // The composition field occupies the lowest bits of the vault-key metadata byte (the
+        // low byte of the faucet-id suffix limb, mirroring
+        // `miden_protocol::asset::AssetVaultKey`), and `Fungible = 0b01` is the only odd
+        // composition, so the limb's parity discriminates fungible assets.
+        assert!(self.key[2].as_canonical_u64() & 1 == 1, "asset is not fungible");
+        let amount = self.value[0];
+        assert!(
+            amount <= AssetAmount::max_inner(),
+            "asset amount exceeds the maximum allowed amount"
+        );
+        AssetAmount { inner: amount }
     }
 }
 
@@ -788,37 +785,28 @@ mod tests {
         let callback_asset =
             Asset::new(Word::new([felt!(0), felt!(0), felt!(5), felt!(0)]), asset.value);
 
-        assert_eq!(asset.amount(), Some(AssetAmount::new(42).unwrap()));
-        assert_eq!(callback_asset.amount(), Some(AssetAmount::new(42).unwrap()));
+        assert_eq!(asset.amount(), AssetAmount::new(42).unwrap());
+        assert_eq!(callback_asset.amount(), AssetAmount::new(42).unwrap());
     }
 
-    /// Ensures non-fungible and malformed asset encodings have no amount.
+    /// Ensures the amount accessor panics for non-fungible assets (even composition bits).
     #[test]
-    fn asset_amount_rejects_invalid_asset_encodings() {
-        let amount = felt!(42);
+    #[should_panic(expected = "asset is not fungible")]
+    fn asset_amount_panics_on_non_fungible() {
         let non_fungible = Asset::new(
             Word::new([felt!(1), felt!(0), felt!(0), felt!(0)]),
-            Word::new([amount, felt!(0), felt!(0), felt!(0)]),
+            Word::new([felt!(42), felt!(0), felt!(0), felt!(0)]),
         );
-        let non_zero_asset_id = Asset::new(
-            Word::new([felt!(1), felt!(0), felt!(1), felt!(0)]),
-            Word::new([amount, felt!(0), felt!(0), felt!(0)]),
-        );
-        // Metadata byte 0b1001: fungible composition but a reserved bit is set.
-        let reserved_metadata = Asset::new(
-            Word::new([felt!(0), felt!(0), felt!(9), felt!(0)]),
-            Word::new([amount, felt!(0), felt!(0), felt!(0)]),
-        );
-        let non_zero_value_padding = Asset::new(
-            Word::new([felt!(0), felt!(0), felt!(1), felt!(0)]),
-            Word::new([amount, felt!(1), felt!(0), felt!(0)]),
-        );
+
+        let _ = non_fungible.amount();
+    }
+
+    /// Ensures the amount accessor panics when the amount exceeds the maximum.
+    #[test]
+    #[should_panic(expected = "asset amount exceeds the maximum allowed amount")]
+    fn asset_amount_panics_on_excessive_amount() {
         let excessive_amount = fungible_asset(Felt::new(AssetAmount::MAX_U64 + 1).unwrap());
 
-        assert_eq!(non_fungible.amount(), None);
-        assert_eq!(non_zero_asset_id.amount(), None);
-        assert_eq!(reserved_metadata.amount(), None);
-        assert_eq!(non_zero_value_padding.amount(), None);
-        assert_eq!(excessive_amount.amount(), None);
+        let _ = excessive_amount.amount();
     }
 }

--- a/sdk/base-sys/src/bindings/types.rs
+++ b/sdk/base-sys/src/bindings/types.rs
@@ -551,8 +551,19 @@ pub struct BlockNumber {
 
 impl BlockNumber {
     /// Returns the block number as a `u32` value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the wrapped felt exceeds the maximum block height (possible only for values
+    /// that bypassed validation, e.g. a WIT record lifted from a raw felt).
     #[inline]
     pub fn as_u32(&self) -> u32 {
+        // Compared in the felt domain: felt comparisons lower to VM intrinsics, which is much
+        // cheaper than u64 comparison libcalls.
+        assert!(
+            self.inner <= Felt::from_u32(u32::MAX),
+            "block number exceeds the maximum block height"
+        );
         self.inner.as_canonical_u64() as u32
     }
 
@@ -643,7 +654,8 @@ mod tests {
     use miden_stdlib_sys::{Felt, Word, felt};
 
     use super::{
-        Asset, AssetAmount, AssetAmountError, felt_from_padded_word, padded_word_from_felt,
+        Asset, AssetAmount, AssetAmountError, BlockNumber, felt_from_padded_word,
+        padded_word_from_felt,
     };
 
     /// Ensures `padded_word_from_felt` zero-pads the trailing three limbs.
@@ -900,5 +912,26 @@ mod tests {
         let excessive_amount = fungible_asset(Felt::new(AssetAmount::MAX_U64 + 1).unwrap());
 
         let _ = excessive_amount.amount();
+    }
+
+    /// Ensures block-number felts validate against the `u32` protocol bound.
+    #[test]
+    fn block_number_try_from_felt_bounds() {
+        let max = Felt::new(u32::MAX as u64).unwrap();
+
+        assert_eq!(BlockNumber::try_from(max).unwrap().as_u32(), u32::MAX);
+        assert!(BlockNumber::try_from(Felt::new(u32::MAX as u64 + 1).unwrap()).is_err());
+    }
+
+    /// Ensures `as_u32` refuses to truncate an out-of-range felt smuggled in through the public
+    /// WIT-record field.
+    #[test]
+    #[should_panic(expected = "block number exceeds the maximum block height")]
+    fn block_number_as_u32_panics_on_out_of_range_felt() {
+        let forged = BlockNumber {
+            inner: Felt::new(u32::MAX as u64 + 1).unwrap(),
+        };
+
+        let _ = forged.as_u32();
     }
 }

--- a/sdk/base-sys/src/bindings/types.rs
+++ b/sdk/base-sys/src/bindings/types.rs
@@ -374,21 +374,24 @@ impl NoteMetadata {
     }
 }
 
-/// Result of searching note metadata for an attachment scheme.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+/// Raw protocol return layout for attachment lookups.
+#[derive(Copy, Clone)]
 #[repr(C)]
-pub struct AttachmentLocation {
+pub(crate) struct RawAttachmentLocation {
     /// Non-zero when the attachment scheme was found.
     pub is_found: Felt,
     /// The matching attachment index, valid only when `is_found` is non-zero.
     pub index: Felt,
 }
 
-impl AttachmentLocation {
-    /// Returns whether the attachment scheme was found.
-    #[inline]
-    pub fn found(&self) -> bool {
-        self.is_found != Felt::new(0).unwrap()
+impl RawAttachmentLocation {
+    /// Converts the protocol return layout into the found attachment index, if any.
+    pub(crate) fn into_attachment_index(self) -> Option<u32> {
+        if self.is_found == Felt::ZERO {
+            return None;
+        }
+        // The transaction kernel guarantees attachment indexes fit in a u32.
+        Some(self.index.as_canonical_u64() as u32)
     }
 }
 

--- a/sdk/base-sys/src/bindings/types.rs
+++ b/sdk/base-sys/src/bindings/types.rs
@@ -500,6 +500,41 @@ impl TryFrom<Word> for NoteType {
     }
 }
 
+/// An account nonce: a counter the transaction kernel increments once per state-changing
+/// transaction.
+///
+/// Nonces compare as integers; they are produced by the account bindings and carry no
+/// arithmetic of their own.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct Nonce {
+    /// The raw field representation. Public only because component-model bindings construct
+    /// WIT records by field.
+    #[doc(hidden)]
+    pub inner: Felt,
+}
+
+impl Nonce {
+    /// Returns the nonce as a `u64` value.
+    #[inline]
+    pub fn as_u64(&self) -> u64 {
+        self.inner.as_canonical_u64()
+    }
+
+    /// Returns the nonce as a raw [`Felt`] for advanced use.
+    #[inline]
+    pub fn as_felt(&self) -> Felt {
+        self.inner
+    }
+}
+
+impl From<Nonce> for Felt {
+    #[inline]
+    fn from(value: Nonce) -> Self {
+        value.inner
+    }
+}
+
 /// The partial hash of a storage slot name.
 ///
 /// A slot id consists of two field elements: a `prefix` and a `suffix`.

--- a/sdk/base-sys/src/bindings/types.rs
+++ b/sdk/base-sys/src/bindings/types.rs
@@ -103,17 +103,27 @@ impl Asset {
     /// Panics if the asset is not fungible or its amount exceeds [`AssetAmount::MAX_U64`].
     #[inline(never)]
     pub fn amount(&self) -> AssetAmount {
-        // The composition field occupies the lowest bits of the vault-key metadata byte (the
-        // low byte of the faucet-id suffix limb, mirroring
-        // `miden_protocol::asset::AssetVaultKey`), and `Fungible = 0b01` is the only odd
-        // composition, so the limb's parity discriminates fungible assets.
-        assert!(self.key[2].as_canonical_u64() & 1 == 1, "asset is not fungible");
+        assert!(self.is_fungible(), "asset is not fungible");
         let amount = self.value[0];
         assert!(
             amount <= AssetAmount::max_inner(),
             "asset amount exceeds the maximum allowed amount"
         );
         AssetAmount { inner: amount }
+    }
+
+    /// Returns `true` if this asset is fungible.
+    ///
+    /// Intended for kernel-encoded assets (e.g. the ones returned by the `get_assets`
+    /// bindings), whose encoding invariants make the composition bit sufficient to discriminate
+    /// fungibility.
+    #[inline]
+    pub fn is_fungible(&self) -> bool {
+        // The composition field occupies the lowest bits of the vault-key metadata byte (the
+        // low byte of the faucet-id suffix limb, mirroring
+        // `miden_protocol::asset::AssetVaultKey`), and `Fungible = 0b01` is the only odd
+        // composition, so the limb's parity discriminates fungible assets.
+        self.key[2].as_canonical_u64() & 1 == 1
     }
 }
 
@@ -879,6 +889,18 @@ mod tests {
             Word::new([felt!(0), felt!(0), felt!(1), felt!(0)]),
             Word::new([amount, felt!(0), felt!(0), felt!(0)]),
         )
+    }
+
+    /// Ensures the fungibility check discriminates by the composition parity.
+    #[test]
+    fn asset_is_fungible() {
+        let non_fungible = Asset::new(
+            Word::new([felt!(0), felt!(0), felt!(2), felt!(0)]),
+            Word::new([felt!(42), felt!(0), felt!(0), felt!(0)]),
+        );
+
+        assert!(fungible_asset(felt!(42)).is_fungible());
+        assert!(!non_fungible.is_fungible());
     }
 
     /// Ensures fungible asset amounts are decoded from valid key/value encodings.

--- a/sdk/base-sys/src/bindings/types.rs
+++ b/sdk/base-sys/src/bindings/types.rs
@@ -535,6 +535,60 @@ impl From<Nonce> for Felt {
     }
 }
 
+/// A block height in the chain.
+///
+/// Block numbers compare as integers and are bounded to `u32` by the protocol. Kernel-returned
+/// heights are trusted; raw felts (e.g. read from note storage) convert via the validated
+/// [`TryFrom<Felt>`] implementation.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct BlockNumber {
+    /// The raw field representation. Public only because component-model bindings construct
+    /// WIT records by field.
+    #[doc(hidden)]
+    pub inner: Felt,
+}
+
+impl BlockNumber {
+    /// Returns the block number as a `u32` value.
+    #[inline]
+    pub fn as_u32(&self) -> u32 {
+        self.inner.as_canonical_u64() as u32
+    }
+
+    /// Returns the block number as a raw [`Felt`] for advanced use.
+    #[inline]
+    pub fn as_felt(&self) -> Felt {
+        self.inner
+    }
+}
+
+impl From<u32> for BlockNumber {
+    fn from(value: u32) -> Self {
+        Self {
+            inner: Felt::from_u32(value),
+        }
+    }
+}
+
+impl TryFrom<Felt> for BlockNumber {
+    type Error = &'static str;
+
+    fn try_from(value: Felt) -> Result<Self, Self::Error> {
+        if value.as_canonical_u64() > u32::MAX as u64 {
+            return Err("block number exceeds the maximum block height");
+        }
+        Ok(Self { inner: value })
+    }
+}
+
+impl From<BlockNumber> for Felt {
+    #[inline]
+    fn from(value: BlockNumber) -> Self {
+        value.inner
+    }
+}
+
 /// The partial hash of a storage slot name.
 ///
 /// A slot id consists of two field elements: a `prefix` and a `suffix`.

--- a/sdk/base/src/types/storage.rs
+++ b/sdk/base/src/types/storage.rs
@@ -1,5 +1,5 @@
 use miden_base_sys::bindings::{
-    StorageSlotId, felt_from_padded_word, padded_word_from_felt, storage,
+    AssetAmount, StorageSlotId, felt_from_padded_word, padded_word_from_felt, storage,
 };
 use miden_stdlib_sys::{Digest, Felt, Word};
 
@@ -32,6 +32,21 @@ impl WordValue for Felt {
 
     fn try_from_word(word: Word) -> Result<Self, &'static str> {
         felt_from_padded_word(word)
+    }
+}
+
+impl WordValue for AssetAmount {
+    fn try_into_word(self) -> Result<Word, &'static str> {
+        // Re-validate before serializing so a directly assigned out-of-range felt cannot enter
+        // account storage.
+        let amount = AssetAmount::try_from(self.as_felt())
+            .map_err(|_| "asset amount exceeds the maximum allowed amount")?;
+        Ok(padded_word_from_felt(amount.into()))
+    }
+
+    fn try_from_word(word: Word) -> Result<Self, &'static str> {
+        AssetAmount::try_from(felt_from_padded_word(word)?)
+            .map_err(|_| "asset amount exceeds the maximum allowed amount")
     }
 }
 
@@ -113,6 +128,16 @@ impl WordKey for Word {
 impl WordKey for Felt {
     fn try_into_word(self) -> Result<Word, &'static str> {
         Ok(padded_word_from_felt(self))
+    }
+}
+
+impl WordKey for AssetAmount {
+    fn try_into_word(self) -> Result<Word, &'static str> {
+        // Re-validate before serializing so a directly assigned out-of-range felt cannot be
+        // used as a storage key.
+        let amount = AssetAmount::try_from(self.as_felt())
+            .map_err(|_| "asset amount exceeds the maximum allowed amount")?;
+        Ok(padded_word_from_felt(amount.into()))
     }
 }
 

--- a/sdk/sdk/CHANGELOG.md
+++ b/sdk/sdk/CHANGELOG.md
@@ -37,7 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Kernel counts are now `u32` instead of `Felt`: `tx::get_num_input_notes` /
   `tx::get_num_output_notes`, `active_account::get_num_procedures` (free function and
   `ActiveAccount` trait method), and the `num_assets` / `num_storage_items` fields of
-  `OutputNoteAssetsInfo`, `InputNoteAssetsInfo`, and `InputNoteStorageInfo` #999
+  `OutputNoteAssetsInfo`, `InputNoteAssetsInfo`, and `InputNoteStorageInfo`. Matching this,
+  `active_account::get_procedure_root` (free function and trait method) takes the procedure
+  index as `u32` instead of `u8` #999
 - `#[account(...)]` now generates the component methods as one trait per referenced interface
   (named after the interface, with the wrapper's visibility, implemented for the wrapper) instead
   of inherent methods on the wrapper struct. Two components that export the same method name can

--- a/sdk/sdk/CHANGELOG.md
+++ b/sdk/sdk/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   account interface. Authentication components keep using `#[auth_script]` (its method is the
   account interface implicitly); `#[auth_script]` and `#[account_procedure]` belong to different
   component kinds and cannot be combined in one component. See the [migration guide](./MIGRATION.md).
+- Account nonces are typed: `active_account::get_nonce` and `native_account::incr_nonce` (free
+  functions and trait methods) return the new `Nonce` wrapper (the WIT `nonce` core type)
+  instead of `Felt`; convert with `Nonce::as_felt`/`as_u64` where the raw value is needed #999
 - Attachment lookups are typed: the `find_attachment` bindings (`note::find_attachment_idx`,
   `active_note`/`input_note`/`output_note::find_attachment`) return `Option<u32>` instead of the
   removed `AttachmentLocation` struct, and the `attachment_idx` parameters of the

--- a/sdk/sdk/CHANGELOG.md
+++ b/sdk/sdk/CHANGELOG.md
@@ -58,6 +58,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     tx/note scripts create notes through an account component wrapper method.
 
 ### Added
+- `AssetAmount` and `AssetAmountError`: a validated fungible asset amount, the on-chain
+  counterpart of `miden_protocol::asset::AssetAmount`. It wraps a `Felt` bounded by
+  `AssetAmount::MAX_U64` (`2^63 - 2^31`) and exposes bounds-checked `+`/`-` (panicking on
+  overflow/underflow and rejecting out-of-range operands), integer comparison, `new(u64)`,
+  `as_u64`/`as_felt`, and conversions from `u8`/`u16`/`u32` (infallible) and `u64`/`Felt`
+  (fallible). Also usable in exported component method signatures
+  (WIT
+  `asset-amount`) and in typed account storage (`StorageValue<AssetAmount>`,
+  `StorageMap<K, AssetAmount>`). `Asset::amount()` decodes the typed amount from a fungible
+  asset's key/value encoding, returning `None` for non-fungible assets #999
 - `#[account(...)]` references accept an `as Alias` to rename the generated trait, e.g.
   `#[account(counter_contract::CounterContract as RemoteCounter)]`. The path still selects the
   interface; only the generated trait is renamed. Use it when the interface name would clash with

--- a/sdk/sdk/CHANGELOG.md
+++ b/sdk/sdk/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   account interface. Authentication components keep using `#[auth_script]` (its method is the
   account interface implicitly); `#[auth_script]` and `#[account_procedure]` belong to different
   component kinds and cannot be combined in one component. See the [migration guide](./MIGRATION.md).
+- Kernel counts are now `u32` instead of `Felt`: `tx::get_num_input_notes` /
+  `tx::get_num_output_notes`, `active_account::get_num_procedures` (free function and
+  `ActiveAccount` trait method), and the `num_assets` / `num_storage_items` fields of
+  `OutputNoteAssetsInfo`, `InputNoteAssetsInfo`, and `InputNoteStorageInfo` #999
 - `#[account(...)]` now generates the component methods as one trait per referenced interface
   (named after the interface, with the wrapper's visibility, implemented for the wrapper) instead
   of inherent methods on the wrapper struct. Two components that export the same method name can

--- a/sdk/sdk/CHANGELOG.md
+++ b/sdk/sdk/CHANGELOG.md
@@ -81,11 +81,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AssetAmount::MAX_U64` (`2^63 - 2^31`) and exposes bounds-checked `+`/`-` (panicking on
   overflow/underflow and rejecting out-of-range operands), integer comparison, `new(u64)`,
   `as_u64`/`as_felt`, and conversions from `u8`/`u16`/`u32` (infallible) and `u64`/`Felt`
-  (fallible). Also usable in exported component method signatures
-  (WIT
-  `asset-amount`) and in typed account storage (`StorageValue<AssetAmount>`,
-  `StorageMap<K, AssetAmount>`). `Asset::amount()` returns the typed amount of a fungible
-  asset, panicking for non-fungible assets #999
+  (fallible). Also usable in exported component method signatures (WIT `asset-amount`) and in
+  typed account storage (`StorageValue<AssetAmount>`, `StorageMap<K, AssetAmount>`).
+  `Asset::amount()` returns the typed amount of a fungible asset, panicking for non-fungible
+  assets, and `Asset::is_fungible()` reports fungibility so mixed-asset note scripts can branch
+  instead #999
 - `#[account(...)]` references accept an `as Alias` to rename the generated trait, e.g.
   `#[account(counter_contract::CounterContract as RemoteCounter)]`. The path still selects the
   interface; only the generated trait is renamed. Use it when the interface name would clash with

--- a/sdk/sdk/CHANGELOG.md
+++ b/sdk/sdk/CHANGELOG.md
@@ -66,8 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (fallible). Also usable in exported component method signatures
   (WIT
   `asset-amount`) and in typed account storage (`StorageValue<AssetAmount>`,
-  `StorageMap<K, AssetAmount>`). `Asset::amount()` decodes the typed amount from a fungible
-  asset's key/value encoding, returning `None` for non-fungible assets #999
+  `StorageMap<K, AssetAmount>`). `Asset::amount()` returns the typed amount of a fungible
+  asset, panicking for non-fungible assets #999
 - `#[account(...)]` references accept an `as Alias` to rename the generated trait, e.g.
   `#[account(counter_contract::CounterContract as RemoteCounter)]`. The path still selects the
   interface; only the generated trait is renamed. Use it when the interface name would clash with

--- a/sdk/sdk/CHANGELOG.md
+++ b/sdk/sdk/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   account interface. Authentication components keep using `#[auth_script]` (its method is the
   account interface implicitly); `#[auth_script]` and `#[account_procedure]` belong to different
   component kinds and cannot be combined in one component. See the [migration guide](./MIGRATION.md).
+- Attachment lookups are typed: the `find_attachment` bindings (`note::find_attachment_idx`,
+  `active_note`/`input_note`/`output_note::find_attachment`) return `Option<u32>` instead of the
+  removed `AttachmentLocation` struct, and the `attachment_idx` parameters of the
+  `write_attachment_to_memory` / `write_indexed_attachment_to_memory` bindings take `u32`
+  instead of `Felt` #999
 - Kernel counts are now `u32` instead of `Felt`: `tx::get_num_input_notes` /
   `tx::get_num_output_notes`, `active_account::get_num_procedures` (free function and
   `ActiveAccount` trait method), and the `num_assets` / `num_storage_items` fields of

--- a/sdk/sdk/CHANGELOG.md
+++ b/sdk/sdk/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   account interface. Authentication components keep using `#[auth_script]` (its method is the
   account interface implicitly); `#[auth_script]` and `#[account_procedure]` belong to different
   component kinds and cannot be combined in one component. See the [migration guide](./MIGRATION.md).
+- Block heights and transaction expiration are typed: `tx::get_block_number` returns the new
+  `BlockNumber` wrapper (WIT `block-number` core type, comparable as an integer, convertible
+  from `u32` and fallibly from `Felt`), `tx::get_block_timestamp` returns `u32` seconds, and
+  `tx::get_expiration_block_delta` / `update_expiration_block_delta` use `u16` (the kernel
+  bounds deltas to `1..=u16::MAX`) #999
 - Account nonces are typed: `active_account::get_nonce` and `native_account::incr_nonce` (free
   functions and trait methods) return the new `Nonce` wrapper (the WIT `nonce` core type)
   instead of `Felt`; convert with `Nonce::as_felt`/`as_u64` where the raw value is needed #999

--- a/sdk/sdk/CHANGELOG.md
+++ b/sdk/sdk/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   component kinds and cannot be combined in one component. See the [migration guide](./MIGRATION.md).
 - Block heights and transaction expiration are typed: `tx::get_block_number` returns the new
   `BlockNumber` wrapper (WIT `block-number` core type, comparable as an integer, convertible
-  from `u32` and fallibly from `Felt`), `tx::get_block_timestamp` returns `u32` seconds, and
+  from `u32` and fallibly from `Felt`; `as_u32` panics if the wrapped felt is out of range),
+  `tx::get_block_timestamp` returns `u32` seconds, and
   `tx::get_expiration_block_delta` / `update_expiration_block_delta` use `u16` (the kernel
   bounds deltas to `1..=u16::MAX`) #999
 - Account nonces are typed: `active_account::get_nonce` and `native_account::incr_nonce` (free

--- a/sdk/sdk/MIGRATION.md
+++ b/sdk/sdk/MIGRATION.md
@@ -12,7 +12,7 @@ directly below this paragraph, above the previous one (newest first, like the
 
 ## Unreleased
 
-### Kernel counters use integer types instead of `Felt`
+### Kernel scalars are typed instead of `Felt` (counts, block heights, nonces, attachments)
 
 Binding surfaces whose values are counts now return `u32`: `tx::get_num_input_notes`,
 `tx::get_num_output_notes`, `active_account::get_num_procedures`, and the
@@ -49,7 +49,8 @@ tx::update_expiration_block_delta(42);
 
 Account nonces are wrapped in the new `Nonce` type (comparable as integers; use
 `as_felt()`/`as_u64()` or `Felt::from(nonce)` where the raw value is needed, e.g. when packing a
-nonce into a `Word`):
+nonce into a `Word` — `ref_block_num` below is a `BlockNumber` from `tx::get_block_number()` and
+converts the same way):
 
 ```rust
 // before
@@ -58,7 +59,7 @@ let salt = Word::from([felt!(0), felt!(0), ref_block_num, final_nonce]);
 
 // after
 let final_nonce: Nonce = self.incr_nonce();
-let salt = Word::from([felt!(0), felt!(0), ref_block_num, final_nonce.into()]);
+let salt = Word::from([felt!(0), felt!(0), ref_block_num.into(), final_nonce.into()]);
 ```
 
 Attachment lookups return `Option<u32>` instead of the removed `AttachmentLocation` struct, and

--- a/sdk/sdk/MIGRATION.md
+++ b/sdk/sdk/MIGRATION.md
@@ -29,6 +29,20 @@ let all_consumed: u32 = tx::get_num_input_notes();
 assert_eq!(all_consumed, 2);
 ```
 
+Account nonces are wrapped in the new `Nonce` type (comparable as integers; use
+`as_felt()`/`as_u64()` or `Felt::from(nonce)` where the raw value is needed, e.g. when packing a
+nonce into a `Word`):
+
+```rust
+// before
+let final_nonce: Felt = self.incr_nonce();
+let salt = Word::from([felt!(0), felt!(0), ref_block_num, final_nonce]);
+
+// after
+let final_nonce: Nonce = self.incr_nonce();
+let salt = Word::from([felt!(0), felt!(0), ref_block_num, final_nonce.into()]);
+```
+
 Attachment lookups return `Option<u32>` instead of the removed `AttachmentLocation` struct, and
 attachment indexes are passed as `u32`:
 

--- a/sdk/sdk/MIGRATION.md
+++ b/sdk/sdk/MIGRATION.md
@@ -16,8 +16,10 @@ directly below this paragraph, above the previous one (newest first, like the
 
 Binding surfaces whose values are counts now return `u32`: `tx::get_num_input_notes`,
 `tx::get_num_output_notes`, `active_account::get_num_procedures`, and the
-`num_assets` / `num_storage_items` fields of the note info structs. Code that compared or
-computed with these as felts now works with plain integers:
+`num_assets` / `num_storage_items` fields of the note info structs. Matching this,
+`active_account::get_procedure_root` takes the procedure index as `u32` (previously `u8`), so
+count-driven loops index directly. Code that compared or computed with these as felts now works
+with plain integers:
 
 ```rust
 // before

--- a/sdk/sdk/MIGRATION.md
+++ b/sdk/sdk/MIGRATION.md
@@ -29,6 +29,22 @@ let all_consumed: u32 = tx::get_num_input_notes();
 assert_eq!(all_consumed, 2);
 ```
 
+Block heights are wrapped in the new `BlockNumber` type (comparable as integers; heights read
+from note storage convert with the validated `BlockNumber::try_from(felt)`), block timestamps
+are `u32` seconds, and expiration deltas are `u16`:
+
+```rust
+// before
+let timelock_height: Felt = inputs[3];
+assert!(tx::get_block_number() >= timelock_height);
+tx::update_expiration_block_delta(Felt::new(42).unwrap());
+
+// after
+let timelock_height = BlockNumber::try_from(inputs[3]).unwrap();
+assert!(tx::get_block_number() >= timelock_height);
+tx::update_expiration_block_delta(42);
+```
+
 Account nonces are wrapped in the new `Nonce` type (comparable as integers; use
 `as_felt()`/`as_u64()` or `Felt::from(nonce)` where the raw value is needed, e.g. when packing a
 nonce into a `Word`):

--- a/sdk/sdk/MIGRATION.md
+++ b/sdk/sdk/MIGRATION.md
@@ -12,6 +12,23 @@ directly below this paragraph, above the previous one (newest first, like the
 
 ## Unreleased
 
+### Kernel counters use integer types instead of `Felt`
+
+Binding surfaces whose values are counts now return `u32`: `tx::get_num_input_notes`,
+`tx::get_num_output_notes`, `active_account::get_num_procedures`, and the
+`num_assets` / `num_storage_items` fields of the note info structs. Code that compared or
+computed with these as felts now works with plain integers:
+
+```rust
+// before
+let all_consumed: Felt = tx::get_num_input_notes();
+assert_eq!(all_consumed, felt!(2));
+
+// after
+let all_consumed: u32 = tx::get_num_input_notes();
+assert_eq!(all_consumed, 2);
+```
+
 ### Mark account interface procedures with `#[account_procedure]`
 
 A component's methods are no longer implicitly part of the account interface. Mark every method that

--- a/sdk/sdk/MIGRATION.md
+++ b/sdk/sdk/MIGRATION.md
@@ -29,6 +29,22 @@ let all_consumed: u32 = tx::get_num_input_notes();
 assert_eq!(all_consumed, 2);
 ```
 
+Attachment lookups return `Option<u32>` instead of the removed `AttachmentLocation` struct, and
+attachment indexes are passed as `u32`:
+
+```rust
+// before
+let location = active_note::find_attachment(scheme);
+if location.found() {
+    let attachment = active_note::write_attachment_to_memory(location.index);
+}
+
+// after
+if let Some(index) = active_note::find_attachment(scheme) {
+    let attachment = active_note::write_attachment_to_memory(index);
+}
+```
+
 ### Mark account interface procedures with `#[account_procedure]`
 
 A component's methods are no longer implicitly part of the account interface. Mark every method that

--- a/tests/integration-network/src/mockchain/asset_amount.rs
+++ b/tests/integration-network/src/mockchain/asset_amount.rs
@@ -1,0 +1,405 @@
+//! Mock-chain tests for the typed fungible-asset amount API (`AssetAmount`).
+//!
+//! Unlike the unit tests in `miden-base-sys`, which decode hand-built asset encodings, these
+//! tests execute the on-chain `AssetAmount` API inside a real transaction: the note script
+//! decodes amounts from kernel-built assets and checks its arithmetic against the kernel's own
+//! vault bookkeeping.
+
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use miden_client::{
+    account::{AccountComponent, component::InitStorageData},
+    asset::{Asset, FungibleAsset},
+    transaction::RawOutputNote,
+};
+use miden_mast_package::Package;
+use miden_protocol::{account::auth::AuthScheme, crypto::rand::RandomCoin};
+use miden_standards::testing::note::NoteBuilder;
+use miden_testing::{Auth, MockChain};
+use midenc_expect_test::expect;
+use midenc_integration_test_support::project;
+
+use super::support::{
+    assert_account_has_fungible_asset, build_send_notes_script, compile_rust_package, execute_tx,
+    note_cargo_toml_for_dependency, note_miden_project_toml_for_dependency, note_script_root,
+    single_note_cycles,
+};
+
+/// On-chain note script exercising the `AssetAmount` API against live kernel state.
+///
+/// For every note asset it decodes the typed amount from the kernel-built encoding, receives the
+/// asset into the wallet, and verifies the vault-amount delta with checked arithmetic,
+/// comparisons, and integer conversion. Any violated assertion aborts the transaction.
+const ASSET_AMOUNT_NOTE_SOURCE: &str = r#"
+#![no_std]
+#![feature(alloc_error_handler)]
+
+use miden::{Asset, AssetAmount, Word, account, active_account, active_note, note};
+
+/// Native account of the note: exposes the `basic-wallet` component methods.
+#[account(basic_wallet::BasicWallet)]
+pub struct Wallet;
+
+/// Reads the typed amount currently held in the active account's vault under `asset_key`.
+fn vault_amount(asset_key: Word) -> AssetAmount {
+    Asset::new(asset_key, active_account::get_asset(asset_key)).amount().unwrap()
+}
+
+/// A note that transfers its assets to the consuming account while verifying the typed
+/// asset-amount API against the transaction kernel's view of the vault.
+#[note]
+struct AssetAmountNote;
+
+#[note]
+impl AssetAmountNote {
+    #[note_script]
+    pub fn script(self, _arg: Word, account: &mut Wallet) {
+        let assets = active_note::get_initial_assets();
+        for asset in assets {
+            // Decode the typed amount from the kernel-built fungible asset encoding.
+            let amount = asset.amount().unwrap();
+            assert!(amount > AssetAmount::ZERO);
+
+            let key = asset.key;
+            let before = vault_amount(key);
+            account.receive_asset(asset);
+            let after = vault_amount(key);
+
+            // The vault amount must grow by exactly the decoded amount (checked addition).
+            assert_eq!(after, before + amount);
+            // Checked subtraction inverts the addition.
+            assert_eq!(after - amount, before);
+            assert_eq!(after - before, amount);
+            // Amounts order and convert like integers.
+            assert!(before < after);
+            assert_eq!(after.as_u64(), before.as_u64() + amount.as_u64());
+        }
+    }
+}
+"#;
+
+/// Compiles the basic-wallet example and returns its package and canonical project root.
+///
+/// The wallet must be compiled before any dependent note project so that its
+/// `target/generated-wit` directory exists.
+fn compile_wallet_package() -> (Arc<Package>, PathBuf) {
+    let wallet_package = compile_rust_package("../../examples/basic-wallet", true);
+    let wallet_root = std::fs::canonicalize("../../examples/basic-wallet")
+        .expect("failed to canonicalize the basic-wallet example path");
+    (wallet_package, wallet_root)
+}
+
+/// Generates and compiles a note project with the given source, depending on the basic-wallet
+/// example.
+fn compile_note_package(note_name: &str, source: &str, wallet_root: &Path) -> Arc<Package> {
+    let note_package_name = format!("miden:{note_name}");
+    let note_project = project(note_name)
+        .file(
+            "miden-project.toml",
+            &note_miden_project_toml_for_dependency(
+                note_name,
+                &note_package_name,
+                "miden:basic-wallet",
+                wallet_root,
+            ),
+        )
+        .file(
+            "Cargo.toml",
+            &note_cargo_toml_for_dependency(
+                note_name,
+                &note_package_name,
+                "miden:basic-wallet",
+                wallet_root,
+            ),
+        )
+        .file("src/lib.rs", source)
+        .build();
+    compile_rust_package(note_project.root(), true)
+}
+
+/// Returns a note script performing a fixed chain of four dependent additions through the
+/// provided expression body, used to compare the cycle costs of the addition implementations.
+///
+/// `add_body` is the body of a `fn(a: AssetAmount, b: AssetAmount) -> AssetAmount` helper, e.g.
+/// `a + b`.
+fn measurement_note_source(add_body: &str) -> String {
+    format!(
+        r#"
+#![no_std]
+#![feature(alloc_error_handler)]
+
+use miden::{{AssetAmount, Word, account, active_note, note}};
+
+/// Native account of the note: exposes the `basic-wallet` component methods.
+#[account(basic_wallet::BasicWallet)]
+pub struct Wallet;
+
+/// The measured addition implementation.
+#[inline(always)]
+fn checked_add(a: AssetAmount, b: AssetAmount) -> AssetAmount {{
+    {add_body}
+}}
+
+/// A note performing a fixed chain of checked additions for cycle measurement.
+#[note]
+struct MeasurementNote;
+
+#[note]
+impl MeasurementNote {{
+    #[note_script]
+    pub fn script(self, _arg: Word, account: &mut Wallet) {{
+        let assets = active_note::get_initial_assets();
+        for asset in assets {{
+            let amount = asset.amount().unwrap();
+            let first = checked_add(amount, amount);
+            let second = checked_add(first, amount);
+            let third = checked_add(second, amount);
+            let fourth = checked_add(third, amount);
+            assert!(fourth > amount);
+            account.receive_asset(asset);
+        }}
+    }}
+}}
+"#
+    )
+}
+
+/// Tests the on-chain `AssetAmount` API (`Asset::amount`, checked `+`/`-`, ordering, `as_u64`)
+/// against kernel-built assets and balances on a mock chain.
+///
+/// Flow:
+/// - The faucet emits two amount-check notes carrying different fungible amounts
+/// - The wallet consumes both notes in one transaction, so the note script checks the typed
+///   arithmetic once against a zero starting balance and once against a non-zero one
+/// - The committed vault must hold the sum of both amounts
+#[test]
+fn asset_amount_api_matches_kernel_balances() {
+    // Compile the contracts first (before creating any runtime)
+    let (wallet_package, wallet_root) = compile_wallet_package();
+    let note_package =
+        compile_note_package("asset-amount-note", ASSET_AMOUNT_NOTE_SOURCE, &wallet_root);
+
+    let wallet_component =
+        AccountComponent::from_package(&wallet_package, &InitStorageData::default()).unwrap();
+
+    let mut builder = MockChain::builder();
+    let max_supply = 1_000_000_000u64;
+    let faucet_account = builder
+        .add_existing_basic_faucet(
+            Auth::BasicAuth {
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
+            },
+            "TEST",
+            max_supply,
+            None,
+        )
+        .unwrap();
+    let faucet_id = faucet_account.id();
+
+    let alice_account = builder
+        .add_existing_account_from_components(
+            Auth::BasicAuth {
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
+            },
+            [wallet_component],
+        )
+        .unwrap();
+    let alice_id = alice_account.id();
+
+    let mut chain = builder.build().unwrap();
+    chain.prove_next_block().unwrap();
+    chain.prove_next_block().unwrap();
+
+    eprintln!("\n=== Step 1: Minting two amount-check notes from the faucet ===");
+    let first_amount = 100_000u64;
+    let second_amount = 25_000u64;
+    let mut note_rng = RandomCoin::new(note_script_root(note_package.as_ref()));
+    let notes = [first_amount, second_amount].map(|amount| {
+        let mint_asset = FungibleAsset::new(faucet_id, amount).unwrap();
+        NoteBuilder::new(faucet_id, &mut note_rng)
+            .package((*note_package).clone())
+            .add_assets([Asset::from(mint_asset)])
+            .build()
+            .unwrap()
+    });
+
+    let faucet_account = chain.committed_account(faucet_id).unwrap().clone();
+    let mint_tx_script = build_send_notes_script(&faucet_account, &notes);
+    let mint_tx_context_builder = chain
+        .build_tx_context(faucet_id, &[], &[])
+        .unwrap()
+        .tx_script(mint_tx_script)
+        .extend_expected_output_notes(
+            notes.iter().cloned().map(RawOutputNote::Full).collect::<Vec<_>>(),
+        );
+    execute_tx(&mut chain, mint_tx_context_builder);
+
+    eprintln!("\n=== Step 2: Alice consumes both notes; the scripts assert the amount API ===");
+    let faucet_inputs = chain.get_foreign_account_inputs(faucet_id).unwrap();
+    let consume_tx_context_builder = chain
+        .build_tx_context(alice_id, &[notes[0].id(), notes[1].id()], &[])
+        .unwrap()
+        .foreign_accounts(vec![faucet_inputs]);
+    execute_tx(&mut chain, consume_tx_context_builder);
+
+    eprintln!("\n=== Step 3: Checking Alice's committed balance is the checked sum ===");
+    let alice_account = chain.committed_account(alice_id).unwrap();
+    assert_account_has_fungible_asset(alice_account, faucet_id, first_amount + second_amount);
+}
+
+/// A note script with the measurement-script shape but no additions, isolating the fixed
+/// note-execution overhead (note setup, `get_assets`, the amount decode, `receive_asset`).
+/// Subtracting its cycle count from the measurement note's yields the absolute cost of the
+/// note's four additions.
+const BASELINE_NOTE_SOURCE: &str = r#"
+#![no_std]
+#![feature(alloc_error_handler)]
+
+use miden::{AssetAmount, Word, account, active_note, note};
+
+/// Native account of the note: exposes the `basic-wallet` component methods.
+#[account(basic_wallet::BasicWallet)]
+pub struct Wallet;
+
+/// A note performing no additions, used as the cycle-measurement baseline.
+#[note]
+struct BaselineNote;
+
+#[note]
+impl BaselineNote {
+    #[note_script]
+    pub fn script(self, _arg: Word, account: &mut Wallet) {
+        let assets = active_note::get_initial_assets();
+        for asset in assets {
+            let amount = asset.amount().unwrap();
+            assert!(amount > AssetAmount::ZERO);
+            account.receive_asset(asset);
+        }
+    }
+}
+"#;
+
+/// Measures the note-execution cycle cost of the panicking felt-native `+` operator.
+///
+/// The measurement note performs four dependent additions; the addition-free baseline note
+/// isolates the fixed note-execution overhead, so the absolute cost of the four additions is
+/// the measurement count minus the baseline. Each note is consumed by a fresh wallet account,
+/// so the vault bookkeeping costs are symmetric.
+#[test]
+fn asset_amount_add_cycles() {
+    // Compile the contracts first (before creating any runtime)
+    let (wallet_package, wallet_root) = compile_wallet_package();
+    let add_note_package = compile_note_package(
+        "asset-amount-add-note",
+        &measurement_note_source("a + b"),
+        &wallet_root,
+    );
+    let baseline_note_package =
+        compile_note_package("asset-amount-baseline-note", BASELINE_NOTE_SOURCE, &wallet_root);
+
+    let wallet_component =
+        AccountComponent::from_package(&wallet_package, &InitStorageData::default()).unwrap();
+
+    let mut builder = MockChain::builder();
+    let max_supply = 1_000_000_000u64;
+    let faucet_account = builder
+        .add_existing_basic_faucet(
+            Auth::BasicAuth {
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
+            },
+            "TEST",
+            max_supply,
+            None,
+        )
+        .unwrap();
+    let faucet_id = faucet_account.id();
+
+    let alice_account = builder
+        .add_existing_account_from_components(
+            Auth::BasicAuth {
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
+            },
+            [wallet_component.clone()],
+        )
+        .unwrap();
+    let alice_id = alice_account.id();
+
+    let bob_account = builder
+        .add_existing_account_from_components(
+            Auth::BasicAuth {
+                auth_scheme: AuthScheme::Falcon512Poseidon2,
+            },
+            [wallet_component],
+        )
+        .unwrap();
+    let bob_id = bob_account.id();
+
+    let mut chain = builder.build().unwrap();
+    chain.prove_next_block().unwrap();
+    chain.prove_next_block().unwrap();
+
+    eprintln!("\n=== Step 1: Minting the measurement and baseline notes ===");
+    let amount = 100_000u64;
+    let build_note = |note_package: &Arc<Package>| {
+        let mint_asset = FungibleAsset::new(faucet_id, amount).unwrap();
+        let mut note_rng = RandomCoin::new(note_script_root(note_package.as_ref()));
+        NoteBuilder::new(faucet_id, &mut note_rng)
+            .package((**note_package).clone())
+            .add_assets([Asset::from(mint_asset)])
+            .build()
+            .unwrap()
+    };
+    let add_note = build_note(&add_note_package);
+    let baseline_note = build_note(&baseline_note_package);
+
+    let notes = [add_note.clone(), baseline_note.clone()];
+    let faucet_account = chain.committed_account(faucet_id).unwrap().clone();
+    let mint_tx_script = build_send_notes_script(&faucet_account, &notes);
+    let mint_tx_context_builder = chain
+        .build_tx_context(faucet_id, &[], &[])
+        .unwrap()
+        .tx_script(mint_tx_script)
+        .extend_expected_output_notes(
+            notes.iter().cloned().map(RawOutputNote::Full).collect::<Vec<_>>(),
+        );
+    execute_tx(&mut chain, mint_tx_context_builder);
+
+    eprintln!("\n=== Step 2: Alice consumes the addition note ===");
+    let faucet_inputs = chain.get_foreign_account_inputs(faucet_id).unwrap();
+    let add_tx_context_builder = chain
+        .build_tx_context(alice_id, &[add_note.id()], &[])
+        .unwrap()
+        .foreign_accounts(vec![faucet_inputs]);
+    let add_measurements = execute_tx(&mut chain, add_tx_context_builder);
+
+    eprintln!("\n=== Step 3: Bob consumes the addition-free baseline note ===");
+    let faucet_inputs = chain.get_foreign_account_inputs(faucet_id).unwrap();
+    let baseline_tx_context_builder = chain
+        .build_tx_context(bob_id, &[baseline_note.id()], &[])
+        .unwrap()
+        .foreign_accounts(vec![faucet_inputs]);
+    let baseline_measurements = execute_tx(&mut chain, baseline_tx_context_builder);
+
+    let add_cycles = single_note_cycles(&add_measurements);
+    let baseline_cycles = single_note_cycles(&baseline_measurements);
+    let add_total = add_cycles.parse::<i64>().unwrap() - baseline_cycles.parse::<i64>().unwrap();
+    eprintln!(
+        "\n=== Note execution: baseline (no additions) = {baseline_cycles} cycles, `+` = \
+         {add_cycles} cycles; four additions cost {add_total} cycles ({} per add) ===",
+        add_total / 4,
+    );
+
+    expect!["6977"].assert_eq(add_cycles);
+    expect!["6200"].assert_eq(baseline_cycles);
+
+    // Both wallets received their asset, so both scripts ran to completion.
+    assert_account_has_fungible_asset(
+        chain.committed_account(alice_id).unwrap(),
+        faucet_id,
+        amount,
+    );
+    assert_account_has_fungible_asset(chain.committed_account(bob_id).unwrap(), faucet_id, amount);
+}

--- a/tests/integration-network/src/mockchain/asset_amount.rs
+++ b/tests/integration-network/src/mockchain/asset_amount.rs
@@ -5,10 +5,7 @@
 //! decodes amounts from kernel-built assets and checks its arithmetic against the kernel's own
 //! vault bookkeeping.
 
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{path::Path, sync::Arc};
 
 use miden_client::{
     account::{AccountComponent, component::InitStorageData},
@@ -19,14 +16,55 @@ use miden_mast_package::Package;
 use miden_protocol::{account::auth::AuthScheme, crypto::rand::RandomCoin};
 use miden_standards::testing::note::NoteBuilder;
 use miden_testing::{Auth, MockChain};
-use midenc_expect_test::expect;
-use midenc_integration_test_support::project;
+use midenc_integration_test_support::{cargo_proj::Project, project};
 
 use super::support::{
+    account_cargo_toml_for, account_miden_project_toml_with_interface,
     assert_account_has_fungible_asset, build_send_notes_script, compile_rust_package, execute_tx,
     note_cargo_toml_for_dependency, note_miden_project_toml_for_dependency, note_script_root,
-    single_note_cycles,
 };
+
+/// Project name of the generated wallet account component.
+const WALLET_NAME: &str = "asset-amount-wallet";
+/// Miden package name of the generated wallet account component.
+const WALLET_PACKAGE: &str = "miden:asset-amount-wallet";
+
+/// Wallet account component consumed by the amount-check note.
+///
+/// The kernel restricts vault reads to the account context, so the component exposes the typed
+/// vault amount as an account procedure; returning `AssetAmount` also exercises the WIT
+/// `asset-amount` core type across the component boundary at run time.
+const AMOUNT_WALLET_SOURCE: &str = r#"
+#![no_std]
+#![feature(alloc_error_handler)]
+
+use miden::{Asset, AssetAmount, Word, active_account, component, component_storage};
+
+#[component_storage]
+struct AmountWalletStorage;
+
+/// API of the amount-check wallet account component.
+#[component]
+trait AmountWallet {
+    /// Adds an asset to the account vault.
+    #[account_procedure]
+    fn receive_asset(&mut self, asset: Asset);
+    /// Returns the typed amount currently held in the vault under `asset_key`.
+    #[account_procedure]
+    fn vault_amount(&self, asset_key: Word) -> AssetAmount;
+}
+
+#[component]
+impl AmountWallet for AmountWalletStorage {
+    fn receive_asset(&mut self, asset: Asset) {
+        self.add_asset(asset);
+    }
+
+    fn vault_amount(&self, asset_key: Word) -> AssetAmount {
+        Asset::new(asset_key, active_account::get_asset(asset_key)).amount()
+    }
+}
+"#;
 
 /// On-chain note script exercising the `AssetAmount` API against live kernel state.
 ///
@@ -37,16 +75,11 @@ const ASSET_AMOUNT_NOTE_SOURCE: &str = r#"
 #![no_std]
 #![feature(alloc_error_handler)]
 
-use miden::{Asset, AssetAmount, Word, account, active_account, active_note, note};
+use miden::{AssetAmount, Word, account, active_note, note};
 
-/// Native account of the note: exposes the `basic-wallet` component methods.
-#[account(basic_wallet::BasicWallet)]
+/// Native account of the note: exposes the amount-wallet component methods.
+#[account(asset_amount_wallet::AmountWallet)]
 pub struct Wallet;
-
-/// Reads the typed amount currently held in the active account's vault under `asset_key`.
-fn vault_amount(asset_key: Word) -> AssetAmount {
-    Asset::new(asset_key, active_account::get_asset(asset_key)).amount()
-}
 
 /// A note that transfers its assets to the consuming account while verifying the typed
 /// asset-amount API against the transaction kernel's view of the vault.
@@ -64,9 +97,9 @@ impl AssetAmountNote {
             assert!(amount > AssetAmount::ZERO);
 
             let key = asset.key;
-            let before = vault_amount(key);
+            let before = account.vault_amount(key);
             account.receive_asset(asset);
-            let after = vault_amount(key);
+            let after = account.vault_amount(key);
 
             // The vault amount must grow by exactly the decoded amount (checked addition).
             assert_eq!(after, before + amount);
@@ -81,19 +114,29 @@ impl AssetAmountNote {
 }
 "#;
 
-/// Compiles the basic-wallet example and returns its package and canonical project root.
+/// Generates and compiles the wallet account component project.
 ///
-/// The wallet must be compiled before any dependent note project so that its
-/// `target/generated-wit` directory exists.
-fn compile_wallet_package() -> (Arc<Package>, PathBuf) {
-    let wallet_package = compile_rust_package("../../examples/basic-wallet", true);
-    let wallet_root = std::fs::canonicalize("../../examples/basic-wallet")
-        .expect("failed to canonicalize the basic-wallet example path");
-    (wallet_package, wallet_root)
+/// The returned [`Project`] keeps the generated directory alive: the dependent note project
+/// resolves the wallet dependency (and its `target/generated-wit`) from that path.
+fn build_wallet_project() -> (Project, Arc<Package>) {
+    let wallet_project = project(WALLET_NAME)
+        .file(
+            "miden-project.toml",
+            &account_miden_project_toml_with_interface(
+                WALLET_NAME,
+                WALLET_PACKAGE,
+                "amount-wallet",
+            ),
+        )
+        .file("Cargo.toml", &account_cargo_toml_for(WALLET_NAME, WALLET_PACKAGE))
+        .file("src/lib.rs", AMOUNT_WALLET_SOURCE)
+        .build();
+    let wallet_package = compile_rust_package(wallet_project.root(), true);
+    (wallet_project, wallet_package)
 }
 
-/// Generates and compiles a note project with the given source, depending on the basic-wallet
-/// example.
+/// Generates and compiles a note project with the given source, depending on the generated
+/// wallet component.
 fn compile_note_package(note_name: &str, source: &str, wallet_root: &Path) -> Arc<Package> {
     let note_package_name = format!("miden:{note_name}");
     let note_project = project(note_name)
@@ -102,85 +145,36 @@ fn compile_note_package(note_name: &str, source: &str, wallet_root: &Path) -> Ar
             &note_miden_project_toml_for_dependency(
                 note_name,
                 &note_package_name,
-                "miden:basic-wallet",
+                WALLET_PACKAGE,
                 wallet_root,
             ),
         )
         .file(
             "Cargo.toml",
-            &note_cargo_toml_for_dependency(
-                note_name,
-                &note_package_name,
-                "miden:basic-wallet",
-                wallet_root,
-            ),
+            &note_cargo_toml_for_dependency(note_name, WALLET_PACKAGE, wallet_root),
         )
         .file("src/lib.rs", source)
         .build();
     compile_rust_package(note_project.root(), true)
 }
 
-/// Returns a note script performing a fixed chain of four dependent additions through the
-/// provided expression body, used to compare the cycle costs of the addition implementations.
-///
-/// `add_body` is the body of a `fn(a: AssetAmount, b: AssetAmount) -> AssetAmount` helper, e.g.
-/// `a + b`.
-fn measurement_note_source(add_body: &str) -> String {
-    format!(
-        r#"
-#![no_std]
-#![feature(alloc_error_handler)]
-
-use miden::{{AssetAmount, Word, account, active_note, note}};
-
-/// Native account of the note: exposes the `basic-wallet` component methods.
-#[account(basic_wallet::BasicWallet)]
-pub struct Wallet;
-
-/// The measured addition implementation.
-#[inline(always)]
-fn checked_add(a: AssetAmount, b: AssetAmount) -> AssetAmount {{
-    {add_body}
-}}
-
-/// A note performing a fixed chain of checked additions for cycle measurement.
-#[note]
-struct MeasurementNote;
-
-#[note]
-impl MeasurementNote {{
-    #[note_script]
-    pub fn script(self, _arg: Word, account: &mut Wallet) {{
-        let assets = active_note::get_initial_assets();
-        for asset in assets {{
-            let amount = asset.amount();
-            let first = checked_add(amount, amount);
-            let second = checked_add(first, amount);
-            let third = checked_add(second, amount);
-            let fourth = checked_add(third, amount);
-            assert!(fourth > amount);
-            account.receive_asset(asset);
-        }}
-    }}
-}}
-"#
-    )
-}
-
 /// Tests the on-chain `AssetAmount` API (`Asset::amount`, checked `+`/`-`, ordering, `as_u64`)
-/// against kernel-built assets and balances on a mock chain.
+/// against kernel-built assets and vault amounts on a mock chain.
 ///
 /// Flow:
 /// - The faucet emits two amount-check notes carrying different fungible amounts
 /// - The wallet consumes both notes in one transaction, so the note script checks the typed
-///   arithmetic once against a zero starting balance and once against a non-zero one
+///   arithmetic once against a zero starting vault amount and once against a non-zero one
 /// - The committed vault must hold the sum of both amounts
 #[test]
 fn asset_amount_api_matches_kernel_balances() {
     // Compile the contracts first (before creating any runtime)
-    let (wallet_package, wallet_root) = compile_wallet_package();
-    let note_package =
-        compile_note_package("asset-amount-note", ASSET_AMOUNT_NOTE_SOURCE, &wallet_root);
+    let (wallet_project, wallet_package) = build_wallet_project();
+    let note_package = compile_note_package(
+        "asset-amount-note",
+        ASSET_AMOUNT_NOTE_SOURCE,
+        wallet_project.root().as_path(),
+    );
 
     let wallet_component =
         AccountComponent::from_package(&wallet_package, &InitStorageData::default()).unwrap();
@@ -231,7 +225,7 @@ fn asset_amount_api_matches_kernel_balances() {
     let mint_tx_context_builder = chain
         .build_tx_context(faucet_id, &[], &[])
         .unwrap()
-        .tx_script(mint_tx_script)
+        .tx_script(mint_tx_script.into())
         .extend_expected_output_notes(
             notes.iter().cloned().map(RawOutputNote::Full).collect::<Vec<_>>(),
         );
@@ -245,161 +239,7 @@ fn asset_amount_api_matches_kernel_balances() {
         .foreign_accounts(vec![faucet_inputs]);
     execute_tx(&mut chain, consume_tx_context_builder);
 
-    eprintln!("\n=== Step 3: Checking Alice's committed balance is the checked sum ===");
+    eprintln!("\n=== Step 3: Checking Alice's committed vault holds the checked sum ===");
     let alice_account = chain.committed_account(alice_id).unwrap();
     assert_account_has_fungible_asset(alice_account, faucet_id, first_amount + second_amount);
-}
-
-/// A note script with the measurement-script shape but no additions, isolating the fixed
-/// note-execution overhead (note setup, `get_assets`, the amount decode, `receive_asset`).
-/// Subtracting its cycle count from the measurement note's yields the absolute cost of the
-/// note's four additions.
-const BASELINE_NOTE_SOURCE: &str = r#"
-#![no_std]
-#![feature(alloc_error_handler)]
-
-use miden::{AssetAmount, Word, account, active_note, note};
-
-/// Native account of the note: exposes the `basic-wallet` component methods.
-#[account(basic_wallet::BasicWallet)]
-pub struct Wallet;
-
-/// A note performing no additions, used as the cycle-measurement baseline.
-#[note]
-struct BaselineNote;
-
-#[note]
-impl BaselineNote {
-    #[note_script]
-    pub fn script(self, _arg: Word, account: &mut Wallet) {
-        let assets = active_note::get_initial_assets();
-        for asset in assets {
-            let amount = asset.amount();
-            assert!(amount > AssetAmount::ZERO);
-            account.receive_asset(asset);
-        }
-    }
-}
-"#;
-
-/// Measures the note-execution cycle cost of the panicking felt-native `+` operator.
-///
-/// The measurement note performs four dependent additions; the addition-free baseline note
-/// isolates the fixed note-execution overhead, so the absolute cost of the four additions is
-/// the measurement count minus the baseline. Each note is consumed by a fresh wallet account,
-/// so the vault bookkeeping costs are symmetric.
-#[test]
-fn asset_amount_add_cycles() {
-    // Compile the contracts first (before creating any runtime)
-    let (wallet_package, wallet_root) = compile_wallet_package();
-    let add_note_package = compile_note_package(
-        "asset-amount-add-note",
-        &measurement_note_source("a + b"),
-        &wallet_root,
-    );
-    let baseline_note_package =
-        compile_note_package("asset-amount-baseline-note", BASELINE_NOTE_SOURCE, &wallet_root);
-
-    let wallet_component =
-        AccountComponent::from_package(&wallet_package, &InitStorageData::default()).unwrap();
-
-    let mut builder = MockChain::builder();
-    let max_supply = 1_000_000_000u64;
-    let faucet_account = builder
-        .add_existing_basic_faucet(
-            Auth::BasicAuth {
-                auth_scheme: AuthScheme::Falcon512Poseidon2,
-            },
-            "TEST",
-            max_supply,
-            None,
-        )
-        .unwrap();
-    let faucet_id = faucet_account.id();
-
-    let alice_account = builder
-        .add_existing_account_from_components(
-            Auth::BasicAuth {
-                auth_scheme: AuthScheme::Falcon512Poseidon2,
-            },
-            [wallet_component.clone()],
-        )
-        .unwrap();
-    let alice_id = alice_account.id();
-
-    let bob_account = builder
-        .add_existing_account_from_components(
-            Auth::BasicAuth {
-                auth_scheme: AuthScheme::Falcon512Poseidon2,
-            },
-            [wallet_component],
-        )
-        .unwrap();
-    let bob_id = bob_account.id();
-
-    let mut chain = builder.build().unwrap();
-    chain.prove_next_block().unwrap();
-    chain.prove_next_block().unwrap();
-
-    eprintln!("\n=== Step 1: Minting the measurement and baseline notes ===");
-    let amount = 100_000u64;
-    let build_note = |note_package: &Arc<Package>| {
-        let mint_asset = FungibleAsset::new(faucet_id, amount).unwrap();
-        let mut note_rng = RandomCoin::new(note_script_root(note_package.as_ref()));
-        NoteBuilder::new(faucet_id, &mut note_rng)
-            .package((**note_package).clone())
-            .add_assets([Asset::from(mint_asset)])
-            .build()
-            .unwrap()
-    };
-    let add_note = build_note(&add_note_package);
-    let baseline_note = build_note(&baseline_note_package);
-
-    let notes = [add_note.clone(), baseline_note.clone()];
-    let faucet_account = chain.committed_account(faucet_id).unwrap().clone();
-    let mint_tx_script = build_send_notes_script(&faucet_account, &notes);
-    let mint_tx_context_builder = chain
-        .build_tx_context(faucet_id, &[], &[])
-        .unwrap()
-        .tx_script(mint_tx_script)
-        .extend_expected_output_notes(
-            notes.iter().cloned().map(RawOutputNote::Full).collect::<Vec<_>>(),
-        );
-    execute_tx(&mut chain, mint_tx_context_builder);
-
-    eprintln!("\n=== Step 2: Alice consumes the addition note ===");
-    let faucet_inputs = chain.get_foreign_account_inputs(faucet_id).unwrap();
-    let add_tx_context_builder = chain
-        .build_tx_context(alice_id, &[add_note.id()], &[])
-        .unwrap()
-        .foreign_accounts(vec![faucet_inputs]);
-    let add_measurements = execute_tx(&mut chain, add_tx_context_builder);
-
-    eprintln!("\n=== Step 3: Bob consumes the addition-free baseline note ===");
-    let faucet_inputs = chain.get_foreign_account_inputs(faucet_id).unwrap();
-    let baseline_tx_context_builder = chain
-        .build_tx_context(bob_id, &[baseline_note.id()], &[])
-        .unwrap()
-        .foreign_accounts(vec![faucet_inputs]);
-    let baseline_measurements = execute_tx(&mut chain, baseline_tx_context_builder);
-
-    let add_cycles = single_note_cycles(&add_measurements);
-    let baseline_cycles = single_note_cycles(&baseline_measurements);
-    let add_total = add_cycles.parse::<i64>().unwrap() - baseline_cycles.parse::<i64>().unwrap();
-    eprintln!(
-        "\n=== Note execution: baseline (no additions) = {baseline_cycles} cycles, `+` = \
-         {add_cycles} cycles; four additions cost {add_total} cycles ({} per add) ===",
-        add_total / 4,
-    );
-
-    expect!["6792"].assert_eq(add_cycles);
-    expect!["6009"].assert_eq(baseline_cycles);
-
-    // Both wallets received their asset, so both scripts ran to completion.
-    assert_account_has_fungible_asset(
-        chain.committed_account(alice_id).unwrap(),
-        faucet_id,
-        amount,
-    );
-    assert_account_has_fungible_asset(chain.committed_account(bob_id).unwrap(), faucet_id, amount);
 }

--- a/tests/integration-network/src/mockchain/asset_amount.rs
+++ b/tests/integration-network/src/mockchain/asset_amount.rs
@@ -45,7 +45,7 @@ pub struct Wallet;
 
 /// Reads the typed amount currently held in the active account's vault under `asset_key`.
 fn vault_amount(asset_key: Word) -> AssetAmount {
-    Asset::new(asset_key, active_account::get_asset(asset_key)).amount().unwrap()
+    Asset::new(asset_key, active_account::get_asset(asset_key)).amount()
 }
 
 /// A note that transfers its assets to the consuming account while verifying the typed
@@ -60,7 +60,7 @@ impl AssetAmountNote {
         let assets = active_note::get_initial_assets();
         for asset in assets {
             // Decode the typed amount from the kernel-built fungible asset encoding.
-            let amount = asset.amount().unwrap();
+            let amount = asset.amount();
             assert!(amount > AssetAmount::ZERO);
 
             let key = asset.key;
@@ -153,7 +153,7 @@ impl MeasurementNote {{
     pub fn script(self, _arg: Word, account: &mut Wallet) {{
         let assets = active_note::get_initial_assets();
         for asset in assets {{
-            let amount = asset.amount().unwrap();
+            let amount = asset.amount();
             let first = checked_add(amount, amount);
             let second = checked_add(first, amount);
             let third = checked_add(second, amount);
@@ -274,7 +274,7 @@ impl BaselineNote {
     pub fn script(self, _arg: Word, account: &mut Wallet) {
         let assets = active_note::get_initial_assets();
         for asset in assets {
-            let amount = asset.amount().unwrap();
+            let amount = asset.amount();
             assert!(amount > AssetAmount::ZERO);
             account.receive_asset(asset);
         }
@@ -392,8 +392,8 @@ fn asset_amount_add_cycles() {
         add_total / 4,
     );
 
-    expect!["6977"].assert_eq(add_cycles);
-    expect!["6200"].assert_eq(baseline_cycles);
+    expect!["6792"].assert_eq(add_cycles);
+    expect!["6009"].assert_eq(baseline_cycles);
 
     // Both wallets received their asset, so both scripts ran to completion.
     assert_account_has_fungible_asset(

--- a/tests/integration-network/src/mockchain/mod.rs
+++ b/tests/integration-network/src/mockchain/mod.rs
@@ -1,5 +1,6 @@
 //! Integration tests which exercise contract deployment and execution on a mock chain.
 
+mod asset_amount;
 mod counter;
 mod fpi;
 mod notes;

--- a/tests/integration-network/src/mockchain/notes/basic_wallet.rs
+++ b/tests/integration-network/src/mockchain/notes/basic_wallet.rs
@@ -271,7 +271,7 @@ pub fn basic_wallet_p2ide_allows_recipient_claim() {
         .unwrap()
         .foreign_accounts(vec![faucet_inputs]);
     let tx_measurements = execute_tx(&mut chain, consume_tx_context_builder);
-    expect!["4805"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["4943"].assert_eq(single_note_cycles(&tx_measurements));
 
     // Step 5: verify balances
     let bob_account = chain.committed_account(bob_id).unwrap();
@@ -404,7 +404,7 @@ pub fn basic_wallet_p2ide_allows_sender_reclaim() {
         .unwrap()
         .foreign_accounts(vec![faucet_inputs]);
     let tx_measurements = execute_tx(&mut chain, reclaim_tx_context_builder);
-    expect!["5329"].assert_eq(single_note_cycles(&tx_measurements));
+    expect!["5518"].assert_eq(single_note_cycles(&tx_measurements));
 
     // Step 5: verify Alice has her original amount back
     let alice_account = chain.committed_account(alice_id).unwrap();

--- a/tests/integration/src/end_to_end/examples/basic_wallet_package_sizes.rs
+++ b/tests/integration/src/end_to_end/examples/basic_wallet_package_sizes.rs
@@ -46,5 +46,5 @@ fn basic_wallet_and_p2id() {
     );
     let p2ide_package = p2ide_test.compile_package();
     assert!(p2ide_package.is_library(), "expected library");
-    expect!["17774"].assert_eq(stripped_mast_size_str(&p2ide_package).as_str());
+    expect!["18604"].assert_eq(stripped_mast_size_str(&p2ide_package).as_str());
 }

--- a/tests/integration/src/sdk/base/account.rs
+++ b/tests/integration/src/sdk/base/account.rs
@@ -196,7 +196,7 @@ fn account_get_vault_root_binding() {
 fn account_get_num_procedures_binding() {
     run_account_binding_test(
         "account_get_num_procedures_binding",
-        "pub fn binding(&self) -> Felt {
+        "pub fn binding(&self) -> u32 {
         self.get_num_procedures()
     }",
     );

--- a/tests/integration/src/sdk/base/active_note.rs
+++ b/tests/integration/src/sdk/base/active_note.rs
@@ -126,7 +126,7 @@ fn active_note_write_attachment_to_memory_binding() {
     run_active_note_binding_test(
         "active_note_write_attachment_to_memory_binding",
         "pub fn binding(&self) -> Felt {
-        let attachment = active_note::write_attachment_to_memory(Felt::new(0).unwrap());
+        let attachment = active_note::write_attachment_to_memory(0);
         Felt::new(attachment.len() as u64).unwrap()
     }",
     );
@@ -136,9 +136,8 @@ fn active_note_write_attachment_to_memory_binding() {
 fn active_note_find_attachment_binding() {
     run_active_note_binding_test(
         "active_note_find_attachment_binding",
-        "pub fn binding(&self) -> Felt {
-        let location = active_note::find_attachment(Felt::new(1).unwrap());
-        location.index
+        "pub fn binding(&self) -> u32 {
+        active_note::find_attachment(Felt::new(1).unwrap()).unwrap_or(0)
     }",
     );
 }

--- a/tests/integration/src/sdk/base/input_note.rs
+++ b/tests/integration/src/sdk/base/input_note.rs
@@ -76,7 +76,7 @@ trim-paths = ["diagnostics", "object"]
 fn input_note_get_initial_assets_info_binding() {
     run_input_note_binding_test(
         "input_note_get_initial_assets_info_binding",
-        "pub fn binding(&self) -> Felt {
+        "pub fn binding(&self) -> u32 {
         let info = input_note::get_initial_assets_info(NoteIdx { inner: Felt::new(0).unwrap() });
         info.num_assets
     }",
@@ -128,7 +128,7 @@ fn input_note_get_sender_binding() {
 fn input_note_get_storage_info_binding() {
     run_input_note_binding_test(
         "input_note_get_storage_info_binding",
-        "pub fn binding(&self) -> Felt {
+        "pub fn binding(&self) -> u32 {
         let info = input_note::get_storage_info(NoteIdx { inner: Felt::new(0).unwrap() });
         info.num_storage_items
     }",

--- a/tests/integration/src/sdk/base/input_note.rs
+++ b/tests/integration/src/sdk/base/input_note.rs
@@ -198,7 +198,7 @@ fn input_note_write_attachment_to_memory_binding() {
         "pub fn binding(&self) -> Felt {
         let attachment = input_note::write_attachment_to_memory(
             NoteIdx { inner: Felt::new(0).unwrap() },
-            Felt::new(0).unwrap(),
+            0,
         );
         Felt::new(attachment.len() as u64).unwrap()
     }",
@@ -209,12 +209,12 @@ fn input_note_write_attachment_to_memory_binding() {
 fn input_note_find_attachment_binding() {
     run_input_note_binding_test(
         "input_note_find_attachment_binding",
-        "pub fn binding(&self) -> Felt {
-        let location = input_note::find_attachment(
+        "pub fn binding(&self) -> u32 {
+        input_note::find_attachment(
             NoteIdx { inner: Felt::new(0).unwrap() },
             Felt::new(1).unwrap(),
-        );
-        location.index
+        )
+        .unwrap_or(0)
     }",
     );
 }

--- a/tests/integration/src/sdk/base/note.rs
+++ b/tests/integration/src/sdk/base/note.rs
@@ -146,7 +146,7 @@ fn note_write_indexed_attachment_to_memory_binding() {
         "pub fn binding(&self) -> Felt {
         let commitments = [Word::from([Felt::new(0).unwrap(); 4])];
         let attachment =
-            note::write_indexed_attachment_to_memory(&commitments, Felt::new(0).unwrap());
+            note::write_indexed_attachment_to_memory(&commitments, 0);
         Felt::new(attachment.len() as u64).unwrap()
     }",
     );
@@ -210,12 +210,12 @@ fn note_metadata_into_tag_binding() {
 fn note_find_attachment_idx_binding() {
     run_note_binding_test(
         "note_find_attachment_idx_binding",
-        "pub fn binding(&self) -> Felt {
-        let location = note::find_attachment_idx(
+        "pub fn binding(&self) -> u32 {
+        note::find_attachment_idx(
             Felt::new(1).unwrap(),
             Word::from([Felt::new(0).unwrap(); 4]),
-        );
-        location.index
+        )
+        .unwrap_or(0)
     }",
     );
 }

--- a/tests/integration/src/sdk/base/output_note.rs
+++ b/tests/integration/src/sdk/base/output_note.rs
@@ -79,7 +79,7 @@ trim-paths = ["diagnostics", "object"]
 fn rust_sdk_output_note_get_assets_info_binding() {
     run_output_note_binding_test(
         "rust_sdk_output_note_get_assets_info_binding",
-        "pub fn binding(&self) -> Felt {
+        "pub fn binding(&self) -> u32 {
         let info = output_note::get_assets_info(NoteIdx { inner: Felt::new(0).unwrap() });
         info.num_assets
     }",

--- a/tests/integration/src/sdk/base/output_note.rs
+++ b/tests/integration/src/sdk/base/output_note.rs
@@ -228,12 +228,12 @@ fn rust_sdk_output_note_add_attachment_from_memory_binding() {
 fn rust_sdk_output_note_find_attachment_binding() {
     run_output_note_binding_test(
         "rust_sdk_output_note_find_attachment_binding",
-        "pub fn binding(&self) -> Felt {
-        let location = output_note::find_attachment(
+        "pub fn binding(&self) -> u32 {
+        output_note::find_attachment(
             NoteIdx { inner: Felt::new(0).unwrap() },
             Felt::new(1).unwrap(),
-        );
-        location.index
+        )
+        .unwrap_or(0)
     }",
     );
 }
@@ -258,7 +258,7 @@ fn rust_sdk_output_note_write_attachment_to_memory_binding() {
         "pub fn binding(&self) -> Felt {
         let attachment = output_note::write_attachment_to_memory(
             NoteIdx { inner: Felt::new(0).unwrap() },
-            Felt::new(0).unwrap(),
+            0,
         );
         Felt::new(attachment.len() as u64).unwrap()
     }",

--- a/tests/integration/src/sdk/base/tx.rs
+++ b/tests/integration/src/sdk/base/tx.rs
@@ -124,7 +124,7 @@ fn rust_sdk_account_tx_get_expiration_block_delta_binding() {
 fn rust_sdk_account_tx_update_expiration_block_delta_binding() {
     run_tx_binding_test(
         "rust_sdk_account_tx_update_expiration_block_delta_binding",
-        "tx::update_expiration_block_delta(Felt::new(42).unwrap());",
+        "tx::update_expiration_block_delta(42);",
     );
 }
 


### PR DESCRIPTION
Closes #999.

The SDK does not send fungible asset amounts as raw `Felt` values. The new `AssetAmount` type contains a `Felt`. The canonical value of this `Felt` is not more than `2^63 - 2^31`. This limit is the maximum fungible amount of the protocol. `AssetAmount` has integer operations only. As a result, the field errors from the issue are not possible. These errors are: a wrap at the field modulus, and a division with the multiplicative inverse.

The protocol 0.16 bindings use raw key words and value words for assets. The kernel does not make assets and does not have balance getter functions. As a result, the guest code gets the typed amount at the points where it reads amounts:

- `Asset::amount()` decodes the amount of a fungible asset and returns an `AssetAmount`. If the asset is not fungible, the function panics. Use `Asset::is_fungible()` in scripts that get assets of the two types. The parity of the metadata limb of the vault key shows the asset type, because `Fungible = 0b01` is the only odd composition value. This check is the check with the smallest cost that kernel-encoded assets permit.
- You can use `AssetAmount` in the signatures of exported component methods. The related WIT type is the `asset-amount` core type. You can also use `AssetAmount` in typed account storage: `StorageValue<AssetAmount>` and `StorageMap<K, AssetAmount>`. To make an `AssetAmount`, use `new(u64)`, `From<u8/u16/u32>` (errors are not possible), or `TryFrom<u64/Felt>` (does validation).
- The `+` and `-` operators do a bounds check. If an overflow or an underflow occurs, the operators panic. See the [implementation](https://github.com/0xMiden/compiler/blob/4f0eb814cbfe4eb77cc03ec4d213800f605a39e6/sdk/base-sys/src/bindings/types.rs?plain=1#L244-L290).

```rust
fn vault_amount(&self, asset_key: Word) -> AssetAmount {
    Asset::new(asset_key, active_account::get_asset(asset_key)).amount()
}

let total = account.vault_amount(key) + asset.amount(); // panics above MAX_U64 instead of wrapping
let rest = total - payment;                             // panics on underflow
```

The other kernel surfaces that had counts or index values as felts also change to integer types:

- Kernel counts are `u32` values. This applies to `tx::get_num_input_notes`, `tx::get_num_output_notes`, `active_account::get_num_procedures`, and the `num_assets` and `num_storage_items` fields of the note info structs. Also, `get_procedure_root` gets its index parameter as a `u32`.
- The attachment search functions return an `Option<u32>`. This type replaces the `AttachmentLocation` struct, which had a felt flag. The attachment index parameters are `u32` values.
- Account nonces use the new `Nonce` type. This type is the `nonce` record from the WIT core-types interface. The interface declared this record before, but the SDK did not use it.
- Block heights use the new `BlockNumber` type (the WIT `block-number` record). You can compare block numbers as integers. Use `TryFrom<Felt>` to do validation of the heights that you read from note storage. The `as_u32` function makes sure that the value obeys the `u32` limit. As a result, a WIT record with a bad value cannot cause an incorrect truncation. The p2ide example now does validation of its timelock height and its reclaim height. Block timestamps are `u32` seconds. Expiration deltas are `u16` values. These types agree with the limits in the kernel documentation.

The arithmetic stays in the field domain. Two times the maximum amount is `2^64 - 2^32 = M - 1`. A compile-time assertion keeps this property safe. As a result, the addition of two correct amounts cannot wrap at the field modulus. The checked add and subtract operations only do an assert on one operand and one comparison. One addition uses 194 cycles on the chain. The `u64::checked_add` version is approximately two times slower. Operators that return a `Result` are approximately 2.3 times slower, because the error value causes a return through memory. The operators panic, but the operators in the off-chain protocol crate return a `Result`. This difference is part of the design. Issue #870 is the point where the two APIs can become the same again. A mock-chain test operates the API against live kernel vault data. The test also gets an `AssetAmount` through the WIT component boundary.

### Why the arithmetic does not use `u64::checked_add`

```rust
pub fn add_as_u64(self, other: Self) -> Self {
    let sum = self
        .as_u64()
        .checked_add(other.as_u64())
        .expect("the sum of two asset amounts must fit in a u64");
    assert!(sum <= Self::MAX_U64, "asset amount addition overflow");
    // The bound check above also guarantees the value is below the field modulus.
    Self {
        inner: Felt::new_unchecked(sum),
    }
}
```

The measurement on a mock chain: one addition uses 378 cycles. The felt version uses 194 cycles. As a result, the u64 version is approximately two times slower. The cause is the u64 emulation on the VM, which operates on felts: one `u32split` for each operand, calls to the `miden::core::math::u64::*` library, and 32-bit limb pairs that go through memory.
